### PR TITLE
Normalize raw string indentation.

### DIFF
--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -12,15 +12,15 @@ fn depend_on_alt_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -61,15 +61,15 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -103,15 +103,15 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -145,15 +145,15 @@ fn depend_on_alt_registry_depends_on_crates_io() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -191,15 +191,15 @@ fn registry_and_path_dep_works() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -225,15 +225,15 @@ fn registry_incompatible_with_git() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            git = ""
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                git = ""
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -255,23 +255,23 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "alternative"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             ".cargo/config",
             &format!(
                 r#"
-            [registries.fakeio]
-            index = "{}"
-        "#,
+                    [registries.fakeio]
+                    index = "{}"
+                "#,
                 fakeio_url
             ),
         )
@@ -285,8 +285,8 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
         .file(
             "config.json",
             r#"
-            {"dl": "https://crates.io/api/v1/crates", "api": "https://crates.io"}
-        "#,
+                {"dl": "https://crates.io/api/v1/crates", "api": "https://crates.io"}
+            "#,
         )
         .build();
 
@@ -311,15 +311,15 @@ fn publish_with_registry_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "alternative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -372,18 +372,18 @@ fn alt_registry_and_crates_io_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            crates_io_dep = "0.0.1"
+                [dependencies]
+                crates_io_dep = "0.0.1"
 
-            [dependencies.alt_reg_dep]
-            version = "0.1.0"
-            registry = "alternative"
-        "#,
+                [dependencies.alt_reg_dep]
+                version = "0.1.0"
+                registry = "alternative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -472,16 +472,16 @@ fn publish_with_crates_io_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = ["me"]
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = ["me"]
+                license = "MIT"
+                description = "foo"
 
-            [dependencies.bar]
-            version = "0.0.1"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -566,16 +566,16 @@ fn patch_alt_reg() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { version = "0.1.0", registry = "alternative" }
+                [dependencies]
+                bar = { version = "0.1.0", registry = "alternative" }
 
-            [patch.alternative]
-            bar = { path = "bar" }
-        "#,
+                [patch.alternative]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -606,15 +606,15 @@ fn bad_registry_name() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "bad name"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "bad name"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -667,14 +667,14 @@ fn no_api() {
         .file(
             "Cargo.toml",
             r#"
-             [package]
-             name = "foo"
-             version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-             [dependencies.bar]
-             version = "0.0.1"
-             registry = "alternative"
-         "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "alternative"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -737,14 +737,14 @@ fn alt_reg_metadata() {
         .file(
             "Cargo.toml",
             r#"
-             [package]
-             name = "foo"
-             version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-             [dependencies]
-             altdep = { version = "0.0.1", registry = "alternative" }
-             iodep = { version = "0.0.1" }
-         "#,
+                [dependencies]
+                altdep = { version = "0.0.1", registry = "alternative" }
+                iodep = { version = "0.0.1" }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1019,14 +1019,14 @@ fn unknown_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1181,15 +1181,15 @@ fn registries_index_relative_url() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "relative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "relative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1230,15 +1230,15 @@ fn registries_index_relative_path_not_allowed() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "0.0.1"
-            registry = "relative"
-        "#,
+                [dependencies.bar]
+                version = "0.0.1"
+                registry = "relative"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -10,9 +10,9 @@ fn bad1() {
         .file(
             ".cargo/config",
             r#"
-              [target]
-              nonexistent-target = "foo"
-        "#,
+                  [target]
+                  nonexistent-target = "foo"
+            "#,
         )
         .build();
     p.cargo("build -v --target=nonexistent-target")
@@ -33,9 +33,9 @@ fn bad2() {
         .file(
             ".cargo/config",
             r#"
-              [http]
-                proxy = 3.0
-        "#,
+                  [http]
+                    proxy = 3.0
+            "#,
         )
         .build();
     p.cargo("publish -v")
@@ -67,9 +67,9 @@ fn bad3() {
         .file(
             ".cargo/config",
             r#"
-            [http]
-              proxy = true
-        "#,
+                [http]
+                  proxy = true
+            "#,
         )
         .build();
     Package::new("foo", "1.0.0").publish();
@@ -93,9 +93,9 @@ fn bad4() {
         .file(
             ".cargo/config",
             r#"
-            [cargo-new]
-              name = false
-        "#,
+                [cargo-new]
+                  name = false
+            "#,
         )
         .build();
     p.cargo("new -v foo")
@@ -118,9 +118,9 @@ fn bad6() {
         .file(
             ".cargo/config",
             r#"
-            [http]
-              user-agent = true
-        "#,
+                [http]
+                  user-agent = true
+            "#,
         )
         .build();
     Package::new("foo", "1.0.0").publish();
@@ -145,9 +145,9 @@ fn bad_cargo_config_jobs() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            jobs = -1
-        "#,
+                [build]
+                jobs = -1
+            "#,
         )
         .build();
     p.cargo("build -v")
@@ -170,14 +170,14 @@ fn invalid_global_config() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.1.0"
-        "#,
+                [dependencies]
+                foo = "0.1.0"
+            "#,
         )
         .file(".cargo/config", "4")
         .file("src/lib.rs", "")
@@ -230,36 +230,36 @@ fn duplicate_packages_in_cargo_lock() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "Cargo.lock",
             r#"
-            [[package]]
-            name = "foo"
-            version = "0.0.1"
-            dependencies = [
-             "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            ]
+                [[package]]
+                name = "foo"
+                version = "0.0.1"
+                dependencies = [
+                 "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                ]
 
-            [[package]]
-            name = "bar"
-            version = "0.1.0"
-            source = "registry+https://github.com/rust-lang/crates.io-index"
+                [[package]]
+                name = "bar"
+                version = "0.1.0"
+                source = "registry+https://github.com/rust-lang/crates.io-index"
 
-            [[package]]
-            name = "bar"
-            version = "0.1.0"
-            source = "registry+https://github.com/rust-lang/crates.io-index"
-        "#,
+                [[package]]
+                name = "bar"
+                version = "0.1.0"
+                source = "registry+https://github.com/rust-lang/crates.io-index"
+            "#,
         )
         .build();
 
@@ -284,31 +284,31 @@ fn bad_source_in_cargo_lock() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "Cargo.lock",
             r#"
-            [[package]]
-            name = "foo"
-            version = "0.0.1"
-            dependencies = [
-             "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            ]
+                [[package]]
+                name = "foo"
+                version = "0.0.1"
+                dependencies = [
+                 "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                ]
 
-            [[package]]
-            name = "bar"
-            version = "0.1.0"
-            source = "You shall not parse"
-        "#,
+                [[package]]
+                name = "bar"
+                version = "0.1.0"
+                source = "You shall not parse"
+            "#,
         )
         .build();
 
@@ -332,13 +332,13 @@ fn bad_dependency_in_lockfile() {
         .file(
             "Cargo.lock",
             r#"
-            [[package]]
-            name = "foo"
-            version = "0.0.1"
-            dependencies = [
-             "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            ]
-        "#,
+                [[package]]
+                name = "foo"
+                version = "0.0.1"
+                dependencies = [
+                 "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                ]
+            "#,
         )
         .build();
 
@@ -351,14 +351,14 @@ fn bad_git_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            foo = { git = "file:.." }
-        "#,
+                [dependencies]
+                foo = { git = "file:.." }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -392,14 +392,14 @@ fn bad_crate_type() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [lib]
-            crate-type = ["bad_type", "rlib"]
-        "#,
+                [lib]
+                crate-type = ["bad_type", "rlib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -418,16 +418,16 @@ fn malformed_override() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [target.x86_64-apple-darwin.freetype]
-            native = {
-              foo: "bar"
-            }
-        "#,
+                [target.x86_64-apple-darwin.freetype]
+                native = {
+                  foo: "bar"
+                }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -442,7 +442,7 @@ Caused by:
   could not parse input as TOML
 
 Caused by:
-  expected a table key, found a newline at line 8 column 23
+  expected a table key, found a newline at line 8 column 27
 ",
         )
         .run();
@@ -454,19 +454,19 @@ fn duplicate_binary_names() {
         .file(
             "Cargo.toml",
             r#"
-           [package]
-           name = "qqq"
-           version = "0.1.0"
-           authors = ["A <a@a.a>"]
+               [package]
+               name = "qqq"
+               version = "0.1.0"
+               authors = ["A <a@a.a>"]
 
-           [[bin]]
-           name = "e"
-           path = "a.rs"
+               [[bin]]
+               name = "e"
+               path = "a.rs"
 
-           [[bin]]
-           name = "e"
-           path = "b.rs"
-        "#,
+               [[bin]]
+               name = "e"
+               path = "b.rs"
+            "#,
         )
         .file("a.rs", r#"fn main() -> () {}"#)
         .file("b.rs", r#"fn main() -> () {}"#)
@@ -491,19 +491,19 @@ fn duplicate_example_names() {
         .file(
             "Cargo.toml",
             r#"
-           [package]
-           name = "qqq"
-           version = "0.1.0"
-           authors = ["A <a@a.a>"]
+               [package]
+               name = "qqq"
+               version = "0.1.0"
+               authors = ["A <a@a.a>"]
 
-           [[example]]
-           name = "ex"
-           path = "examples/ex.rs"
+               [[example]]
+               name = "ex"
+               path = "examples/ex.rs"
 
-           [[example]]
-           name = "ex"
-           path = "examples/ex2.rs"
-        "#,
+               [[example]]
+               name = "ex"
+               path = "examples/ex2.rs"
+            "#,
         )
         .file("examples/ex.rs", r#"fn main () -> () {}"#)
         .file("examples/ex2.rs", r#"fn main () -> () {}"#)
@@ -528,19 +528,19 @@ fn duplicate_bench_names() {
         .file(
             "Cargo.toml",
             r#"
-           [package]
-           name = "qqq"
-           version = "0.1.0"
-           authors = ["A <a@a.a>"]
+               [package]
+               name = "qqq"
+               version = "0.1.0"
+               authors = ["A <a@a.a>"]
 
-           [[bench]]
-           name = "ex"
-           path = "benches/ex.rs"
+               [[bench]]
+               name = "ex"
+               path = "benches/ex.rs"
 
-           [[bench]]
-           name = "ex"
-           path = "benches/ex2.rs"
-        "#,
+               [[bench]]
+               name = "ex"
+               path = "benches/ex2.rs"
+            "#,
         )
         .file("benches/ex.rs", r#"fn main () {}"#)
         .file("benches/ex2.rs", r#"fn main () {}"#)
@@ -569,17 +569,17 @@ fn duplicate_deps() {
         .file(
             "Cargo.toml",
             r#"
-           [package]
-           name = "qqq"
-           version = "0.0.1"
-           authors = []
+               [package]
+               name = "qqq"
+               version = "0.0.1"
+               authors = []
 
-           [dependencies]
-           bar = { path = "shim-bar" }
+               [dependencies]
+               bar = { path = "shim-bar" }
 
-           [target.x86_64-unknown-linux-gnu.dependencies]
-           bar = { path = "linux-bar" }
-        "#,
+               [target.x86_64-unknown-linux-gnu.dependencies]
+               bar = { path = "linux-bar" }
+            "#,
         )
         .file("src/main.rs", r#"fn main () {}"#)
         .build();
@@ -608,17 +608,17 @@ fn duplicate_deps_diff_sources() {
         .file(
             "Cargo.toml",
             r#"
-           [package]
-           name = "qqq"
-           version = "0.0.1"
-           authors = []
+               [package]
+               name = "qqq"
+               version = "0.0.1"
+               authors = []
 
-           [target.i686-unknown-linux-gnu.dependencies]
-           bar = { path = "shim-bar" }
+               [target.i686-unknown-linux-gnu.dependencies]
+               bar = { path = "shim-bar" }
 
-           [target.x86_64-unknown-linux-gnu.dependencies]
-           bar = { path = "linux-bar" }
-        "#,
+               [target.x86_64-unknown-linux-gnu.dependencies]
+               bar = { path = "linux-bar" }
+            "#,
         )
         .file("src/main.rs", r#"fn main () {}"#)
         .build();
@@ -643,14 +643,14 @@ fn unused_keys() {
         .file(
             "Cargo.toml",
             r#"
-           [package]
-           name = "foo"
-           version = "0.1.0"
-           authors = []
+               [package]
+               name = "foo"
+               version = "0.1.0"
+               authors = []
 
-           [target.foo]
-           bar = "3"
-        "#,
+               [target.foo]
+               bar = "3"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -669,17 +669,17 @@ warning: unused manifest key: target.foo.bar
         .file(
             "Cargo.toml",
             r#"
-           cargo-features = ["named-profiles"]
+               cargo-features = ["named-profiles"]
 
-           [package]
-           name = "foo"
-           version = "0.1.0"
-           authors = []
+               [package]
+               name = "foo"
+               version = "0.1.0"
+               authors = []
 
-           [profile.debug]
-           debug = 1
-           inherits = "dev"
-        "#,
+               [profile.debug]
+               debug = 1
+               inherits = "dev"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -702,13 +702,13 @@ warning: use `[profile.dev]` to configure debug builds
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            bulid = "foo"
-        "#,
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                bulid = "foo"
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
@@ -727,15 +727,15 @@ warning: unused manifest key: project.bulid
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [lib]
-            build = "foo"
-        "#,
+                [lib]
+                build = "foo"
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
@@ -756,13 +756,13 @@ fn unused_keys_in_virtual_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-            bulid = "foo"
-        "#,
+                [workspace]
+                members = ["bar"]
+                bulid = "foo"
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
-        .file("bar/src/lib.rs", r"")
+        .file("bar/src/lib.rs", "")
         .build();
     p.cargo("build --workspace")
         .with_stderr(
@@ -781,14 +781,14 @@ fn empty_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = {}
-        "#,
+                [dependencies]
+                bar = {}
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -835,16 +835,16 @@ fn ambiguous_git_reference() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.bar]
-            git = "http://127.0.0.1"
-            branch = "master"
-            tag = "some-tag"
-        "#,
+                [dependencies.bar]
+                git = "http://127.0.0.1"
+                branch = "master"
+                tag = "some-tag"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -867,14 +867,14 @@ fn fragment_in_git_url() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.bar]
-            git = "http://127.0.0.1#foo"
-        "#,
+                [dependencies.bar]
+                git = "http://127.0.0.1#foo"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -910,23 +910,23 @@ fn bad_source_config2() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.crates-io]
-            registry = 'http://example.com'
-            replace-with = 'bar'
-        "#,
+                [source.crates-io]
+                registry = 'http://example.com'
+                replace-with = 'bar'
+            "#,
         )
         .build();
 
@@ -956,23 +956,23 @@ fn bad_source_config3() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.crates-io]
-            registry = 'https://example.com'
-            replace-with = 'crates-io'
-        "#,
+                [source.crates-io]
+                registry = 'https://example.com'
+                replace-with = 'crates-io'
+            "#,
         )
         .build();
 
@@ -1001,26 +1001,26 @@ fn bad_source_config4() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.crates-io]
-            replace-with = 'bar'
+                [source.crates-io]
+                replace-with = 'bar'
 
-            [source.bar]
-            registry = 'https://example.com'
-            replace-with = 'crates-io'
-        "#,
+                [source.bar]
+                registry = 'https://example.com'
+                replace-with = 'crates-io'
+            "#,
         )
         .build();
 
@@ -1050,26 +1050,26 @@ fn bad_source_config5() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.crates-io]
-            registry = 'https://example.com'
-            replace-with = 'bar'
+                [source.crates-io]
+                registry = 'https://example.com'
+                replace-with = 'bar'
 
-            [source.bar]
-            registry = 'not a url'
-        "#,
+                [source.bar]
+                registry = 'not a url'
+            "#,
         )
         .build();
 
@@ -1092,15 +1092,15 @@ fn both_git_and_path_specified() {
         .file(
             "Cargo.toml",
             r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-        [dependencies.bar]
-        git = "http://127.0.0.1"
-        path = "bar"
-    "#,
+                [dependencies.bar]
+                git = "http://127.0.0.1"
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1123,23 +1123,23 @@ fn bad_source_config6() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.crates-io]
-            registry = 'https://example.com'
-            replace-with = ['not', 'a', 'string']
-        "#,
+                [source.crates-io]
+                registry = 'https://example.com'
+                replace-with = ['not', 'a', 'string']
+            "#,
         )
         .build();
 
@@ -1162,15 +1162,15 @@ fn ignored_git_revision() {
         .file(
             "Cargo.toml",
             r#"
-        [package]
-        name = "foo"
-        version = "0.0.0"
-        authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-        [dependencies.bar]
-        path = "bar"
-        branch = "spam"
-    "#,
+                [dependencies.bar]
+                path = "bar"
+                branch = "spam"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1190,23 +1190,23 @@ fn bad_source_config7() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.foo]
-            registry = 'https://example.com'
-            local-registry = 'file:///another/file'
-        "#,
+                [source.foo]
+                registry = 'https://example.com'
+                local-registry = 'file:///another/file'
+            "#,
         )
         .build();
 
@@ -1224,22 +1224,22 @@ fn bad_source_config8() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.foo]
-            branch = "somebranch"
-        "#,
+                [source.foo]
+                branch = "somebranch"
+            "#,
         )
         .build();
 
@@ -1258,14 +1258,14 @@ fn bad_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            bar = 3
-        "#,
+                [dependencies]
+                bar = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1289,14 +1289,14 @@ fn bad_debuginfo() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [profile.dev]
-            debug = 'a'
-        "#,
+                [profile.dev]
+                debug = 'a'
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1320,12 +1320,12 @@ fn bad_opt_level() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = 3
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -30,7 +30,8 @@ fn cargo_bench_simple() {
             #[bench]
             fn bench_hello(_b: &mut test::Bencher) {
                 assert_eq!(hello(), "hello")
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -64,21 +65,24 @@ fn bench_bench_implicit() {
             #[cfg(test)]
             extern crate test;
             #[bench] fn run1(_ben: &mut test::Bencher) { }
-            fn main() { println!("Hello main!"); }"#,
+            fn main() { println!("Hello main!"); }
+            "#,
         )
         .file(
             "tests/other.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run3(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run3(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             "benches/mybench.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run2(_ben: &mut test::Bencher) { }
+            "#,
         )
         .build();
 
@@ -109,21 +113,24 @@ fn bench_bin_implicit() {
             #[cfg(test)]
             extern crate test;
             #[bench] fn run1(_ben: &mut test::Bencher) { }
-            fn main() { println!("Hello main!"); }"#,
+            fn main() { println!("Hello main!"); }
+            "#,
         )
         .file(
             "tests/other.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run3(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run3(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             "benches/mybench.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run2(_ben: &mut test::Bencher) { }
+            "#,
         )
         .build();
 
@@ -151,14 +158,16 @@ fn bench_tarname() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             "benches/bin2.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run2(_ben: &mut test::Bencher) { }
+            "#,
         )
         .build();
 
@@ -186,21 +195,24 @@ fn bench_multiple_targets() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             "benches/bin2.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run2(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run2(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             "benches/bin3.rs",
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run3(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run3(_ben: &mut test::Bencher) { }
+            "#,
         )
         .build();
 
@@ -222,12 +234,12 @@ fn cargo_bench_verbose() {
         .file(
             "src/main.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
-            fn main() {}
-            #[bench] fn bench_hello(_b: &mut test::Bencher) {}
-        "#,
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
+                fn main() {}
+                #[bench] fn bench_hello(_b: &mut test::Bencher) {}
+            "#,
         )
         .build();
 
@@ -275,11 +287,11 @@ fn many_similar_names() {
         .file(
             "benches/foo.rs",
             r#"
-            #![feature(test)]
-            extern crate foo;
-            extern crate test;
-            #[bench] fn bench_bench(_b: &mut test::Bencher) { foo::foo() }
-        "#,
+                #![feature(test)]
+                extern crate foo;
+                extern crate test;
+                #[bench] fn bench_bench(_b: &mut test::Bencher) { foo::foo() }
+            "#,
         )
         .build();
 
@@ -315,7 +327,8 @@ fn cargo_bench_failing_test() {
             #[bench]
             fn bench_hello(_b: &mut test::Bencher) {
                 assert_eq!(hello(), "nope")
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -353,33 +366,33 @@ fn bench_with_lib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name = "baz"
-            path = "src/main.rs"
-        "#,
+                [[bin]]
+                name = "baz"
+                path = "src/main.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
-            ///
-            /// ```rust
-            /// extern crate foo;
-            /// fn main() {
-            ///     println!("{}", foo::foo());
-            /// }
-            /// ```
-            ///
-            pub fn foo(){}
-            #[bench] fn lib_bench(_b: &mut test::Bencher) {}
-        "#,
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
+                ///
+                /// ```rust
+                /// extern crate foo;
+                /// fn main() {
+                ///     println!("{}", foo::foo());
+                /// }
+                /// ```
+                ///
+                pub fn foo(){}
+                #[bench] fn lib_bench(_b: &mut test::Bencher) {}
+            "#,
         )
         .file(
             "src/main.rs",
@@ -422,14 +435,14 @@ fn bench_with_deep_lib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.foo]
-            path = "../foo"
-        "#,
+                [dependencies.foo]
+                path = "../foo"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -484,39 +497,39 @@ fn external_bench_explicit() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bench]]
-            name = "bench"
-            path = "src/bench.rs"
-        "#,
+                [[bench]]
+                name = "bench"
+                path = "src/bench.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
-            pub fn get_hello() -> &'static str { "Hello" }
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
+                pub fn get_hello() -> &'static str { "Hello" }
 
-            #[bench]
-            fn internal_bench(_b: &mut test::Bencher) {}
-        "#,
+                #[bench]
+                fn internal_bench(_b: &mut test::Bencher) {}
+            "#,
         )
         .file(
             "src/bench.rs",
             r#"
-            #![feature(test)]
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-            extern crate test;
+                #![feature(test)]
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+                extern crate test;
 
-            #[bench]
-            fn external_bench(_b: &mut test::Bencher) {}
-        "#,
+                #[bench]
+                fn external_bench(_b: &mut test::Bencher) {}
+            "#,
         )
         .build();
 
@@ -543,27 +556,27 @@ fn external_bench_implicit() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
 
-            pub fn get_hello() -> &'static str { "Hello" }
+                pub fn get_hello() -> &'static str { "Hello" }
 
-            #[bench]
-            fn internal_bench(_b: &mut test::Bencher) {}
-        "#,
+                #[bench]
+                fn internal_bench(_b: &mut test::Bencher) {}
+            "#,
         )
         .file(
             "benches/external.rs",
             r#"
-            #![feature(test)]
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-            extern crate test;
+                #![feature(test)]
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+                extern crate test;
 
-            #[bench]
-            fn external_bench(_b: &mut test::Bencher) {}
-        "#,
+                #[bench]
+                fn external_bench(_b: &mut test::Bencher) {}
+            "#,
         )
         .build();
 
@@ -664,7 +677,7 @@ fn dont_run_examples() {
     }
 
     let p = project()
-        .file("src/lib.rs", r"")
+        .file("src/lib.rs", "")
         .file(
             "examples/dont-run-me-i-will-fail.rs",
             r#"fn main() { panic!("Examples should not be run by 'cargo test'"); }"#,
@@ -751,16 +764,16 @@ fn lib_bin_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            [[bin]]
-            name = "foo"
-        "#,
+                [lib]
+                name = "foo"
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -858,16 +871,16 @@ fn lib_with_standard_name2() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "syntax"
-            bench = false
-            doctest = false
-        "#,
+                [lib]
+                name = "syntax"
+                bench = false
+                doctest = false
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
@@ -908,56 +921,56 @@ fn bench_dylib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate_type = ["dylib"]
+                [lib]
+                name = "foo"
+                crate_type = ["dylib"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(test)]
-            extern crate bar as the_bar;
-            #[cfg(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate bar as the_bar;
+                #[cfg(test)]
+                extern crate test;
 
-            pub fn bar() { the_bar::baz(); }
+                pub fn bar() { the_bar::baz(); }
 
-            #[bench]
-            fn foo(_b: &mut test::Bencher) {}
-        "#,
+                #[bench]
+                fn foo(_b: &mut test::Bencher) {}
+            "#,
         )
         .file(
             "benches/bench.rs",
             r#"
-            #![feature(test)]
-            extern crate foo as the_foo;
-            extern crate test;
+                #![feature(test)]
+                extern crate foo as the_foo;
+                extern crate test;
 
-            #[bench]
-            fn foo(_b: &mut test::Bencher) { the_foo::bar(); }
-        "#,
+                #[bench]
+                fn foo(_b: &mut test::Bencher) { the_foo::bar(); }
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            crate_type = ["dylib"]
-        "#,
+                [lib]
+                name = "bar"
+                crate_type = ["dylib"]
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn baz() {}")
         .build();
@@ -1002,12 +1015,12 @@ fn bench_twice_with_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file(
@@ -1051,38 +1064,38 @@ fn bench_with_examples() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "6.6.6"
-            authors = []
+                [package]
+                name = "foo"
+                version = "6.6.6"
+                authors = []
 
-            [[example]]
-            name = "teste1"
+                [[example]]
+                name = "teste1"
 
-            [[bench]]
-            name = "testb1"
-        "#,
+                [[bench]]
+                name = "testb1"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
-            #[cfg(test)]
-            use test::Bencher;
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
+                #[cfg(test)]
+                use test::Bencher;
 
-            pub fn f1() {
-                println!("f1");
-            }
+                pub fn f1() {
+                    println!("f1");
+                }
 
-            pub fn f2() {}
+                pub fn f2() {}
 
-            #[bench]
-            fn bench_bench1(_b: &mut Bencher) {
-                f2();
-            }
-        "#,
+                #[bench]
+                fn bench_bench1(_b: &mut Bencher) {
+                    f2();
+                }
+            "#,
         )
         .file(
             "benches/testb1.rs",
@@ -1102,13 +1115,13 @@ fn bench_with_examples() {
         .file(
             "examples/teste1.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            fn main() {
-                println!("example1");
-                foo::f1();
-            }
-        "#,
+                fn main() {
+                    println!("example1");
+                    foo::f1();
+                }
+            "#,
         )
         .build();
 
@@ -1138,20 +1151,20 @@ fn test_a_bench() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            authors = []
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                authors = []
+                version = "0.1.0"
 
-            [lib]
-            name = "foo"
-            test = false
-            doctest = false
+                [lib]
+                name = "foo"
+                test = false
+                doctest = false
 
-            [[bench]]
-            name = "b"
-            test = true
-        "#,
+                [[bench]]
+                name = "b"
+                test = true
+            "#,
         )
         .file("src/lib.rs", "")
         .file("benches/b.rs", "#[test] fn foo() {}")
@@ -1179,15 +1192,15 @@ fn test_bench_no_run() {
         .file(
             "benches/bbaz.rs",
             r#"
-            #![feature(test)]
+                #![feature(test)]
 
-            extern crate test;
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_baz(_: &mut Bencher) {}
-        "#,
+                #[bench]
+                fn bench_baz(_: &mut Bencher) {}
+            "#,
         )
         .build();
 
@@ -1231,7 +1244,8 @@ fn test_bench_no_fail_fast() {
             #[bench]
             fn bench_nope(_b: &mut test::Bencher) {
                 assert_eq!("nope", hello())
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -1255,17 +1269,17 @@ fn test_bench_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            authors = []
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                authors = []
+                version = "0.1.0"
 
-            [dependencies.bar]
-            path = "../bar"
+                [dependencies.bar]
+                path = "../bar"
 
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1275,28 +1289,28 @@ fn test_bench_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            authors = []
-            version = "0.1.0"
+                [project]
+                name = "bar"
+                authors = []
+                version = "0.1.0"
 
-            [[bench]]
-            name = "bbar"
-            test = true
-        "#,
+                [[bench]]
+                name = "bbar"
+                test = true
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "benches/bbar.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_bar(_b: &mut Bencher) {}
-        "#,
+                #[bench]
+                fn bench_bar(_b: &mut Bencher) {}
+            "#,
         )
         .build();
 
@@ -1305,28 +1319,28 @@ fn test_bench_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            authors = []
-            version = "0.1.0"
+                [project]
+                name = "baz"
+                authors = []
+                version = "0.1.0"
 
-            [[bench]]
-            name = "bbaz"
-            test = true
-        "#,
+                [[bench]]
+                name = "bbaz"
+                test = true
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "benches/bbaz.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_baz(_b: &mut Bencher) {}
-        "#,
+                #[bench]
+                fn bench_baz(_b: &mut Bencher) {}
+            "#,
         )
         .build();
 
@@ -1348,42 +1362,42 @@ fn bench_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "benches/foo.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_foo(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_foo(_: &mut Bencher) -> () { () }
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .file(
             "bar/benches/bar.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_bar(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_bar(_: &mut Bencher) -> () { () }
+            "#,
         )
         .build();
 
@@ -1405,28 +1419,28 @@ fn bench_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
 
-            #[bench]
-            pub fn bar(b: &mut test::Bencher) {
-                b.iter(|| {});
-            }
-        "#,
+                #[bench]
+                pub fn bar(b: &mut test::Bencher) {
+                    b.iter(|| {});
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
@@ -1454,37 +1468,37 @@ fn bench_all_virtual_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .file(
             "bar/benches/bar.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_bar(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_bar(_: &mut Bencher) -> () { () }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .file(
             "baz/benches/baz.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_baz(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_baz(_: &mut Bencher) -> () { () }
+            "#,
         )
         .build();
 
@@ -1508,26 +1522,26 @@ fn legacy_bench_name() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [[bench]]
-            name = "bench"
-        "#,
+                [[bench]]
+                name = "bench"
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
             "src/bench.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_foo(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_foo(_: &mut Bencher) -> () { () }
+            "#,
         )
         .build();
 
@@ -1550,33 +1564,33 @@ fn bench_virtual_manifest_all_implied() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn foo() {}")
         .file(
             "bar/benches/bar.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
-            use test::Bencher;
-            #[bench]
-            fn bench_bar(_: &mut Bencher) -> () { () }
-        "#,
+                #![feature(test)]
+                extern crate test;
+                use test::Bencher;
+                #[bench]
+                fn bench_bar(_: &mut Bencher) -> () { () }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .file(
             "baz/benches/baz.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
-            use test::Bencher;
-            #[bench]
-            fn bench_baz(_: &mut Bencher) -> () { () }
-        "#,
+                #![feature(test)]
+                extern crate test;
+                use test::Bencher;
+                #[bench]
+                fn bench_baz(_: &mut Bencher) -> () { () }
+            "#,
         )
         .build();
 
@@ -1600,41 +1614,41 @@ fn json_artifact_includes_executable_for_benchmark() {
         .file(
             "benches/benchmark.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_foo(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_foo(_: &mut Bencher) -> () { () }
+            "#,
         )
         .build();
 
     p.cargo("bench --no-run --message-format=json")
         .with_json(
             r#"
-            {
-                "executable": "[..]/foo/target/release/deps/benchmark-[..][EXE]",
-                "features": [],
-                "filenames": "{...}",
-                "fresh": false,
-                "package_id": "foo 0.0.1 ([..])",
-                "profile": "{...}",
-                "reason": "compiler-artifact",
-                "target": {
-                    "crate_types": [ "bin" ],
-                    "kind": [ "bench" ],
-                    "doctest": false,
-                    "edition": "2015",
-                    "name": "benchmark",
-                    "src_path": "[..]/foo/benches/benchmark.rs",
-                    "test": false
+                {
+                    "executable": "[..]/foo/target/release/deps/benchmark-[..][EXE]",
+                    "features": [],
+                    "filenames": "{...}",
+                    "fresh": false,
+                    "package_id": "foo 0.0.1 ([..])",
+                    "profile": "{...}",
+                    "reason": "compiler-artifact",
+                    "target": {
+                        "crate_types": [ "bin" ],
+                        "kind": [ "bench" ],
+                        "doctest": false,
+                        "edition": "2015",
+                        "name": "benchmark",
+                        "src_path": "[..]/foo/benches/benchmark.rs",
+                        "test": false
+                    }
                 }
-            }
 
-            {"reason": "build-finished", "success": true}
-        "#,
+                {"reason": "build-finished", "success": true}
+            "#,
         )
         .run();
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -73,17 +73,17 @@ fn incremental_profile() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [profile.dev]
-            incremental = false
+                [profile.dev]
+                incremental = false
 
-            [profile.release]
-            incremental = true
-        "#,
+                [profile.release]
+                incremental = true
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -116,9 +116,9 @@ fn incremental_config() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            incremental = false
-        "#,
+                [build]
+                incremental = false
+            "#,
         )
         .build();
 
@@ -179,10 +179,10 @@ fn cargo_compile_with_invalid_manifest2() {
     let p = project()
         .file(
             "Cargo.toml",
-            r"
-            [project]
-            foo = bar
-        ",
+            "
+                [project]
+                foo = bar
+            ",
         )
         .build();
 
@@ -196,7 +196,7 @@ Caused by:
   could not parse input as TOML
 
 Caused by:
-  invalid number at line 3 column 19
+  invalid number at line 3 column 23
 ",
         )
         .run();
@@ -228,18 +228,18 @@ fn cargo_compile_duplicate_build_targets() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "main"
-            path = "src/main.rs"
-            crate-type = ["dylib"]
+                [lib]
+                name = "main"
+                path = "src/main.rs"
+                crate-type = ["dylib"]
 
-            [dependencies]
-        "#,
+                [dependencies]
+            "#,
         )
         .file("src/main.rs", "#![allow(warnings)] fn main() {}")
         .build();
@@ -318,14 +318,14 @@ fn cargo_compile_with_invalid_bin_target_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [[bin]]
-            name = ""
-        "#,
+                [[bin]]
+                name = ""
+            "#,
         )
         .build();
 
@@ -348,14 +348,14 @@ fn cargo_compile_with_forbidden_bin_target_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [[bin]]
-            name = "build"
-        "#,
+                [[bin]]
+                name = "build"
+            "#,
         )
         .build();
 
@@ -378,16 +378,16 @@ fn cargo_compile_with_bin_and_crate_type() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [[bin]]
-            name = "the_foo_bin"
-            path = "src/foo.rs"
-            crate-type = ["cdylib", "rlib"]
-        "#,
+                [[bin]]
+                name = "the_foo_bin"
+                path = "src/foo.rs"
+                crate-type = ["cdylib", "rlib"]
+            "#,
         )
         .file("src/foo.rs", "fn main() {}")
         .build();
@@ -411,20 +411,20 @@ fn cargo_compile_api_exposes_artifact_paths() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [[bin]]
-            name = "the_foo_bin"
-            path = "src/bin.rs"
+                [[bin]]
+                name = "the_foo_bin"
+                path = "src/bin.rs"
 
-            [lib]
-            name = "the_foo_lib"
-            path = "src/foo.rs"
-            crate-type = ["cdylib", "rlib"]
-        "#,
+                [lib]
+                name = "the_foo_lib"
+                path = "src/foo.rs"
+                crate-type = ["cdylib", "rlib"]
+            "#,
         )
         .file("src/foo.rs", "pub fn bar() {}")
         .file("src/bin.rs", "pub fn main() {}")
@@ -461,16 +461,16 @@ fn cargo_compile_with_bin_and_proc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [[bin]]
-            name = "the_foo_bin"
-            path = "src/foo.rs"
-            proc-macro = true
-        "#,
+                [[bin]]
+                name = "the_foo_bin"
+                path = "src/foo.rs"
+                proc-macro = true
+            "#,
         )
         .file("src/foo.rs", "fn main() {}")
         .build();
@@ -493,14 +493,14 @@ fn cargo_compile_with_invalid_lib_target_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [lib]
-            name = ""
-        "#,
+                [lib]
+                name = ""
+            "#,
         )
         .build();
 
@@ -523,13 +523,13 @@ fn cargo_compile_with_invalid_non_numeric_dep_version() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            crossbeam = "y"
-        "#,
+                [dependencies]
+                crossbeam = "y"
+            "#,
         )
         .build();
 
@@ -584,16 +584,16 @@ fn cargo_compile_with_invalid_code_in_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file("src/main.rs", "invalid rust code!")
         .build();
@@ -632,31 +632,31 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
+                [dependencies.bar]
+                path = "bar"
 
-            [[bin]]
+                [[bin]]
 
-            name = "foo"
-        "#,
+                name = "foo"
+            "#,
         )
         .file("src/foo.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "bar/src/bar.rs",
             r#"
-            pub fn gimme() -> &'static str {
-                "test passed"
-            }
+                pub fn gimme() -> &'static str {
+                    "test passed"
+                }
 
-            fn dead() {}
-        "#,
+                fn dead() {}
+            "#,
         )
         .build();
 
@@ -675,51 +675,51 @@ fn cargo_compile_with_nested_deps_inferred() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = 'bar'
+                [dependencies.bar]
+                path = 'bar'
 
-            [[bin]]
-            name = "foo"
-        "#,
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file("src/foo.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            extern crate baz;
+                extern crate baz;
 
-            pub fn gimme() -> String {
-                baz::gimme()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    baz::gimme()
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.5.0"))
         .file(
             "baz/src/lib.rs",
             r#"
-            pub fn gimme() -> String {
-                "test passed".to_string()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    "test passed".to_string()
+                }
+            "#,
         )
         .build();
 
@@ -738,51 +738,51 @@ fn cargo_compile_with_nested_deps_correct_bin() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
+                [dependencies.bar]
+                path = "bar"
 
-            [[bin]]
-            name = "foo"
-        "#,
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            extern crate baz;
+                extern crate baz;
 
-            pub fn gimme() -> String {
-                baz::gimme()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    baz::gimme()
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.5.0"))
         .file(
             "baz/src/lib.rs",
             r#"
-            pub fn gimme() -> String {
-                "test passed".to_string()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    "test passed".to_string()
+                }
+            "#,
         )
         .build();
 
@@ -801,52 +801,52 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.baz]
-            path = "../baz"
+                [dependencies.baz]
+                path = "../baz"
 
-            [lib]
+                [lib]
 
-            name = "bar"
-        "#,
+                name = "bar"
+            "#,
         )
         .file(
             "bar/src/bar.rs",
             r#"
-            extern crate baz;
+                extern crate baz;
 
-            pub fn gimme() -> String {
-                baz::gimme()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    baz::gimme()
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "baz/src/baz.rs",
             r#"
-            pub fn gimme() -> String {
-                "test passed".to_string()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    "test passed".to_string()
+                }
+            "#,
         )
         .build();
 
@@ -865,58 +865,58 @@ fn cargo_compile_with_nested_deps_longhand() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
-            version = "0.5.0"
+                [dependencies.bar]
+                path = "bar"
+                version = "0.5.0"
 
-            [[bin]]
+                [[bin]]
 
-            name = "foo"
-        "#,
+                name = "foo"
+            "#,
         )
         .file("src/foo.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.baz]
-            path = "../baz"
-            version = "0.5.0"
+                [dependencies.baz]
+                path = "../baz"
+                version = "0.5.0"
 
-            [lib]
+                [lib]
 
-            name = "bar"
-        "#,
+                name = "bar"
+            "#,
         )
         .file(
             "bar/src/bar.rs",
             r#"
-            extern crate baz;
+                extern crate baz;
 
-            pub fn gimme() -> String {
-                baz::gimme()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    baz::gimme()
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "baz/src/baz.rs",
             r#"
-            pub fn gimme() -> String {
-                "test passed".to_string()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    "test passed".to_string()
+                }
+            "#,
         )
         .build();
 
@@ -937,20 +937,20 @@ fn cargo_compile_with_dep_name_mismatch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "foo"
-            version = "0.0.1"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.0.1"
+                authors = ["wycats@example.com"]
 
-            [[bin]]
+                [[bin]]
 
-            name = "foo"
+                name = "foo"
 
-            [dependencies.notquitebar]
+                [dependencies.notquitebar]
 
-            path = "bar"
-        "#,
+                path = "bar"
+            "#,
         )
         .file("src/bin/foo.rs", &main_file(r#""i am foo""#, &["bar"]))
         .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
@@ -960,10 +960,11 @@ fn cargo_compile_with_dep_name_mismatch() {
     p.cargo("build")
         .with_status(101)
         .with_stderr(
-            r#"error: no matching package named `notquitebar` found
+            "\
+error: no matching package named `notquitebar` found
 location searched: [CWD]/bar
 required by package `foo v0.0.1 ([CWD])`
-"#,
+",
         )
         .run();
 }
@@ -975,13 +976,13 @@ fn cargo_compile_with_invalid_dep_rename() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "buggin"
-            version = "0.1.0"
+                [package]
+                name = "buggin"
+                version = "0.1.0"
 
-            [dependencies]
-            "haha this isn't a valid name 🐛" = { package = "libc", version = "0.1" }
-        "#,
+                [dependencies]
+                "haha this isn't a valid name 🐛" = { package = "libc", version = "0.1" }
+            "#,
         )
         .file("src/main.rs", &main_file(r#""What's good?""#, &[]))
         .build();
@@ -1006,9 +1007,9 @@ fn cargo_compile_with_filename() {
         .file(
             "src/bin/a.rs",
             r#"
-            extern crate foo;
-            fn main() { println!("hello a.rs"); }
-        "#,
+                extern crate foo;
+                fn main() { println!("hello a.rs"); }
+            "#,
         )
         .file("examples/a.rs", r#"fn main() { println!("example"); }"#)
         .build();
@@ -1061,15 +1062,15 @@ fn incompatible_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
+                [project]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = "0.1.0"
-            baz = "0.1.0"
-            qux = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+                baz = "0.1.0"
+                qux = "0.1.0"
+            "#,
         )
         .file("src/main.rs", "fn main(){}")
         .build();
@@ -1107,15 +1108,15 @@ fn incompatible_dependencies_with_multi_semver() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
+                [project]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = "0.1.0"
-            baz = "0.1.0"
-            bad = ">=1.0.1, <=2.0.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+                baz = "0.1.0"
+                bad = ">=1.0.1, <=2.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main(){}")
         .build();
@@ -1149,14 +1150,14 @@ fn compile_path_dep_then_change_version() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -1173,7 +1174,7 @@ fn compile_path_dep_then_change_version() {
 #[cargo_test]
 fn ignores_carriage_return_in_lockfile() {
     let p = project()
-        .file("src/main.rs", r"mod a; fn main() {}")
+        .file("src/main.rs", "mod a; fn main() {}")
         .file("src/a.rs", "")
         .build();
 
@@ -1192,28 +1193,28 @@ fn cargo_default_env_metadata_env_var() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "// hi")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            crate_type = ["dylib"]
-        "#,
+                [lib]
+                name = "bar"
+                crate_type = ["dylib"]
+            "#,
         )
         .file("bar/src/lib.rs", "// hello")
         .build();
@@ -1279,74 +1280,74 @@ fn crate_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-        [project]
-        name = "foo"
-        version = "0.5.1-alpha.1"
-        description = "This is foo"
-        homepage = "https://example.com"
-        repository = "https://example.com/repo.git"
-        authors = ["wycats@example.com"]
-        license = "MIT OR Apache-2.0"
-        license_file = "license.txt"
+            [project]
+            name = "foo"
+            version = "0.5.1-alpha.1"
+            description = "This is foo"
+            homepage = "https://example.com"
+            repository = "https://example.com/repo.git"
+            authors = ["wycats@example.com"]
+            license = "MIT OR Apache-2.0"
+            license_file = "license.txt"
 
-        [[bin]]
-        name = "foo-bar"
-        path = "src/main.rs"
-        "#,
+            [[bin]]
+            name = "foo-bar"
+            path = "src/main.rs"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
 
-            static VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
-            static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
-            static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
-            static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
-            static VERSION: &'static str = env!("CARGO_PKG_VERSION");
-            static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
-            static PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
-            static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
-            static REPOSITORY: &'static str = env!("CARGO_PKG_REPOSITORY");
-            static LICENSE: &'static str = env!("CARGO_PKG_LICENSE");
-            static LICENSE_FILE: &'static str = env!("CARGO_PKG_LICENSE_FILE");
-            static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
-            static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
-            static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
+                static VERSION_MAJOR: &'static str = env!("CARGO_PKG_VERSION_MAJOR");
+                static VERSION_MINOR: &'static str = env!("CARGO_PKG_VERSION_MINOR");
+                static VERSION_PATCH: &'static str = env!("CARGO_PKG_VERSION_PATCH");
+                static VERSION_PRE: &'static str = env!("CARGO_PKG_VERSION_PRE");
+                static VERSION: &'static str = env!("CARGO_PKG_VERSION");
+                static CARGO_MANIFEST_DIR: &'static str = env!("CARGO_MANIFEST_DIR");
+                static PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
+                static HOMEPAGE: &'static str = env!("CARGO_PKG_HOMEPAGE");
+                static REPOSITORY: &'static str = env!("CARGO_PKG_REPOSITORY");
+                static LICENSE: &'static str = env!("CARGO_PKG_LICENSE");
+                static LICENSE_FILE: &'static str = env!("CARGO_PKG_LICENSE_FILE");
+                static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
+                static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
+                static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
 
 
-            fn main() {
-                let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
-                                VERSION_MINOR, VERSION_PATCH, VERSION_PRE,
-                                CARGO_MANIFEST_DIR);
-                 assert_eq!(s, foo::version());
-                 println!("{}", s);
-                 assert_eq!("foo", PKG_NAME);
-                 assert_eq!("foo-bar", BIN_NAME);
-                 assert_eq!("foo_bar", CRATE_NAME);
-                 assert_eq!("https://example.com", HOMEPAGE);
-                 assert_eq!("https://example.com/repo.git", REPOSITORY);
-                 assert_eq!("MIT OR Apache-2.0", LICENSE);
-                 assert_eq!("This is foo", DESCRIPTION);
-                let s = format!("{}.{}.{}-{}", VERSION_MAJOR,
-                                VERSION_MINOR, VERSION_PATCH, VERSION_PRE);
-                assert_eq!(s, VERSION);
-            }
-        "#,
+                fn main() {
+                    let s = format!("{}-{}-{} @ {} in {}", VERSION_MAJOR,
+                                    VERSION_MINOR, VERSION_PATCH, VERSION_PRE,
+                                    CARGO_MANIFEST_DIR);
+                     assert_eq!(s, foo::version());
+                     println!("{}", s);
+                     assert_eq!("foo", PKG_NAME);
+                     assert_eq!("foo-bar", BIN_NAME);
+                     assert_eq!("foo_bar", CRATE_NAME);
+                     assert_eq!("https://example.com", HOMEPAGE);
+                     assert_eq!("https://example.com/repo.git", REPOSITORY);
+                     assert_eq!("MIT OR Apache-2.0", LICENSE);
+                     assert_eq!("This is foo", DESCRIPTION);
+                    let s = format!("{}.{}.{}-{}", VERSION_MAJOR,
+                                    VERSION_MINOR, VERSION_PATCH, VERSION_PRE);
+                    assert_eq!(s, VERSION);
+                }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn version() -> String {
-                format!("{}-{}-{} @ {} in {}",
-                        env!("CARGO_PKG_VERSION_MAJOR"),
-                        env!("CARGO_PKG_VERSION_MINOR"),
-                        env!("CARGO_PKG_VERSION_PATCH"),
-                        env!("CARGO_PKG_VERSION_PRE"),
-                        env!("CARGO_MANIFEST_DIR"))
-            }
-        "#,
+                pub fn version() -> String {
+                    format!("{}-{}-{} @ {} in {}",
+                            env!("CARGO_PKG_VERSION_MAJOR"),
+                            env!("CARGO_PKG_VERSION_MINOR"),
+                            env!("CARGO_PKG_VERSION_PATCH"),
+                            env!("CARGO_PKG_VERSION_PRE"),
+                            env!("CARGO_MANIFEST_DIR"))
+                }
+            "#,
         )
         .build();
 
@@ -1368,34 +1369,34 @@ fn crate_authors_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.1-alpha.1"
-            authors = ["wycats@example.com", "neikos@example.com"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.1-alpha.1"
+                authors = ["wycats@example.com", "neikos@example.com"]
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            static AUTHORS: &'static str = env!("CARGO_PKG_AUTHORS");
+                static AUTHORS: &'static str = env!("CARGO_PKG_AUTHORS");
 
-            fn main() {
-                let s = "wycats@example.com:neikos@example.com";
-                assert_eq!(AUTHORS, foo::authors());
-                println!("{}", AUTHORS);
-                assert_eq!(s, AUTHORS);
-            }
-        "#,
+                fn main() {
+                    let s = "wycats@example.com:neikos@example.com";
+                    assert_eq!(AUTHORS, foo::authors());
+                    println!("{}", AUTHORS);
+                    assert_eq!(s, AUTHORS);
+                }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn authors() -> String {
-                format!("{}", env!("CARGO_PKG_AUTHORS"))
-            }
-        "#,
+                pub fn authors() -> String {
+                    format!("{}", env!("CARGO_PKG_AUTHORS"))
+                }
+            "#,
         )
         .build();
 
@@ -1417,11 +1418,11 @@ fn vv_prints_rustc_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = ["escape='\"@example.com"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = ["escape='\"@example.com"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1463,13 +1464,13 @@ fn crate_library_path_env_var() {
         .file(
             "src/main.rs",
             &format!(
-                r##"
-            fn main() {{
-                let search_path = env!("{}");
-                let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
-                assert!(!paths.contains(&"".into()));
-            }}
-        "##,
+                r#"
+                    fn main() {{
+                        let search_path = env!("{}");
+                        let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
+                        assert!(!paths.contains(&"".into()));
+                    }}
+                "#,
                 dylib_path_envvar()
             ),
         )
@@ -1497,17 +1498,17 @@ fn many_crate_types_old_style_lib_location() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [lib]
+                [lib]
 
-            name = "foo"
-            crate_type = ["rlib", "dylib"]
-        "#,
+                name = "foo"
+                crate_type = ["rlib", "dylib"]
+            "#,
         )
         .file("src/foo.rs", "pub fn foo() {}")
         .build();
@@ -1530,17 +1531,17 @@ fn many_crate_types_correct() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [lib]
+                [lib]
 
-            name = "foo"
-            crate_type = ["rlib", "dylib"]
-        "#,
+                name = "foo"
+                crate_type = ["rlib", "dylib"]
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
@@ -1557,20 +1558,20 @@ fn self_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.test]
+                [dependencies.test]
 
-            path = "."
+                path = "."
 
-            [lib]
-            name = "test"
-            path = "src/test.rs"
-        "#,
+                [lib]
+                name = "test"
+                path = "src/test.rs"
+            "#,
         )
         .file("src/test.rs", "fn main() {}")
         .build();
@@ -1634,15 +1635,15 @@ fn lto_build() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [profile.release]
-            lto = true
-        "#,
+                [profile.release]
+                lto = true
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1706,30 +1707,30 @@ fn verbose_release_build_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.foo]
-            path = "foo"
-        "#,
+                [dependencies.foo]
+                path = "foo"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate_type = ["dylib", "rlib"]
-        "#,
+                [lib]
+                name = "foo"
+                crate_type = ["dylib", "rlib"]
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .build();
@@ -1768,45 +1769,45 @@ fn explicit_examples() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "1.0.0"
+                authors = []
 
-            [lib]
-            name = "foo"
-            path = "src/lib.rs"
+                [lib]
+                name = "foo"
+                path = "src/lib.rs"
 
-            [[example]]
-            name = "hello"
-            path = "examples/ex-hello.rs"
+                [[example]]
+                name = "hello"
+                path = "examples/ex-hello.rs"
 
-            [[example]]
-            name = "goodbye"
-            path = "examples/ex-goodbye.rs"
-        "#,
+                [[example]]
+                name = "goodbye"
+                path = "examples/ex-goodbye.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn get_hello() -> &'static str { "Hello" }
-            pub fn get_goodbye() -> &'static str { "Goodbye" }
-            pub fn get_world() -> &'static str { "World" }
-        "#,
+                pub fn get_hello() -> &'static str { "Hello" }
+                pub fn get_goodbye() -> &'static str { "Goodbye" }
+                pub fn get_world() -> &'static str { "World" }
+            "#,
         )
         .file(
             "examples/ex-hello.rs",
             r#"
-            extern crate foo;
-            fn main() { println!("{}, {}!", foo::get_hello(), foo::get_world()); }
-        "#,
+                extern crate foo;
+                fn main() { println!("{}, {}!", foo::get_hello(), foo::get_world()); }
+            "#,
         )
         .file(
             "examples/ex-goodbye.rs",
             r#"
-            extern crate foo;
-            fn main() { println!("{}, {}!", foo::get_goodbye(), foo::get_world()); }
-        "#,
+                extern crate foo;
+                fn main() { println!("{}, {}!", foo::get_goodbye(), foo::get_world()); }
+            "#,
         )
         .build();
 
@@ -1825,18 +1826,18 @@ fn non_existing_example() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "1.0.0"
+                authors = []
 
-            [lib]
-            name = "foo"
-            path = "src/lib.rs"
+                [lib]
+                name = "foo"
+                path = "src/lib.rs"
 
-            [[example]]
-            name = "hello"
-        "#,
+                [[example]]
+                name = "hello"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1879,14 +1880,14 @@ fn legacy_binary_paths_warnings() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "1.0.0"
+                authors = []
 
-            [[bin]]
-            name = "bar"
-        "#,
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}")
@@ -1904,14 +1905,14 @@ please set bin.path in Cargo.toml",
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "1.0.0"
+                authors = []
 
-            [[bin]]
-            name = "bar"
-        "#,
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/bin/main.rs", "fn main() {}")
@@ -1929,14 +1930,14 @@ please set bin.path in Cargo.toml",
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "1.0.0"
+                authors = []
 
-            [[bin]]
-            name = "bar"
-        "#,
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/bar.rs", "fn main() {}")
         .build();
@@ -1956,28 +1957,28 @@ fn implicit_examples() {
         .file(
             "src/lib.rs",
             r#"
-            pub fn get_hello() -> &'static str { "Hello" }
-            pub fn get_goodbye() -> &'static str { "Goodbye" }
-            pub fn get_world() -> &'static str { "World" }
-        "#,
+                pub fn get_hello() -> &'static str { "Hello" }
+                pub fn get_goodbye() -> &'static str { "Goodbye" }
+                pub fn get_world() -> &'static str { "World" }
+            "#,
         )
         .file(
             "examples/hello.rs",
             r#"
-            extern crate foo;
-            fn main() {
-                println!("{}, {}!", foo::get_hello(), foo::get_world());
-            }
-        "#,
+                extern crate foo;
+                fn main() {
+                    println!("{}, {}!", foo::get_hello(), foo::get_world());
+                }
+            "#,
         )
         .file(
             "examples/goodbye.rs",
             r#"
-            extern crate foo;
-            fn main() {
-                println!("{}, {}!", foo::get_goodbye(), foo::get_world());
-            }
-        "#,
+                extern crate foo;
+                fn main() {
+                    println!("{}, {}!", foo::get_goodbye(), foo::get_world());
+                }
+            "#,
         )
         .build();
 
@@ -1997,14 +1998,14 @@ fn standard_build_no_ndebug() {
         .file(
             "src/foo.rs",
             r#"
-            fn main() {
-                if cfg!(debug_assertions) {
-                    println!("slow")
-                } else {
-                    println!("fast")
+                fn main() {
+                    if cfg!(debug_assertions) {
+                        println!("slow")
+                    } else {
+                        println!("fast")
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
 
@@ -2019,14 +2020,14 @@ fn release_build_ndebug() {
         .file(
             "src/foo.rs",
             r#"
-            fn main() {
-                if cfg!(debug_assertions) {
-                    println!("slow")
-                } else {
-                    println!("fast")
+                fn main() {
+                    if cfg!(debug_assertions) {
+                        println!("slow")
+                    } else {
+                        println!("fast")
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
 
@@ -2048,14 +2049,14 @@ fn deletion_causes_failure() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -2108,15 +2109,15 @@ fn simple_staticlib() {
         .file(
             "Cargo.toml",
             r#"
-              [package]
-              name = "foo"
-              authors = []
-              version = "0.0.1"
+                  [package]
+                  name = "foo"
+                  authors = []
+                  version = "0.0.1"
 
-              [lib]
-              name = "foo"
-              crate-type = ["staticlib"]
-        "#,
+                  [lib]
+                  name = "foo"
+                  crate-type = ["staticlib"]
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
@@ -2131,15 +2132,15 @@ fn staticlib_rlib_and_bin() {
         .file(
             "Cargo.toml",
             r#"
-              [package]
-              name = "foo"
-              authors = []
-              version = "0.0.1"
+                  [package]
+                  name = "foo"
+                  authors = []
+                  version = "0.0.1"
 
-              [lib]
-              name = "foo"
-              crate-type = ["staticlib", "rlib"]
-        "#,
+                  [lib]
+                  name = "foo"
+                  crate-type = ["staticlib", "rlib"]
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file("src/main.rs", "extern crate foo; fn main() { foo::foo(); }")
@@ -2154,13 +2155,13 @@ fn opt_out_of_bin() {
         .file(
             "Cargo.toml",
             r#"
-              bin = []
+                  bin = []
 
-              [package]
-              name = "foo"
-              authors = []
-              version = "0.0.1"
-        "#,
+                  [package]
+                  name = "foo"
+                  authors = []
+                  version = "0.0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/main.rs", "bad syntax")
@@ -2174,15 +2175,15 @@ fn single_lib() {
         .file(
             "Cargo.toml",
             r#"
-              [package]
-              name = "foo"
-              authors = []
-              version = "0.0.1"
+                  [package]
+                  name = "foo"
+                  authors = []
+                  version = "0.0.1"
 
-              [lib]
-              name = "foo"
-              path = "src/bar.rs"
-        "#,
+                  [lib]
+                  name = "foo"
+                  path = "src/bar.rs"
+            "#,
         )
         .file("src/bar.rs", "")
         .build();
@@ -2195,13 +2196,13 @@ fn freshness_ignores_excluded() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
-            exclude = ["src/b*.rs"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
+                exclude = ["src/b*.rs"]
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
@@ -2233,29 +2234,29 @@ fn rebuild_preserves_out_dir() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = 'build.rs'
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = 'build.rs'
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::fs::File;
-            use std::path::Path;
+                use std::env;
+                use std::fs::File;
+                use std::path::Path;
 
-            fn main() {
-                let path = Path::new(&env::var("OUT_DIR").unwrap()).join("foo");
-                if env::var_os("FIRST").is_some() {
-                    File::create(&path).unwrap();
-                } else {
-                    File::create(&path).unwrap();
+                fn main() {
+                    let path = Path::new(&env::var("OUT_DIR").unwrap()).join("foo");
+                    if env::var_os("FIRST").is_some() {
+                        File::create(&path).unwrap();
+                    } else {
+                        File::create(&path).unwrap();
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
         .build();
@@ -2288,14 +2289,14 @@ fn dep_no_libs() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.0"))
@@ -2310,15 +2311,15 @@ fn recompile_space_in_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [lib]
-            name = "foo"
-            path = "src/my lib.rs"
-        "#,
+                [lib]
+                name = "foo"
+                path = "src/my lib.rs"
+            "#,
         )
         .file("src/my lib.rs", "")
         .build();
@@ -2407,19 +2408,19 @@ fn cargo_platform_specific_dependency() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
+                    build = "build.rs"
 
-            [target.{host}.dependencies]
-            dep = {{ path = "dep" }}
-            [target.{host}.build-dependencies]
-            build = {{ path = "build" }}
-            [target.{host}.dev-dependencies]
-            dev = {{ path = "dev" }}
-        "#,
+                    [target.{host}.dependencies]
+                    dep = {{ path = "dep" }}
+                    [target.{host}.build-dependencies]
+                    build = {{ path = "build" }}
+                    [target.{host}.dev-dependencies]
+                    dev = {{ path = "dev" }}
+                "#,
                 host = host
             ),
         )
@@ -2452,15 +2453,15 @@ fn bad_platform_specific_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [target.wrong-target.dependencies.bar]
-            path = "bar"
-        "#,
+                [target.wrong-target.dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
@@ -2482,15 +2483,15 @@ fn cargo_platform_specific_dependency_wrong_platform() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [target.non-existing-triplet.dependencies.bar]
-            path = "bar"
-        "#,
+                [target.non-existing-triplet.dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
@@ -2515,15 +2516,15 @@ fn example_as_lib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["lib"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["lib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")
@@ -2539,15 +2540,15 @@ fn example_as_rlib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["rlib"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["rlib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")
@@ -2563,15 +2564,15 @@ fn example_as_dylib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["dylib"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["dylib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")
@@ -2587,15 +2588,15 @@ fn example_as_proc_macro() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["proc-macro"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["proc-macro"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -2656,14 +2657,14 @@ fn transitive_dependencies_not_available() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.aaaaa]
-            path = "a"
-        "#,
+                [dependencies.aaaaa]
+                path = "a"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -2672,14 +2673,14 @@ fn transitive_dependencies_not_available() {
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "aaaaa"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "aaaaa"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bbbbb]
-            path = "../b"
-        "#,
+                [dependencies.bbbbb]
+                path = "../b"
+            "#,
         )
         .file("a/src/lib.rs", "extern crate bbbbb;")
         .file("b/Cargo.toml", &basic_manifest("bbbbb", "0.0.1"))
@@ -2698,27 +2699,27 @@ fn cyclic_deps_rejected() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.foo]
-            path = ".."
-        "#,
+                [dependencies.foo]
+                path = ".."
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -2739,15 +2740,15 @@ fn predictable_filenames() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate-type = ["dylib", "rlib"]
-        "#,
+                [lib]
+                name = "foo"
+                crate-type = ["dylib", "rlib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -2776,14 +2777,14 @@ fn dashes_in_crate_name_bad() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo-bar"
-        "#,
+                [lib]
+                name = "foo-bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/main.rs", "extern crate foo_bar; fn main() {}")
@@ -2981,19 +2982,19 @@ fn build_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies.d1]
-                path = "d1"
-            [dependencies.d2]
-                path = "d2"
-
-            [[bin]]
+                [package]
                 name = "foo"
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.d1]
+                    path = "d1"
+                [dependencies.d2]
+                    path = "d2"
+
+                [[bin]]
+                    name = "foo"
+            "#,
         )
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .file("d1/Cargo.toml", &basic_bin_manifest("d1"))
@@ -3002,15 +3003,15 @@ fn build_multiple_packages() {
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
-
-            [[bin]]
+                [package]
                 name = "d2"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [[bin]]
+                    name = "d2"
+                    doctest = false
+            "#,
         )
         .file("d2/src/main.rs", "fn main() { println!(\"d2\"); }")
         .build();
@@ -3042,17 +3043,17 @@ fn invalid_spec() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies.d1]
-                path = "d1"
-
-            [[bin]]
+                [package]
                 name = "foo"
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.d1]
+                    path = "d1"
+
+                [[bin]]
+                    name = "foo"
+            "#,
         )
         .file("src/bin/foo.rs", &main_file(r#""i am foo""#, &[]))
         .file("d1/Cargo.toml", &basic_bin_manifest("d1"))
@@ -3094,14 +3095,14 @@ fn panic_abort_compiles_with_panic_abort() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.dev]
-            panic = 'abort'
-        "#,
+                [profile.dev]
+                panic = 'abort'
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3116,15 +3117,15 @@ fn compiler_json_error_format() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "build.rs",
@@ -3137,126 +3138,126 @@ fn compiler_json_error_format() {
 
     let output = |fresh| {
         r#"
-    {
-        "reason":"compiler-artifact",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{
-            "kind":["custom-build"],
-            "crate_types":["bin"],
-            "doctest": false,
-            "edition": "2015",
-            "name":"build-script-build",
-            "src_path":"[..]build.rs",
-            "test": false
-        },
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": 2,
-            "opt_level": "0",
-            "overflow_checks": true,
-            "test": false
-        },
-        "executable": null,
-        "features": [],
-        "filenames": "{...}",
-        "fresh": $FRESH
-    }
+            {
+                "reason":"compiler-artifact",
+                "package_id":"foo 0.5.0 ([..])",
+                "target":{
+                    "kind":["custom-build"],
+                    "crate_types":["bin"],
+                    "doctest": false,
+                    "edition": "2015",
+                    "name":"build-script-build",
+                    "src_path":"[..]build.rs",
+                    "test": false
+                },
+                "profile": {
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "test": false
+                },
+                "executable": null,
+                "features": [],
+                "filenames": "{...}",
+                "fresh": $FRESH
+            }
 
-    {
-        "reason":"compiler-message",
-        "package_id":"bar 0.5.0 ([..])",
-        "target":{
-            "kind":["lib"],
-            "crate_types":["lib"],
-            "doctest": true,
-            "edition": "2015",
-            "name":"bar",
-            "src_path":"[..]lib.rs",
-            "test": true
-        },
-        "message":"{...}"
-    }
+            {
+                "reason":"compiler-message",
+                "package_id":"bar 0.5.0 ([..])",
+                "target":{
+                    "kind":["lib"],
+                    "crate_types":["lib"],
+                    "doctest": true,
+                    "edition": "2015",
+                    "name":"bar",
+                    "src_path":"[..]lib.rs",
+                    "test": true
+                },
+                "message":"{...}"
+            }
 
-    {
-        "reason":"compiler-artifact",
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": 2,
-            "opt_level": "0",
-            "overflow_checks": true,
-            "test": false
-        },
-        "executable": null,
-        "features": [],
-        "package_id":"bar 0.5.0 ([..])",
-        "target":{
-            "kind":["lib"],
-            "crate_types":["lib"],
-            "doctest": true,
-            "edition": "2015",
-            "name":"bar",
-            "src_path":"[..]lib.rs",
-            "test": true
-        },
-        "filenames":[
-            "[..].rlib",
-            "[..].rmeta"
-        ],
-        "fresh": $FRESH
-    }
+            {
+                "reason":"compiler-artifact",
+                "profile": {
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "test": false
+                },
+                "executable": null,
+                "features": [],
+                "package_id":"bar 0.5.0 ([..])",
+                "target":{
+                    "kind":["lib"],
+                    "crate_types":["lib"],
+                    "doctest": true,
+                    "edition": "2015",
+                    "name":"bar",
+                    "src_path":"[..]lib.rs",
+                    "test": true
+                },
+                "filenames":[
+                    "[..].rlib",
+                    "[..].rmeta"
+                ],
+                "fresh": $FRESH
+            }
 
-    {
-        "reason":"build-script-executed",
-        "package_id":"foo 0.5.0 ([..])",
-        "linked_libs":[],
-        "linked_paths":[],
-        "env":[],
-        "cfgs":["xyz"],
-        "out_dir": "[..]target/debug/build/foo-[..]/out"
-    }
+            {
+                "reason":"build-script-executed",
+                "package_id":"foo 0.5.0 ([..])",
+                "linked_libs":[],
+                "linked_paths":[],
+                "env":[],
+                "cfgs":["xyz"],
+                "out_dir": "[..]target/debug/build/foo-[..]/out"
+            }
 
-    {
-        "reason":"compiler-message",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{
-            "kind":["bin"],
-            "crate_types":["bin"],
-            "doctest": false,
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]main.rs",
-            "test": true
-        },
-        "message":"{...}"
-    }
+            {
+                "reason":"compiler-message",
+                "package_id":"foo 0.5.0 ([..])",
+                "target":{
+                    "kind":["bin"],
+                    "crate_types":["bin"],
+                    "doctest": false,
+                    "edition": "2015",
+                    "name":"foo",
+                    "src_path":"[..]main.rs",
+                    "test": true
+                },
+                "message":"{...}"
+            }
 
-    {
-        "reason":"compiler-artifact",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{
-            "kind":["bin"],
-            "crate_types":["bin"],
-            "doctest": false,
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]main.rs",
-            "test": true
-        },
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": 2,
-            "opt_level": "0",
-            "overflow_checks": true,
-            "test": false
-        },
-        "executable": "[..]/foo/target/debug/foo[EXE]",
-        "features": [],
-        "filenames": "{...}",
-        "fresh": $FRESH
-    }
+            {
+                "reason":"compiler-artifact",
+                "package_id":"foo 0.5.0 ([..])",
+                "target":{
+                    "kind":["bin"],
+                    "crate_types":["bin"],
+                    "doctest": false,
+                    "edition": "2015",
+                    "name":"foo",
+                    "src_path":"[..]main.rs",
+                    "test": true
+                },
+                "profile": {
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "test": false
+                },
+                "executable": "[..]/foo/target/debug/foo[EXE]",
+                "features": [],
+                "filenames": "{...}",
+                "fresh": $FRESH
+            }
 
-    {"reason": "build-finished", "success": true}
-"#
+            {"reason": "build-finished", "success": true}
+        "#
         .replace("$FRESH", fresh)
     };
 
@@ -3299,48 +3300,48 @@ fn message_format_json_forward_stderr() {
     p.cargo("rustc --release --bin foo --message-format JSON")
         .with_json_contains_unordered(
             r#"
-    {
-        "reason":"compiler-message",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{
-            "kind":["bin"],
-            "crate_types":["bin"],
-            "doctest": false,
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]",
-            "test": true
-        },
-        "message":"{...}"
-    }
+                {
+                    "reason":"compiler-message",
+                    "package_id":"foo 0.5.0 ([..])",
+                    "target":{
+                        "kind":["bin"],
+                        "crate_types":["bin"],
+                        "doctest": false,
+                        "edition": "2015",
+                        "name":"foo",
+                        "src_path":"[..]",
+                        "test": true
+                    },
+                    "message":"{...}"
+                }
 
-    {
-        "reason":"compiler-artifact",
-        "package_id":"foo 0.5.0 ([..])",
-        "target":{
-            "kind":["bin"],
-            "crate_types":["bin"],
-            "doctest": false,
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]",
-            "test": true
-        },
-        "profile":{
-            "debug_assertions":false,
-            "debuginfo":null,
-            "opt_level":"3",
-            "overflow_checks": false,
-            "test":false
-        },
-        "executable": "{...}",
-        "features":[],
-        "filenames": "{...}",
-        "fresh": false
-    }
+                {
+                    "reason":"compiler-artifact",
+                    "package_id":"foo 0.5.0 ([..])",
+                    "target":{
+                        "kind":["bin"],
+                        "crate_types":["bin"],
+                        "doctest": false,
+                        "edition": "2015",
+                        "name":"foo",
+                        "src_path":"[..]",
+                        "test": true
+                    },
+                    "profile":{
+                        "debug_assertions":false,
+                        "debuginfo":null,
+                        "opt_level":"3",
+                        "overflow_checks": false,
+                        "test":false
+                    },
+                    "executable": "{...}",
+                    "features":[],
+                    "filenames": "{...}",
+                    "fresh": false
+                }
 
-    {"reason": "build-finished", "success": true}
-"#,
+                {"reason": "build-finished", "success": true}
+            "#,
         )
         .run();
 }
@@ -3351,19 +3352,19 @@ fn no_warn_about_package_metadata() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [package.metadata]
-            foo = "bar"
-            a = true
-            b = 3
+                [package.metadata]
+                foo = "bar"
+                a = true
+                b = 3
 
-            [package.metadata.another]
-            bar = 3
-        "#,
+                [package.metadata.another]
+                bar = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3432,15 +3433,15 @@ fn build_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -3462,13 +3463,13 @@ fn build_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -3490,15 +3491,15 @@ fn build_all_workspace_implicit_examples() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", "fn main() {}")
@@ -3536,9 +3537,9 @@ fn build_all_virtual_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -3564,9 +3565,9 @@ fn build_virtual_manifest_all_implied() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -3592,9 +3593,9 @@ fn build_virtual_manifest_one_project() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -3618,9 +3619,9 @@ fn build_all_virtual_manifest_implicit_examples() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "")
@@ -3662,20 +3663,20 @@ fn build_all_member_dependency_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a"]
-        "#,
+                [workspace]
+                members = ["a"]
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
+                [project]
+                name = "a"
+                version = "0.1.0"
 
-            [dependencies]
-            a = "0.1.0"
-        "#,
+                [dependencies]
+                a = "0.1.0"
+            "#,
         )
         .file("a/src/lib.rs", "pub fn a() {}")
         .build();
@@ -3700,15 +3701,15 @@ fn run_proper_binary() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            [[bin]]
-            name = "main"
-            [[bin]]
-            name = "other"
-        "#,
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
+                [[bin]]
+                name = "main"
+                [[bin]]
+                name = "other"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -3738,15 +3739,15 @@ fn run_proper_alias_binary_from_src() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            [[bin]]
-            name = "foo"
-            [[bin]]
-            name = "bar"
-        "#,
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
+                [[bin]]
+                name = "foo"
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/foo.rs", r#"fn main() { println!("foo"); }"#)
         .file("src/bar.rs", r#"fn main() { println!("bar"); }"#)
@@ -3763,15 +3764,15 @@ fn run_proper_alias_binary_main_rs() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            [[bin]]
-            name = "foo"
-            [[bin]]
-            name = "bar"
-        "#,
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
+                [[bin]]
+                name = "foo"
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/main.rs", r#"fn main() { println!("main"); }"#)
         .build();
@@ -3870,14 +3871,14 @@ fn cdylib_not_lifted() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            authors = []
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                authors = []
+                version = "0.1.0"
 
-            [lib]
-            crate-type = ["cdylib"]
-        "#,
+                [lib]
+                crate-type = ["cdylib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3908,14 +3909,14 @@ fn cdylib_final_outputs() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo-bar"
-            authors = []
-            version = "0.1.0"
+                [project]
+                name = "foo-bar"
+                authors = []
+                version = "0.1.0"
 
-            [lib]
-            crate-type = ["cdylib"]
-        "#,
+                [lib]
+                crate-type = ["cdylib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3948,19 +3949,19 @@ fn deterministic_cfg_flags() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                build = "build.rs"
 
-            [features]
-            default = ["f_a", "f_b", "f_c", "f_d"]
-            f_a = []
-            f_b = []
-            f_c = []
-            f_d = []
-        "#,
+                [features]
+                default = ["f_a", "f_b", "f_c", "f_d"]
+                f_a = []
+                f_b = []
+                f_c = []
+                f_d = []
+            "#,
         )
         .file(
             "build.rs",
@@ -3998,17 +3999,17 @@ fn explicit_bins_without_paths() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [[bin]]
-            name = "foo"
+                [[bin]]
+                name = "foo"
 
-            [[bin]]
-            name = "bar"
-        "#,
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/main.rs", "fn main() {}")
@@ -4073,15 +4074,15 @@ fn inferred_bin_path() {
         .file(
             "Cargo.toml",
             r#"
-        [package]
-        name = "foo"
-        version = "0.1.0"
-        authors = []
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            authors = []
 
-        [[bin]]
-        name = "bar"
-        # Note, no `path` key!
-        "#,
+            [[bin]]
+            name = "bar"
+            # Note, no `path` key!
+            "#,
         )
         .file("src/bin/bar/main.rs", "fn main() {}")
         .build();
@@ -4217,13 +4218,13 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "testless"
-            version = "0.1.0"
+                [project]
+                name = "testless"
+                version = "0.1.0"
 
-            [[bin]]
-            name = "a_bin"
-        "#,
+                [[bin]]
+                name = "a_bin"
+            "#,
         )
         .file("src/lib.rs", "")
         .publish();
@@ -4232,13 +4233,13 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            testless = "0.1.0"
-        "#,
+                [dependencies]
+                testless = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -4438,25 +4439,25 @@ fn no_linkable_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            [dependencies]
-            the_lib = { path = "the_lib" }
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                [dependencies]
+                the_lib = { path = "the_lib" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "the_lib/Cargo.toml",
             r#"
-            [package]
-            name = "the_lib"
-            version = "0.1.0"
-            [lib]
-            name = "the_lib"
-            crate-type = ["staticlib"]
-        "#,
+                [package]
+                name = "the_lib"
+                version = "0.1.0"
+                [lib]
+                name = "the_lib"
+                crate-type = ["staticlib"]
+            "#,
         )
         .file("the_lib/src/lib.rs", "pub fn foo() {}")
         .build();
@@ -4475,14 +4476,14 @@ fn avoid_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dev-dependencies]
-            baz = "1.0.0"
-        "#,
+                [dev-dependencies]
+                baz = "1.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -4510,9 +4511,9 @@ fn default_cargo_config_jobs() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            jobs = 1
-        "#,
+                [build]
+                jobs = 1
+            "#,
         )
         .build();
     p.cargo("build -v").run();
@@ -4525,9 +4526,9 @@ fn good_cargo_config_jobs() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            jobs = 4
-        "#,
+                [build]
+                jobs = 4
+            "#,
         )
         .build();
     p.cargo("build -v").run();
@@ -4560,9 +4561,9 @@ fn target_filters_workspace() {
         .file(
             "Cargo.toml",
             r#"
-        [workspace]
-        members = ["a", "b"]
-        "#,
+            [workspace]
+            members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_lib_manifest("a"))
         .file("a/src/lib.rs", "")
@@ -4599,9 +4600,9 @@ fn target_filters_workspace_not_found() {
         .file(
             "Cargo.toml",
             r#"
-        [workspace]
-        members = ["a", "b"]
-        "#,
+            [workspace]
+            members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_bin_manifest("a"))
         .file("a/src/main.rs", "fn main() {}")
@@ -4623,44 +4624,44 @@ fn signal_display() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [dependencies]
-            pm = { path = "pm" }
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [dependencies]
+                pm = { path = "pm" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #[macro_use]
-            extern crate pm;
+                #[macro_use]
+                extern crate pm;
 
-            #[derive(Foo)]
-            pub struct S;
-        "#,
+                #[derive(Foo)]
+                pub struct S;
+            "#,
         )
         .file(
             "pm/Cargo.toml",
             r#"
-            [package]
-            name = "pm"
-            version = "0.1.0"
-            [lib]
-            proc-macro = true
-        "#,
+                [package]
+                name = "pm"
+                version = "0.1.0"
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "pm/src/lib.rs",
             r#"
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[proc_macro_derive(Foo)]
-            pub fn derive(_input: TokenStream) -> TokenStream {
-                std::process::abort()
-            }
-        "#,
+                #[proc_macro_derive(Foo)]
+                pub fn derive(_input: TokenStream) -> TokenStream {
+                    std::process::abort()
+                }
+            "#,
         )
         .build();
 
@@ -4893,16 +4894,16 @@ fn build_with_relative_cargo_home_path() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "foo"
-            version = "0.0.1"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.0.1"
+                authors = ["wycats@example.com"]
 
-            [dependencies]
+                [dependencies]
 
-            "test-dependency" = { path = "src/test_dependency" }
-        "#,
+                "test-dependency" = { path = "src/test_dependency" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("src/test_dependency/src/lib.rs", r#" "#)
@@ -4926,7 +4927,8 @@ fn user_specific_cfgs_are_filtered_out() {
             fn main() {
                 assert!(std::env::var_os("CARGO_CFG_PROC_MACRO").is_none());
                 assert!(std::env::var_os("CARGO_CFG_DEBUG_ASSERTIONS").is_none());
-            }"#,
+            }
+            "#,
         )
         .build();
 

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -14,28 +14,28 @@ fn cargo_build_plan_simple() {
         .masquerade_as_nightly_cargo()
         .with_json(
             r#"
-    {
-        "inputs": [
-            "[..]/foo/Cargo.toml"
-        ],
-        "invocations": [
             {
-                "args": "{...}",
-                "cwd": "[..]/cit/[..]/foo",
-                "deps": [],
-                "env": "{...}",
-                "kind": null,
-                "links": "{...}",
-                "outputs": "{...}",
-                "package_name": "foo",
-                "package_version": "0.5.0",
-                "program": "rustc",
-                "target_kind": ["bin"],
-                "compile_mode": "build"
+                "inputs": [
+                    "[..]/foo/Cargo.toml"
+                ],
+                "invocations": [
+                    {
+                        "args": "{...}",
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": "{...}",
+                        "package_name": "foo",
+                        "package_version": "0.5.0",
+                        "program": "rustc",
+                        "target_kind": ["bin"],
+                        "compile_mode": "build"
+                    }
+                ]
             }
-        ]
-    }
-    "#,
+            "#,
         )
         .run();
     assert!(!p.bin("foo").is_file());
@@ -47,24 +47,24 @@ fn cargo_build_plan_single_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.5.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.5.0"
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
-            pub fn foo() { bar::bar(); }
+                extern crate bar;
+                pub fn foo() { bar::bar(); }
 
-            #[test]
-            fn test() { foo(); }
-        "#,
+                #[test]
+                fn test() { foo(); }
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -73,49 +73,49 @@ fn cargo_build_plan_single_dep() {
         .masquerade_as_nightly_cargo()
         .with_json(
             r#"
-    {
-        "inputs": [
-            "[..]/foo/Cargo.toml",
-            "[..]/foo/bar/Cargo.toml"
-        ],
-        "invocations": [
             {
-                "args": "{...}",
-                "cwd": "[..]/cit/[..]/foo",
-                "deps": [],
-                "env": "{...}",
-                "kind": null,
-                "links": "{...}",
-                "outputs": [
-                    "[..]/foo/target/debug/deps/libbar-[..].rlib",
-                    "[..]/foo/target/debug/deps/libbar-[..].rmeta"
+                "inputs": [
+                    "[..]/foo/Cargo.toml",
+                    "[..]/foo/bar/Cargo.toml"
                 ],
-                "package_name": "bar",
-                "package_version": "0.0.1",
-                "program": "rustc",
-                "target_kind": ["lib"],
-                "compile_mode": "build"
-            },
-            {
-                "args": "{...}",
-                "cwd": "[..]/cit/[..]/foo",
-                "deps": [0],
-                "env": "{...}",
-                "kind": null,
-                "links": "{...}",
-                "outputs": [
-                    "[..]/foo/target/debug/deps/libfoo-[..].rlib",
-                    "[..]/foo/target/debug/deps/libfoo-[..].rmeta"
-                ],
-                "package_name": "foo",
-                "package_version": "0.5.0",
-                "program": "rustc",
-                "target_kind": ["lib"],
-                "compile_mode": "build"
+                "invocations": [
+                    {
+                        "args": "{...}",
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": [
+                            "[..]/foo/target/debug/deps/libbar-[..].rlib",
+                            "[..]/foo/target/debug/deps/libbar-[..].rmeta"
+                        ],
+                        "package_name": "bar",
+                        "package_version": "0.0.1",
+                        "program": "rustc",
+                        "target_kind": ["lib"],
+                        "compile_mode": "build"
+                    },
+                    {
+                        "args": "{...}",
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [0],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": [
+                            "[..]/foo/target/debug/deps/libfoo-[..].rlib",
+                            "[..]/foo/target/debug/deps/libfoo-[..].rmeta"
+                        ],
+                        "package_name": "foo",
+                        "package_version": "0.5.0",
+                        "program": "rustc",
+                        "target_kind": ["lib"],
+                        "compile_mode": "build"
+                    }
+                ]
             }
-        ]
-    }
-    "#,
+            "#,
         )
         .run();
 }
@@ -126,13 +126,13 @@ fn cargo_build_plan_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
-        "#,
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", r#"fn main() {}"#)
         .file("build.rs", r#"fn main() {}"#)
@@ -142,56 +142,56 @@ fn cargo_build_plan_build_script() {
         .masquerade_as_nightly_cargo()
         .with_json(
             r#"
-    {
-        "inputs": [
-            "[..]/foo/Cargo.toml"
-        ],
-        "invocations": [
             {
-                "args": "{...}",
-                "cwd": "[..]/cit/[..]/foo",
-                "deps": [],
-                "env": "{...}",
-                "kind": null,
-                "links": "{...}",
-                "outputs": "{...}",
-                "package_name": "foo",
-                "package_version": "0.5.0",
-                "program": "rustc",
-                "target_kind": ["custom-build"],
-                "compile_mode": "build"
-            },
-            {
-                "args": "{...}",
-                "cwd": "[..]/cit/[..]/foo",
-                "deps": [0],
-                "env": "{...}",
-                "kind": null,
-                "links": "{...}",
-                "outputs": [],
-                "package_name": "foo",
-                "package_version": "0.5.0",
-                "program": "[..]/build-script-build",
-                "target_kind": ["custom-build"],
-                "compile_mode": "run-custom-build"
-            },
-            {
-                "args": "{...}",
-                "cwd": "[..]/cit/[..]/foo",
-                "deps": [1],
-                "env": "{...}",
-                "kind": null,
-                "links": "{...}",
-                "outputs": "{...}",
-                "package_name": "foo",
-                "package_version": "0.5.0",
-                "program": "rustc",
-                "target_kind": ["bin"],
-                "compile_mode": "build"
+                "inputs": [
+                    "[..]/foo/Cargo.toml"
+                ],
+                "invocations": [
+                    {
+                        "args": "{...}",
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": "{...}",
+                        "package_name": "foo",
+                        "package_version": "0.5.0",
+                        "program": "rustc",
+                        "target_kind": ["custom-build"],
+                        "compile_mode": "build"
+                    },
+                    {
+                        "args": "{...}",
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [0],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": [],
+                        "package_name": "foo",
+                        "package_version": "0.5.0",
+                        "program": "[..]/build-script-build",
+                        "target_kind": ["custom-build"],
+                        "compile_mode": "run-custom-build"
+                    },
+                    {
+                        "args": "{...}",
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [1],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": "{...}",
+                        "package_name": "foo",
+                        "package_version": "0.5.0",
+                        "program": "rustc",
+                        "target_kind": ["bin"],
+                        "compile_mode": "build"
+                    }
+                ]
             }
-        ]
-    }
-    "#,
+            "#,
         )
         .run();
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -17,13 +17,13 @@ fn custom_build_script_failed() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
-        "#,
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("build.rs", "fn main() { std::process::exit(101); }")
@@ -49,33 +49,33 @@ fn custom_build_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [features]
-            bar_feat = ["bar/foo"]
+                [features]
+                bar_feat = ["bar/foo"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
 
-            [features]
-            foo = []
-        "#,
+                [features]
+                foo = []
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn hello() {}");
 
@@ -171,13 +171,13 @@ fn custom_build_script_wrong_rustc_flags() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
-        "#,
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
@@ -201,36 +201,36 @@ fn custom_build_script_rustc_flags() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.foo]
-            path = "foo"
-        "#,
+                [dependencies.foo]
+                path = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "foo/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
-        "#,
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .file(
             "foo/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-flags=-l nonexistinglib -L /dummy/path1 -L /dummy/path2");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-flags=-l nonexistinglib -L /dummy/path1 -L /dummy/path2");
+                }
+            "#,
         )
         .build();
 
@@ -260,36 +260,36 @@ fn custom_build_script_rustc_flags_no_space() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.foo]
-            path = "foo"
-        "#,
+                [dependencies.foo]
+                path = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "foo/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
-        "#,
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .file(
             "foo/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-flags=-lnonexistinglib -L/dummy/path1 -L/dummy/path2");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-flags=-lnonexistinglib -L/dummy/path1 -L/dummy/path2");
+                }
+            "#,
         )
         .build();
 
@@ -319,12 +319,12 @@ fn links_no_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -350,29 +350,29 @@ fn links_duplicates() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
 
-            [dependencies.a-sys]
-            path = "a-sys"
-        "#,
+                [dependencies.a-sys]
+                path = "a-sys"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "")
         .file(
             "a-sys/Cargo.toml",
             r#"
-            [project]
-            name = "a-sys"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a-sys"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
+            "#,
         )
         .file("a-sys/src/lib.rs", "")
         .file("a-sys/build.rs", "")
@@ -453,44 +453,44 @@ fn links_duplicates_deep_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.a-sys]
-            path = "a-sys"
-        "#,
+                [dependencies.a-sys]
+                path = "a-sys"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file("a/build.rs", "")
         .file(
             "a/a-sys/Cargo.toml",
             r#"
-            [project]
-            name = "a-sys"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a-sys"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
+            "#,
         )
         .file("a/a-sys/src/lib.rs", "")
         .file("a/a-sys/build.rs", "")
@@ -518,51 +518,51 @@ fn overrides_and_links() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::env;
-            fn main() {
-                assert_eq!(env::var("DEP_FOO_FOO").ok().expect("FOO missing"),
-                           "bar");
-                assert_eq!(env::var("DEP_FOO_BAR").ok().expect("BAR missing"),
-                           "baz");
-            }
-        "#,
+                use std::env;
+                fn main() {
+                    assert_eq!(env::var("DEP_FOO_FOO").ok().expect("FOO missing"),
+                               "bar");
+                    assert_eq!(env::var("DEP_FOO_BAR").ok().expect("BAR missing"),
+                               "baz");
+                }
+            "#,
         )
         .file(
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.foo]
-            rustc-flags = "-L foo -L bar"
-            foo = "bar"
-            bar = "baz"
-        "#,
+                    [target.{}.foo]
+                    rustc-flags = "-L foo -L bar"
+                    foo = "bar"
+                    bar = "baz"
+                "#,
                 target
             ),
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file("a/build.rs", "not valid rust code")
@@ -591,12 +591,12 @@ fn unused_overrides() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -604,11 +604,11 @@ fn unused_overrides() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.foo]
-            rustc-flags = "-L foo -L bar"
-            foo = "bar"
-            bar = "baz"
-        "#,
+                    [target.{}.foo]
+                    rustc-flags = "-L foo -L bar"
+                    foo = "bar"
+                    bar = "baz"
+                "#,
                 target
             ),
         )
@@ -623,51 +623,51 @@ fn links_passes_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::env;
-            fn main() {
-                assert_eq!(env::var("DEP_FOO_FOO").unwrap(), "bar");
-                assert_eq!(env::var("DEP_FOO_BAR").unwrap(), "baz");
-            }
-        "#,
+                use std::env;
+                fn main() {
+                    assert_eq!(env::var("DEP_FOO_FOO").unwrap(), "bar");
+                    assert_eq!(env::var("DEP_FOO_BAR").unwrap(), "baz");
+                }
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "a/build.rs",
             r#"
-            use std::env;
-            fn main() {
-                let lib = env::var("CARGO_MANIFEST_LINKS").unwrap();
-                assert_eq!(lib, "foo");
+                use std::env;
+                fn main() {
+                    let lib = env::var("CARGO_MANIFEST_LINKS").unwrap();
+                    assert_eq!(lib, "foo");
 
-                println!("cargo:foo=bar");
-                println!("cargo:bar=baz");
-            }
-        "#,
+                    println!("cargo:foo=bar");
+                    println!("cargo:bar=baz");
+                }
+            "#,
         )
         .build();
 
@@ -680,12 +680,12 @@ fn only_rerun_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -716,25 +716,25 @@ fn rebuild_continues_to_pass_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::time::Duration;
-            fn main() {
-                println!("cargo:foo=bar");
-                println!("cargo:bar=baz");
-                std::thread::sleep(Duration::from_millis(500));
-            }
-        "#,
+                use std::time::Duration;
+                fn main() {
+                    println!("cargo:foo=bar");
+                    println!("cargo:bar=baz");
+                    std::thread::sleep(Duration::from_millis(500));
+                }
+            "#,
         )
         .build();
     a.root().move_into_the_past();
@@ -744,15 +744,15 @@ fn rebuild_continues_to_pass_env_vars() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    build = "build.rs"
 
-            [dependencies.a]
-            path = '{}'
-        "#,
+                    [dependencies.a]
+                    path = '{}'
+                "#,
                 a.root().display()
             ),
         )
@@ -760,12 +760,12 @@ fn rebuild_continues_to_pass_env_vars() {
         .file(
             "build.rs",
             r#"
-            use std::env;
-            fn main() {
-                assert_eq!(env::var("DEP_FOO_FOO").unwrap(), "bar");
-                assert_eq!(env::var("DEP_FOO_BAR").unwrap(), "baz");
-            }
-        "#,
+                use std::env;
+                fn main() {
+                    assert_eq!(env::var("DEP_FOO_FOO").unwrap(), "bar");
+                    assert_eq!(env::var("DEP_FOO_BAR").unwrap(), "baz");
+                }
+            "#,
         )
         .build();
 
@@ -784,12 +784,12 @@ fn testing_and_such() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -849,28 +849,28 @@ fn propagation_of_l_flags() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.a]
-            path = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "bar"
-            build = "build.rs"
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "bar"
+                build = "build.rs"
 
-            [dependencies.b]
-            path = "../b"
-        "#,
+                [dependencies.b]
+                path = "../b"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
@@ -880,13 +880,13 @@ fn propagation_of_l_flags() {
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file("b/build.rs", "bad file")
@@ -894,9 +894,9 @@ fn propagation_of_l_flags() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.foo]
-            rustc-flags = "-L foo"
-        "#,
+                    [target.{}.foo]
+                    rustc-flags = "-L foo"
+                "#,
                 target
             ),
         )
@@ -920,48 +920,48 @@ fn propagation_of_l_flags_new() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.a]
-            path = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "bar"
-            build = "build.rs"
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "bar"
+                build = "build.rs"
 
-            [dependencies.b]
-            path = "../b"
-        "#,
+                [dependencies.b]
+                path = "../b"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "a/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=bar");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=bar");
+                }
+            "#,
         )
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file("b/build.rs", "bad file")
@@ -969,9 +969,9 @@ fn propagation_of_l_flags_new() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.foo]
-            rustc-link-search = ["foo"]
-        "#,
+                    [target.{}.foo]
+                    rustc-link-search = ["foo"]
+                "#,
                 target
             ),
         )
@@ -994,14 +994,14 @@ fn build_deps_simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-            [build-dependencies.a]
-            path = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+                [build-dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -1038,14 +1038,14 @@ fn build_deps_not_for_normal() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-            [build-dependencies.aaaaa]
-            path = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+                [build-dependencies.aaaaa]
+                path = "a"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -1084,15 +1084,15 @@ fn build_cmd_with_a_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.a]
-            path = "a"
-        "#,
+                [build-dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -1106,15 +1106,15 @@ fn build_cmd_with_a_build_cmd() {
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.b]
-            path = "../b"
-        "#,
+                [build-dependencies.b]
+                path = "../b"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
@@ -1162,25 +1162,25 @@ fn out_dir_is_preserved() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::fs::File;
-            use std::path::Path;
-            fn main() {
-                let out = env::var("OUT_DIR").unwrap();
-                File::create(Path::new(&out).join("foo")).unwrap();
-            }
-        "#,
+                use std::env;
+                use std::fs::File;
+                use std::path::Path;
+                fn main() {
+                    let out = env::var("OUT_DIR").unwrap();
+                    File::create(Path::new(&out).join("foo")).unwrap();
+                }
+            "#,
         )
         .build();
 
@@ -1242,22 +1242,22 @@ fn output_separate_lines() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-flags=-L foo");
-                println!("cargo:rustc-flags=-l static=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-flags=-L foo");
+                    println!("cargo:rustc-flags=-l static=foo");
+                }
+            "#,
         )
         .build();
     p.cargo("build -v")
@@ -1280,22 +1280,22 @@ fn output_separate_lines_new() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=foo");
-                println!("cargo:rustc-link-lib=static=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=foo");
+                    println!("cargo:rustc-link-lib=static=foo");
+                }
+            "#,
         )
         .build();
     p.cargo("build -v")
@@ -1319,41 +1319,41 @@ fn code_generation() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            include!(concat!(env!("OUT_DIR"), "/hello.rs"));
+                include!(concat!(env!("OUT_DIR"), "/hello.rs"));
 
-            fn main() {
-                println!("{}", message());
-            }
-        "#,
+                fn main() {
+                    println!("{}", message());
+                }
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::fs;
-            use std::path::PathBuf;
+                use std::env;
+                use std::fs;
+                use std::path::PathBuf;
 
-            fn main() {
-                let dst = PathBuf::from(env::var("OUT_DIR").unwrap());
-                fs::write(dst.join("hello.rs"),
-                    "
-                    pub fn message() -> &'static str {
-                        \"Hello, World!\"
-                    }
-                    ")
-                .unwrap();
-            }
-        "#,
+                fn main() {
+                    let dst = PathBuf::from(env::var("OUT_DIR").unwrap());
+                    fs::write(dst.join("hello.rs"),
+                        "
+                        pub fn message() -> &'static str {
+                            \"Hello, World!\"
+                        }
+                        ")
+                    .unwrap();
+                }
+            "#,
         )
         .build();
 
@@ -1376,19 +1376,19 @@ fn release_with_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .build();
 
@@ -1401,12 +1401,12 @@ fn build_script_only() {
         .file(
             "Cargo.toml",
             r#"
-              [project]
-              name = "foo"
-              version = "0.0.0"
-              authors = []
-              build = "build.rs"
-        "#,
+                  [project]
+                  name = "foo"
+                  version = "0.0.0"
+                  authors = []
+                  build = "build.rs"
+            "#,
         )
         .file("build.rs", r#"fn main() {}"#)
         .build();
@@ -1429,44 +1429,44 @@ fn shared_dep_with_a_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.a]
-            path = "a"
+                [dependencies.a]
+                path = "a"
 
-            [build-dependencies.b]
-            path = "b"
-        "#,
+                [build-dependencies.b]
+                path = "b"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("a/build.rs", "fn main() {}")
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.5.0"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies.a]
-            path = "../a"
-        "#,
+                [dependencies.a]
+                path = "../a"
+            "#,
         )
         .file("b/src/lib.rs", "")
         .build();
@@ -1479,46 +1479,46 @@ fn transitive_dep_host() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.b]
-            path = "b"
-        "#,
+                [build-dependencies.b]
+                path = "b"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("a/build.rs", "fn main() {}")
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.5.0"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.5.0"
+                authors = []
 
-            [lib]
-            name = "b"
-            plugin = true
+                [lib]
+                name = "b"
+                plugin = true
 
-            [dependencies.a]
-            path = "../a"
-        "#,
+                [dependencies.a]
+                path = "../a"
+            "#,
         )
         .file("b/src/lib.rs", "")
         .build();
@@ -1531,38 +1531,38 @@ fn test_a_lib_with_a_build_command() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            include!(concat!(env!("OUT_DIR"), "/foo.rs"));
+                include!(concat!(env!("OUT_DIR"), "/foo.rs"));
 
-            /// ```
-            /// foo::bar();
-            /// ```
-            pub fn bar() {
-                assert_eq!(foo(), 1);
-            }
-        "#,
+                /// ```
+                /// foo::bar();
+                /// ```
+                pub fn bar() {
+                    assert_eq!(foo(), 1);
+                }
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::fs;
-            use std::path::PathBuf;
+                use std::env;
+                use std::fs;
+                use std::path::PathBuf;
 
-            fn main() {
-                let out = PathBuf::from(env::var("OUT_DIR").unwrap());
-                fs::write(out.join("foo.rs"), "fn foo() -> i32 { 1 }").unwrap();
-            }
-        "#,
+                fn main() {
+                    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
+                    fs::write(out.join("foo.rs"), "fn foo() -> i32 { 1 }").unwrap();
+                }
+            "#,
         )
         .build();
     p.cargo("test").run();
@@ -1574,25 +1574,25 @@ fn test_dev_dep_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dev-dependencies.a]
-            path = "a"
-        "#,
+                [dev-dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("a/build.rs", "fn main() {}")
         .file("a/src/lib.rs", "")
@@ -1608,15 +1608,15 @@ fn build_script_with_dynamic_native_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "builder"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "builder"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "builder"
-            crate-type = ["dylib"]
-        "#,
+                [lib]
+                name = "builder"
+                crate-type = ["dylib"]
+            "#,
         )
         .file("src/lib.rs", "#[no_mangle] pub extern fn foo() {}")
         .build();
@@ -1625,62 +1625,62 @@ fn build_script_with_dynamic_native_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.bar]
-            path = "bar"
-        "#,
+                [build-dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("build.rs", "extern crate bar; fn main() { bar::bar() }")
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "bar/build.rs",
             r#"
-            use std::env;
-            use std::fs;
-            use std::path::PathBuf;
+                use std::env;
+                use std::fs;
+                use std::path::PathBuf;
 
-            fn main() {
-                let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-                let root = PathBuf::from(env::var("BUILDER_ROOT").unwrap());
-                let file = format!("{}builder{}",
-                    env::consts::DLL_PREFIX,
-                    env::consts::DLL_SUFFIX);
-                let src = root.join(&file);
-                let dst = out_dir.join(&file);
-                fs::copy(src, dst).unwrap();
-                if cfg!(target_env = "msvc") {
-                    fs::copy(root.join("builder.dll.lib"),
-                             out_dir.join("builder.dll.lib")).unwrap();
+                fn main() {
+                    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+                    let root = PathBuf::from(env::var("BUILDER_ROOT").unwrap());
+                    let file = format!("{}builder{}",
+                        env::consts::DLL_PREFIX,
+                        env::consts::DLL_SUFFIX);
+                    let src = root.join(&file);
+                    let dst = out_dir.join(&file);
+                    fs::copy(src, dst).unwrap();
+                    if cfg!(target_env = "msvc") {
+                        fs::copy(root.join("builder.dll.lib"),
+                                 out_dir.join("builder.dll.lib")).unwrap();
+                    }
+                    println!("cargo:rustc-link-search=native={}", out_dir.display());
                 }
-                println!("cargo:rustc-link-search=native={}", out_dir.display());
-            }
-        "#,
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            pub fn bar() {
-                #[cfg_attr(not(target_env = "msvc"), link(name = "builder"))]
-                #[cfg_attr(target_env = "msvc", link(name = "builder.dll"))]
-                extern { fn foo(); }
-                unsafe { foo() }
-            }
-        "#,
+                pub fn bar() {
+                    #[cfg_attr(not(target_env = "msvc"), link(name = "builder"))]
+                    #[cfg_attr(target_env = "msvc", link(name = "builder.dll"))]
+                    extern { fn foo(); }
+                    unsafe { foo() }
+                }
+            "#,
         )
         .build();
 
@@ -1702,25 +1702,25 @@ fn profile_and_opt_level_set_correctly() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-              use std::env;
+                  use std::env;
 
-              fn main() {
-                  assert_eq!(env::var("OPT_LEVEL").unwrap(), "3");
-                  assert_eq!(env::var("PROFILE").unwrap(), "release");
-                  assert_eq!(env::var("DEBUG").unwrap(), "false");
-              }
-        "#,
+                  fn main() {
+                      assert_eq!(env::var("OPT_LEVEL").unwrap(), "3");
+                      assert_eq!(env::var("PROFILE").unwrap(), "release");
+                      assert_eq!(env::var("DEBUG").unwrap(), "false");
+                  }
+            "#,
         )
         .build();
     p.cargo("bench").run();
@@ -1732,26 +1732,26 @@ fn profile_debug_0() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [profile.dev]
-            debug = 0
-        "#,
+                [profile.dev]
+                debug = 0
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-              use std::env;
+                  use std::env;
 
-              fn main() {
-                  assert_eq!(env::var("OPT_LEVEL").unwrap(), "0");
-                  assert_eq!(env::var("PROFILE").unwrap(), "debug");
-                  assert_eq!(env::var("DEBUG").unwrap(), "false");
-              }
-        "#,
+                  fn main() {
+                      assert_eq!(env::var("OPT_LEVEL").unwrap(), "0");
+                      assert_eq!(env::var("PROFILE").unwrap(), "debug");
+                      assert_eq!(env::var("DEBUG").unwrap(), "false");
+                  }
+            "#,
         )
         .build();
     p.cargo("build").run();
@@ -1763,15 +1763,15 @@ fn build_script_with_lto() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [profile.dev]
-            lto = true
-        "#,
+                [profile.dev]
+                lto = true
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -1785,32 +1785,32 @@ fn test_duplicate_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.bar]
-            path = "bar"
+                [dependencies.bar]
+                path = "bar"
 
-            [build-dependencies.bar]
-            path = "bar"
-        "#,
+                [build-dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate bar;
-            fn main() { bar::do_nothing() }
-        "#,
+                extern crate bar;
+                fn main() { bar::do_nothing() }
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            extern crate bar;
-            fn main() { bar::do_nothing() }
-        "#,
+                extern crate bar;
+                fn main() { bar::do_nothing() }
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn do_nothing() {}")
@@ -1825,12 +1825,12 @@ fn cfg_feedback() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", "#[cfg(foo)] fn main() {}")
         .file(
@@ -1849,13 +1849,13 @@ fn cfg_override() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", "#[cfg(foo)] fn main() {}")
         .file("build.rs", "")
@@ -1863,9 +1863,9 @@ fn cfg_override() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.a]
-            rustc-cfg = ["foo"]
-        "#,
+                    [target.{}.a]
+                    rustc-cfg = ["foo"]
+                "#,
                 target
             ),
         )
@@ -1880,12 +1880,12 @@ fn cfg_test() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
@@ -1894,24 +1894,24 @@ fn cfg_test() {
         .file(
             "src/lib.rs",
             r#"
-            ///
-            /// ```
-            /// extern crate foo;
-            ///
-            /// fn main() {
-            ///     foo::foo()
-            /// }
-            /// ```
-            ///
-            #[cfg(foo)]
-            pub fn foo() {}
+                ///
+                /// ```
+                /// extern crate foo;
+                ///
+                /// fn main() {
+                ///     foo::foo()
+                /// }
+                /// ```
+                ///
+                #[cfg(foo)]
+                pub fn foo() {}
 
-            #[cfg(foo)]
-            #[test]
-            fn test_foo() {
-                foo()
-            }
-        "#,
+                #[cfg(foo)]
+                #[test]
+                fn test_foo() {
+                    foo()
+                }
+            "#,
         )
         .file("tests/test.rs", "#[cfg(foo)] #[test] fn test_bar() {}")
         .build();
@@ -1942,15 +1942,15 @@ fn cfg_doc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "build.rs",
@@ -1960,12 +1960,12 @@ fn cfg_doc() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "bar/build.rs",
@@ -1985,46 +1985,46 @@ fn cfg_override_test() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-            links = "a"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+                links = "a"
+            "#,
         )
         .file("build.rs", "")
         .file(
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.a]
-            rustc-cfg = ["foo"]
-        "#,
+                    [target.{}.a]
+                    rustc-cfg = ["foo"]
+                "#,
                 rustc_host()
             ),
         )
         .file(
             "src/lib.rs",
             r#"
-            ///
-            /// ```
-            /// extern crate foo;
-            ///
-            /// fn main() {
-            ///     foo::foo()
-            /// }
-            /// ```
-            ///
-            #[cfg(foo)]
-            pub fn foo() {}
+                ///
+                /// ```
+                /// extern crate foo;
+                ///
+                /// fn main() {
+                ///     foo::foo()
+                /// }
+                /// ```
+                ///
+                #[cfg(foo)]
+                pub fn foo() {}
 
-            #[cfg(foo)]
-            #[test]
-            fn test_foo() {
-                foo()
-            }
-        "#,
+                #[cfg(foo)]
+                #[test]
+                fn test_foo() {
+                    foo()
+                }
+            "#,
         )
         .file("tests/test.rs", "#[cfg(foo)] #[test] fn test_bar() {}")
         .build();
@@ -2053,26 +2053,26 @@ fn cfg_override_doc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-            links = "a"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+                links = "a"
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             ".cargo/config",
             &format!(
                 r#"
-            [target.{target}.a]
-            rustc-cfg = ["foo"]
-            [target.{target}.b]
-            rustc-cfg = ["bar"]
-        "#,
+                    [target.{target}.a]
+                    rustc-cfg = ["foo"]
+                    [target.{target}.b]
+                    rustc-cfg = ["bar"]
+                "#,
                 target = rustc_host()
             ),
         )
@@ -2081,13 +2081,13 @@ fn cfg_override_doc() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-            links = "b"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+                links = "b"
+            "#,
         )
         .file("bar/build.rs", "")
         .file("bar/src/lib.rs", "#[cfg(bar)] pub fn bar() {}")
@@ -2104,21 +2104,21 @@ fn env_build() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            const FOO: &'static str = env!("FOO");
-            fn main() {
-                println!("{}", FOO);
-            }
-        "#,
+                const FOO: &'static str = env!("FOO");
+                fn main() {
+                    println!("{}", FOO);
+                }
+            "#,
         )
         .file(
             "build.rs",
@@ -2135,12 +2135,12 @@ fn env_test() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
@@ -2153,13 +2153,13 @@ fn env_test() {
         .file(
             "tests/test.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            #[test]
-            fn test_foo() {
-                assert_eq!("foo", foo::FOO);
-            }
-        "#,
+                #[test]
+                fn test_foo() {
+                    assert_eq!("foo", foo::FOO);
+                }
+            "#,
         )
         .build();
     p.cargo("test -v")
@@ -2188,19 +2188,19 @@ fn env_doc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            const FOO: &'static str = env!("FOO");
-            fn main() {}
-        "#,
+                const FOO: &'static str = env!("FOO");
+                fn main() {}
+            "#,
         )
         .file(
             "build.rs",
@@ -2216,47 +2216,47 @@ fn flags_go_into_tests() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            b = { path = "b" }
-        "#,
+                [dependencies]
+                b = { path = "b" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("tests/foo.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            a = { path = "../a" }
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                a = { path = "../a" }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "a/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=test");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=test");
+                }
+            "#,
         )
         .build();
 
@@ -2297,60 +2297,60 @@ fn diamond_passes_args_only_once() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-            b = { path = "b" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+                b = { path = "b" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("tests/foo.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            b = { path = "../b" }
-            c = { path = "../c" }
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                b = { path = "../b" }
+                c = { path = "../c" }
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            c = { path = "../c" }
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                c = { path = "../c" }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file(
             "c/Cargo.toml",
             r#"
-            [project]
-            name = "c"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "c"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "c/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=native=test");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=native=test");
+                }
+            "#,
         )
         .file("c/src/lib.rs", "")
         .build();
@@ -2381,23 +2381,23 @@ fn adding_an_override_invalidates() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(".cargo/config", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=native=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=native=foo");
+                }
+            "#,
         )
         .build();
 
@@ -2442,13 +2442,13 @@ fn changing_an_override_invalidates() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -2504,13 +2504,13 @@ fn fresh_builds_possible_with_link_libs() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "nativefoo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "nativefoo"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -2556,13 +2556,13 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "foo"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "foo"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -2609,22 +2609,22 @@ fn rebuild_only_on_explicit_paths() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rerun-if-changed=foo");
-                println!("cargo:rerun-if-changed=bar");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rerun-if-changed=foo");
+                    println!("cargo:rerun-if-changed=bar");
+                }
+            "#,
         )
         .build();
 
@@ -2720,34 +2720,34 @@ fn doctest_receives_build_link_args() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.a]
-            path = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "bar"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "bar"
+                build = "build.rs"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "a/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=native=bar");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=native=bar");
+                }
+            "#,
         )
         .build();
 
@@ -2764,44 +2764,44 @@ fn please_respect_the_dag() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [dependencies]
-            a = { path = 'a' }
-        "#,
+                [dependencies]
+                a = { path = 'a' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=native=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=native=foo");
+                }
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "bar"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "bar"
+                build = "build.rs"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "a/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=native=bar");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=native=bar");
+                }
+            "#,
         )
         .build();
 
@@ -2816,30 +2816,30 @@ fn non_utf8_output() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            use std::io::prelude::*;
+                use std::io::prelude::*;
 
-            fn main() {
-                let mut out = std::io::stdout();
-                // print something that's not utf8
-                out.write_all(b"\xff\xff\n").unwrap();
+                fn main() {
+                    let mut out = std::io::stdout();
+                    // print something that's not utf8
+                    out.write_all(b"\xff\xff\n").unwrap();
 
-                // now print some cargo metadata that's utf8
-                println!("cargo:rustc-cfg=foo");
+                    // now print some cargo metadata that's utf8
+                    println!("cargo:rustc-cfg=foo");
 
-                // now print more non-utf8
-                out.write_all(b"\xff\xff\n").unwrap();
-            }
-        "#,
+                    // now print more non-utf8
+                    out.write_all(b"\xff\xff\n").unwrap();
+                }
+            "#,
         )
         .file("src/main.rs", "#[cfg(foo)] fn main() {}")
         .build();
@@ -2853,32 +2853,32 @@ fn custom_target_dir() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [build]
-            target-dir = 'test'
-        "#,
+                [build]
+                target-dir = 'test'
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("a/build.rs", "fn main() {}")
         .file("a/src/lib.rs", "")
@@ -2893,17 +2893,17 @@ fn panic_abort_with_build_scripts() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [profile.release]
-            panic = 'abort'
+                [profile.release]
+                panic = 'abort'
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -2913,15 +2913,15 @@ fn panic_abort_with_build_scripts() {
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies]
-            b = { path = "../b" }
-        "#,
+                [build-dependencies]
+                b = { path = "../b" }
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
@@ -2931,11 +2931,11 @@ fn panic_abort_with_build_scripts() {
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+            "#,
         )
         .file("b/src/lib.rs", "")
         .build();
@@ -2955,22 +2955,22 @@ fn warnings_emitted() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:warning=foo");
-                println!("cargo:warning=bar");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:warning=foo");
+                    println!("cargo:warning=bar");
+                }
+            "#,
         )
         .build();
 
@@ -2995,23 +2995,23 @@ fn warnings_emitted_when_build_script_panics() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:warning=foo");
-                println!("cargo:warning=bar");
-                panic!();
-            }
-        "#,
+                fn main() {
+                    println!("cargo:warning=foo");
+                    println!("cargo:warning=bar");
+                    panic!();
+                }
+            "#,
         )
         .build();
 
@@ -3051,14 +3051,14 @@ fn warnings_hidden_for_upstream() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3110,14 +3110,14 @@ fn warnings_printed_on_vv() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3148,24 +3148,24 @@ fn output_shows_on_vv() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::io::prelude::*;
+                use std::io::prelude::*;
 
-            fn main() {
-                std::io::stderr().write_all(b"stderr\n").unwrap();
-                std::io::stdout().write_all(b"stdout\n").unwrap();
-            }
-        "#,
+                fn main() {
+                    std::io::stderr().write_all(b"stderr\n").unwrap();
+                    std::io::stdout().write_all(b"stdout\n").unwrap();
+                }
+            "#,
         )
         .build();
 
@@ -3192,30 +3192,30 @@ fn links_with_dots() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-            links = "a.b"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+                links = "a.b"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-link-search=bar")
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-link-search=bar")
+                }
+            "#,
         )
         .file(
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.'a.b']
-            rustc-link-search = ["foo"]
-        "#,
+                    [target.{}.'a.b']
+                    rustc-link-search = ["foo"]
+                "#,
                 target
             ),
         )
@@ -3232,24 +3232,24 @@ fn rustc_and_rustdoc_set_correctly() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-              use std::env;
+                  use std::env;
 
-              fn main() {
-                  assert_eq!(env::var("RUSTC").unwrap(), "rustc");
-                  assert_eq!(env::var("RUSTDOC").unwrap(), "rustdoc");
-              }
-        "#,
+                  fn main() {
+                      assert_eq!(env::var("RUSTC").unwrap(), "rustc");
+                      assert_eq!(env::var("RUSTDOC").unwrap(), "rustdoc");
+                  }
+            "#,
         )
         .build();
     p.cargo("bench").run();
@@ -3261,28 +3261,28 @@ fn cfg_env_vars_available() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::env;
+                use std::env;
 
-            fn main() {
-                let fam = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-                if cfg!(unix) {
-                    assert_eq!(fam, "unix");
-                } else {
-                    assert_eq!(fam, "windows");
+                fn main() {
+                    let fam = env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+                    if cfg!(unix) {
+                        assert_eq!(fam, "unix");
+                    } else {
+                        assert_eq!(fam, "windows");
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
     p.cargo("bench").run();
@@ -3294,42 +3294,42 @@ fn switch_features_rerun() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [features]
-            foo = []
-        "#,
+                [features]
+                foo = []
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                println!(include_str!(concat!(env!("OUT_DIR"), "/output")));
-            }
-        "#,
+                fn main() {
+                    println!(include_str!(concat!(env!("OUT_DIR"), "/output")));
+                }
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::fs;
-            use std::path::Path;
+                use std::env;
+                use std::fs;
+                use std::path::Path;
 
-            fn main() {
-                let out_dir = env::var_os("OUT_DIR").unwrap();
-                let output = Path::new(&out_dir).join("output");
+                fn main() {
+                    let out_dir = env::var_os("OUT_DIR").unwrap();
+                    let output = Path::new(&out_dir).join("output");
 
-                if env::var_os("CARGO_FEATURE_FOO").is_some() {
-                    fs::write(output, "foo").unwrap();
-                } else {
-                    fs::write(output, "bar").unwrap();
+                    if env::var_os("CARGO_FEATURE_FOO").is_some() {
+                        fs::write(output, "foo").unwrap();
+                    } else {
+                        fs::write(output, "bar").unwrap();
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
 
@@ -3349,20 +3349,20 @@ fn assume_build_script_when_build_rs_present() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                if ! cfg!(foo) {
-                    panic!("the build script was not run");
+                fn main() {
+                    if ! cfg!(foo) {
+                        panic!("the build script was not run");
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-cfg=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-cfg=foo");
+                }
+            "#,
         )
         .build();
 
@@ -3375,30 +3375,30 @@ fn if_build_set_to_false_dont_treat_build_rs_as_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = false
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = false
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                if cfg!(foo) {
-                    panic!("the build script was run");
+                fn main() {
+                    if cfg!(foo) {
+                        panic!("the build script was run");
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-cfg=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-cfg=foo");
+                }
+            "#,
         )
         .build();
 
@@ -3499,17 +3499,17 @@ fn deterministic_rustc_dependency_flags() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            dep1 = "*"
-            dep2 = "*"
-            dep3 = "*"
-            dep4 = "*"
-        "#,
+                [dependencies]
+                dep1 = "*"
+                dep2 = "*"
+                dep3 = "*"
+                dep4 = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -3531,46 +3531,46 @@ fn links_duplicates_with_cycle() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
 
-            [dependencies.a]
-            path = "a"
+                [dependencies.a]
+                path = "a"
 
-            [dev-dependencies]
-            b = { path = "b" }
-        "#,
+                [dev-dependencies]
+                b = { path = "b" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            links = "a"
-            build = "build.rs"
-        "#,
+                [project]
+                name = "a"
+                version = "0.5.0"
+                authors = []
+                links = "a"
+                build = "build.rs"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file("a/build.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = ".." }
-        "#,
+                [dependencies]
+                foo = { path = ".." }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .build();
@@ -3614,14 +3614,14 @@ fn _rename_with_link_search_path(cross: bool) {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [lib]
-            crate-type = ["cdylib"]
-        "#,
+                [lib]
+                crate-type = ["cdylib"]
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -3637,48 +3637,48 @@ fn _rename_with_link_search_path(cross: bool) {
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::fs;
-            use std::path::PathBuf;
+                use std::env;
+                use std::fs;
+                use std::path::PathBuf;
 
-            fn main() {
-                // Move the `libfoo.so` from the root of our project into the
-                // build directory. This way Cargo should automatically manage
-                // `LD_LIBRARY_PATH` and such.
-                let root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
-                let file = format!("{}foo{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX);
-                let src = root.join(&file);
+                fn main() {
+                    // Move the `libfoo.so` from the root of our project into the
+                    // build directory. This way Cargo should automatically manage
+                    // `LD_LIBRARY_PATH` and such.
+                    let root = PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+                    let file = format!("{}foo{}", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX);
+                    let src = root.join(&file);
 
-                let dst_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-                let dst = dst_dir.join(&file);
+                    let dst_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+                    let dst = dst_dir.join(&file);
 
-                fs::copy(&src, &dst).unwrap();
-                // handle windows, like below
-                drop(fs::copy(root.join("foo.dll.lib"), dst_dir.join("foo.dll.lib")));
+                    fs::copy(&src, &dst).unwrap();
+                    // handle windows, like below
+                    drop(fs::copy(root.join("foo.dll.lib"), dst_dir.join("foo.dll.lib")));
 
-                println!("cargo:rerun-if-changed=build.rs");
-                if cfg!(target_env = "msvc") {
-                    println!("cargo:rustc-link-lib=foo.dll");
-                } else {
-                    println!("cargo:rustc-link-lib=foo");
+                    println!("cargo:rerun-if-changed=build.rs");
+                    if cfg!(target_env = "msvc") {
+                        println!("cargo:rustc-link-lib=foo.dll");
+                    } else {
+                        println!("cargo:rustc-link-lib=foo");
+                    }
+                    println!("cargo:rustc-link-search=all={}",
+                             dst.parent().unwrap().display());
                 }
-                println!("cargo:rustc-link-search=all={}",
-                         dst.parent().unwrap().display());
-            }
-        "#,
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern {
-                #[link_name = "cargo_test_foo"]
-                fn foo();
-            }
+                extern {
+                    #[link_name = "cargo_test_foo"]
+                    fn foo();
+                }
 
-            fn main() {
-                unsafe { foo(); }
-            }
-        "#,
+                fn main() {
+                    unsafe { foo(); }
+                }
+            "#,
         );
     let p2 = p2.build();
 
@@ -3770,17 +3770,17 @@ fn optional_build_script_dep() {
         .file(
             "build.rs",
             r#"
-            #[cfg(feature = "bar")]
-            extern crate bar;
+                #[cfg(feature = "bar")]
+                extern crate bar;
 
-            fn main() {
-                #[cfg(feature = "bar")] {
-                    println!("cargo:rustc-env=FOO={}", bar::bar());
-                    return
+                fn main() {
+                    #[cfg(feature = "bar")] {
+                        println!("cargo:rustc-env=FOO={}", bar::bar());
+                        return
+                    }
+                    println!("cargo:rustc-env=FOO=0");
                 }
-                println!("cargo:rustc-env=FOO=0");
-            }
-        "#,
+            "#,
         )
         .file(
             "src/main.rs",

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -10,10 +10,10 @@ fn rerun_if_env_changes() {
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rerun-if-env-changed=FOO");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rerun-if-env-changed=FOO");
+                }
+            "#,
         )
         .build();
 
@@ -64,11 +64,11 @@ fn rerun_if_env_or_file_changes() {
         .file(
             "build.rs",
             r#"
-            fn main() {
-                println!("cargo:rerun-if-env-changed=FOO");
-                println!("cargo:rerun-if-changed=foo");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rerun-if-env-changed=FOO");
+                    println!("cargo:rerun-if-changed=foo");
+                }
+            "#,
         )
         .file("foo", "")
         .build();

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -10,9 +10,9 @@ fn alias_incorrect_config_type() {
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            b-cargo-test = 5
-        "#,
+                [alias]
+                b-cargo-test = 5
+            "#,
         )
         .build();
 
@@ -34,9 +34,9 @@ fn alias_config() {
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            b-cargo-test = "build"
-        "#,
+                [alias]
+                b-cargo-test = "build"
+            "#,
         )
         .build();
 
@@ -53,14 +53,14 @@ fn alias_config() {
 fn recursive_alias() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", r"fn main() {}")
+        .file("src/main.rs", "fn main() {}")
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            b-cargo-test = "build"
-            a-cargo-test = ["b-cargo-test", "-v"]
-        "#,
+                [alias]
+                b-cargo-test = "build"
+                a-cargo-test = ["b-cargo-test", "-v"]
+            "#,
         )
         .build();
 
@@ -81,9 +81,9 @@ fn alias_list_test() {
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            b-cargo-test = ["build", "--release"]
-         "#,
+               [alias]
+               b-cargo-test = ["build", "--release"]
+            "#,
         )
         .build();
 
@@ -101,9 +101,9 @@ fn alias_with_flags_config() {
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            b-cargo-test = "build --release"
-         "#,
+               [alias]
+               b-cargo-test = "build --release"
+            "#,
         )
         .build();
 
@@ -121,9 +121,9 @@ fn alias_cannot_shadow_builtin_command() {
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            build = "fetch"
-         "#,
+               [alias]
+               build = "fetch"
+            "#,
         )
         .build();
 
@@ -146,9 +146,9 @@ fn alias_override_builtin_alias() {
         .file(
             ".cargo/config",
             r#"
-            [alias]
-            b = "run"
-         "#,
+               [alias]
+               b = "run"
+            "#,
         )
         .build();
 

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -162,10 +162,10 @@ error: no such subcommand: `biuld`
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                println!("Similar, but not identical to, build");
-            }
-        "#,
+                fn main() {
+                    println!("Similar, but not identical to, build");
+                }
+            "#,
         )
         .publish();
 
@@ -314,11 +314,11 @@ fn cargo_subcommand_args() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                let args: Vec<_> = ::std::env::args().collect();
-                println!("{:?}", args);
-            }
-        "#,
+                fn main() {
+                    let args: Vec<_> = ::std::env::args().collect();
+                    println!("{:?}", args);
+                }
+            "#,
         )
         .build();
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -8,12 +8,12 @@ fn feature_required() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-            im-a-teapot = true
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+                im-a-teapot = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -61,13 +61,13 @@ fn unknown_feature() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["foo"]
+                cargo-features = ["foo"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -90,13 +90,13 @@ fn stable_feature_warns() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["test-dummy-stable"]
+                cargo-features = ["test-dummy-stable"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -118,14 +118,14 @@ fn nightly_feature_requires_nightly() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["test-dummy-unstable"]
+                cargo-features = ["test-dummy-unstable"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-            im-a-teapot = true
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+                im-a-teapot = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -160,27 +160,27 @@ fn nightly_feature_requires_nightly_in_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            cargo-features = ["test-dummy-unstable"]
+                cargo-features = ["test-dummy-unstable"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-            im-a-teapot = true
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+                im-a-teapot = true
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -225,14 +225,14 @@ fn cant_publish() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["test-dummy-unstable"]
+                cargo-features = ["test-dummy-unstable"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-            im-a-teapot = true
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+                im-a-teapot = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -267,14 +267,14 @@ fn z_flags_rejected() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["test-dummy-unstable"]
+                cargo-features = ["test-dummy-unstable"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-            im-a-teapot = true
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+                im-a-teapot = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -313,13 +313,13 @@ fn publish_allowed() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["test-dummy-unstable"]
+                cargo-features = ["test-dummy-unstable"]
 
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -10,16 +10,16 @@ fn cfg_easy() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [target.'cfg(unix)'.dependencies]
-            b = { path = 'b' }
-            [target."cfg(windows)".dependencies]
-            b = { path = 'b' }
-        "#,
+                [target.'cfg(unix)'.dependencies]
+                b = { path = 'b' }
+                [target."cfg(windows)".dependencies]
+                b = { path = 'b' }
+            "#,
         )
         .file("src/lib.rs", "extern crate b;")
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
@@ -36,14 +36,14 @@ fn dont_include() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "a"
+                    version = "0.0.1"
+                    authors = []
 
-            [target.'cfg({})'.dependencies]
-            b = {{ path = 'b' }}
-        "#,
+                    [target.'cfg({})'.dependencies]
+                    b = {{ path = 'b' }}
+                "#,
                 other_family
             ),
         )
@@ -73,14 +73,14 @@ fn works_through_the_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -116,17 +116,17 @@ fn ignore_version_from_other_platform() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [target.'cfg({})'.dependencies]
-            bar = "0.1.0"
+                    [target.'cfg({})'.dependencies]
+                    bar = "0.1.0"
 
-            [target.'cfg({})'.dependencies]
-            bar = "0.2.0"
-        "#,
+                    [target.'cfg({})'.dependencies]
+                    bar = "0.2.0"
+                "#,
                 this_family, other_family
             ),
         )
@@ -156,14 +156,14 @@ fn bad_target_spec() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [target.'cfg(4)'.dependencies]
-            bar = "0.1.0"
-        "#,
+                [target.'cfg(4)'.dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -187,14 +187,14 @@ fn bad_target_spec2() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [target.'cfg(bar =)'.dependencies]
-            baz = "0.1.0"
-        "#,
+                [target.'cfg(bar =)'.dependencies]
+                baz = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -219,25 +219,25 @@ fn multiple_match_ok() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "a"
+                    version = "0.0.1"
+                    authors = []
 
-            [target.'cfg(unix)'.dependencies]
-            b = {{ path = 'b' }}
-            [target.'cfg(target_family = "unix")'.dependencies]
-            b = {{ path = 'b' }}
-            [target."cfg(windows)".dependencies]
-            b = {{ path = 'b' }}
-            [target.'cfg(target_family = "windows")'.dependencies]
-            b = {{ path = 'b' }}
-            [target."cfg(any(windows, unix))".dependencies]
-            b = {{ path = 'b' }}
+                    [target.'cfg(unix)'.dependencies]
+                    b = {{ path = 'b' }}
+                    [target.'cfg(target_family = "unix")'.dependencies]
+                    b = {{ path = 'b' }}
+                    [target."cfg(windows)".dependencies]
+                    b = {{ path = 'b' }}
+                    [target.'cfg(target_family = "windows")'.dependencies]
+                    b = {{ path = 'b' }}
+                    [target."cfg(any(windows, unix))".dependencies]
+                    b = {{ path = 'b' }}
 
-            [target.{}.dependencies]
-            b = {{ path = 'b' }}
-        "#,
+                    [target.{}.dependencies]
+                    b = {{ path = 'b' }}
+                "#,
                 rustc_host()
             ),
         )
@@ -254,14 +254,14 @@ fn any_ok() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [target."cfg(any(windows, unix))".dependencies]
-            b = { path = 'b' }
-        "#,
+                [target."cfg(any(windows, unix))".dependencies]
+                b = { path = 'b' }
+            "#,
         )
         .file("src/lib.rs", "extern crate b;")
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
@@ -278,23 +278,23 @@ fn cfg_looks_at_rustflags_for_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [target.'cfg(with_b)'.dependencies]
-            b = { path = 'b' }
-        "#,
+                [target.'cfg(with_b)'.dependencies]
+                b = { path = 'b' }
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[cfg(with_b)]
-            extern crate b;
+                #[cfg(with_b)]
+                extern crate b;
 
-            fn main() { b::foo(); }
-        "#,
+                fn main() { b::foo(); }
+            "#,
         )
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "pub fn foo() {}")
@@ -317,51 +317,51 @@ fn bad_cfg_discovery() {
         .file(
             "src/main.rs",
             r#"
-fn run_rustc() -> String {
-    let mut cmd = std::process::Command::new("rustc");
-    for arg in std::env::args_os().skip(1) {
-        cmd.arg(arg);
-    }
-    String::from_utf8(cmd.output().unwrap().stdout).unwrap()
-}
+            fn run_rustc() -> String {
+                let mut cmd = std::process::Command::new("rustc");
+                for arg in std::env::args_os().skip(1) {
+                    cmd.arg(arg);
+                }
+                String::from_utf8(cmd.output().unwrap().stdout).unwrap()
+            }
 
-fn main() {
-    let mode = std::env::var("FUNKY_MODE").unwrap();
-    if mode == "bad-version" {
-        println!("foo");
-        return;
-    }
-    if std::env::args_os().any(|a| a == "-vV") {
-        print!("{}", run_rustc());
-        return;
-    }
-    if mode == "no-crate-types" {
-        return;
-    }
-    if mode == "bad-crate-type" {
-        println!("foo");
-        return;
-    }
-    let output = run_rustc();
-    let mut lines = output.lines();
-    let sysroot = loop {
-        let line = lines.next().unwrap();
-        if line.contains("___") {
-            println!("{}", line);
-        } else {
-            break line;
-        }
-    };
-    if mode == "no-sysroot" {
-        return;
-    }
-    println!("{}", sysroot);
-    if mode != "bad-cfg" {
-        panic!("unexpected");
-    }
-    println!("123");
-}
-"#,
+            fn main() {
+                let mode = std::env::var("FUNKY_MODE").unwrap();
+                if mode == "bad-version" {
+                    println!("foo");
+                    return;
+                }
+                if std::env::args_os().any(|a| a == "-vV") {
+                    print!("{}", run_rustc());
+                    return;
+                }
+                if mode == "no-crate-types" {
+                    return;
+                }
+                if mode == "bad-crate-type" {
+                    println!("foo");
+                    return;
+                }
+                let output = run_rustc();
+                let mut lines = output.lines();
+                let sysroot = loop {
+                    let line = lines.next().unwrap();
+                    if line.contains("___") {
+                        println!("{}", line);
+                    } else {
+                        break line;
+                    }
+                };
+                if mode == "no-sysroot" {
+                    return;
+                }
+                println!("{}", sysroot);
+                if mode != "bad-cfg" {
+                    panic!("unexpected");
+                }
+                println!("123");
+            }
+            "#,
         )
         .build();
     p.cargo("build").run();

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -13,14 +13,14 @@ fn check_success() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -42,14 +42,14 @@ fn check_fail() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -74,33 +74,33 @@ fn custom_derive() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-#[macro_use]
-extern crate bar;
+            #[macro_use]
+            extern crate bar;
 
-trait B {
-    fn b(&self);
-}
+            trait B {
+                fn b(&self);
+            }
 
-#[derive(B)]
-struct A;
+            #[derive(B)]
+            struct A;
 
-fn main() {
-    let a = A;
-    a.b();
-}
-"#,
+            fn main() {
+                let a = A;
+                a.b();
+            }
+            "#,
         )
         .build();
     let _bar = project()
@@ -108,26 +108,26 @@ fn main() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            [lib]
-            proc-macro = true
-        "#,
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-extern crate proc_macro;
+            extern crate proc_macro;
 
-use proc_macro::TokenStream;
+            use proc_macro::TokenStream;
 
-#[proc_macro_derive(B)]
-pub fn derive(_input: TokenStream) -> TokenStream {
-    format!("impl B for A {{ fn b(&self) {{}} }}").parse().unwrap()
-}
-"#,
+            #[proc_macro_derive(B)]
+            pub fn derive(_input: TokenStream) -> TokenStream {
+                format!("impl B for A {{ fn b(&self) {{}} }}").parse().unwrap()
+            }
+            "#,
         )
         .build();
 
@@ -140,14 +140,14 @@ fn check_build() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -171,14 +171,14 @@ fn build_check() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -218,54 +218,56 @@ fn issue_3419() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            rustc-serialize = "*"
-        "#,
+                [dependencies]
+                rustc-serialize = "*"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate rustc_serialize;
+                extern crate rustc_serialize;
 
-            use rustc_serialize::Decodable;
+                use rustc_serialize::Decodable;
 
-            pub fn take<T: Decodable>() {}
-        "#,
+                pub fn take<T: Decodable>() {}
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate rustc_serialize;
+                extern crate rustc_serialize;
 
-            extern crate foo;
+                extern crate foo;
 
-            #[derive(RustcDecodable)]
-            pub struct Foo;
+                #[derive(RustcDecodable)]
+                pub struct Foo;
 
-            fn main() {
-                foo::take::<Foo>();
-            }
-        "#,
+                fn main() {
+                    foo::take::<Foo>();
+                }
+            "#,
         )
         .build();
 
     Package::new("rustc-serialize", "1.0.0")
         .file(
             "src/lib.rs",
-            r#"pub trait Decodable: Sized {
+            r#"
+                pub trait Decodable: Sized {
                     fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error>;
-                 }
-                 pub trait Decoder {
-                    type Error;
-                    fn read_struct<T, F>(&mut self, s_name: &str, len: usize, f: F)
-                                         -> Result<T, Self::Error>
-                    where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
-                 } "#,
+                }
+                pub trait Decoder {
+                   type Error;
+                   fn read_struct<T, F>(&mut self, s_name: &str, len: usize, f: F)
+                                        -> Result<T, Self::Error>
+                   where F: FnOnce(&mut Self) -> Result<T, Self::Error>;
+                }
+            "#,
         )
         .publish();
 
@@ -279,16 +281,16 @@ fn dylib_check_preserves_build_cache() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [lib]
-            crate-type = ["dylib"]
+                [lib]
+                crate-type = ["dylib"]
 
-            [dependencies]
-        "#,
+                [dependencies]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -316,14 +318,14 @@ fn rustc_check() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -351,14 +353,14 @@ fn rustc_check_err() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -385,15 +387,15 @@ fn check_all() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [workspace]
-            [dependencies]
-            b = { path = "b" }
-        "#,
+                [workspace]
+                [dependencies]
+                b = { path = "b" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("examples/a.rs", "fn main() {}")
@@ -418,9 +420,9 @@ fn check_virtual_all_implied() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -440,10 +442,11 @@ fn exclude_warns_on_non_existing_package() {
     p.cargo("check --workspace --exclude bar")
         .with_stdout("")
         .with_stderr(
-            r#"[WARNING] excluded package(s) bar not found in workspace `[CWD]`
+            "\
+[WARNING] excluded package(s) bar not found in workspace `[CWD]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-"#,
+",
         )
         .run();
 }
@@ -492,14 +495,14 @@ fn check_unit_test_profile() {
         .file(
             "src/lib.rs",
             r#"
-            #[cfg(test)]
-            mod tests {
-                #[test]
-                fn it_works() {
-                    badtext
+                #[cfg(test)]
+                mod tests {
+                    #[test]
+                    fn it_works() {
+                        badtext
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
 
@@ -517,54 +520,54 @@ fn check_filters() {
         .file(
             "src/lib.rs",
             r#"
-            fn unused_normal_lib() {}
-            #[cfg(test)]
-            mod tests {
-                fn unused_unit_lib() {}
-            }
-        "#,
+                fn unused_normal_lib() {}
+                #[cfg(test)]
+                mod tests {
+                    fn unused_unit_lib() {}
+                }
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {}
-            fn unused_normal_bin() {}
-            #[cfg(test)]
-            mod tests {
-                fn unused_unit_bin() {}
-            }
-        "#,
+                fn main() {}
+                fn unused_normal_bin() {}
+                #[cfg(test)]
+                mod tests {
+                    fn unused_unit_bin() {}
+                }
+            "#,
         )
         .file(
             "tests/t1.rs",
             r#"
-            fn unused_normal_t1() {}
-            #[cfg(test)]
-            mod tests {
-                fn unused_unit_t1() {}
-            }
-        "#,
+                fn unused_normal_t1() {}
+                #[cfg(test)]
+                mod tests {
+                    fn unused_unit_t1() {}
+                }
+            "#,
         )
         .file(
             "examples/ex1.rs",
             r#"
-            fn main() {}
-            fn unused_normal_ex1() {}
-            #[cfg(test)]
-            mod tests {
-                fn unused_unit_ex1() {}
-            }
-        "#,
+                fn main() {}
+                fn unused_normal_ex1() {}
+                #[cfg(test)]
+                mod tests {
+                    fn unused_unit_ex1() {}
+                }
+            "#,
         )
         .file(
             "benches/b1.rs",
             r#"
-            fn unused_normal_b1() {}
-            #[cfg(test)]
-            mod tests {
-                fn unused_unit_b1() {}
-            }
-        "#,
+                fn unused_normal_b1() {}
+                #[cfg(test)]
+                mod tests {
+                    fn unused_unit_b1() {}
+                }
+            "#,
         )
         .build();
 
@@ -784,9 +787,9 @@ fn rustc_workspace_wrapper_affects_all_workspace_members() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -809,17 +812,17 @@ fn rustc_workspace_wrapper_includes_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
+                [workspace]
+                members = ["bar"]
 
-            [dependencies]
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                baz = { path = "baz" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -844,9 +847,9 @@ fn rustc_workspace_wrapper_respects_primary_units() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -869,17 +872,17 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
+                [workspace]
+                members = ["bar"]
 
-            [dependencies]
-            baz = "1.0.0"
-        "#,
+                [dependencies]
+                baz = "1.0.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -41,19 +41,19 @@ fn clean_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies.d1]
-                path = "d1"
-            [dependencies.d2]
-                path = "d2"
-
-            [[bin]]
+                [package]
                 name = "foo"
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.d1]
+                    path = "d1"
+                [dependencies.d2]
+                    path = "d2"
+
+                [[bin]]
+                    name = "foo"
+            "#,
         )
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
         .file("d1/Cargo.toml", &basic_bin_manifest("d1"))
@@ -92,14 +92,14 @@ fn clean_release() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -135,14 +135,14 @@ fn clean_doc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -167,29 +167,29 @@ fn build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "build.rs",
             r#"
-            use std::path::PathBuf;
-            use std::env;
+                use std::path::PathBuf;
+                use std::env;
 
-            fn main() {
-                let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-                if env::var("FIRST").is_ok() {
-                    std::fs::File::create(out.join("out")).unwrap();
-                } else {
-                    assert!(!out.join("out").exists());
+                fn main() {
+                    let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+                    if env::var("FIRST").is_ok() {
+                        std::fs::File::create(out.join("out")).unwrap();
+                    } else {
+                        assert!(!out.join("out").exists());
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -222,14 +222,14 @@ fn clean_git() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            dep = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    dep = {{ git = '{}' }}
+                "#,
                 git.url()
             ),
         )
@@ -247,14 +247,14 @@ fn registry() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
-        "#,
+                [dependencies]
+                bar = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -272,13 +272,13 @@ fn clean_verbose() {
         .file(
             "Cargo.toml",
             r#"
-        [package]
-        name = "foo"
-        version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-        [dependencies]
-        bar = "0.1"
-    "#,
+                [dependencies]
+                bar = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -120,27 +120,27 @@ fn multiple_registry_fetches() {
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("a/src/main.rs", "fn main() {}")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.0"
+                [package]
+                name = "bar"
+                authors = []
+                version = "0.0.0"
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("b/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -195,14 +195,14 @@ fn git_same_repo_different_tags() {
             "a/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                    [package]
+                    name = "foo"
+                    authors = []
+                    version = "0.0.0"
 
-            [dependencies]
-            dep = {{ git = '{}', tag = 'tag1' }}
-        "#,
+                    [dependencies]
+                    dep = {{ git = '{}', tag = 'tag1' }}
+                "#,
                 a.url()
             ),
         )
@@ -214,14 +214,14 @@ fn git_same_repo_different_tags() {
             "b/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.0"
+                    [package]
+                    name = "bar"
+                    authors = []
+                    version = "0.0.0"
 
-            [dependencies]
-            dep = {{ git = '{}', tag = 'tag2' }}
-        "#,
+                    [dependencies]
+                    dep = {{ git = '{}', tag = 'tag2' }}
+                "#,
                 a.url()
             ),
         )
@@ -261,14 +261,14 @@ fn git_same_branch_different_revs() {
             "a/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                    [package]
+                    name = "foo"
+                    authors = []
+                    version = "0.0.0"
 
-            [dependencies]
-            dep = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    dep = {{ git = '{}' }}
+                "#,
                 a.url()
             ),
         )
@@ -280,14 +280,14 @@ fn git_same_branch_different_revs() {
             "b/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.0"
+                    [package]
+                    name = "bar"
+                    authors = []
+                    version = "0.0.0"
 
-            [dependencies]
-            dep = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    dep = {{ git = '{}' }}
+                "#,
                 a.url()
             ),
         )
@@ -359,27 +359,27 @@ fn killing_cargo_releases_the_lock() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
+                build = "build.rs"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "build.rs",
             r#"
-            use std::net::TcpStream;
+                use std::net::TcpStream;
 
-            fn main() {
-                if std::env::var("A").is_ok() {
-                    TcpStream::connect(&std::env::var("ADDR").unwrap()[..])
-                              .unwrap();
-                    std::thread::sleep(std::time::Duration::new(10, 0));
+                fn main() {
+                    if std::env::var("A").is_ok() {
+                        TcpStream::connect(&std::env::var("ADDR").unwrap()[..])
+                                  .unwrap();
+                        std::thread::sleep(std::time::Duration::new(10, 0));
+                    }
                 }
-            }
-        "#,
+            "#,
         );
     let p = p.build();
 
@@ -469,15 +469,15 @@ fn no_deadlock_with_git_dependencies() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                    [package]
+                    name = "foo"
+                    authors = []
+                    version = "0.0.0"
 
-            [dependencies]
-            dep1 = {{ git = '{}' }}
-            dep2 = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    dep1 = {{ git = '{}' }}
+                    dep2 = {{ git = '{}' }}
+                "#,
                 dep1.url(),
                 dep2.url()
             ),

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -110,22 +110,22 @@ fn read_env_vars_for_config() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            use std::env;
-            fn main() {
-                assert_eq!(env::var("NUM_JOBS").unwrap(), "100");
-            }
-        "#,
+                use std::env;
+                fn main() {
+                    assert_eq!(env::var("NUM_JOBS").unwrap(), "100");
+                }
+            "#,
         )
         .build();
 

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -21,14 +21,14 @@ fn deleting_database_files() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
 
-            [dependencies]
-            bar = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    bar = {{ git = '{}' }}
+                "#,
                 git_project.url()
             ),
         )
@@ -79,14 +79,14 @@ fn deleting_checkout_files() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
 
-            [dependencies]
-            bar = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    bar = {{ git = '{}' }}
+                "#,
                 git_project.url()
             ),
         )

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -15,21 +15,21 @@ fn simple_cross() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
             &format!(
                 r#"
-            fn main() {{
-                assert_eq!(std::env::var("TARGET").unwrap(), "{}");
-            }}
-        "#,
+                    fn main() {{
+                        assert_eq!(std::env::var("TARGET").unwrap(), "{}");
+                    }}
+                "#,
                 cross_compile::alternate()
             ),
         )
@@ -37,11 +37,11 @@ fn simple_cross() {
             "src/main.rs",
             &format!(
                 r#"
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -67,30 +67,30 @@ fn simple_cross_config() {
             ".cargo/config",
             &format!(
                 r#"
-            [build]
-            target = "{}"
-        "#,
+                    [build]
+                    target = "{}"
+                "#,
                 cross_compile::alternate()
             ),
         )
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
             &format!(
                 r#"
-            fn main() {{
-                assert_eq!(std::env::var("TARGET").unwrap(), "{}");
-            }}
-        "#,
+                    fn main() {{
+                        assert_eq!(std::env::var("TARGET").unwrap(), "{}");
+                    }}
+                "#,
                 cross_compile::alternate()
             ),
         )
@@ -98,11 +98,11 @@ fn simple_cross_config() {
             "src/main.rs",
             &format!(
                 r#"
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -127,14 +127,14 @@ fn simple_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::bar(); }")
         .build();
@@ -165,9 +165,9 @@ fn linker() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}]
-            linker = "my-linker-tool"
-        "#,
+                    [target.{}]
+                    linker = "my-linker-tool"
+                "#,
                 target
             ),
         )
@@ -176,11 +176,11 @@ fn linker() {
             "src/foo.rs",
             &format!(
                 r#"
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -220,23 +220,23 @@ fn plugin_with_extra_dylib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #![feature(plugin)]
-            #![plugin(bar)]
+                #![feature(plugin)]
+                #![plugin(bar)]
 
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .build();
     let _bar = project()
@@ -244,34 +244,34 @@ fn plugin_with_extra_dylib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            plugin = true
+                [lib]
+                name = "bar"
+                plugin = true
 
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(plugin_registrar, rustc_private)]
+                #![feature(plugin_registrar, rustc_private)]
 
-            extern crate baz;
-            extern crate rustc_driver;
+                extern crate baz;
+                extern crate rustc_driver;
 
-            use rustc_driver::plugin::Registry;
+                use rustc_driver::plugin::Registry;
 
-            #[plugin_registrar]
-            pub fn foo(reg: &mut Registry) {
-                println!("{}", baz::baz());
-            }
-        "#,
+                #[plugin_registrar]
+                pub fn foo(reg: &mut Registry) {
+                    println!("{}", baz::baz());
+                }
+            "#,
         )
         .build();
     let _baz = project()
@@ -279,15 +279,15 @@ fn plugin_with_extra_dylib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "baz"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "baz"
-            crate_type = ["dylib"]
-        "#,
+                [lib]
+                name = "baz"
+                crate_type = ["dylib"]
+            "#,
         )
         .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
         .build();
@@ -306,27 +306,27 @@ fn cross_tests() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            authors = []
-            version = "0.0.0"
+                [project]
+                name = "foo"
+                authors = []
+                version = "0.0.0"
 
-            [[bin]]
-            name = "bar"
-        "#,
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file(
             "src/bin/bar.rs",
             &format!(
                 r#"
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-            #[test] fn test() {{ main() }}
-        "#,
+                    #[allow(unused_extern_crates)]
+                    extern crate foo;
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                    #[test] fn test() {{ main() }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -334,10 +334,10 @@ fn cross_tests() {
             "src/lib.rs",
             &format!(
                 r#"
-            use std::env;
-            pub fn foo() {{ assert_eq!(env::consts::ARCH, "{}"); }}
-            #[test] fn test_foo() {{ foo() }}
-        "#,
+                    use std::env;
+                    pub fn foo() {{ assert_eq!(env::consts::ARCH, "{}"); }}
+                    #[test] fn test_foo() {{ foo() }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -369,11 +369,11 @@ fn no_cross_doctests() {
         .file(
             "src/lib.rs",
             r#"
-            //! ```
-            //! extern crate foo;
-            //! assert!(true);
-            //! ```
-        "#,
+                //! ```
+                //! extern crate foo;
+                //! assert!(true);
+                //! ```
+            "#,
         )
         .build();
 
@@ -448,11 +448,11 @@ fn simple_cargo_run() {
             "src/main.rs",
             &format!(
                 r#"
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -473,36 +473,36 @@ fn cross_with_a_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = 'build.rs'
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = 'build.rs'
+            "#,
         )
         .file(
             "build.rs",
             &format!(
                 r#"
-            use std::env;
-            use std::path::PathBuf;
-            fn main() {{
-                assert_eq!(env::var("TARGET").unwrap(), "{0}");
-                let mut path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-                assert_eq!(path.file_name().unwrap().to_str().unwrap(), "out");
-                path.pop();
-                assert!(path.file_name().unwrap().to_str().unwrap()
-                            .starts_with("foo-"));
-                path.pop();
-                assert_eq!(path.file_name().unwrap().to_str().unwrap(), "build");
-                path.pop();
-                assert_eq!(path.file_name().unwrap().to_str().unwrap(), "debug");
-                path.pop();
-                assert_eq!(path.file_name().unwrap().to_str().unwrap(), "{0}");
-                path.pop();
-                assert_eq!(path.file_name().unwrap().to_str().unwrap(), "target");
-            }}
-        "#,
+                    use std::env;
+                    use std::path::PathBuf;
+                    fn main() {{
+                        assert_eq!(env::var("TARGET").unwrap(), "{0}");
+                        let mut path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "out");
+                        path.pop();
+                        assert!(path.file_name().unwrap().to_str().unwrap()
+                                    .starts_with("foo-"));
+                        path.pop();
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "build");
+                        path.pop();
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "debug");
+                        path.pop();
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "{0}");
+                        path.pop();
+                        assert_eq!(path.file_name().unwrap().to_str().unwrap(), "target");
+                    }}
+                "#,
                 target
             ),
         )
@@ -536,25 +536,25 @@ fn build_script_needed_for_host_and_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = 'build.rs'
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = 'build.rs'
 
-            [dependencies.d1]
-            path = "d1"
-            [build-dependencies.d2]
-            path = "d2"
-        "#,
+                [dependencies.d1]
+                path = "d1"
+                [build-dependencies.d2]
+                path = "d2"
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate d2;
-            fn main() { d2::d2(); }
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate d2;
+                fn main() { d2::d2(); }
+            "#,
         )
         .file(
             "src/main.rs",
@@ -567,35 +567,35 @@ fn build_script_needed_for_host_and_target() {
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.0"
-            authors = []
-            build = 'build.rs'
-        "#,
+                [package]
+                name = "d1"
+                version = "0.0.0"
+                authors = []
+                build = 'build.rs'
+            "#,
         )
         .file("d1/src/lib.rs", "pub fn d1() {}")
         .file(
             "d1/build.rs",
             r#"
-            use std::env;
-            fn main() {
-                let target = env::var("TARGET").unwrap();
-                println!("cargo:rustc-flags=-L /path/to/{}", target);
-            }
-        "#,
+                use std::env;
+                fn main() {
+                    let target = env::var("TARGET").unwrap();
+                    println!("cargo:rustc-flags=-L /path/to/{}", target);
+                }
+            "#,
         )
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "d2"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.d1]
-            path = "../d1"
-        "#,
+                [dependencies.d1]
+                path = "../d1"
+            "#,
         )
         .file(
             "d2/src/lib.rs",
@@ -644,14 +644,14 @@ fn build_deps_for_the_right_arch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies.d2]
-            path = "d2"
-        "#,
+                [dependencies.d2]
+                path = "d2"
+            "#,
         )
         .file("src/main.rs", "extern crate d2; fn main() {}")
         .file("d1/Cargo.toml", &basic_manifest("d1", "0.0.0"))
@@ -659,15 +659,15 @@ fn build_deps_for_the_right_arch() {
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "d2"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.d1]
-            path = "../d1"
-        "#,
+                [build-dependencies.d1]
+                path = "../d1"
+            "#,
         )
         .file("d2/build.rs", "extern crate d1; fn main() {}")
         .file("d2/src/lib.rs", "")
@@ -687,40 +687,40 @@ fn build_script_only_host() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.d1]
-            path = "d1"
-        "#,
+                [build-dependencies.d1]
+                path = "d1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("build.rs", "extern crate d1; fn main() {}")
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "d1"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("d1/src/lib.rs", "pub fn d1() {}")
         .file(
             "d1/build.rs",
             r#"
-            use std::env;
+                use std::env;
 
-            fn main() {
-                assert!(env::var("OUT_DIR").unwrap().replace("\\", "/")
-                                           .contains("target/debug/build/d1-"),
-                        "bad: {:?}", env::var("OUT_DIR"));
-            }
-        "#,
+                fn main() {
+                    assert!(env::var("OUT_DIR").unwrap().replace("\\", "/")
+                                               .contains("target/debug/build/d1-"),
+                            "bad: {:?}", env::var("OUT_DIR"));
+                }
+            "#,
         )
         .build();
 
@@ -737,16 +737,16 @@ fn plugin_build_script_right_arch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [lib]
-            name = "foo"
-            plugin = true
-        "#,
+                [lib]
+                name = "foo"
+                plugin = true
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
@@ -778,15 +778,15 @@ fn build_script_with_platform_specific_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [build-dependencies.d1]
-            path = "d1"
-        "#,
+                [build-dependencies.d1]
+                path = "d1"
+            "#,
         )
         .file(
             "build.rs",
@@ -801,14 +801,14 @@ fn build_script_with_platform_specific_dependencies() {
             "d1/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "d1"
-            version = "0.0.0"
-            authors = []
+                    [package]
+                    name = "d1"
+                    version = "0.0.0"
+                    authors = []
 
-            [target.{}.dependencies]
-            d2 = {{ path = "../d2" }}
-        "#,
+                    [target.{}.dependencies]
+                    d2 = {{ path = "../d2" }}
+                "#,
                 host
             ),
         )
@@ -851,18 +851,18 @@ fn platform_specific_dependencies_do_not_leak() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [dependencies.d1]
-            path = "d1"
+                [dependencies.d1]
+                path = "d1"
 
-            [build-dependencies.d1]
-            path = "d1"
-        "#,
+                [build-dependencies.d1]
+                path = "d1"
+            "#,
         )
         .file("build.rs", "extern crate d1; fn main() {}")
         .file("src/lib.rs", "")
@@ -870,14 +870,14 @@ fn platform_specific_dependencies_do_not_leak() {
             "d1/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "d1"
-            version = "0.0.0"
-            authors = []
+                    [package]
+                    name = "d1"
+                    version = "0.0.0"
+                    authors = []
 
-            [target.{}.dependencies]
-            d2 = {{ path = "../d2" }}
-        "#,
+                    [target.{}.dependencies]
+                    d2 = {{ path = "../d2" }}
+                "#,
                 host
             ),
         )
@@ -906,18 +906,18 @@ fn platform_specific_variables_reflected_in_build_scripts() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
+                    build = "build.rs"
 
-            [target.{host}.dependencies]
-            d1 = {{ path = "d1" }}
+                    [target.{host}.dependencies]
+                    d1 = {{ path = "d1" }}
 
-            [target.{target}.dependencies]
-            d2 = {{ path = "d2" }}
-        "#,
+                    [target.{target}.dependencies]
+                    d2 = {{ path = "d2" }}
+                "#,
                 host = host,
                 target = target
             ),
@@ -926,22 +926,22 @@ fn platform_specific_variables_reflected_in_build_scripts() {
             "build.rs",
             &format!(
                 r#"
-            use std::env;
+                    use std::env;
 
-            fn main() {{
-                let platform = env::var("TARGET").unwrap();
-                let (expected, not_expected) = match &platform[..] {{
-                    "{host}" => ("DEP_D1_VAL", "DEP_D2_VAL"),
-                    "{target}" => ("DEP_D2_VAL", "DEP_D1_VAL"),
-                    _ => panic!("unknown platform")
-                }};
+                    fn main() {{
+                        let platform = env::var("TARGET").unwrap();
+                        let (expected, not_expected) = match &platform[..] {{
+                            "{host}" => ("DEP_D1_VAL", "DEP_D2_VAL"),
+                            "{target}" => ("DEP_D2_VAL", "DEP_D1_VAL"),
+                            _ => panic!("unknown platform")
+                        }};
 
-                env::var(expected).ok()
-                    .expect(&format!("missing {{}}", expected));
-                env::var(not_expected).err()
-                    .expect(&format!("found {{}}", not_expected));
-            }}
-        "#,
+                        env::var(expected).ok()
+                            .expect(&format!("missing {{}}", expected));
+                        env::var(not_expected).err()
+                            .expect(&format!("found {{}}", not_expected));
+                    }}
+                "#,
                 host = host,
                 target = target
             ),
@@ -950,26 +950,26 @@ fn platform_specific_variables_reflected_in_build_scripts() {
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.0"
-            authors = []
-            links = "d1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "d1"
+                version = "0.0.0"
+                authors = []
+                links = "d1"
+                build = "build.rs"
+            "#,
         )
         .file("d1/build.rs", r#"fn main() { println!("cargo:val=1") }"#)
         .file("d1/src/lib.rs", "")
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.0"
-            authors = []
-            links = "d2"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "d2"
+                version = "0.0.0"
+                authors = []
+                links = "d2"
+                build = "build.rs"
+            "#,
         )
         .file("d2/build.rs", r#"fn main() { println!("cargo:val=1") }"#)
         .file("d2/src/lib.rs", "")
@@ -993,61 +993,61 @@ fn cross_test_dylib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate_type = ["dylib"]
+                [lib]
+                name = "foo"
+                crate_type = ["dylib"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar as the_bar;
+                extern crate bar as the_bar;
 
-            pub fn bar() { the_bar::baz(); }
+                pub fn bar() { the_bar::baz(); }
 
-            #[test]
-            fn foo() { bar(); }
-        "#,
+                #[test]
+                fn foo() { bar(); }
+            "#,
         )
         .file(
             "tests/test.rs",
             r#"
-            extern crate foo as the_foo;
+                extern crate foo as the_foo;
 
-            #[test]
-            fn foo() { the_foo::bar(); }
-        "#,
+                #[test]
+                fn foo() { the_foo::bar(); }
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            crate_type = ["dylib"]
-        "#,
+                [lib]
+                name = "bar"
+                crate_type = ["dylib"]
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             &format!(
                 r#"
-             use std::env;
-             pub fn baz() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                     use std::env;
+                     pub fn baz() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -14,24 +14,24 @@ fn simple_cross_package() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            repository = "bar"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                repository = "bar"
+            "#,
         )
         .file(
             "src/main.rs",
             &format!(
                 r#"
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )
@@ -72,24 +72,24 @@ fn publish_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            repository = "bar"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                repository = "bar"
+            "#,
         )
         .file(
             "src/main.rs",
             &format!(
                 r#"
-            use std::env;
-            fn main() {{
-                assert_eq!(env::consts::ARCH, "{}");
-            }}
-        "#,
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
                 cross_compile::alternate_arch()
             ),
         )

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -13,38 +13,38 @@ fn custom_target_minimal() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(no_core)]
-            #![feature(lang_items)]
-            #![no_core]
+                #![feature(no_core)]
+                #![feature(lang_items)]
+                #![no_core]
 
-            pub fn foo() -> u32 {
-                42
-            }
+                pub fn foo() -> u32 {
+                    42
+                }
 
-            #[lang = "sized"]
-            pub trait Sized {
-                // Empty.
-            }
-            #[lang = "copy"]
-            pub trait Copy {
-                // Empty.
-            }
-        "#,
+                #[lang = "sized"]
+                pub trait Sized {
+                    // Empty.
+                }
+                #[lang = "copy"]
+                pub trait Copy {
+                    // Empty.
+                }
+            "#,
         )
         .file(
             "custom-target.json",
             r#"
-            {
-                "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
-                "arch": "x86_64",
-                "target-endian": "little",
-                "target-pointer-width": "64",
-                "target-c-int-width": "32",
-                "os": "none",
-                "linker-flavor": "ld.lld"
-            }
-        "#,
+                {
+                    "llvm-target": "x86_64-unknown-none-gnu",
+                    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                    "arch": "x86_64",
+                    "target-endian": "little",
+                    "target-pointer-width": "64",
+                    "target-c-int-width": "32",
+                    "os": "none",
+                    "linker-flavor": "ld.lld"
+                }
+            "#,
         )
         .build();
 
@@ -69,70 +69,70 @@ fn custom_target_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "foo"
-            version = "0.0.1"
-            authors = ["author@example.com"]
+                name = "foo"
+                version = "0.0.1"
+                authors = ["author@example.com"]
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(no_core)]
-            #![feature(lang_items)]
-            #![feature(optin_builtin_traits)]
-            #![no_core]
+                #![feature(no_core)]
+                #![feature(lang_items)]
+                #![feature(optin_builtin_traits)]
+                #![no_core]
 
-            extern crate bar;
+                extern crate bar;
 
-            pub fn foo() -> u32 {
-                bar::bar()
-            }
+                pub fn foo() -> u32 {
+                    bar::bar()
+                }
 
-            #[lang = "freeze"]
-            unsafe auto trait Freeze {}
-        "#,
+                #[lang = "freeze"]
+                unsafe auto trait Freeze {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file(
             "bar/src/lib.rs",
             r#"
-            #![feature(no_core)]
-            #![feature(lang_items)]
-            #![no_core]
+                #![feature(no_core)]
+                #![feature(lang_items)]
+                #![no_core]
 
-            pub fn bar() -> u32 {
-                42
-            }
+                pub fn bar() -> u32 {
+                    42
+                }
 
-            #[lang = "sized"]
-            pub trait Sized {
-                // Empty.
-            }
-            #[lang = "copy"]
-            pub trait Copy {
-                // Empty.
-            }
-        "#,
+                #[lang = "sized"]
+                pub trait Sized {
+                    // Empty.
+                }
+                #[lang = "copy"]
+                pub trait Copy {
+                    // Empty.
+                }
+            "#,
         )
         .file(
             "custom-target.json",
             r#"
-            {
-                "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
-                "arch": "x86_64",
-                "target-endian": "little",
-                "target-pointer-width": "64",
-                "target-c-int-width": "32",
-                "os": "none",
-                "linker-flavor": "ld.lld"
-            }
-        "#,
+                {
+                    "llvm-target": "x86_64-unknown-none-gnu",
+                    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                    "arch": "x86_64",
+                    "target-endian": "little",
+                    "target-pointer-width": "64",
+                    "target-c-int-width": "32",
+                    "os": "none",
+                    "linker-flavor": "ld.lld"
+                }
+            "#,
         )
         .build();
 
@@ -149,37 +149,37 @@ fn custom_bin_target() {
         .file(
             "src/main.rs",
             r#"
-            #![feature(no_core)]
-            #![feature(lang_items)]
-            #![no_core]
-            #![no_main]
+                #![feature(no_core)]
+                #![feature(lang_items)]
+                #![no_core]
+                #![no_main]
 
-            #[lang = "sized"]
-            pub trait Sized {
-                // Empty.
-            }
-            #[lang = "copy"]
-            pub trait Copy {
-                // Empty.
-            }
-        "#,
+                #[lang = "sized"]
+                pub trait Sized {
+                    // Empty.
+                }
+                #[lang = "copy"]
+                pub trait Copy {
+                    // Empty.
+                }
+            "#,
         )
         .file(
             "custom-bin-target.json",
             r#"
-            {
-                "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
-                "arch": "x86_64",
-                "target-endian": "little",
-                "target-pointer-width": "64",
-                "target-c-int-width": "32",
-                "os": "none",
-                "linker-flavor": "ld.lld",
-                "linker": "rust-lld",
-                "executables": true
-            }
-        "#,
+                {
+                    "llvm-target": "x86_64-unknown-none-gnu",
+                    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                    "arch": "x86_64",
+                    "target-endian": "little",
+                    "target-pointer-width": "64",
+                    "target-c-int-width": "32",
+                    "os": "none",
+                    "linker-flavor": "ld.lld",
+                    "linker": "rust-lld",
+                    "executables": true
+                }
+            "#,
         )
         .build();
 

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -17,27 +17,27 @@ fn ctrl_c_kills_everyone() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             &format!(
                 r#"
-            use std::net::TcpStream;
-            use std::io::Read;
+                    use std::net::TcpStream;
+                    use std::io::Read;
 
-            fn main() {{
-                let mut socket = TcpStream::connect("{}").unwrap();
-                let _ = socket.read(&mut [0; 10]);
-                panic!("that read should never return");
-            }}
-        "#,
+                    fn main() {{
+                        let mut socket = TcpStream::connect("{}").unwrap();
+                        let _ = socket.read(&mut [0; 10]);
+                        panic!("that read should never return");
+                    }}
+                "#,
                 addr
             ),
         )

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -109,15 +109,15 @@ fn build_dep_info_lib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["lib"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["lib"]
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
@@ -134,15 +134,15 @@ fn build_dep_info_rlib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["rlib"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["rlib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")
@@ -158,15 +158,15 @@ fn build_dep_info_dylib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[example]]
-            name = "ex"
-            crate-type = ["dylib"]
-        "#,
+                [[example]]
+                name = "ex"
+                crate-type = ["dylib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/ex.rs", "")

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -88,14 +88,14 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -126,14 +126,14 @@ fn simple_install() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.0.1"
-        "#,
+                [dependencies]
+                foo = "0.0.1"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -168,15 +168,15 @@ fn simple_install_fail() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.1.0"
-            baz = "9.8.7"
-        "#,
+                [dependencies]
+                foo = "0.1.0"
+                baz = "9.8.7"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -212,18 +212,18 @@ fn install_without_feature_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.0.1"
-            baz = { version = "9.8.7", optional = true }
+                [dependencies]
+                foo = "0.0.1"
+                baz = { version = "9.8.7", optional = true }
 
-            [features]
-            wantbaz = ["baz"]
-        "#,
+                [features]
+                wantbaz = ["baz"]
+            "#,
         )
         .file(
             "src/main.rs",
@@ -256,14 +256,14 @@ fn not_there() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -303,14 +303,14 @@ fn multiple() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -335,14 +335,14 @@ fn crates_io_then_directory() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -392,14 +392,14 @@ fn crates_io_then_bad_checksum() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -451,14 +451,14 @@ fn bad_file_checksum() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -496,14 +496,14 @@ fn only_dot_files_ok() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -529,14 +529,14 @@ fn random_files_ok() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -562,14 +562,14 @@ fn git_lock_file_doesnt_change() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            git = {{ git = '{0}' }}
-        "#,
+                    [dependencies]
+                    git = {{ git = '{0}' }}
+                "#,
                 git.url()
             ),
         )
@@ -623,14 +623,14 @@ fn git_override_requires_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            git = { git = 'https://example.com/' }
-        "#,
+                [dependencies]
+                git = { git = 'https://example.com/' }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -13,12 +13,12 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "pub fn foo() {}")
@@ -43,15 +43,15 @@ fn doc_no_libs() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name = "foo"
-            doc = false
-        "#,
+                [[bin]]
+                name = "foo"
+                doc = false
+            "#,
         )
         .file("src/main.rs", "bad code")
         .build();
@@ -81,14 +81,14 @@ fn doc_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "extern crate bar; pub fn foo() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -130,14 +130,14 @@ fn doc_no_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "extern crate bar; pub fn foo() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -165,14 +165,14 @@ fn doc_only_bin() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; pub fn foo() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -192,30 +192,30 @@ fn doc_multiple_targets_same_name_lib() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar"]
-        "#,
+                [workspace]
+                members = ["foo", "bar"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [lib]
-            name = "foo_lib"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [lib]
+                name = "foo_lib"
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            [lib]
-            name = "foo_lib"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                [lib]
+                name = "foo_lib"
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -234,31 +234,31 @@ fn doc_multiple_targets_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar"]
-        "#,
+                [workspace]
+                members = ["foo", "bar"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [[bin]]
-            name = "foo_lib"
-            path = "src/foo_lib.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [[bin]]
+                name = "foo_lib"
+                path = "src/foo_lib.rs"
+            "#,
         )
         .file("foo/src/foo_lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            [lib]
-            name = "foo_lib"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                [lib]
+                name = "foo_lib"
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -279,30 +279,30 @@ fn doc_multiple_targets_same_name_bin() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar"]
-        "#,
+                [workspace]
+                members = ["foo", "bar"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [[bin]]
-            name = "foo-cli"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [[bin]]
+                name = "foo-cli"
+            "#,
         )
         .file("foo/src/foo-cli.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            [[bin]]
-            name = "foo-cli"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                [[bin]]
+                name = "foo-cli"
+            "#,
         )
         .file("bar/src/foo-cli.rs", "")
         .build();
@@ -321,31 +321,31 @@ fn doc_multiple_targets_same_name_undoced() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar"]
-        "#,
+                [workspace]
+                members = ["foo", "bar"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [[bin]]
-            name = "foo-cli"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [[bin]]
+                name = "foo-cli"
+            "#,
         )
         .file("foo/src/foo-cli.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            [[bin]]
-            name = "foo-cli"
-            doc = false
-        "#,
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                [[bin]]
+                name = "foo-cli"
+                doc = false
+            "#,
         )
         .file("bar/src/foo-cli.rs", "")
         .build();
@@ -359,19 +359,19 @@ fn doc_lib_bin_same_name_documents_lib() {
         .file(
             "src/main.rs",
             r#"
-            //! Binary documentation
-            extern crate foo;
-            fn main() {
-                foo::foo();
-            }
-        "#,
+                //! Binary documentation
+                extern crate foo;
+                fn main() {
+                    foo::foo();
+                }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            //! Library documentation
-            pub fn foo() {}
-        "#,
+                //! Library documentation
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -394,19 +394,19 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
         .file(
             "src/main.rs",
             r#"
-            //! Binary documentation
-            extern crate foo;
-            fn main() {
-                foo::foo();
-            }
-        "#,
+                //! Binary documentation
+                extern crate foo;
+                fn main() {
+                    foo::foo();
+                }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            //! Library documentation
-            pub fn foo() {}
-        "#,
+                //! Library documentation
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -429,19 +429,19 @@ fn doc_lib_bin_same_name_documents_named_bin_when_requested() {
         .file(
             "src/main.rs",
             r#"
-            //! Binary documentation
-            extern crate foo;
-            fn main() {
-                foo::foo();
-            }
-        "#,
+                //! Binary documentation
+                extern crate foo;
+                fn main() {
+                    foo::foo();
+                }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            //! Library documentation
-            pub fn foo() {}
-        "#,
+                //! Library documentation
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -465,19 +465,19 @@ fn doc_lib_bin_same_name_documents_bins_when_requested() {
         .file(
             "src/main.rs",
             r#"
-            //! Binary documentation
-            extern crate foo;
-            fn main() {
-                foo::foo();
-            }
-        "#,
+                //! Binary documentation
+                extern crate foo;
+                fn main() {
+                    foo::foo();
+                }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            //! Library documentation
-            pub fn foo() {}
-        "#,
+                //! Library documentation
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -501,27 +501,27 @@ fn doc_dash_p() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "extern crate a;")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.b]
-            path = "../b"
-        "#,
+                [dependencies.b]
+                path = "../b"
+            "#,
         )
         .file("a/src/lib.rs", "extern crate b;")
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
@@ -564,16 +564,16 @@ fn doc_target() {
         .file(
             "src/lib.rs",
             r#"
-            #![feature(no_core, lang_items)]
-            #![no_core]
+                #![feature(no_core, lang_items)]
+                #![no_core]
 
-            #[lang = "sized"]
-            trait Sized {}
+                #[lang = "sized"]
+                trait Sized {}
 
-            extern {
-                pub static A: u32;
-            }
-        "#,
+                extern {
+                    pub static A: u32;
+                }
+            "#,
         )
         .build();
 
@@ -591,14 +591,14 @@ fn target_specific_not_documented() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [target.foo.dependencies]
-            a = { path = "a" }
-        "#,
+                [target.foo.dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -614,14 +614,14 @@ fn output_not_captured() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -650,16 +650,16 @@ fn target_specific_documented() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [target.foo.dependencies]
-            a = {{ path = "a" }}
-            [target.{}.dependencies]
-            a = {{ path = "a" }}
-        "#,
+                    [target.foo.dependencies]
+                    a = {{ path = "a" }}
+                    [target.{}.dependencies]
+                    a = {{ path = "a" }}
+                "#,
                 rustc_host()
             ),
         )
@@ -691,14 +691,14 @@ fn no_document_build_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [build-dependencies]
-            a = { path = "a" }
-        "#,
+                [build-dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -738,17 +738,17 @@ fn doc_multiple_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
+                [dependencies.bar]
+                path = "bar"
 
-            [dependencies.baz]
-            path = "baz"
-        "#,
+                [dependencies.baz]
+                path = "baz"
+            "#,
         )
         .file("src/lib.rs", "extern crate bar; pub fn foo() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -770,38 +770,38 @@ fn features() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
+                [dependencies.bar]
+                path = "bar"
 
-            [features]
-            foo = ["bar/bar"]
-        "#,
+                [features]
+                foo = ["bar/bar"]
+            "#,
         )
         .file("src/lib.rs", r#"#[cfg(feature = "foo")] pub fn foo() {}"#)
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            bar = []
-        "#,
+                [features]
+                bar = []
+            "#,
         )
         .file(
             "bar/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rustc-cfg=bar");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rustc-cfg=bar");
+                }
+            "#,
         )
         .file(
             "bar/src/lib.rs",
@@ -820,9 +820,9 @@ fn rerun_when_dir_removed() {
         .file(
             "src/lib.rs",
             r#"
-            /// dox
-            pub fn foo() {}
-        "#,
+                /// dox
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -841,19 +841,19 @@ fn document_only_lib() {
         .file(
             "src/lib.rs",
             r#"
-            /// dox
-            pub fn foo() {}
-        "#,
+                /// dox
+                pub fn foo() {}
+            "#,
         )
         .file(
             "src/bin/bar.rs",
             r#"
-            /// ```
-            /// ☃
-            /// ```
-            pub fn foo() {}
-            fn main() { foo(); }
-        "#,
+                /// ```
+                /// ☃
+                /// ```
+                pub fn foo() {}
+                fn main() { foo(); }
+            "#,
         )
         .build();
     p.cargo("doc --lib").run();
@@ -866,14 +866,14 @@ fn plugins_no_use_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            proc-macro = true
-        "#,
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -886,15 +886,15 @@ fn doc_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -915,9 +915,9 @@ fn doc_all_virtual_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -938,9 +938,9 @@ fn doc_virtual_manifest_all_implied() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -961,20 +961,20 @@ fn doc_all_member_dependency_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
+                [project]
+                name = "bar"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
@@ -994,9 +994,9 @@ fn doc_workspace_open_help_message() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar"]
-        "#,
+                [workspace]
+                members = ["foo", "bar"]
+            "#,
         )
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
@@ -1020,19 +1020,19 @@ fn doc_workspace_open_different_library_and_package_names() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo"]
-        "#,
+                [workspace]
+                members = ["foo"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [lib]
-            name = "foolib"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [lib]
+                name = "foolib"
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .build();
@@ -1051,20 +1051,20 @@ fn doc_workspace_open_binary() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo"]
-        "#,
+                [workspace]
+                members = ["foo"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [[bin]]
-            name = "foobin"
-            path = "src/main.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [[bin]]
+                name = "foobin"
+                path = "src/main.rs"
+            "#,
         )
         .file("foo/src/main.rs", "")
         .build();
@@ -1083,22 +1083,22 @@ fn doc_workspace_open_binary_and_library() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo"]
-        "#,
+                [workspace]
+                members = ["foo"]
+            "#,
         )
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [lib]
-            name = "foolib"
-            [[bin]]
-            name = "foobin"
-            path = "src/main.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [lib]
+                name = "foolib"
+                [[bin]]
+                name = "foobin"
+                path = "src/main.rs"
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .file("foo/src/main.rs", "")
@@ -1117,12 +1117,12 @@ fn doc_edition() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            edition = "2018"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                edition = "2018"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1142,14 +1142,14 @@ fn doc_target_edition() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            edition = "2018"
-        "#,
+                [lib]
+                edition = "2018"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1171,17 +1171,17 @@ fn issue_5345() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [target.'cfg(all(windows, target_arch = "x86"))'.dependencies]
-            bar = "0.1"
+                [target.'cfg(all(windows, target_arch = "x86"))'.dependencies]
+                bar = "0.1"
 
-            [target.'cfg(not(all(windows, target_arch = "x86")))'.dependencies]
-            bar = "0.2"
-        "#,
+                [target.'cfg(not(all(windows, target_arch = "x86")))'.dependencies]
+                bar = "0.2"
+            "#,
         )
         .file("src/lib.rs", "extern crate bar;")
         .build();
@@ -1212,9 +1212,9 @@ fn doc_private_ws() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
         .file("a/src/lib.rs", "fn p() {}")
@@ -1258,14 +1258,14 @@ fn doc_cap_lints() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            a = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    a = {{ git = '{}' }}
+                "#,
                 a.url()
             ),
         )
@@ -1378,11 +1378,11 @@ fn bin_private_items() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1430,14 +1430,14 @@ fn bin_private_items_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1483,11 +1483,11 @@ fn crate_versions() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.2.4"
-            authors = []
-        "#,
+                [package]
+                name = "foo"
+                version = "1.2.4"
+                authors = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1514,11 +1514,11 @@ fn crate_versions_flag_is_overridden() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "1.2.4"
-            authors = []
-        "#,
+                [package]
+                name = "foo"
+                version = "1.2.4"
+                authors = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -10,14 +10,14 @@ fn invalid1() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            bar = ["baz"]
-        "#,
+                [features]
+                bar = ["baz"]
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -41,17 +41,17 @@ fn invalid2() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            bar = ["baz"]
+                [features]
+                bar = ["baz"]
 
-            [dependencies.bar]
-            path = "foo"
-        "#,
+                [dependencies.bar]
+                path = "foo"
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -75,17 +75,17 @@ fn invalid3() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            bar = ["baz"]
+                [features]
+                bar = ["baz"]
 
-            [dependencies.baz]
-            path = "foo"
-        "#,
+                [dependencies.baz]
+                path = "foo"
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -110,15 +110,15 @@ fn invalid4() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            features = ["bar"]
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                features = ["bar"]
+            "#,
         )
         .file("src/main.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -154,15 +154,15 @@ fn invalid5() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies.bar]
-            path = "bar"
-            optional = true
-        "#,
+                [dev-dependencies.bar]
+                path = "bar"
+                optional = true
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -186,14 +186,14 @@ fn invalid6() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            foo = ["bar/baz"]
-        "#,
+                [features]
+                foo = ["bar/baz"]
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -217,15 +217,15 @@ fn invalid7() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            foo = ["bar/baz"]
-            bar = []
-        "#,
+                [features]
+                foo = ["bar/baz"]
+                bar = []
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -249,15 +249,15 @@ fn invalid8() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            features = ["foo/bar"]
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                features = ["foo/bar"]
+            "#,
         )
         .file("src/main.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -276,14 +276,14 @@ fn invalid9() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -304,28 +304,28 @@ fn invalid10() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            features = ["baz"]
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                features = ["baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.baz]
-            path = "baz"
-        "#,
+                [dependencies.baz]
+                path = "baz"
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .file("bar/baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
@@ -352,56 +352,56 @@ fn no_transitive_dep_feature_requirement() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.derived]
-            path = "derived"
+                [dependencies.derived]
+                path = "derived"
 
-            [features]
-            default = ["derived/bar/qux"]
-        "#,
+                [features]
+                default = ["derived/bar/qux"]
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate derived;
-            fn main() { derived::test(); }
-        "#,
+                extern crate derived;
+                fn main() { derived::test(); }
+            "#,
         )
         .file(
             "derived/Cargo.toml",
             r#"
-            [package]
-            name = "derived"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "derived"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("derived/src/lib.rs", "extern crate bar; pub use bar::test;")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            qux = []
-        "#,
+                [features]
+                qux = []
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #[cfg(feature = "qux")]
-            pub fn test() { print!("test"); }
-        "#,
+                #[cfg(feature = "qux")]
+                pub fn test() { print!("test"); }
+            "#,
         )
         .build();
     p.cargo("build")
@@ -416,26 +416,26 @@ fn no_feature_doesnt_build() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[cfg(feature = "bar")]
-            extern crate bar;
-            #[cfg(feature = "bar")]
-            fn main() { bar::bar(); println!("bar") }
-            #[cfg(not(feature = "bar"))]
-            fn main() {}
-        "#,
+                #[cfg(feature = "bar")]
+                extern crate bar;
+                #[cfg(feature = "bar")]
+                fn main() { bar::bar(); println!("bar") }
+                #[cfg(not(feature = "bar"))]
+                fn main() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -469,29 +469,29 @@ fn default_feature_pulled_in() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["bar"]
+                [features]
+                default = ["bar"]
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[cfg(feature = "bar")]
-            extern crate bar;
-            #[cfg(feature = "bar")]
-            fn main() { bar::bar(); println!("bar") }
-            #[cfg(not(feature = "bar"))]
-            fn main() {}
-        "#,
+                #[cfg(feature = "bar")]
+                extern crate bar;
+                #[cfg(feature = "bar")]
+                fn main() { bar::bar(); println!("bar") }
+                #[cfg(not(feature = "bar"))]
+                fn main() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -525,14 +525,14 @@ fn cyclic_feature() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["default"]
-        "#,
+                [features]
+                default = ["default"]
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -549,15 +549,15 @@ fn cyclic_feature2() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            foo = ["bar"]
-            bar = ["foo"]
-        "#,
+                [features]
+                foo = ["bar"]
+                bar = ["foo"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -571,39 +571,39 @@ fn groups_on_groups_on_groups() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["f1"]
-            f1 = ["f2", "bar"]
-            f2 = ["f3", "f4"]
-            f3 = ["f5", "f6", "baz"]
-            f4 = ["f5", "f7"]
-            f5 = ["f6"]
-            f6 = ["f7"]
-            f7 = ["bar"]
+                [features]
+                default = ["f1"]
+                f1 = ["f2", "bar"]
+                f2 = ["f3", "f4"]
+                f3 = ["f5", "f6", "baz"]
+                f4 = ["f5", "f7"]
+                f5 = ["f6"]
+                f6 = ["f7"]
+                f7 = ["bar"]
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
+                [dependencies.bar]
+                path = "bar"
+                optional = true
 
-            [dependencies.baz]
-            path = "baz"
-            optional = true
-        "#,
+                [dependencies.baz]
+                path = "baz"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate bar;
-            #[allow(unused_extern_crates)]
-            extern crate baz;
-            fn main() {}
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate bar;
+                #[allow(unused_extern_crates)]
+                extern crate baz;
+                fn main() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -629,29 +629,29 @@ fn many_cli_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
+                [dependencies.bar]
+                path = "bar"
+                optional = true
 
-            [dependencies.baz]
-            path = "baz"
-            optional = true
-        "#,
+                [dependencies.baz]
+                path = "baz"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate bar;
-            #[allow(unused_extern_crates)]
-            extern crate baz;
-            fn main() {}
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate bar;
+                #[allow(unused_extern_crates)]
+                extern crate baz;
+                fn main() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -678,68 +678,68 @@ fn union_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.d1]
-            path = "d1"
-            features = ["f1"]
-            [dependencies.d2]
-            path = "d2"
-            features = ["f2"]
-        "#,
+                [dependencies.d1]
+                path = "d1"
+                features = ["f1"]
+                [dependencies.d2]
+                path = "d2"
+                features = ["f2"]
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate d1;
-            extern crate d2;
-            fn main() {
-                d2::f1();
-                d2::f2();
-            }
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate d1;
+                extern crate d2;
+                fn main() {
+                    d2::f1();
+                    d2::f2();
+                }
+            "#,
         )
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "d1"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            f1 = ["d2"]
+                [features]
+                f1 = ["d2"]
 
-            [dependencies.d2]
-            path = "../d2"
-            features = ["f1"]
-            optional = true
-        "#,
+                [dependencies.d2]
+                path = "../d2"
+                features = ["f1"]
+                optional = true
+            "#,
         )
         .file("d1/src/lib.rs", "")
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "d2"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            f1 = []
-            f2 = []
-        "#,
+                [features]
+                f1 = []
+                f2 = []
+            "#,
         )
         .file(
             "d2/src/lib.rs",
             r#"
-            #[cfg(feature = "f1")] pub fn f1() {}
-            #[cfg(feature = "f2")] pub fn f2() {}
-        "#,
+                #[cfg(feature = "f1")] pub fn f1() {}
+                #[cfg(feature = "f2")] pub fn f2() {}
+            "#,
         )
         .build();
 
@@ -761,30 +761,30 @@ fn many_features_no_rebuilds() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name    = "b"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name    = "b"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies.a]
-            path = "a"
-            features = ["fall"]
-        "#,
+                [dependencies.a]
+                path = "a"
+                features = ["fall"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name    = "a"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name    = "a"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            ftest  = []
-            ftest2 = []
-            fall   = ["ftest", "ftest2"]
-        "#,
+                [features]
+                ftest  = []
+                ftest2 = []
+                fall   = ["ftest", "ftest2"]
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -826,30 +826,30 @@ fn transitive_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            foo = ["bar/baz"]
+                [features]
+                foo = ["bar/baz"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::baz(); }")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            baz = []
-        "#,
+                [features]
+                baz = []
+            "#,
         )
         .file(
             "bar/src/lib.rs",
@@ -866,37 +866,37 @@ fn everything_in_the_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            f1 = ["d1/f1"]
-            f2 = ["d2"]
+                [features]
+                f1 = ["d1/f1"]
+                f2 = ["d2"]
 
-            [dependencies.d1]
-            path = "d1"
-            [dependencies.d2]
-            path = "d2"
-            optional = true
-            [dependencies.d3]
-            path = "d3"
-            optional = true
-        "#,
+                [dependencies.d1]
+                path = "d1"
+                [dependencies.d2]
+                path = "d2"
+                optional = true
+                [dependencies.d3]
+                path = "d3"
+                optional = true
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "d1"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            f1 = []
-        "#,
+                [features]
+                f1 = []
+            "#,
         )
         .file("d1/src/lib.rs", "")
         .file("d2/Cargo.toml", &basic_manifest("d2", "0.0.2"))
@@ -904,14 +904,14 @@ fn everything_in_the_lockfile() {
         .file(
             "d3/Cargo.toml",
             r#"
-            [package]
-            name = "d3"
-            version = "0.0.3"
-            authors = []
+                [package]
+                name = "d3"
+                version = "0.0.3"
+                authors = []
 
-            [features]
-            f3 = []
-        "#,
+                [features]
+                f3 = []
+            "#,
         )
         .file("d3/src/lib.rs", "")
         .build();
@@ -941,42 +941,42 @@ fn no_rebuild_when_frobbing_default_feature() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-            b = { path = "b" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+                b = { path = "b" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            a = { path = "../a", features = ["f1"], default-features = false }
-        "#,
+                [dependencies]
+                a = { path = "../a", features = ["f1"], default-features = false }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            default = ["f1"]
-            f1 = []
-        "#,
+                [features]
+                default = ["f1"]
+                f1 = []
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -992,42 +992,42 @@ fn unions_work_with_no_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-            b = { path = "b" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+                b = { path = "b" }
+            "#,
         )
         .file("src/lib.rs", "extern crate a; pub fn foo() { a::a(); }")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            a = { path = "../a", features = [], default-features = false }
-        "#,
+                [dependencies]
+                a = { path = "../a", features = [], default-features = false }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            default = ["f1"]
-            f1 = []
-        "#,
+                [features]
+                default = ["f1"]
+                f1 = []
+            "#,
         )
         .file("a/src/lib.rs", r#"#[cfg(feature = "f1")] pub fn a() {}"#)
         .build();
@@ -1043,16 +1043,16 @@ fn optional_and_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name    = "test"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name    = "test"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = "foo", optional = true }
-            [dev-dependencies]
-            foo = { path = "foo" }
-        "#,
+                [dependencies]
+                foo = { path = "foo", optional = true }
+                [dev-dependencies]
+                foo = { path = "foo" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -1075,17 +1075,17 @@ fn activating_feature_activates_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name    = "test"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name    = "test"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = "foo", optional = true }
+                [dependencies]
+                foo = { path = "foo", optional = true }
 
-            [features]
-            a = ["foo/a"]
-        "#,
+                [features]
+                a = ["foo/a"]
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -1094,14 +1094,14 @@ fn activating_feature_activates_dep() {
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            a = []
-        "#,
+                [features]
+                a = []
+            "#,
         )
         .file("foo/src/lib.rs", r#"#[cfg(feature = "a")] pub fn bar() {}"#)
         .build();
@@ -1115,57 +1115,57 @@ fn dep_feature_in_cmd_line() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.derived]
-            path = "derived"
-        "#,
+                [dependencies.derived]
+                path = "derived"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate derived;
-            fn main() { derived::test(); }
-        "#,
+                extern crate derived;
+                fn main() { derived::test(); }
+            "#,
         )
         .file(
             "derived/Cargo.toml",
             r#"
-            [package]
-            name = "derived"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "derived"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
+                [dependencies.bar]
+                path = "../bar"
 
-            [features]
-            default = []
-            derived-feat = ["bar/some-feat"]
-        "#,
+                [features]
+                default = []
+                derived-feat = ["bar/some-feat"]
+            "#,
         )
         .file("derived/src/lib.rs", "extern crate bar; pub use bar::test;")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            some-feat = []
-        "#,
+                [features]
+                some-feat = []
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #[cfg(feature = "some-feat")]
-            pub fn test() { print!("test"); }
-        "#,
+                #[cfg(feature = "some-feat")]
+                pub fn test() { print!("test"); }
+            "#,
         )
         .build();
 
@@ -1199,37 +1199,37 @@ fn all_features_flag_enables_all_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            foo = []
-            bar = []
+                [features]
+                foo = []
+                bar = []
 
-            [dependencies.baz]
-            path = "baz"
-            optional = true
-        "#,
+                [dependencies.baz]
+                path = "baz"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[cfg(feature = "foo")]
-            pub fn foo() {}
+                #[cfg(feature = "foo")]
+                pub fn foo() {}
 
-            #[cfg(feature = "bar")]
-            pub fn bar() {
-                extern crate baz;
-                baz::baz();
-            }
+                #[cfg(feature = "bar")]
+                pub fn bar() {
+                    extern crate baz;
+                    baz::baz();
+                }
 
-            fn main() {
-                foo();
-                bar();
-            }
-        "#,
+                fn main() {
+                    foo();
+                    bar();
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
@@ -1244,29 +1244,29 @@ fn many_cli_features_comma_delimited() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
+                [dependencies.bar]
+                path = "bar"
+                optional = true
 
-            [dependencies.baz]
-            path = "baz"
-            optional = true
-        "#,
+                [dependencies.baz]
+                path = "baz"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate bar;
-            #[allow(unused_extern_crates)]
-            extern crate baz;
-            fn main() {}
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate bar;
+                #[allow(unused_extern_crates)]
+                extern crate baz;
+                fn main() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -1292,41 +1292,41 @@ fn many_cli_features_comma_and_space_delimited() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
+                [dependencies.bar]
+                path = "bar"
+                optional = true
 
-            [dependencies.baz]
-            path = "baz"
-            optional = true
+                [dependencies.baz]
+                path = "baz"
+                optional = true
 
-            [dependencies.bam]
-            path = "bam"
-            optional = true
+                [dependencies.bam]
+                path = "bam"
+                optional = true
 
-            [dependencies.bap]
-            path = "bap"
-            optional = true
-        "#,
+                [dependencies.bap]
+                path = "bap"
+                optional = true
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate bar;
-            #[allow(unused_extern_crates)]
-            extern crate baz;
-            #[allow(unused_extern_crates)]
-            extern crate bam;
-            #[allow(unused_extern_crates)]
-            extern crate bap;
-            fn main() {}
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate bar;
+                #[allow(unused_extern_crates)]
+                extern crate baz;
+                #[allow(unused_extern_crates)]
+                extern crate bam;
+                #[allow(unused_extern_crates)]
+                extern crate bap;
+                fn main() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -1359,17 +1359,17 @@ fn namespaced_invalid_feature() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            bar = ["baz"]
-        "#,
+                [features]
+                bar = ["baz"]
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -1394,17 +1394,17 @@ fn namespaced_invalid_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            bar = ["crate:baz"]
-        "#,
+                [features]
+                bar = ["crate:baz"]
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -1429,20 +1429,20 @@ fn namespaced_non_optional_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            bar = ["crate:baz"]
+                [features]
+                bar = ["crate:baz"]
 
-            [dependencies]
-            baz = "0.1"
-        "#,
+                [dependencies]
+                baz = "0.1"
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -1468,20 +1468,20 @@ fn namespaced_implicit_feature() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            bar = ["baz"]
+                [features]
+                bar = ["baz"]
 
-            [dependencies]
-            baz = { version = "0.1", optional = true }
-        "#,
+                [dependencies]
+                baz = { version = "0.1", optional = true }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1495,20 +1495,20 @@ fn namespaced_shadowed_dep() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            baz = []
+                [features]
+                baz = []
 
-            [dependencies]
-            baz = { version = "0.1", optional = true }
-        "#,
+                [dependencies]
+                baz = { version = "0.1", optional = true }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1531,20 +1531,20 @@ fn namespaced_shadowed_non_optional() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            baz = []
+                [features]
+                baz = []
 
-            [dependencies]
-            baz = "0.1"
-        "#,
+                [dependencies]
+                baz = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1568,20 +1568,20 @@ fn namespaced_implicit_non_optional() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            bar = ["baz"]
+                [features]
+                bar = ["baz"]
 
-            [dependencies]
-            baz = "0.1"
-        "#,
+                [dependencies]
+                baz = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1603,20 +1603,20 @@ fn namespaced_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["namespaced-features"]
+                cargo-features = ["namespaced-features"]
 
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            namespaced-features = true
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                namespaced-features = true
 
-            [features]
-            baz = ["crate:baz"]
+                [features]
+                baz = ["crate:baz"]
 
-            [dependencies]
-            baz = { version = "0.1", optional = true }
-        "#,
+                [dependencies]
+                baz = { version = "0.1", optional = true }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1695,52 +1695,52 @@ fn feature_off_dylib() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
+                [workspace]
+                members = ["bar"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            crate-type = ["dylib"]
+                [lib]
+                crate-type = ["dylib"]
 
-            [features]
-            f1 = []
-        "#,
+                [features]
+                f1 = []
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn hello() -> &'static str {
-                if cfg!(feature = "f1") {
-                    "f1"
-                } else {
-                    "no f1"
+                pub fn hello() -> &'static str {
+                    if cfg!(feature = "f1") {
+                        "f1"
+                    } else {
+                        "no f1"
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
+                [package]
+                name = "bar"
+                version = "0.0.1"
 
-            [dependencies]
-            foo = { path = ".." }
-        "#,
+                [dependencies]
+                foo = { path = ".." }
+            "#,
         )
         .file(
             "bar/src/main.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            fn main() {
-                assert_eq!(foo::hello(), "no f1");
-            }
-        "#,
+                fn main() {
+                    assert_eq!(foo::hello(), "no f1");
+                }
+            "#,
         )
         .build();
 
@@ -1756,18 +1756,18 @@ fn warn_if_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+               [project]
+               name = "foo"
+               version = "0.0.1"
+               authors = []
 
-            [dependencies.bar]
-            path = "bar"
-            optional = true
+               [dependencies.bar]
+               path = "bar"
+               optional = true
 
-            [features]
-            default-features = ["bar"]
-         "#,
+               [features]
+               default-features = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -1797,7 +1797,7 @@ fn no_feature_for_non_optional_dep() {
 
                 [dependencies]
                 bar = { path = "bar" }
-             "#,
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1817,7 +1817,7 @@ fn no_feature_for_non_optional_dep() {
 
                 [features]
                 a = []
-             "#,
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
@@ -1839,7 +1839,7 @@ fn features_option_given_twice() {
                 [features]
                 a = []
                 b = []
-             "#,
+            "#,
         )
         .file(
             "src/main.rs",
@@ -2219,7 +2219,8 @@ fn nonexistent_required_features() {
                                  "required_dependency/not_existing",
                                  "required_dependency/simple",
                                  "optional_dependency/optional",
-                                 "not_specified_dependency/some_feature"]"#,
+                                 "not_specified_dependency/some_feature"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("examples/ololo.rs", "fn main() {}")
@@ -2227,9 +2228,10 @@ fn nonexistent_required_features() {
 
     p.cargo("build --examples")
         .with_stderr_contains(
-            r#"warning: feature `not_present` is not present in [features] section.
-warning: feature `not_existing` does not exist in package `required_dependency v0.1.0`.
-warning: dependency `not_specified_dependency` specified in required-features as `not_specified_dependency/some_feature` does not exist."#,
+"[WARNING] feature `not_present` is not present in [features] section.
+[WARNING] feature `not_existing` does not exist in package `required_dependency v0.1.0`.
+[WARNING] dependency `not_specified_dependency` specified in required-features as `not_specified_dependency/some_feature` does not exist.
+",
         )
         .run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1262,17 +1262,17 @@ fn build_dep_activated() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            # This should never be selected.
-            [target.'{}'.build-dependencies]
-            targetdep = "1.0"
+                # This should never be selected.
+                [target.'{}'.build-dependencies]
+                targetdep = "1.0"
 
-            [target.'{}'.build-dependencies]
-            hostdep = {{version="1.0", features=["feat1"]}}
-            "#,
+                [target.'{}'.build-dependencies]
+                hostdep = {{version="1.0", features=["feat1"]}}
+                "#,
                 alternate(),
                 rustc_host()
             ),

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -37,17 +37,17 @@ fn fetch_all_platform_dependencies_when_no_target_is_given() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [target.{host}.dependencies]
-            d1 = "1.2.3"
+                    [target.{host}.dependencies]
+                    d1 = "1.2.3"
 
-            [target.{target}.dependencies]
-            d2 = "0.1.2"
-        "#,
+                    [target.{target}.dependencies]
+                    d2 = "0.1.2"
+                "#,
                 host = host,
                 target = target
             ),
@@ -84,17 +84,17 @@ fn fetch_platform_specific_dependencies() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [target.{host}.dependencies]
-            d1 = "1.2.3"
+                    [target.{host}.dependencies]
+                    d1 = "1.2.3"
 
-            [target.{target}.dependencies]
-            d2 = "0.1.2"
-        "#,
+                    [target.{target}.dependencies]
+                    d2 = "0.1.2"
+                "#,
                 host = host,
                 target = target
             ),

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -76,7 +76,7 @@ fn broken_fixes_backed_out() {
         )
         .file(
             "foo/src/main.rs",
-            r##"
+            r#"
                 use std::env;
                 use std::fs;
                 use std::io::Write;
@@ -106,7 +106,7 @@ fn broken_fixes_backed_out() {
                         .expect("failed to run rustc");
                     process::exit(status.code().unwrap_or(2));
                 }
-            "##,
+            "#,
         )
         .file(
             "bar/Cargo.toml",
@@ -664,9 +664,9 @@ fn fix_features() {
         .file(
             "src/lib.rs",
             r#"
-            #[cfg(feature = "bar")]
-            pub fn foo() -> u32 { let mut x = 3; x }
-        "#,
+                #[cfg(feature = "bar")]
+                pub fn foo() -> u32 { let mut x = 3; x }
+            "#,
         )
         .build();
 
@@ -1184,7 +1184,7 @@ fn fix_to_broken_code() {
         )
         .file(
             "foo/src/main.rs",
-            r##"
+            r#"
                 use std::env;
                 use std::fs;
                 use std::io::Write;
@@ -1211,7 +1211,7 @@ fn fix_to_broken_code() {
                         .expect("failed to run rustc");
                     process::exit(status.code().unwrap_or(2));
                 }
-            "##,
+            "#,
         )
         .file(
             "bar/Cargo.toml",

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -98,28 +98,28 @@ fn rebuild_sub_package_then_while_package() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.1"
 
-            [dependencies.a]
-            path = "a"
-            [dependencies.b]
-            path = "b"
-        "#,
+                [dependencies.a]
+                path = "a"
+                [dependencies.b]
+                path = "b"
+            "#,
         )
         .file("src/lib.rs", "extern crate a; extern crate b;")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            authors = []
-            version = "0.0.1"
-            [dependencies.b]
-            path = "../b"
-        "#,
+                [package]
+                name = "a"
+                authors = []
+                version = "0.0.1"
+                [dependencies.b]
+                path = "../b"
+            "#,
         )
         .file("a/src/lib.rs", "extern crate b;")
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
@@ -177,14 +177,14 @@ fn changing_lib_features_caches_targets() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.1"
 
-            [features]
-            foo = []
-        "#,
+                [features]
+                foo = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -226,14 +226,14 @@ fn changing_profiles_caches_targets() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.1"
 
-            [profile.dev]
-            panic = "abort"
-        "#,
+                [profile.dev]
+                panic = "abort"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -282,80 +282,80 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            target-dir = "./target"
-        "#,
+                [build]
+                target-dir = "./target"
+            "#,
         )
         .file(
             "dep_crate/Cargo.toml",
             r#"
-            [package]
-            name    = "dep_crate"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name    = "dep_crate"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            ftest  = []
-        "#,
+                [features]
+                ftest  = []
+            "#,
         )
         .file(
             "dep_crate/src/lib.rs",
             r#"
-            #[cfg(feature = "ftest")]
-            pub fn yo() {
-                println!("ftest on")
-            }
-            #[cfg(not(feature = "ftest"))]
-            pub fn yo() {
-                println!("ftest off")
-            }
-        "#,
+                #[cfg(feature = "ftest")]
+                pub fn yo() {
+                    println!("ftest on")
+                }
+                #[cfg(not(feature = "ftest"))]
+                pub fn yo() {
+                    println!("ftest off")
+                }
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name    = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name    = "a"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            dep_crate = {path = "../dep_crate", features = []}
-        "#,
+                [dependencies]
+                dep_crate = {path = "../dep_crate", features = []}
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "a/src/main.rs",
             r#"
-            extern crate dep_crate;
-            use dep_crate::yo;
-            fn main() {
-                yo();
-            }
-        "#,
+                extern crate dep_crate;
+                use dep_crate::yo;
+                fn main() {
+                    yo();
+                }
+            "#,
         )
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name    = "b"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name    = "b"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            dep_crate = {path = "../dep_crate", features = ["ftest"]}
-        "#,
+                [dependencies]
+                dep_crate = {path = "../dep_crate", features = ["ftest"]}
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file(
             "b/src/main.rs",
             r#"
-            extern crate dep_crate;
-            use dep_crate::yo;
-            fn main() {
-                yo();
-            }
-        "#,
+                extern crate dep_crate;
+                use dep_crate::yo;
+                fn main() {
+                    yo();
+                }
+            "#,
         )
         .build();
 
@@ -448,23 +448,23 @@ fn changing_bin_features_caches_targets() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.1"
 
-            [features]
-            foo = []
-        "#,
+                [features]
+                foo = []
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                let msg = if cfg!(feature = "foo") { "feature on" } else { "feature off" };
-                println!("{}", msg);
-            }
-        "#,
+                fn main() {
+                    let msg = if cfg!(feature = "foo") { "feature on" } else { "feature off" };
+                    println!("{}", msg);
+                }
+            "#,
         )
         .build();
 
@@ -517,10 +517,10 @@ fn rebuild_tests_if_lib_changes() {
         .file(
             "tests/foo.rs",
             r#"
-            extern crate foo;
-            #[test]
-            fn test() { foo::foo(); }
-        "#,
+                extern crate foo;
+                #[test]
+                fn test() { foo::foo(); }
+            "#,
         )
         .build();
 
@@ -543,43 +543,43 @@ fn no_rebuild_transitive_target_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-            [dev-dependencies]
-            b = { path = "b" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+                [dev-dependencies]
+                b = { path = "b" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("tests/foo.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [target.foo.dependencies]
-            c = { path = "../c" }
-        "#,
+                [target.foo.dependencies]
+                c = { path = "../c" }
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            c = { path = "../c" }
-        "#,
+                [dependencies]
+                c = { path = "../c" }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file("c/Cargo.toml", &basic_manifest("c", "0.0.1"))
@@ -605,33 +605,33 @@ fn rerun_if_changed_in_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "a/build.rs",
             r#"
-            fn main() {
-                println!("cargo:rerun-if-changed=build.rs");
-            }
-        "#,
+                fn main() {
+                    println!("cargo:rerun-if-changed=build.rs");
+                }
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -647,49 +647,49 @@ fn same_build_dir_cached_packages() {
         .file(
             "a1/Cargo.toml",
             r#"
-            [package]
-            name = "a1"
-            version = "0.0.1"
-            authors = []
-            [dependencies]
-            b = { path = "../b" }
-        "#,
+                [package]
+                name = "a1"
+                version = "0.0.1"
+                authors = []
+                [dependencies]
+                b = { path = "../b" }
+            "#,
         )
         .file("a1/src/lib.rs", "")
         .file(
             "a2/Cargo.toml",
             r#"
-            [package]
-            name = "a2"
-            version = "0.0.1"
-            authors = []
-            [dependencies]
-            b = { path = "../b" }
-        "#,
+                [package]
+                name = "a2"
+                version = "0.0.1"
+                authors = []
+                [dependencies]
+                b = { path = "../b" }
+            "#,
         )
         .file("a2/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
-            [dependencies]
-            c = { path = "../c" }
-        "#,
+                [package]
+                name = "b"
+                version = "0.0.1"
+                authors = []
+                [dependencies]
+                c = { path = "../c" }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file(
             "c/Cargo.toml",
             r#"
-            [package]
-            name = "c"
-            version = "0.0.1"
-            authors = []
-            [dependencies]
-            d = { path = "../d" }
-        "#,
+                [package]
+                name = "c"
+                version = "0.0.1"
+                authors = []
+                [dependencies]
+                d = { path = "../d" }
+            "#,
         )
         .file("c/src/lib.rs", "")
         .file("d/Cargo.toml", &basic_manifest("d", "0.0.1"))
@@ -697,9 +697,9 @@ fn same_build_dir_cached_packages() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            target-dir = "./target"
-        "#,
+                [build]
+                target-dir = "./target"
+            "#,
         )
         .build();
 
@@ -733,14 +733,14 @@ fn no_rebuild_if_build_artifacts_move_backwards_in_time() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -763,14 +763,14 @@ fn rebuild_if_build_artifacts_move_forward_in_time() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -800,20 +800,20 @@ fn rebuild_if_environment_changes() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            description = "old desc"
-            version = "0.0.1"
-            authors = []
-        "#,
+                [package]
+                name = "foo"
+                description = "old desc"
+                version = "0.0.1"
+                authors = []
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                println!("{}", env!("CARGO_PKG_DESCRIPTION"));
-            }
-        "#,
+                fn main() {
+                    println!("{}", env!("CARGO_PKG_DESCRIPTION"));
+                }
+            "#,
         )
         .build();
 
@@ -1134,16 +1134,16 @@ fn reuse_shared_build_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            shared = {path = "shared"}
+                [dependencies]
+                shared = {path = "shared"}
 
-            [workspace]
-            members = ["shared", "bar"]
-        "#,
+                [workspace]
+                members = ["shared", "bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("shared/Cargo.toml", &basic_manifest("shared", "0.0.1"))
@@ -1151,13 +1151,13 @@ fn reuse_shared_build_dep() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
+                [package]
+                name = "bar"
+                version = "0.0.1"
 
-            [build-dependencies]
-            shared = { path = "../shared" }
-        "#,
+                [build-dependencies]
+                shared = { path = "../shared" }
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .file("bar/build.rs", "fn main() {}")
@@ -1206,13 +1206,13 @@ fn update_dependency_mtime_does_not_rebuild() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -1281,16 +1281,16 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [features]
-            a = []
-        "#,
+                [features]
+                a = []
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -1343,19 +1343,19 @@ fn reuse_panic_build_dep_test() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [build-dependencies]
-            bar = { path = "bar" }
+                [build-dependencies]
+                bar = { path = "bar" }
 
-            [dev-dependencies]
-            bar = { path = "bar" }
+                [dev-dependencies]
+                bar = { path = "bar" }
 
-            [profile.dev]
-            panic = "abort"
-        "#,
+                [profile.dev]
+                panic = "abort"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -1387,17 +1387,17 @@ fn reuse_panic_pm() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { path = "bar" }
-            somepm = { path = "somepm" }
+                [dependencies]
+                bar = { path = "bar" }
+                somepm = { path = "somepm" }
 
-            [profile.dev]
-            panic = "abort"
-        "#,
+                [profile.dev]
+                panic = "abort"
+            "#,
         )
         .file("src/lib.rs", "extern crate bar;")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -1405,16 +1405,16 @@ fn reuse_panic_pm() {
         .file(
             "somepm/Cargo.toml",
             r#"
-            [package]
-            name = "somepm"
-            version = "0.0.1"
+                [package]
+                name = "somepm"
+                version = "0.0.1"
 
-            [lib]
-            proc-macro = true
+                [lib]
+                proc-macro = true
 
-            [dependencies]
-            bar = { path = "../bar" }
-        "#,
+                [dependencies]
+                bar = { path = "../bar" }
+            "#,
         )
         .file("somepm/src/lib.rs", "extern crate bar;")
         .build();
@@ -1448,16 +1448,16 @@ fn bust_patched_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            registry2 = "0.1.0"
+                [dependencies]
+                registry2 = "0.1.0"
 
-            [patch.crates-io]
-            registry1 = { path = "reg1new" }
-        "#,
+                [patch.crates-io]
+                registry1 = { path = "reg1new" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("reg1new/Cargo.toml", &basic_manifest("registry1", "0.1.0"))
@@ -1506,62 +1506,62 @@ fn rebuild_on_mid_build_file_modification() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["root", "proc_macro_dep"]
-        "#,
+                [workspace]
+                members = ["root", "proc_macro_dep"]
+            "#,
         )
         .file(
             "root/Cargo.toml",
             r#"
-            [package]
-            name = "root"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "root"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            proc_macro_dep = { path = "../proc_macro_dep" }
-        "#,
+                [dependencies]
+                proc_macro_dep = { path = "../proc_macro_dep" }
+            "#,
         )
         .file(
             "root/src/lib.rs",
             r#"
-            #[macro_use]
-            extern crate proc_macro_dep;
+                #[macro_use]
+                extern crate proc_macro_dep;
 
-            #[derive(Noop)]
-            pub struct X;
-        "#,
+                #[derive(Noop)]
+                pub struct X;
+            "#,
         )
         .file(
             "proc_macro_dep/Cargo.toml",
             r#"
-            [package]
-            name = "proc_macro_dep"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "proc_macro_dep"
+                version = "0.1.0"
+                authors = []
 
-            [lib]
-            proc-macro = true
-        "#,
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "proc_macro_dep/src/lib.rs",
             &format!(
                 r#"
-                extern crate proc_macro;
+                    extern crate proc_macro;
 
-                use std::io::Read;
-                use std::net::TcpStream;
-                use proc_macro::TokenStream;
+                    use std::io::Read;
+                    use std::net::TcpStream;
+                    use proc_macro::TokenStream;
 
-                #[proc_macro_derive(Noop)]
-                pub fn noop(_input: TokenStream) -> TokenStream {{
-                    let mut stream = TcpStream::connect("{}").unwrap();
-                    let mut v = Vec::new();
-                    stream.read_to_end(&mut v).unwrap();
-                    "".parse().unwrap()
-                }}
-            "#,
+                    #[proc_macro_derive(Noop)]
+                    pub fn noop(_input: TokenStream) -> TokenStream {{
+                        let mut stream = TcpStream::connect("{}").unwrap();
+                        let mut v = Vec::new();
+                        stream.read_to_end(&mut v).unwrap();
+                        "".parse().unwrap()
+                    }}
+                "#,
                 addr
             ),
         )
@@ -1622,11 +1622,11 @@ fn dirty_both_lib_and_test() {
     let slib = |n| {
         format!(
             r#"
-            #[no_mangle]
-            pub extern "C" fn doit() -> i32 {{
-                return {};
-            }}
-        "#,
+                #[no_mangle]
+                pub extern "C" fn doit() -> i32 {{
+                    return {};
+                }}
+            "#,
             n
         )
     };
@@ -1635,43 +1635,43 @@ fn dirty_both_lib_and_test() {
         .file(
             "src/lib.rs",
             r#"
-            extern "C" {
-                fn doit() -> i32;
-            }
+                extern "C" {
+                    fn doit() -> i32;
+                }
 
-            #[test]
-            fn t1() {
-                assert_eq!(unsafe { doit() }, 1, "doit assert failure");
-            }
-        "#,
+                #[test]
+                fn t1() {
+                    assert_eq!(unsafe { doit() }, 1, "doit assert failure");
+                }
+            "#,
         )
         .file(
             "build.rs",
             r#"
-            use std::env;
-            use std::path::PathBuf;
-            use std::process::Command;
+                use std::env;
+                use std::path::PathBuf;
+                use std::process::Command;
 
-            fn main() {
-                let rustc = env::var_os("RUSTC").unwrap();
-                let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-                assert!(
-                    Command::new(rustc)
-                        .args(&[
-                            "--crate-type=staticlib",
-                            "--out-dir",
-                            out_dir.to_str().unwrap(),
-                            "slib.rs"
-                        ])
-                        .status()
-                        .unwrap()
-                        .success(),
-                    "slib build failed"
-                );
-                println!("cargo:rustc-link-lib=slib");
-                println!("cargo:rustc-link-search={}", out_dir.display());
-            }
-        "#,
+                fn main() {
+                    let rustc = env::var_os("RUSTC").unwrap();
+                    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+                    assert!(
+                        Command::new(rustc)
+                            .args(&[
+                                "--crate-type=staticlib",
+                                "--out-dir",
+                                out_dir.to_str().unwrap(),
+                                "slib.rs"
+                            ])
+                            .status()
+                            .unwrap()
+                            .success(),
+                        "slib build failed"
+                    );
+                    println!("cargo:rustc-link-lib=slib");
+                    println!("cargo:rustc-link-search={}", out_dir.display());
+                }
+            "#,
         )
         .file("slib.rs", &slib(2))
         .build();
@@ -2039,21 +2039,21 @@ fn move_target_directory_with_path_deps() {
         .file(
             "a/build.rs",
             r###"
-            use std::env;
-            use std::fs;
-            use std::path::Path;
+                use std::env;
+                use std::fs;
+                use std::path::Path;
 
-            fn main() {
-                println!("cargo:rerun-if-changed=build.rs");
-                let out_dir = env::var("OUT_DIR").unwrap();
-                let dest_path = Path::new(&out_dir).join("hello.rs");
-                fs::write(&dest_path, r#"
-                    pub fn message() -> &'static str {
-                        "Hello, World!"
-                    }
-                "#).unwrap();
-            }
-        "###,
+                fn main() {
+                    println!("cargo:rerun-if-changed=build.rs");
+                    let out_dir = env::var("OUT_DIR").unwrap();
+                    let dest_path = Path::new(&out_dir).join("hello.rs");
+                    fs::write(&dest_path, r#"
+                        pub fn message() -> &'static str {
+                            "Hello, World!"
+                        }
+                    "#).unwrap();
+                }
+            "###,
         )
         .file(
             "a/src/lib.rs",

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -64,14 +64,14 @@ fn no_index_update() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.1"
 
-            [dependencies]
-            serde = "1.0"
-        "#,
+                [dependencies]
+                serde = "1.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -30,10 +30,10 @@ fn cargo_compile_simple_git_dep() {
             .file(
                 "src/dep1.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "hello world"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "hello world"
+                    }
+                "#,
             )
     });
 
@@ -42,16 +42,16 @@ fn cargo_compile_simple_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            git = '{}'
-        "#,
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -92,10 +92,10 @@ fn cargo_compile_git_dep_branch() {
             .file(
                 "src/dep1.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "hello world"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "hello world"
+                    }
+                "#,
             )
     });
 
@@ -110,18 +110,18 @@ fn cargo_compile_git_dep_branch() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            git = '{}'
-            branch = "branchy"
+                    git = '{}'
+                    branch = "branchy"
 
-        "#,
+                "#,
                 git_project.url()
             ),
         )
@@ -162,10 +162,10 @@ fn cargo_compile_git_dep_tag() {
             .file(
                 "src/dep1.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "hello world"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "hello world"
+                    }
+                "#,
             )
     });
 
@@ -186,17 +186,17 @@ fn cargo_compile_git_dep_tag() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            git = '{}'
-            tag = "v0.1.0"
-        "#,
+                    git = '{}'
+                    tag = "v0.1.0"
+                "#,
                 git_project.url()
             ),
         )
@@ -237,40 +237,40 @@ fn cargo_compile_with_nested_paths() {
             .file(
                 "Cargo.toml",
                 r#"
-                [project]
+                    [project]
 
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
+                    name = "dep1"
+                    version = "0.5.0"
+                    authors = ["carlhuda@example.com"]
 
-                [dependencies.dep2]
+                    [dependencies.dep2]
 
-                version = "0.5.0"
-                path = "vendor/dep2"
+                    version = "0.5.0"
+                    path = "vendor/dep2"
 
-                [lib]
+                    [lib]
 
-                name = "dep1"
-            "#,
+                    name = "dep1"
+                "#,
             )
             .file(
                 "src/dep1.rs",
                 r#"
-                extern crate dep2;
+                    extern crate dep2;
 
-                pub fn hello() -> &'static str {
-                    dep2::hello()
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        dep2::hello()
+                    }
+                "#,
             )
             .file("vendor/dep2/Cargo.toml", &basic_lib_manifest("dep2"))
             .file(
                 "vendor/dep2/src/dep2.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "hello world"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "hello world"
+                    }
+                "#,
             )
     });
 
@@ -279,21 +279,21 @@ fn cargo_compile_with_nested_paths() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            version = "0.5.0"
-            git = '{}'
+                    version = "0.5.0"
+                    git = '{}'
 
-            [[bin]]
+                    [[bin]]
 
-            name = "foo"
-        "#,
+                    name = "foo"
+                "#,
                 git_project.url()
             ),
         )
@@ -318,10 +318,10 @@ fn cargo_compile_with_malformed_nested_paths() {
             .file(
                 "src/dep1.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "hello world"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "hello world"
+                    }
+                "#,
             )
             .file("vendor/dep2/Cargo.toml", "!INVALID!")
             .file(
@@ -331,7 +331,8 @@ fn cargo_compile_with_malformed_nested_paths() {
                 name = "dep3"
                 version = "0.5.0"
                 [dependencies]
-                subdep1 = { path = "../require-extra-build-step" }"#,
+                subdep1 = { path = "../require-extra-build-step" }
+                "#,
             )
             .file("vendor/dep3/src/lib.rs", "")
     });
@@ -341,21 +342,21 @@ fn cargo_compile_with_malformed_nested_paths() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            version = "0.5.0"
-            git = '{}'
+                    version = "0.5.0"
+                    git = '{}'
 
-            [[bin]]
+                    [[bin]]
 
-            name = "foo"
-        "#,
+                    name = "foo"
+                "#,
                 git_project.url()
             ),
         )
@@ -380,19 +381,19 @@ fn cargo_compile_with_meta_package() {
             .file(
                 "dep1/src/dep1.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "this is dep1"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "this is dep1"
+                    }
+                "#,
             )
             .file("dep2/Cargo.toml", &basic_lib_manifest("dep2"))
             .file(
                 "dep2/src/dep2.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "this is dep2"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "this is dep2"
+                    }
+                "#,
             )
     });
 
@@ -401,26 +402,26 @@ fn cargo_compile_with_meta_package() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            version = "0.5.0"
-            git = '{}'
+                    version = "0.5.0"
+                    git = '{}'
 
-            [dependencies.dep2]
+                    [dependencies.dep2]
 
-            version = "0.5.0"
-            git = '{}'
+                    version = "0.5.0"
+                    git = '{}'
 
-            [[bin]]
+                    [[bin]]
 
-            name = "foo"
-        "#,
+                    name = "foo"
+                "#,
                 git_project.url(),
                 git_project.url()
             ),
@@ -452,20 +453,20 @@ fn cargo_compile_with_short_ssh_git() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep]
+                    [dependencies.dep]
 
-            git = "{}"
+                    git = "{}"
 
-            [[bin]]
+                    [[bin]]
 
-            name = "foo"
-        "#,
+                    name = "foo"
+                "#,
                 url
             ),
         )
@@ -511,18 +512,18 @@ fn two_revs_same_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.0"
+                    authors = []
 
-            [dependencies.bar]
-            git = '{}'
-            rev = "{}"
+                    [dependencies.bar]
+                    git = '{}'
+                    rev = "{}"
 
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                    [dependencies.baz]
+                    path = "../baz"
+                "#,
                 bar.url(),
                 rev1
             ),
@@ -530,14 +531,14 @@ fn two_revs_same_deps() {
         .file(
             "src/main.rs",
             r#"
-            extern crate bar;
-            extern crate baz;
+                extern crate bar;
+                extern crate baz;
 
-            fn main() {
-                assert_eq!(bar::bar(), 1);
-                assert_eq!(baz::baz(), 2);
-            }
-        "#,
+                fn main() {
+                    assert_eq!(bar::bar(), 1);
+                    assert_eq!(baz::baz(), 2);
+                }
+            "#,
         )
         .build();
 
@@ -547,15 +548,15 @@ fn two_revs_same_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "baz"
-            version = "0.0.0"
-            authors = []
+                    [package]
+                    name = "baz"
+                    version = "0.0.0"
+                    authors = []
 
-            [dependencies.bar]
-            git = '{}'
-            rev = "{}"
-        "#,
+                    [dependencies.bar]
+                    git = '{}'
+                    rev = "{}"
+                "#,
                 bar.url(),
                 rev2
             ),
@@ -563,9 +564,9 @@ fn two_revs_same_deps() {
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
-            pub fn baz() -> i32 { bar::bar() }
-        "#,
+                extern crate bar;
+                pub fn baz() -> i32 { bar::bar() }
+            "#,
         )
         .build();
 
@@ -587,17 +588,17 @@ fn recompilation() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                    [dependencies.bar]
 
-            version = "0.5.0"
-            git = '{}'
-        "#,
+                    version = "0.5.0"
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -687,40 +688,40 @@ fn update_with_shared_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
-            path = "dep1"
-            [dependencies.dep2]
-            path = "dep2"
-        "#,
+                [dependencies.dep1]
+                path = "dep1"
+                [dependencies.dep2]
+                path = "dep2"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate dep1;
-            #[allow(unused_extern_crates)]
-            extern crate dep2;
-            fn main() {}
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate dep1;
+                #[allow(unused_extern_crates)]
+                extern crate dep2;
+                fn main() {}
+            "#,
         )
         .file(
             "dep1/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "dep1"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    [package]
+                    name = "dep1"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            version = "0.5.0"
-            git = '{}'
-        "#,
+                    [dependencies.bar]
+                    version = "0.5.0"
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -729,15 +730,15 @@ fn update_with_shared_deps() {
             "dep2/Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "dep2"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    [package]
+                    name = "dep2"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            version = "0.5.0"
-            git = '{}'
-        "#,
+                    [dependencies.bar]
+                    version = "0.5.0"
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -848,16 +849,16 @@ fn dep_with_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            git = '{}'
-        "#,
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -914,16 +915,16 @@ fn dep_with_bad_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            git = '{}'
-        "#,
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -979,17 +980,17 @@ fn two_deps_only_update_one() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
-            git = '{}'
-            [dependencies.dep2]
-            git = '{}'
-        "#,
+                    [dependencies.dep1]
+                    git = '{}'
+                    [dependencies.dep2]
+                    git = '{}'
+                "#,
                 git1.url(),
                 git2.url()
             ),
@@ -1051,24 +1052,24 @@ fn stale_cached_version() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.0"
+                    authors = []
 
-            [dependencies.bar]
-            git = '{}'
-        "#,
+                    [dependencies.bar]
+                    git = '{}'
+                "#,
                 bar.url()
             ),
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate bar;
+                extern crate bar;
 
-            fn main() { assert_eq!(bar::bar(), 1) }
-        "#,
+                fn main() { assert_eq!(bar::bar(), 1) }
+            "#,
         )
         .build();
 
@@ -1146,13 +1147,13 @@ fn dep_with_changed_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            [dependencies.dep1]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
+                    [dependencies.dep1]
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -1242,8 +1243,8 @@ fn dev_deps_with_testing() {
             .file(
                 "src/lib.rs",
                 r#"
-            pub fn gimme() -> &'static str { "zoidberg" }
-        "#,
+                    pub fn gimme() -> &'static str { "zoidberg" }
+                "#,
             )
     });
 
@@ -1252,30 +1253,30 @@ fn dev_deps_with_testing() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dev-dependencies.bar]
-            version = "0.5.0"
-            git = '{}'
-        "#,
+                    [dev-dependencies.bar]
+                    version = "0.5.0"
+                    git = '{}'
+                "#,
                 p2.url()
             ),
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {}
+                fn main() {}
 
-            #[cfg(test)]
-            mod tests {
-                extern crate bar;
-                #[test] fn foo() { bar::gimme(); }
-            }
-        "#,
+                #[cfg(test)]
+                mod tests {
+                    extern crate bar;
+                    #[test] fn foo() { bar::gimme(); }
+                }
+            "#,
         )
         .build();
 
@@ -1313,12 +1314,12 @@ fn git_build_cmd_freshness() {
             .file(
                 "Cargo.toml",
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                    [package]
+                    name = "foo"
+                    version = "0.0.0"
+                    authors = []
+                    build = "build.rs"
+                "#,
             )
             .file("build.rs", "fn main() {}")
             .file("src/lib.rs", "pub fn bar() -> i32 { 1 }")
@@ -1355,8 +1356,8 @@ fn git_name_not_always_needed() {
             .file(
                 "src/lib.rs",
                 r#"
-            pub fn gimme() -> &'static str { "zoidberg" }
-        "#,
+                    pub fn gimme() -> &'static str { "zoidberg" }
+                "#,
             )
     });
 
@@ -1370,14 +1371,14 @@ fn git_name_not_always_needed() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
 
-            [dev-dependencies.bar]
-            git = '{}'
-        "#,
+                    [dev-dependencies.bar]
+                    git = '{}'
+                "#,
                 p2.url()
             ),
         )
@@ -1413,14 +1414,14 @@ fn git_repo_changing_no_rebuild() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "p1"
-            version = "0.5.0"
-            authors = []
-            build = 'build.rs'
-            [dependencies.bar]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "p1"
+                    version = "0.5.0"
+                    authors = []
+                    build = 'build.rs'
+                    [dependencies.bar]
+                    git = '{}'
+                "#,
                 bar.url()
             ),
         )
@@ -1453,13 +1454,13 @@ fn git_repo_changing_no_rebuild() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "p2"
-            version = "0.5.0"
-            authors = []
-            [dependencies.bar]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "p2"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.bar]
+                    git = '{}'
+                "#,
                 bar.url()
             ),
         )
@@ -1489,52 +1490,52 @@ fn git_dep_build_cmd() {
             .file(
                 "Cargo.toml",
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                    [dependencies.bar]
 
-            version = "0.5.0"
-            path = "bar"
+                    version = "0.5.0"
+                    path = "bar"
 
-            [[bin]]
+                    [[bin]]
 
-            name = "foo"
-        "#,
+                    name = "foo"
+                "#,
             )
             .file("src/foo.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
             .file(
                 "bar/Cargo.toml",
                 r#"
-            [project]
+                    [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
+                    name = "bar"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
+                    build = "build.rs"
 
-            [lib]
-            name = "bar"
-            path = "src/bar.rs"
-        "#,
+                    [lib]
+                    name = "bar"
+                    path = "src/bar.rs"
+                "#,
             )
             .file(
                 "bar/src/bar.rs.in",
                 r#"
-            pub fn gimme() -> i32 { 0 }
-        "#,
+                    pub fn gimme() -> i32 { 0 }
+                "#,
             )
             .file(
                 "bar/build.rs",
                 r#"
-            use std::fs;
-            fn main() {
-                fs::copy("src/bar.rs.in", "src/bar.rs").unwrap();
-            }
-        "#,
+                    use std::fs;
+                    fn main() {
+                        fs::copy("src/bar.rs.in", "src/bar.rs").unwrap();
+                    }
+                "#,
             )
     });
 
@@ -1565,13 +1566,13 @@ fn fetch_downloads() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.bar]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.bar]
+                    git = '{}'
+                "#,
                 bar.url()
             ),
         )
@@ -1600,13 +1601,13 @@ fn warnings_in_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.bar]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.bar]
+                    git = '{}'
+                "#,
                 bar.url()
             ),
         )
@@ -1643,14 +1644,14 @@ fn update_ambiguous() {
                 "Cargo.toml",
                 &format!(
                     r#"
-            [package]
-            name = "baz"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                        [package]
+                        name = "baz"
+                        version = "0.5.0"
+                        authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            git = '{}'
-        "#,
+                        [dependencies.bar]
+                        git = '{}'
+                    "#,
                     bar2.url()
                 ),
             )
@@ -1662,15 +1663,15 @@ fn update_ambiguous() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.bar]
-            git = '{}'
-            [dependencies.baz]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.bar]
+                    git = '{}'
+                    [dependencies.baz]
+                    git = '{}'
+                "#,
                 bar1.url(),
                 baz.url()
             ),
@@ -1709,15 +1710,15 @@ fn update_one_dep_in_repo_with_many_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.bar]
-            git = '{}'
-            [dependencies.a]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.bar]
+                    git = '{}'
+                    [dependencies.a]
+                    git = '{}'
+                "#,
                 bar.url(),
                 bar.url()
             ),
@@ -1744,14 +1745,14 @@ fn switch_deps_does_not_update_transitive() {
                 "Cargo.toml",
                 &format!(
                     r#"
-            [package]
-            name = "dep"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                        [package]
+                        name = "dep"
+                        version = "0.5.0"
+                        authors = ["wycats@example.com"]
 
-            [dependencies.transitive]
-            git = '{}'
-        "#,
+                        [dependencies.transitive]
+                        git = '{}'
+                    "#,
                     transitive.url()
                 ),
             )
@@ -1763,14 +1764,14 @@ fn switch_deps_does_not_update_transitive() {
                 "Cargo.toml",
                 &format!(
                     r#"
-            [package]
-            name = "dep"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                        [package]
+                        name = "dep"
+                        version = "0.5.0"
+                        authors = ["wycats@example.com"]
 
-            [dependencies.transitive]
-            git = '{}'
-        "#,
+                        [dependencies.transitive]
+                        git = '{}'
+                    "#,
                     transitive.url()
                 ),
             )
@@ -1782,13 +1783,13 @@ fn switch_deps_does_not_update_transitive() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.dep]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.dep]
+                    git = '{}'
+                "#,
                 dep1.url()
             ),
         )
@@ -1847,14 +1848,14 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             .file(
                 "Cargo.toml",
                 r#"
-            [package]
-            name = "dep"
-            version = "0.5.0"
-            authors = []
+                    [package]
+                    name = "dep"
+                    version = "0.5.0"
+                    authors = []
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                    [dependencies.a]
+                    path = "a"
+                "#,
             )
             .file("src/lib.rs", "")
             .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
@@ -1866,13 +1867,13 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.dep]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.dep]
+                    git = '{}'
+                "#,
                 dep.url()
             ),
         )
@@ -1916,26 +1917,26 @@ fn switch_sources() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies.b]
-            path = "b"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                [dependencies.b]
+                path = "b"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "b/Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            [dependencies.a]
-            git = '{}'
-        "#,
+                    [project]
+                    name = "b"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies.a]
+                    git = '{}'
+                "#,
                 a1.url()
             ),
         )
@@ -1989,12 +1990,12 @@ fn dont_require_submodules_are_checked_out() {
         p.file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
@@ -2027,13 +2028,13 @@ fn doctest_same_name() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "a"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            a = {{ git = '{}' }}
-        "#,
+                    [project]
+                    name = "a"
+                    version = "0.5.0"
+                    authors = []
+                    [dependencies]
+                    a = {{ git = '{}' }}
+                "#,
                 a2.url()
             ),
         )
@@ -2045,23 +2046,23 @@ fn doctest_same_name() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            a = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    a = {{ git = '{}' }}
+                "#,
                 a1.url()
             ),
         )
         .file(
             "src/lib.rs",
             r#"
-            #[macro_use]
-            extern crate a;
-        "#,
+                #[macro_use]
+                extern crate a;
+            "#,
         )
         .build();
 
@@ -2084,14 +2085,14 @@ fn lints_are_suppressed() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            a = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    a = {{ git = '{}' }}
+                "#,
                 a.url()
             ),
         )
@@ -2127,14 +2128,14 @@ fn denied_lints_are_allowed() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            a = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    a = {{ git = '{}' }}
+                "#,
                 a.url()
             ),
         )
@@ -2165,15 +2166,15 @@ fn add_a_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            a = {{ path = 'a' }}
-            git = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    a = {{ path = 'a' }}
+                    git = {{ git = '{}' }}
+                "#,
                 git.url()
             ),
         )
@@ -2229,15 +2230,15 @@ fn two_at_rev_instead_of_tag() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            git1 = {{ git = '{0}', rev = 'v0.1.0' }}
-            git2 = {{ git = '{0}', rev = 'v0.1.0' }}
-        "#,
+                    [dependencies]
+                    git1 = {{ git = '{0}', rev = 'v0.1.0' }}
+                    git2 = {{ git = '{0}', rev = 'v0.1.0' }}
+                "#,
                 git.url()
             ),
         )
@@ -2255,19 +2256,19 @@ fn include_overrides_gitignore() {
         repo.file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.5.0"
-            include = ["src/lib.rs", "ignored.txt", "Cargo.toml"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                include = ["src/lib.rs", "ignored.txt", "Cargo.toml"]
+            "#,
         )
         .file(
             ".gitignore",
             r#"
-            /target
-            Cargo.lock
-            ignored.txt
-        "#,
+                /target
+                Cargo.lock
+                ignored.txt
+            "#,
         )
         .file("src/lib.rs", "")
         .file("ignored.txt", "")
@@ -2306,26 +2307,26 @@ fn invalid_git_dependency_manifest() {
             .file(
                 "Cargo.toml",
                 r#"
-                [project]
+                    [project]
 
-                name = "dep1"
-                version = "0.5.0"
-                authors = ["carlhuda@example.com"]
-                categories = ["algorithms"]
-                categories = ["algorithms"]
+                    name = "dep1"
+                    version = "0.5.0"
+                    authors = ["carlhuda@example.com"]
+                    categories = ["algorithms"]
+                    categories = ["algorithms"]
 
-                [lib]
+                    [lib]
 
-                name = "dep1"
-            "#,
+                    name = "dep1"
+                "#,
             )
             .file(
                 "src/dep1.rs",
                 r#"
-                pub fn hello() -> &'static str {
-                    "hello world"
-                }
-            "#,
+                    pub fn hello() -> &'static str {
+                        "hello world"
+                    }
+                "#,
             )
     });
 
@@ -2334,16 +2335,16 @@ fn invalid_git_dependency_manifest() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
+                    [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.dep1]
+                    [dependencies.dep1]
 
-            git = '{}'
-        "#,
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
@@ -2376,7 +2377,7 @@ Caused by:
   could not parse input as TOML
 
 Caused by:
-  duplicate key: `categories` for key `project` at line 10 column 17",
+  duplicate key: `categories` for key `project` at line 10 column 21",
             path2url(&git_root),
             path2url(&git_root),
         ))
@@ -2430,14 +2431,14 @@ fn failed_submodule_checkout() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
 
-            [dependencies]
-            dep1 = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    dep1 = {{ git = '{}' }}
+                "#,
                 git_project.url()
             ),
         )
@@ -2530,14 +2531,14 @@ fn templatedir_doesnt_cause_problems() {
             "Cargo.toml",
             &format!(
                 r#"
-                [project]
-                name = "fo"
-                version = "0.5.0"
-                authors = []
+                    [project]
+                    name = "fo"
+                    version = "0.5.0"
+                    authors = []
 
-                [dependencies]
-                dep1 = {{ git = '{}' }}
-            "#,
+                    [dependencies]
+                    dep1 = {{ git = '{}' }}
+                "#,
                 git_project.url()
             ),
         )

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -78,11 +78,11 @@ fn setup_failed_auth_test() -> (SocketAddr, JoinHandle<()>, Arc<AtomicUsize>) {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                println!("username=foo");
-                println!("password=bar");
-            }
-        "#,
+                fn main() {
+                    println!("username=foo");
+                    println!("password=bar");
+                }
+            "#,
         )
         .build();
 
@@ -110,14 +110,14 @@ fn http_auth_offered() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies.bar]
-            git = "http://127.0.0.1:{}/foo/bar"
-        "#,
+                    [dependencies.bar]
+                    git = "http://127.0.0.1:{}/foo/bar"
+                "#,
                 addr.port()
             ),
         )
@@ -183,14 +183,14 @@ fn https_something_happens() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies.bar]
-            git = "https://127.0.0.1:{}/foo/bar"
-        "#,
+                    [dependencies.bar]
+                    git = "https://127.0.0.1:{}/foo/bar"
+                "#,
                 addr.port()
             ),
         )
@@ -244,14 +244,14 @@ fn ssh_something_happens() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies.bar]
-            git = "ssh://127.0.0.1:{}/foo/bar"
-        "#,
+                    [dependencies.bar]
+                    git = "ssh://127.0.0.1:{}/foo/bar"
+                "#,
                 addr.port()
             ),
         )
@@ -280,14 +280,14 @@ fn net_err_suggests_fetch_with_cli() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [dependencies]
-            foo = { git = "ssh://needs-proxy.invalid/git" }
-        "#,
+                [dependencies]
+                foo = { git = "ssh://needs-proxy.invalid/git" }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -24,14 +24,14 @@ fn run_test(path_env: Option<&OsStr>) {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -33,7 +33,8 @@ fn help_external_subcommand() {
                 if ::std::env::args().nth(2) == Some(String::from("--help")) {
                     println!("fancy help output");
                 }
-            }"#,
+            }
+            "#,
         )
         .publish();
     cargo_process("install cargo-fake-help").run();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -413,14 +413,14 @@ fn multiple_crates_auto_binaries() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "a" }
-        "#,
+                [dependencies]
+                bar = { path = "a" }
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() {}")
         .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -437,14 +437,14 @@ fn multiple_crates_auto_examples() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "a" }
-        "#,
+                [dependencies]
+                bar = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "extern crate bar;")
         .file(
@@ -472,14 +472,14 @@ fn no_binaries_or_examples() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "a" }
-        "#,
+                [dependencies]
+                bar = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -834,12 +834,12 @@ fn installs_from_cwd_with_2018_warnings() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            edition = "2018"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                edition = "2018"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -953,14 +953,14 @@ fn git_with_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -968,15 +968,15 @@ fn git_with_lockfile() {
         .file(
             "Cargo.lock",
             r#"
-            [[package]]
-            name = "foo"
-            version = "0.1.0"
-            dependencies = [ "bar 0.1.0" ]
+                [[package]]
+                name = "foo"
+                version = "0.1.0"
+                dependencies = [ "bar 0.1.0" ]
 
-            [[package]]
-            name = "bar"
-            version = "0.1.0"
-        "#,
+                [[package]]
+                name = "bar"
+                version = "0.1.0"
+            "#,
         )
         .build();
 
@@ -1017,27 +1017,27 @@ fn use_path_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["baz"]
-        "#,
+                [workspace]
+                members = ["baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "baz/Cargo.toml",
             r#"
-            [package]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "baz"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = "1"
-        "#,
+                [dependencies]
+                foo = "1"
+            "#,
         )
         .file("baz/src/lib.rs", "")
         .build();
@@ -1056,14 +1056,14 @@ fn dev_dependencies_no_check() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dev-dependencies]
-            baz = "1.0.0"
-        "#,
+                [dev-dependencies]
+                baz = "1.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1082,14 +1082,14 @@ fn dev_dependencies_lock_file_untouched() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dev-dependencies]
-            bar = { path = "a" }
-        "#,
+                [dev-dependencies]
+                bar = { path = "a" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -1321,17 +1321,17 @@ fn lock_file_path_deps_ok() {
         .file(
             "Cargo.lock",
             r#"
-[[package]]
-name = "bar"
-version = "0.1.0"
+            [[package]]
+            name = "bar"
+            version = "0.1.0"
 
-[[package]]
-name = "foo"
-version = "0.1.0"
-dependencies = [
- "bar 0.1.0",
-]
-"#,
+            [[package]]
+            name = "foo"
+            version = "0.1.0"
+            dependencies = [
+             "bar 0.1.0",
+            ]
+            "#,
         )
         .publish();
 
@@ -1461,9 +1461,9 @@ fn install_global_cargo_config() {
 
     toml.push_str(
         r#"
-        [build]
-        target = 'nonexistent'
-    "#,
+            [build]
+            target = 'nonexistent'
+        "#,
     );
     fs::write(&config, toml).unwrap();
 
@@ -1597,30 +1597,30 @@ fn install_cargo_package_in_a_patched_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["baz"]
-        "#,
+                [workspace]
+                members = ["baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "baz/Cargo.toml",
             r#"
-            [package]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "baz"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            fizz = "1"
+                [dependencies]
+                fizz = "1"
 
-            [patch.crates-io]
-            fizz = { version = "=1.0.0" }
-        "#,
+                [patch.crates-io]
+                fizz = { version = "=1.0.0" }
+            "#,
         )
         .file("baz/src/lib.rs", "")
         .build();

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -335,14 +335,16 @@ fn change_features_rebuilds() {
     Package::new("foo", "1.0.0")
         .file(
             "src/main.rs",
-            r#"fn main() {
-            if cfg!(feature = "f1") {
-                println!("f1");
+            r#"
+            fn main() {
+                if cfg!(feature = "f1") {
+                    println!("f1");
+                }
+                if cfg!(feature = "f2") {
+                    println!("f2");
+                }
             }
-            if cfg!(feature = "f2") {
-                println!("f2");
-            }
-        }"#,
+            "#,
         )
         .file(
             "Cargo.toml",

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -12,41 +12,41 @@ fn jobserver_exists() {
         .file(
             "build.rs",
             r#"
-            use std::env;
+                use std::env;
 
-            fn main() {
-                let var = env::var("CARGO_MAKEFLAGS").unwrap();
-                let arg = var.split(' ')
-                             .find(|p| p.starts_with("--jobserver"))
-                             .unwrap();
-                let val = &arg[arg.find('=').unwrap() + 1..];
-                validate(val);
-            }
-
-            #[cfg(unix)]
-            fn validate(s: &str) {
-                use std::fs::File;
-                use std::io::*;
-                use std::os::unix::prelude::*;
-
-                let fds = s.split(',').collect::<Vec<_>>();
-                println!("{}", s);
-                assert_eq!(fds.len(), 2);
-                unsafe {
-                    let mut read = File::from_raw_fd(fds[0].parse().unwrap());
-                    let mut write = File::from_raw_fd(fds[1].parse().unwrap());
-
-                    let mut buf = [0];
-                    assert_eq!(read.read(&mut buf).unwrap(), 1);
-                    assert_eq!(write.write(&buf).unwrap(), 1);
+                fn main() {
+                    let var = env::var("CARGO_MAKEFLAGS").unwrap();
+                    let arg = var.split(' ')
+                                 .find(|p| p.starts_with("--jobserver"))
+                                 .unwrap();
+                    let val = &arg[arg.find('=').unwrap() + 1..];
+                    validate(val);
                 }
-            }
 
-            #[cfg(windows)]
-            fn validate(_: &str) {
-                // a little too complicated for a test...
-            }
-        "#,
+                #[cfg(unix)]
+                fn validate(s: &str) {
+                    use std::fs::File;
+                    use std::io::*;
+                    use std::os::unix::prelude::*;
+
+                    let fds = s.split(',').collect::<Vec<_>>();
+                    println!("{}", s);
+                    assert_eq!(fds.len(), 2);
+                    unsafe {
+                        let mut read = File::from_raw_fd(fds[0].parse().unwrap());
+                        let mut write = File::from_raw_fd(fds[1].parse().unwrap());
+
+                        let mut buf = [0];
+                        assert_eq!(read.read(&mut buf).unwrap(), 1);
+                        assert_eq!(write.write(&buf).unwrap(), 1);
+                    }
+                }
+
+                #[cfg(windows)]
+                fn validate(_: &str) {
+                    // a little too complicated for a test...
+                }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -72,65 +72,65 @@ fn makes_jobserver_used() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            d1 = { path = "d1" }
-            d2 = { path = "d2" }
-            d3 = { path = "d3" }
-        "#,
+                [dependencies]
+                d1 = { path = "d1" }
+                d2 = { path = "d2" }
+                d3 = { path = "d3" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-            build = "../dbuild.rs"
-        "#,
+                [package]
+                name = "d1"
+                version = "0.0.1"
+                authors = []
+                build = "../dbuild.rs"
+            "#,
         )
         .file("d1/src/lib.rs", "")
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
-            build = "../dbuild.rs"
-        "#,
+                [package]
+                name = "d2"
+                version = "0.0.1"
+                authors = []
+                build = "../dbuild.rs"
+            "#,
         )
         .file("d2/src/lib.rs", "")
         .file(
             "d3/Cargo.toml",
             r#"
-            [package]
-            name = "d3"
-            version = "0.0.1"
-            authors = []
-            build = "../dbuild.rs"
-        "#,
+                [package]
+                name = "d3"
+                version = "0.0.1"
+                authors = []
+                build = "../dbuild.rs"
+            "#,
         )
         .file("d3/src/lib.rs", "")
         .file(
             "dbuild.rs",
             r#"
-            use std::net::TcpStream;
-            use std::env;
-            use std::io::Read;
+                use std::net::TcpStream;
+                use std::env;
+                use std::io::Read;
 
-            fn main() {
-                let addr = env::var("ADDR").unwrap();
-                let mut stream = TcpStream::connect(addr).unwrap();
-                let mut v = Vec::new();
-                stream.read_to_end(&mut v).unwrap();
-            }
-        "#,
+                fn main() {
+                    let addr = env::var("ADDR").unwrap();
+                    let mut stream = TcpStream::connect(addr).unwrap();
+                    let mut v = Vec::new();
+                    stream.read_to_end(&mut v).unwrap();
+                }
+            "#,
         )
         .file(
             "Makefile",

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -33,14 +33,14 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.0.1"
-        "#,
+                [dependencies]
+                bar = "0.0.1"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -71,14 +71,14 @@ fn depend_on_yanked() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.0.1"
-        "#,
+                [dependencies]
+                bar = "0.0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -114,14 +114,14 @@ fn multiple_versions() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -166,26 +166,26 @@ fn multiple_names() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-            baz = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+                baz = "*"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
-            extern crate baz;
-            pub fn foo() {
-                bar::bar();
-                baz::baz();
-            }
-        "#,
+                extern crate bar;
+                extern crate baz;
+                pub fn foo() {
+                    bar::bar();
+                    baz::baz();
+                }
+            "#,
         )
         .build();
 
@@ -220,26 +220,26 @@ fn interdependent() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-            baz = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+                baz = "*"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
-            extern crate baz;
-            pub fn foo() {
-                bar::bar();
-                baz::baz();
-            }
-        "#,
+                extern crate bar;
+                extern crate baz;
+                pub fn foo() {
+                    bar::bar();
+                    baz::baz();
+                }
+            "#,
         )
         .build();
 
@@ -288,26 +288,26 @@ fn path_dep_rewritten() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-            baz = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+                baz = "*"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
-            extern crate baz;
-            pub fn foo() {
-                bar::bar();
-                baz::baz();
-            }
-        "#,
+                extern crate bar;
+                extern crate baz;
+                pub fn foo() {
+                    bar::bar();
+                    baz::baz();
+                }
+            "#,
         )
         .build();
 
@@ -332,26 +332,26 @@ fn invalid_dir_bad() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             r#"
-            [source.crates-io]
-            registry = 'https://wut'
-            replace-with = 'my-awesome-local-directory'
+                [source.crates-io]
+                registry = 'https://wut'
+                replace-with = 'my-awesome-local-directory'
 
-            [source.my-awesome-local-directory]
-            local-registry = '/path/to/nowhere'
-        "#,
+                [source.my-awesome-local-directory]
+                local-registry = '/path/to/nowhere'
+            "#,
         )
         .build();
 
@@ -391,14 +391,14 @@ fn different_directory_replacing_the_registry_is_bad() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -460,14 +460,14 @@ fn crates_io_registry_url_is_optional() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.0.1"
-        "#,
+                [dependencies]
+                bar = "0.0.1"
+            "#,
         )
         .file(
             "src/lib.rs",

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -57,14 +57,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("Cargo.lock", old_lockfile)
@@ -103,14 +103,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("Cargo.lock", &old_lockfile)
@@ -194,14 +194,14 @@ fn wrong_checksum_is_an_error() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -257,14 +257,14 @@ fn unlisted_checksum_is_bad_if_we_calculate() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -323,14 +323,14 @@ fn listed_checksum_bad_if_we_cannot_compute() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = {{ git = '{}' }}
-        "#,
+                    [dependencies]
+                    bar = {{ git = '{}' }}
+                "#,
                 git.url()
             ),
         )
@@ -389,14 +389,14 @@ fn current_lockfile_format() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "");
     let p = p.build();
@@ -447,14 +447,14 @@ dependencies = [
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("Cargo.lock", lockfile);
@@ -492,14 +492,14 @@ fn locked_correct_error() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "");
     let p = p.build();
@@ -543,14 +543,14 @@ dependencies = [
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("Cargo.lock", &lockfile)

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -152,9 +152,9 @@ fn registry_credentials() {
     t!(f.write_all(
         format!(
             r#"
-        [registries.alternative2]
-        index = '{}'
-    "#,
+                [registries.alternative2]
+                index = '{}'
+            "#,
             registry::generate_url("alternative2-registry")
         )
         .as_bytes(),

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -390,17 +390,17 @@ fn project_with_dep(crate_types: &str) -> Project {
             "bar/Cargo.toml",
             &format!(
                 r#"
-                [package]
-                name = "bar"
-                version = "0.0.0"
+                    [package]
+                    name = "bar"
+                    version = "0.0.0"
 
-                [dependencies]
-                registry = "*"
-                registry-shared = "*"
+                    [dependencies]
+                    registry = "*"
+                    registry-shared = "*"
 
-                [lib]
-                crate-type = [{}]
-            "#,
+                    [lib]
+                    crate-type = [{}]
+                "#,
                 crate_types
             ),
         )

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -14,19 +14,19 @@ fn bad_file_member_exclusion() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = [ "crates/*" ]
-        "#,
+                [workspace]
+                members = [ "crates/*" ]
+            "#,
         )
         .file("crates/.DS_Store", "PLACEHOLDER")
         .file(
             "crates/bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+            "#,
         )
         .file("crates/bar/src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -17,29 +17,29 @@ fn toml_deserialize_manifest_error() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foobar == "0.55"
-        "#,
+                [dependencies]
+                foobar == "0.55"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .build();
@@ -66,29 +66,29 @@ fn member_manifest_path_io_error() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foobar = { path = "nosuch" }
-        "#,
+                [dependencies]
+                foobar = { path = "nosuch" }
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .build();
@@ -116,29 +116,29 @@ fn member_manifest_version_error() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            i-dont-exist = "0.55"
-        "#,
+                [dependencies]
+                i-dont-exist = "0.55"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -13,11 +13,11 @@ fn metabuild_gated() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = ["mb"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = ["mb"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -43,16 +43,16 @@ fn basic_project() -> Project {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = ["mb", "mb-other"]
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = ["mb", "mb-other"]
 
-            [build-dependencies]
-            mb = {path="mb"}
-            mb-other = {path="mb-other"}
-        "#,
+                [build-dependencies]
+                mb = {path="mb"}
+                mb-other = {path="mb-other"}
+            "#,
         )
         .file("src/lib.rs", "")
         .file("mb/Cargo.toml", &basic_lib_manifest("mb"))
@@ -63,10 +63,10 @@ fn basic_project() -> Project {
         .file(
             "mb-other/Cargo.toml",
             r#"
-            [package]
-            name = "mb-other"
-            version = "0.0.1"
-        "#,
+                [package]
+                name = "mb-other"
+                version = "0.0.1"
+            "#,
         )
         .file(
             "mb-other/src/lib.rs",
@@ -91,15 +91,15 @@ fn metabuild_error_both() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = "mb"
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = "mb"
 
-            [build-dependencies]
-            mb = {path="mb"}
-        "#,
+                [build-dependencies]
+                mb = {path="mb"}
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", r#"fn main() {}"#)
@@ -130,12 +130,12 @@ fn metabuild_missing_dep() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = "mb"
-        "#,
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = "mb"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -159,15 +159,15 @@ fn metabuild_optional_dep() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = "mb"
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = "mb"
 
-            [build-dependencies]
-            mb = {path="mb", optional=true}
-        "#,
+                [build-dependencies]
+                mb = {path="mb", optional=true}
+            "#,
         )
         .file("src/lib.rs", "")
         .file("mb/Cargo.toml", &basic_lib_manifest("mb"))
@@ -195,26 +195,26 @@ fn metabuild_lib_name() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = "mb"
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = "mb"
 
-            [build-dependencies]
-            mb = {path="mb"}
-        "#,
+                [build-dependencies]
+                mb = {path="mb"}
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "mb/Cargo.toml",
             r#"
-            [package]
-            name = "mb"
-            version = "0.0.1"
-            [lib]
-            name = "other"
-        "#,
+                [package]
+                name = "mb"
+                version = "0.0.1"
+                [lib]
+                name = "other"
+            "#,
         )
         .file(
             "mb/src/lib.rs",
@@ -243,15 +243,15 @@ fn metabuild_fresh() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            metabuild = "mb"
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                metabuild = "mb"
 
-            [build-dependencies]
-            mb = {path="mb"}
-        "#,
+                [build-dependencies]
+                mb = {path="mb"}
+            "#,
         )
         .file("src/lib.rs", "")
         .file("mb/Cargo.toml", &basic_lib_manifest("mb"))
@@ -285,26 +285,28 @@ fn metabuild_links() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            links = "cat"
-            metabuild = "mb"
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                links = "cat"
+                metabuild = "mb"
 
-            [build-dependencies]
-            mb = {path="mb"}
-        "#,
+                [build-dependencies]
+                mb = {path="mb"}
+            "#,
         )
         .file("src/lib.rs", "")
         .file("mb/Cargo.toml", &basic_lib_manifest("mb"))
         .file(
             "mb/src/lib.rs",
-            r#"pub fn metabuild() {
-                assert_eq!(std::env::var("CARGO_MANIFEST_LINKS"),
-                    Ok("cat".to_string()));
-                println!("Hello mb");
-            }"#,
+            r#"
+                pub fn metabuild() {
+                    assert_eq!(std::env::var("CARGO_MANIFEST_LINKS"),
+                        Ok("cat".to_string()));
+                    println!("Hello mb");
+                }
+            "#,
         )
         .build();
 
@@ -320,16 +322,16 @@ fn metabuild_override() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            links = "cat"
-            metabuild = "mb"
+                cargo-features = ["metabuild"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                links = "cat"
+                metabuild = "mb"
 
-            [build-dependencies]
-            mb = {path="mb"}
-        "#,
+                [build-dependencies]
+                mb = {path="mb"}
+            "#,
         )
         .file("src/lib.rs", "")
         .file("mb/Cargo.toml", &basic_lib_manifest("mb"))
@@ -341,9 +343,9 @@ fn metabuild_override() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}.cat]
-            rustc-link-lib = ["a"]
-        "#,
+                    [target.{}.cat]
+                    rustc-link-lib = ["a"]
+                "#,
                 rustc_host()
             ),
         )
@@ -358,37 +360,37 @@ fn metabuild_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["member1", "member2"]
-        "#,
+                [workspace]
+                members = ["member1", "member2"]
+            "#,
         )
         .file(
             "member1/Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "member1"
-            version = "0.0.1"
-            metabuild = ["mb1", "mb2"]
+                cargo-features = ["metabuild"]
+                [package]
+                name = "member1"
+                version = "0.0.1"
+                metabuild = ["mb1", "mb2"]
 
-            [build-dependencies]
-            mb1 = {path="../../mb1"}
-            mb2 = {path="../../mb2"}
-        "#,
+                [build-dependencies]
+                mb1 = {path="../../mb1"}
+                mb2 = {path="../../mb2"}
+            "#,
         )
         .file("member1/src/lib.rs", "")
         .file(
             "member2/Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "member2"
-            version = "0.0.1"
-            metabuild = ["mb1"]
+                cargo-features = ["metabuild"]
+                [package]
+                name = "member2"
+                version = "0.0.1"
+                metabuild = ["mb1"]
 
-            [build-dependencies]
-            mb1 = {path="../../mb1"}
-        "#,
+                [build-dependencies]
+                mb1 = {path="../../mb1"}
+            "#,
         )
         .file("member2/src/lib.rs", "")
         .build();
@@ -454,95 +456,95 @@ fn metabuild_build_plan() {
         .masquerade_as_nightly_cargo()
         .with_json(
             r#"
-{
-    "invocations": [
-        {
-            "package_name": "mb",
-            "package_version": "0.5.0",
-            "target_kind": ["lib"],
-            "compile_mode": "build",
-            "kind": null,
-            "deps": [],
-            "outputs": [
-                "[..]/target/debug/deps/libmb-[..].rlib",
-                "[..]/target/debug/deps/libmb-[..].rmeta"
-            ],
-            "links": {},
-            "program": "rustc",
-            "args": "{...}",
-            "env": "{...}",
-            "cwd": "[..]"
-        },
-        {
-            "package_name": "mb-other",
-            "package_version": "0.0.1",
-            "target_kind": ["lib"],
-            "compile_mode": "build",
-            "kind": null,
-            "deps": [],
-            "outputs": [
-                "[..]/target/debug/deps/libmb_other-[..].rlib",
-                "[..]/target/debug/deps/libmb_other-[..].rmeta"
-            ],
-            "links": {},
-            "program": "rustc",
-            "args": "{...}",
-            "env": "{...}",
-            "cwd": "[..]"
-        },
-        {
-            "package_name": "foo",
-            "package_version": "0.0.1",
-            "target_kind": ["custom-build"],
-            "compile_mode": "build",
-            "kind": null,
-            "deps": [0, 1],
-            "outputs": "{...}",
-            "links": "{...}",
-            "program": "rustc",
-            "args": "{...}",
-            "env": "{...}",
-            "cwd": "[..]"
-        },
-        {
-            "package_name": "foo",
-            "package_version": "0.0.1",
-            "target_kind": ["custom-build"],
-            "compile_mode": "run-custom-build",
-            "kind": null,
-            "deps": [2],
-            "outputs": [],
-            "links": {},
-            "program": "[..]/foo/target/debug/build/foo-[..]/metabuild-foo",
-            "args": [],
-            "env": "{...}",
-            "cwd": "[..]"
-        },
-        {
-            "package_name": "foo",
-            "package_version": "0.0.1",
-            "target_kind": ["lib"],
-            "compile_mode": "build",
-            "kind": null,
-            "deps": [3],
-            "outputs": [
-                "[..]/foo/target/debug/deps/libfoo-[..].rlib",
-                "[..]/foo/target/debug/deps/libfoo-[..].rmeta"
-            ],
-            "links": "{...}",
-            "program": "rustc",
-            "args": "{...}",
-            "env": "{...}",
-            "cwd": "[..]"
-        }
-    ],
-    "inputs": [
-        "[..]/foo/Cargo.toml",
-        "[..]/foo/mb/Cargo.toml",
-        "[..]/foo/mb-other/Cargo.toml"
-    ]
-}
-"#,
+            {
+                "invocations": [
+                    {
+                        "package_name": "mb",
+                        "package_version": "0.5.0",
+                        "target_kind": ["lib"],
+                        "compile_mode": "build",
+                        "kind": null,
+                        "deps": [],
+                        "outputs": [
+                            "[..]/target/debug/deps/libmb-[..].rlib",
+                            "[..]/target/debug/deps/libmb-[..].rmeta"
+                        ],
+                        "links": {},
+                        "program": "rustc",
+                        "args": "{...}",
+                        "env": "{...}",
+                        "cwd": "[..]"
+                    },
+                    {
+                        "package_name": "mb-other",
+                        "package_version": "0.0.1",
+                        "target_kind": ["lib"],
+                        "compile_mode": "build",
+                        "kind": null,
+                        "deps": [],
+                        "outputs": [
+                            "[..]/target/debug/deps/libmb_other-[..].rlib",
+                            "[..]/target/debug/deps/libmb_other-[..].rmeta"
+                        ],
+                        "links": {},
+                        "program": "rustc",
+                        "args": "{...}",
+                        "env": "{...}",
+                        "cwd": "[..]"
+                    },
+                    {
+                        "package_name": "foo",
+                        "package_version": "0.0.1",
+                        "target_kind": ["custom-build"],
+                        "compile_mode": "build",
+                        "kind": null,
+                        "deps": [0, 1],
+                        "outputs": "{...}",
+                        "links": "{...}",
+                        "program": "rustc",
+                        "args": "{...}",
+                        "env": "{...}",
+                        "cwd": "[..]"
+                    },
+                    {
+                        "package_name": "foo",
+                        "package_version": "0.0.1",
+                        "target_kind": ["custom-build"],
+                        "compile_mode": "run-custom-build",
+                        "kind": null,
+                        "deps": [2],
+                        "outputs": [],
+                        "links": {},
+                        "program": "[..]/foo/target/debug/build/foo-[..]/metabuild-foo",
+                        "args": [],
+                        "env": "{...}",
+                        "cwd": "[..]"
+                    },
+                    {
+                        "package_name": "foo",
+                        "package_version": "0.0.1",
+                        "target_kind": ["lib"],
+                        "compile_mode": "build",
+                        "kind": null,
+                        "deps": [3],
+                        "outputs": [
+                            "[..]/foo/target/debug/deps/libfoo-[..].rlib",
+                            "[..]/foo/target/debug/deps/libfoo-[..].rmeta"
+                        ],
+                        "links": "{...}",
+                        "program": "rustc",
+                        "args": "{...}",
+                        "env": "{...}",
+                        "cwd": "[..]"
+                    }
+                ],
+                "inputs": [
+                    "[..]/foo/Cargo.toml",
+                    "[..]/foo/mb/Cargo.toml",
+                    "[..]/foo/mb-other/Cargo.toml"
+                ]
+            }
+            "#,
         )
         .run();
 
@@ -557,36 +559,36 @@ fn metabuild_two_versions() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["member1", "member2"]
-        "#,
+                [workspace]
+                members = ["member1", "member2"]
+            "#,
         )
         .file(
             "member1/Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "member1"
-            version = "0.0.1"
-            metabuild = ["mb"]
+                cargo-features = ["metabuild"]
+                [package]
+                name = "member1"
+                version = "0.0.1"
+                metabuild = ["mb"]
 
-            [build-dependencies]
-            mb = {path="../../mb1"}
-        "#,
+                [build-dependencies]
+                mb = {path="../../mb1"}
+            "#,
         )
         .file("member1/src/lib.rs", "")
         .file(
             "member2/Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "member2"
-            version = "0.0.1"
-            metabuild = ["mb"]
+                cargo-features = ["metabuild"]
+                [package]
+                name = "member2"
+                version = "0.0.1"
+                metabuild = ["mb"]
 
-            [build-dependencies]
-            mb = {path="../../mb2"}
-        "#,
+                [build-dependencies]
+                mb = {path="../../mb2"}
+            "#,
         )
         .file("member2/src/lib.rs", "")
         .build();
@@ -640,15 +642,15 @@ fn metabuild_external_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["metabuild"]
-            [package]
-            name = "dep"
-            version = "1.0.0"
-            metabuild = ["mb"]
+                cargo-features = ["metabuild"]
+                [package]
+                name = "dep"
+                version = "1.0.0"
+                metabuild = ["mb"]
 
-            [build-dependencies]
-            mb = "1.0"
-        "#,
+                [build-dependencies]
+                mb = "1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build_dep("mb", "1.0.0")
@@ -683,39 +685,39 @@ fn metabuild_json_artifact() {
         .masquerade_as_nightly_cargo()
         .with_json_contains_unordered(
             r#"
-{
-  "executable": null,
-  "features": [],
-  "filenames": "{...}",
-  "fresh": false,
-  "package_id": "foo [..]",
-  "profile": "{...}",
-  "reason": "compiler-artifact",
-  "target": {
-    "crate_types": [
-      "bin"
-    ],
-    "doctest": false,
-    "edition": "2018",
-    "kind": [
-      "custom-build"
-    ],
-    "name": "metabuild-foo",
-    "src_path": "[..]/foo/target/.metabuild/metabuild-foo-[..].rs",
-    "test": false
-  }
-}
+            {
+              "executable": null,
+              "features": [],
+              "filenames": "{...}",
+              "fresh": false,
+              "package_id": "foo [..]",
+              "profile": "{...}",
+              "reason": "compiler-artifact",
+              "target": {
+                "crate_types": [
+                  "bin"
+                ],
+                "doctest": false,
+                "edition": "2018",
+                "kind": [
+                  "custom-build"
+                ],
+                "name": "metabuild-foo",
+                "src_path": "[..]/foo/target/.metabuild/metabuild-foo-[..].rs",
+                "test": false
+              }
+            }
 
-{
-  "cfgs": [],
-  "env": [],
-  "linked_libs": [],
-  "linked_paths": [],
-  "package_id": "foo [..]",
-  "out_dir": "[..]",
-  "reason": "build-script-executed"
-}
-"#,
+            {
+              "cfgs": [],
+              "env": [],
+              "linked_libs": [],
+              "linked_paths": [],
+              "package_id": "foo [..]",
+              "out_dir": "[..]",
+              "reason": "build-script-executed"
+            }
+            "#,
         )
         .run();
 }
@@ -730,32 +732,32 @@ fn metabuild_failed_build_json() {
         .with_status(101)
         .with_json_contains_unordered(
             r#"
-{
-  "message": {
-    "children": "{...}",
-    "code": "{...}",
-    "level": "error",
-    "message": "cannot find function `metabuild` in [..] `mb`",
-    "rendered": "[..]",
-    "spans": "{...}"
-  },
-  "package_id": "foo [..]",
-  "reason": "compiler-message",
-  "target": {
-    "crate_types": [
-      "bin"
-    ],
-    "doctest": false,
-    "edition": "2018",
-    "kind": [
-      "custom-build"
-    ],
-    "name": "metabuild-foo",
-    "src_path": null,
-    "test": false
-  }
-}
-"#,
+            {
+              "message": {
+                "children": "{...}",
+                "code": "{...}",
+                "level": "error",
+                "message": "cannot find function `metabuild` in [..] `mb`",
+                "rendered": "[..]",
+                "spans": "{...}"
+              },
+              "package_id": "foo [..]",
+              "reason": "compiler-message",
+              "target": {
+                "crate_types": [
+                  "bin"
+                ],
+                "doctest": false,
+                "edition": "2018",
+                "kind": [
+                  "custom-build"
+                ],
+                "name": "metabuild-foo",
+                "src_path": null,
+                "test": false
+              }
+            }
+            "#,
         )
         .run();
 }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -267,21 +267,21 @@ fn cargo_metadata_with_deps_and_version() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [[bin]]
-            name = "foo"
+                [[bin]]
+                name = "foo"
 
-            [dependencies]
-            bar = "*"
-            [dev-dependencies]
-            foobar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+                [dev-dependencies]
+                foobar = "*"
+            "#,
         )
         .build();
     Package::new("baz", "0.0.1").publish();
@@ -737,17 +737,17 @@ fn workspace_metadata() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
+                [workspace]
+                members = ["bar", "baz"]
 
-            [workspace.metadata]
-            tool1 = "hello"
-            tool2 = [1, 2, 3]
+                [workspace.metadata]
+                tool1 = "hello"
+                tool2 = [1, 2, 3]
 
-            [workspace.metadata.foo]
-            bar = 3
+                [workspace.metadata.foo]
+                bar = 3
 
-        "#,
+            "#,
         )
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
@@ -868,9 +868,9 @@ fn workspace_metadata_no_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
@@ -1119,15 +1119,15 @@ fn multiple_features() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            a = []
-            b = []
-        "#,
+                [features]
+                a = []
+                b = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1141,18 +1141,18 @@ fn package_metadata() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = ["wycats@example.com"]
-            categories = ["database"]
-            keywords = ["database"]
-            readme = "README.md"
-            repository = "https://github.com/rust-lang/cargo"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = ["wycats@example.com"]
+                categories = ["database"]
+                keywords = ["database"]
+                readme = "README.md"
+                repository = "https://github.com/rust-lang/cargo"
 
-            [package.metadata.bar]
-            baz = "quux"
-        "#,
+                [package.metadata.bar]
+                baz = "quux"
+            "#,
         )
         .file("README.md", "")
         .file("src/lib.rs", "")
@@ -1217,16 +1217,16 @@ fn package_publish() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = ["wycats@example.com"]
-            categories = ["database"]
-            keywords = ["database"]
-            readme = "README.md"
-            repository = "https://github.com/rust-lang/cargo"
-            publish = ["my-registry"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = ["wycats@example.com"]
+                categories = ["database"]
+                keywords = ["database"]
+                readme = "README.md"
+                repository = "https://github.com/rust-lang/cargo"
+                publish = ["my-registry"]
+            "#,
         )
         .file("README.md", "")
         .file("src/lib.rs", "")
@@ -1287,9 +1287,9 @@ fn cargo_metadata_path_to_cargo_toml_project() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
@@ -1304,67 +1304,67 @@ fn cargo_metadata_path_to_cargo_toml_project() {
         .arg(p.root().join("target/package/bar-0.5.0/Cargo.toml"))
         .with_json(
             r#"
-        {
-            "packages": [
             {
-                "authors": [
-                    "wycats@example.com"
-                ],
-                "categories": [],
-                "dependencies": [],
-                "description": null,
-                "edition": "2015",
-                "features": {},
-                "id": "bar 0.5.0 ([..])",
-                "keywords": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null,
-                "name": "bar",
-                "readme": null,
-                "repository": null,
-                "source": null,
-                "targets": [
+                "packages": [
                 {
-                    "crate_types": [
-                        "lib"
+                    "authors": [
+                        "wycats@example.com"
                     ],
-                    "doctest": true,
-                    "test": true,
-                    "edition": "2015",
-                    "kind": [
-                        "lib"
-                    ],
-                    "name": "bar",
-                    "src_path": "[..]src/lib.rs"
-                }
-                ],
-                "version": "0.5.0"
-            }
-            ],
-            "resolve": {
-                "nodes": [
-                {
+                    "categories": [],
                     "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "bar 0.5.0 ([..])"
+                    "description": null,
+                    "edition": "2015",
+                    "features": {},
+                    "id": "bar 0.5.0 ([..])",
+                    "keywords": [],
+                    "license": null,
+                    "license_file": null,
+                    "links": null,
+                    "manifest_path": "[..]Cargo.toml",
+                    "metadata": null,
+                    "publish": null,
+                    "name": "bar",
+                    "readme": null,
+                    "repository": null,
+                    "source": null,
+                    "targets": [
+                    {
+                        "crate_types": [
+                            "lib"
+                        ],
+                        "doctest": true,
+                        "test": true,
+                        "edition": "2015",
+                        "kind": [
+                            "lib"
+                        ],
+                        "name": "bar",
+                        "src_path": "[..]src/lib.rs"
+                    }
+                    ],
+                    "version": "0.5.0"
                 }
                 ],
-                "root": "bar 0.5.0 (path+file:[..])"
-            },
-            "target_directory": "[..]",
-            "version": 1,
-            "workspace_members": [
-                "bar 0.5.0 (path+file:[..])"
-            ],
-            "workspace_root": "[..]",
-            "metadata": null
-        }
-"#,
+                "resolve": {
+                    "nodes": [
+                    {
+                        "dependencies": [],
+                        "deps": [],
+                        "features": [],
+                        "id": "bar 0.5.0 ([..])"
+                    }
+                    ],
+                    "root": "bar 0.5.0 (path+file:[..])"
+                },
+                "target_directory": "[..]",
+                "version": 1,
+                "workspace_members": [
+                    "bar 0.5.0 (path+file:[..])"
+                ],
+                "workspace_root": "[..]",
+                "metadata": null
+            }
+            "#,
         )
         .run();
 }
@@ -1376,78 +1376,78 @@ fn package_edition_2018() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = ["wycats@example.com"]
-            edition = "2018"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = ["wycats@example.com"]
+                edition = "2018"
+            "#,
         )
         .build();
     p.cargo("metadata")
         .with_json(
             r#"
-        {
-            "packages": [
-                {
-                    "authors": [
-                        "wycats@example.com"
-                    ],
-                    "categories": [],
-                    "dependencies": [],
-                    "description": null,
-                    "edition": "2018",
-                    "features": {},
-                    "id": "foo 0.1.0 (path+file:[..])",
-                    "keywords": [],
-                    "license": null,
-                    "license_file": null,
-                    "links": null,
-                    "manifest_path": "[..]Cargo.toml",
-                    "metadata": null,
-                    "publish": null,
-                    "name": "foo",
-                    "readme": null,
-                    "repository": null,
-                    "source": null,
-                    "targets": [
-                        {
-                            "crate_types": [
-                                "lib"
-                            ],
-                            "doctest": true,
-                            "test": true,
-                            "edition": "2018",
-                            "kind": [
-                                "lib"
-                            ],
-                            "name": "foo",
-                            "src_path": "[..]src/lib.rs"
-                        }
-                    ],
-                    "version": "0.1.0"
-                }
-            ],
-            "resolve": {
-                "nodes": [
+            {
+                "packages": [
                     {
+                        "authors": [
+                            "wycats@example.com"
+                        ],
+                        "categories": [],
                         "dependencies": [],
-                        "deps": [],
-                        "features": [],
-                        "id": "foo 0.1.0 (path+file:[..])"
+                        "description": null,
+                        "edition": "2018",
+                        "features": {},
+                        "id": "foo 0.1.0 (path+file:[..])",
+                        "keywords": [],
+                        "license": null,
+                        "license_file": null,
+                        "links": null,
+                        "manifest_path": "[..]Cargo.toml",
+                        "metadata": null,
+                        "publish": null,
+                        "name": "foo",
+                        "readme": null,
+                        "repository": null,
+                        "source": null,
+                        "targets": [
+                            {
+                                "crate_types": [
+                                    "lib"
+                                ],
+                                "doctest": true,
+                                "test": true,
+                                "edition": "2018",
+                                "kind": [
+                                    "lib"
+                                ],
+                                "name": "foo",
+                                "src_path": "[..]src/lib.rs"
+                            }
+                        ],
+                        "version": "0.1.0"
                     }
                 ],
-                "root": "foo 0.1.0 (path+file:[..])"
-            },
-            "target_directory": "[..]",
-            "version": 1,
-            "workspace_members": [
-                "foo 0.1.0 (path+file:[..])"
-            ],
-            "workspace_root": "[..]",
-            "metadata": null
-        }
-        "#,
+                "resolve": {
+                    "nodes": [
+                        {
+                            "dependencies": [],
+                            "deps": [],
+                            "features": [],
+                            "id": "foo 0.1.0 (path+file:[..])"
+                        }
+                    ],
+                    "root": "foo 0.1.0 (path+file:[..])"
+                },
+                "target_directory": "[..]",
+                "version": 1,
+                "workspace_members": [
+                    "foo 0.1.0 (path+file:[..])"
+                ],
+                "workspace_root": "[..]",
+                "metadata": null
+            }
+            "#,
         )
         .run();
 }
@@ -1460,94 +1460,94 @@ fn target_edition_2018() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = ["wycats@example.com"]
-            edition = "2015"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = ["wycats@example.com"]
+                edition = "2015"
 
-            [lib]
-            edition = "2018"
-        "#,
+                [lib]
+                edition = "2018"
+            "#,
         )
         .build();
     p.cargo("metadata")
         .with_json(
             r#"
-        {
-            "packages": [
-                {
-                    "authors": [
-                        "wycats@example.com"
-                    ],
-                    "categories": [],
-                    "dependencies": [],
-                    "description": null,
-                    "edition": "2015",
-                    "features": {},
-                    "id": "foo 0.1.0 (path+file:[..])",
-                    "keywords": [],
-                    "license": null,
-                    "license_file": null,
-                    "links": null,
-                    "manifest_path": "[..]Cargo.toml",
-                    "metadata": null,
-                    "publish": null,
-                    "name": "foo",
-                    "readme": null,
-                    "repository": null,
-                    "source": null,
-                    "targets": [
-                        {
-                            "crate_types": [
-                                "lib"
-                            ],
-                            "doctest": true,
-                            "test": true,
-                            "edition": "2018",
-                            "kind": [
-                                "lib"
-                            ],
-                            "name": "foo",
-                            "src_path": "[..]src/lib.rs"
-                        },
-                        {
-                            "crate_types": [
-                                "bin"
-                            ],
-                            "doctest": false,
-                            "test": true,
-                            "edition": "2015",
-                            "kind": [
-                                "bin"
-                            ],
-                            "name": "foo",
-                            "src_path": "[..]src/main.rs"
-                        }
-                    ],
-                    "version": "0.1.0"
-                }
-            ],
-            "resolve": {
-                "nodes": [
+            {
+                "packages": [
                     {
+                        "authors": [
+                            "wycats@example.com"
+                        ],
+                        "categories": [],
                         "dependencies": [],
-                        "deps": [],
-                        "features": [],
-                        "id": "foo 0.1.0 (path+file:[..])"
+                        "description": null,
+                        "edition": "2015",
+                        "features": {},
+                        "id": "foo 0.1.0 (path+file:[..])",
+                        "keywords": [],
+                        "license": null,
+                        "license_file": null,
+                        "links": null,
+                        "manifest_path": "[..]Cargo.toml",
+                        "metadata": null,
+                        "publish": null,
+                        "name": "foo",
+                        "readme": null,
+                        "repository": null,
+                        "source": null,
+                        "targets": [
+                            {
+                                "crate_types": [
+                                    "lib"
+                                ],
+                                "doctest": true,
+                                "test": true,
+                                "edition": "2018",
+                                "kind": [
+                                    "lib"
+                                ],
+                                "name": "foo",
+                                "src_path": "[..]src/lib.rs"
+                            },
+                            {
+                                "crate_types": [
+                                    "bin"
+                                ],
+                                "doctest": false,
+                                "test": true,
+                                "edition": "2015",
+                                "kind": [
+                                    "bin"
+                                ],
+                                "name": "foo",
+                                "src_path": "[..]src/main.rs"
+                            }
+                        ],
+                        "version": "0.1.0"
                     }
                 ],
-                "root": "foo 0.1.0 (path+file:[..])"
-            },
-            "target_directory": "[..]",
-            "version": 1,
-            "workspace_members": [
-                "foo 0.1.0 (path+file:[..])"
-            ],
-            "workspace_root": "[..]",
-            "metadata": null
-        }
-        "#,
+                "resolve": {
+                    "nodes": [
+                        {
+                            "dependencies": [],
+                            "deps": [],
+                            "features": [],
+                            "id": "foo 0.1.0 (path+file:[..])"
+                        }
+                    ],
+                    "root": "foo 0.1.0 (path+file:[..])"
+                },
+                "target_directory": "[..]",
+                "version": 1,
+                "workspace_members": [
+                    "foo 0.1.0 (path+file:[..])"
+                ],
+                "workspace_root": "[..]",
+                "metadata": null
+            }
+            "#,
         )
         .run();
 }
@@ -1561,15 +1561,15 @@ fn rename_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { version = "0.1.0" }
-            baz = { version = "0.2.0", package = "bar" }
-        "#,
+                [dependencies]
+                bar = { version = "0.1.0" }
+                baz = { version = "0.2.0", package = "bar" }
+            "#,
         )
         .file("src/lib.rs", "extern crate bar; extern crate baz;")
         .build();
@@ -1791,78 +1791,78 @@ fn metadata_links() {
     p.cargo("metadata")
         .with_json(
             r#"
-{
-  "packages": [
-    {
-      "authors": [],
-      "categories": [],
-      "dependencies": [],
-      "description": null,
-      "edition": "2015",
-      "features": {},
-      "id": "foo 0.5.0 [..]",
-      "keywords": [],
-      "license": null,
-      "license_file": null,
-      "links": "a",
-      "manifest_path": "[..]/foo/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "name": "foo",
-      "readme": null,
-      "repository": null,
-      "source": null,
-      "targets": [
-        {
-          "crate_types": [
-            "lib"
-          ],
-          "doctest": true,
-          "test": true,
-          "edition": "2015",
-          "kind": [
-            "lib"
-          ],
-          "name": "foo",
-          "src_path": "[..]/foo/src/lib.rs"
-        },
-        {
-          "crate_types": [
-            "bin"
-          ],
-          "doctest": false,
-          "test": false,
-          "edition": "2015",
-          "kind": [
-            "custom-build"
-          ],
-          "name": "build-script-build",
-          "src_path": "[..]/foo/build.rs"
-        }
-      ],
-      "version": "0.5.0"
-    }
-  ],
-  "resolve": {
-    "nodes": [
-      {
-        "dependencies": [],
-        "deps": [],
-        "features": [],
-        "id": "foo 0.5.0 [..]"
-      }
-    ],
-    "root": "foo 0.5.0 [..]"
-  },
-  "target_directory": "[..]/foo/target",
-  "version": 1,
-  "workspace_members": [
-    "foo 0.5.0 [..]"
-  ],
-  "workspace_root": "[..]/foo",
-  "metadata": null
-}
-"#,
+            {
+              "packages": [
+                {
+                  "authors": [],
+                  "categories": [],
+                  "dependencies": [],
+                  "description": null,
+                  "edition": "2015",
+                  "features": {},
+                  "id": "foo 0.5.0 [..]",
+                  "keywords": [],
+                  "license": null,
+                  "license_file": null,
+                  "links": "a",
+                  "manifest_path": "[..]/foo/Cargo.toml",
+                  "metadata": null,
+                  "publish": null,
+                  "name": "foo",
+                  "readme": null,
+                  "repository": null,
+                  "source": null,
+                  "targets": [
+                    {
+                      "crate_types": [
+                        "lib"
+                      ],
+                      "doctest": true,
+                      "test": true,
+                      "edition": "2015",
+                      "kind": [
+                        "lib"
+                      ],
+                      "name": "foo",
+                      "src_path": "[..]/foo/src/lib.rs"
+                    },
+                    {
+                      "crate_types": [
+                        "bin"
+                      ],
+                      "doctest": false,
+                      "test": false,
+                      "edition": "2015",
+                      "kind": [
+                        "custom-build"
+                      ],
+                      "name": "build-script-build",
+                      "src_path": "[..]/foo/build.rs"
+                    }
+                  ],
+                  "version": "0.5.0"
+                }
+              ],
+              "resolve": {
+                "nodes": [
+                  {
+                    "dependencies": [],
+                    "deps": [],
+                    "features": [],
+                    "id": "foo 0.5.0 [..]"
+                  }
+                ],
+                "root": "foo 0.5.0 [..]"
+              },
+              "target_directory": "[..]/foo/target",
+              "version": 1,
+              "workspace_members": [
+                "foo 0.5.0 [..]"
+              ],
+              "workspace_root": "[..]/foo",
+              "metadata": null
+            }
+            "#,
         )
         .run()
 }
@@ -1873,12 +1873,12 @@ fn deps_with_bin_only() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [dependencies]
-            bdep = { path = "bdep" }
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [dependencies]
+                bdep = { path = "bdep" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bdep/Cargo.toml", &basic_bin_manifest("bdep"))
@@ -1888,78 +1888,78 @@ fn deps_with_bin_only() {
     p.cargo("metadata")
         .with_json(
             r#"
-{
-  "packages": [
-    {
-      "name": "foo",
-      "version": "0.1.0",
-      "id": "foo 0.1.0 ([..])",
-      "license": null,
-      "license_file": null,
-      "description": null,
-      "source": null,
-      "dependencies": [
-        {
-          "name": "bdep",
-          "source": null,
-          "req": "*",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
-          "features": [],
-          "target": null,
-          "registry": null
-        }
-      ],
-      "targets": [
-        {
-          "kind": [
-            "lib"
-          ],
-          "crate_types": [
-            "lib"
-          ],
-          "name": "foo",
-          "src_path": "[..]/foo/src/lib.rs",
-          "edition": "2015",
-          "doctest": true,
-          "test": true
-        }
-      ],
-      "features": {},
-      "manifest_path": "[..]/foo/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": null,
-      "edition": "2015",
-      "links": null
-    }
-  ],
-  "workspace_members": [
-    "foo 0.1.0 ([..])"
-  ],
-  "resolve": {
-    "nodes": [
-      {
-        "id": "foo 0.1.0 ([..])",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      }
-    ],
-    "root": "foo 0.1.0 ([..])"
-  },
-  "target_directory": "[..]/foo/target",
-  "version": 1,
-  "workspace_root": "[..]foo",
-  "metadata": null
-}
-"#,
+            {
+              "packages": [
+                {
+                  "name": "foo",
+                  "version": "0.1.0",
+                  "id": "foo 0.1.0 ([..])",
+                  "license": null,
+                  "license_file": null,
+                  "description": null,
+                  "source": null,
+                  "dependencies": [
+                    {
+                      "name": "bdep",
+                      "source": null,
+                      "req": "*",
+                      "kind": null,
+                      "rename": null,
+                      "optional": false,
+                      "uses_default_features": true,
+                      "features": [],
+                      "target": null,
+                      "registry": null
+                    }
+                  ],
+                  "targets": [
+                    {
+                      "kind": [
+                        "lib"
+                      ],
+                      "crate_types": [
+                        "lib"
+                      ],
+                      "name": "foo",
+                      "src_path": "[..]/foo/src/lib.rs",
+                      "edition": "2015",
+                      "doctest": true,
+                      "test": true
+                    }
+                  ],
+                  "features": {},
+                  "manifest_path": "[..]/foo/Cargo.toml",
+                  "metadata": null,
+                  "publish": null,
+                  "authors": [],
+                  "categories": [],
+                  "keywords": [],
+                  "readme": null,
+                  "repository": null,
+                  "edition": "2015",
+                  "links": null
+                }
+              ],
+              "workspace_members": [
+                "foo 0.1.0 ([..])"
+              ],
+              "resolve": {
+                "nodes": [
+                  {
+                    "id": "foo 0.1.0 ([..])",
+                    "dependencies": [],
+                    "deps": [],
+                    "features": []
+                  }
+                ],
+                "root": "foo 0.1.0 ([..])"
+              },
+              "target_directory": "[..]/foo/target",
+              "version": 1,
+              "workspace_root": "[..]foo",
+              "metadata": null
+            }
+            "#,
         )
         .run();
 }
@@ -2629,70 +2629,70 @@ fn dep_kinds() {
     p.cargo("metadata")
         .with_json(
             r#"
-{
-  "packages": "{...}",
-  "workspace_members": "{...}",
-  "target_directory": "{...}",
-  "version": 1,
-  "workspace_root": "{...}",
-  "metadata": null,
-  "resolve": {
-    "nodes": [
-      {
-        "id": "bar 0.1.0 [..]",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "foo 0.1.0 [..]",
-        "dependencies": [
-          "bar 0.1.0 [..]",
-          "winapi 0.1.0 [..]"
-        ],
-        "deps": [
-          {
-            "name": "bar",
-            "pkg": "bar 0.1.0 [..]",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              },
-              {
-                "kind": "dev",
-                "target": null
-              },
-              {
-                "kind": "build",
-                "target": null
+            {
+              "packages": "{...}",
+              "workspace_members": "{...}",
+              "target_directory": "{...}",
+              "version": 1,
+              "workspace_root": "{...}",
+              "metadata": null,
+              "resolve": {
+                "nodes": [
+                  {
+                    "id": "bar 0.1.0 [..]",
+                    "dependencies": [],
+                    "deps": [],
+                    "features": []
+                  },
+                  {
+                    "id": "foo 0.1.0 [..]",
+                    "dependencies": [
+                      "bar 0.1.0 [..]",
+                      "winapi 0.1.0 [..]"
+                    ],
+                    "deps": [
+                      {
+                        "name": "bar",
+                        "pkg": "bar 0.1.0 [..]",
+                        "dep_kinds": [
+                          {
+                            "kind": null,
+                            "target": null
+                          },
+                          {
+                            "kind": "dev",
+                            "target": null
+                          },
+                          {
+                            "kind": "build",
+                            "target": null
+                          }
+                        ]
+                      },
+                      {
+                        "name": "winapi",
+                        "pkg": "winapi 0.1.0 [..]",
+                        "dep_kinds": [
+                          {
+                            "kind": null,
+                            "target": "cfg(windows)"
+                          }
+                        ]
+                      }
+                    ],
+                    "features": []
+                  },
+                  {
+                    "id": "winapi 0.1.0 [..]",
+                    "dependencies": [],
+                    "deps": [],
+                    "features": []
+                  }
+                ],
+                "root": "foo 0.1.0 [..]"
               }
-            ]
-          },
-          {
-            "name": "winapi",
-            "pkg": "winapi 0.1.0 [..]",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": "cfg(windows)"
-              }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "winapi 0.1.0 [..]",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      }
-    ],
-    "root": "foo 0.1.0 [..]"
-  }
-}
-"#,
+            }
+            "#,
         )
         .run();
 }
@@ -2710,19 +2710,19 @@ fn dep_kinds_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [features]
-            feat1 = []
+                [features]
+                feat1 = []
 
-            [dependencies]
-            dep = { path="dep" }
+                [dependencies]
+                dep = { path="dep" }
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -2744,66 +2744,66 @@ fn dep_kinds_workspace() {
     p.cargo("metadata")
         .with_json(
             r#"
-{
-  "packages": "{...}",
-  "workspace_members": "{...}",
-  "target_directory": "[..]/foo/target",
-  "version": 1,
-  "workspace_root": "[..]/foo",
-  "metadata": null,
-  "resolve": {
-    "nodes": [
-      {
-        "id": "bar 0.1.0 (path+file://[..]/foo/bar)",
-        "dependencies": [
-          "foo 0.1.0 (path+file://[..]/foo)"
-        ],
-        "deps": [
-          {
-            "name": "foo",
-            "pkg": "foo 0.1.0 (path+file://[..]/foo)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
+            {
+              "packages": "{...}",
+              "workspace_members": "{...}",
+              "target_directory": "[..]/foo/target",
+              "version": 1,
+              "workspace_root": "[..]/foo",
+              "metadata": null,
+              "resolve": {
+                "nodes": [
+                  {
+                    "id": "bar 0.1.0 (path+file://[..]/foo/bar)",
+                    "dependencies": [
+                      "foo 0.1.0 (path+file://[..]/foo)"
+                    ],
+                    "deps": [
+                      {
+                        "name": "foo",
+                        "pkg": "foo 0.1.0 (path+file://[..]/foo)",
+                        "dep_kinds": [
+                          {
+                            "kind": null,
+                            "target": null
+                          }
+                        ]
+                      }
+                    ],
+                    "features": []
+                  },
+                  {
+                    "id": "dep 0.5.0 (path+file://[..]/foo/dep)",
+                    "dependencies": [],
+                    "deps": [],
+                    "features": []
+                  },
+                  {
+                    "id": "foo 0.1.0 (path+file://[..]/foo)",
+                    "dependencies": [
+                      "dep 0.5.0 (path+file://[..]/foo/dep)"
+                    ],
+                    "deps": [
+                      {
+                        "name": "dep",
+                        "pkg": "dep 0.5.0 (path+file://[..]/foo/dep)",
+                        "dep_kinds": [
+                          {
+                            "kind": null,
+                            "target": null
+                          }
+                        ]
+                      }
+                    ],
+                    "features": [
+                      "feat1"
+                    ]
+                  }
+                ],
+                "root": "foo 0.1.0 (path+file://[..]/foo)"
               }
-            ]
-          }
-        ],
-        "features": []
-      },
-      {
-        "id": "dep 0.5.0 (path+file://[..]/foo/dep)",
-        "dependencies": [],
-        "deps": [],
-        "features": []
-      },
-      {
-        "id": "foo 0.1.0 (path+file://[..]/foo)",
-        "dependencies": [
-          "dep 0.5.0 (path+file://[..]/foo/dep)"
-        ],
-        "deps": [
-          {
-            "name": "dep",
-            "pkg": "dep 0.5.0 (path+file://[..]/foo/dep)",
-            "dep_kinds": [
-              {
-                "kind": null,
-                "target": null
-              }
-            ]
-          }
-        ],
-        "features": [
-          "feat1"
-        ]
-      }
-    ],
-    "root": "foo 0.1.0 (path+file://[..]/foo)"
-  }
-}
-"#,
+            }
+            "#,
         )
         .run();
 }

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -16,14 +16,14 @@ fn minimal_version_cli() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.0.1"
 
-            [dependencies]
-            dep = "1.0"
-        "#,
+                [dependencies]
+                dep = "1.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -8,24 +8,24 @@ fn net_retry_loads_from_config() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            git = "http://127.0.0.1:11/foo/bar"
-        "#,
+                [dependencies.bar]
+                git = "http://127.0.0.1:11/foo/bar"
+            "#,
         )
         .file("src/main.rs", "")
         .file(
             ".cargo/config",
             r#"
-        [net]
-        retry=1
-        [http]
-        timeout=1
-         "#,
+           [net]
+           retry=1
+           [http]
+           timeout=1
+            "#,
         )
         .build();
 
@@ -44,21 +44,21 @@ fn net_retry_git_outputs_warning() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            git = "http://127.0.0.1:11/foo/bar"
-        "#,
+                [dependencies.bar]
+                git = "http://127.0.0.1:11/foo/bar"
+            "#,
         )
         .file(
             ".cargo/config",
             r#"
-        [http]
-        timeout=1
-         "#,
+           [http]
+           timeout=1
+            "#,
         )
         .file("src/main.rs", "")
         .build();

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -519,7 +519,7 @@ fn offline_resolve_optional_fail() {
 
             [dependencies]
             dep = { version = "2.0", optional = true }
-            "#,
+        "#,
     );
 
     p.cargo("build --offline")

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -30,21 +30,21 @@ fn static_library_with_debug() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            crate-type = ["staticlib"]
-        "#,
+                [lib]
+                crate-type = ["staticlib"]
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #[no_mangle]
-            pub extern "C" fn foo() { println!("Hello, World!") }
-        "#,
+                #[no_mangle]
+                pub extern "C" fn foo() { println!("Hello, World!") }
+            "#,
         )
         .build();
 
@@ -66,21 +66,21 @@ fn dynamic_library_with_debug() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            crate-type = ["cdylib"]
-        "#,
+                [lib]
+                crate-type = ["cdylib"]
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #[no_mangle]
-            pub extern "C" fn foo() { println!("Hello, World!") }
-        "#,
+                #[no_mangle]
+                pub extern "C" fn foo() { println!("Hello, World!") }
+            "#,
         )
         .build();
 
@@ -102,20 +102,20 @@ fn rlib_with_debug() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            crate-type = ["rlib"]
-        "#,
+                [lib]
+                crate-type = ["rlib"]
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn foo() { println!("Hello, World!") }
-        "#,
+                pub fn foo() { println!("Hello, World!") }
+            "#,
         )
         .build();
 
@@ -137,27 +137,27 @@ fn include_only_the_binary_from_the_current_package() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [workspace]
+                [workspace]
 
-            [dependencies]
-            utils = { path = "./utils" }
-        "#,
+                [dependencies]
+                utils = { path = "./utils" }
+            "#,
         )
         .file("src/lib.rs", "extern crate utils;")
         .file(
             "src/main.rs",
             r#"
-            extern crate foo;
-            extern crate utils;
-            fn main() {
-                println!("Hello, World!")
-            }
-        "#,
+                extern crate foo;
+                extern crate utils;
+                fn main() {
+                    println!("Hello, World!")
+                }
+            "#,
         )
         .file("utils/Cargo.toml", &basic_manifest("utils", "0.0.1"))
         .file("utils/src/lib.rs", "")

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -36,13 +36,13 @@ fn simple_list() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -66,13 +66,13 @@ fn simple_add() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -95,13 +95,13 @@ fn simple_remove() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -15,14 +15,14 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            exclude = ["*.txt"]
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                exclude = ["*.txt"]
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .file("src/bar.txt", "") // should be ignored when packaging
@@ -83,12 +83,12 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -109,14 +109,14 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            repository = "bar"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                repository = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -225,23 +225,23 @@ fn vcs_file_collision() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            description = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-            exclude = ["*.no-existe"]
-        "#,
+                [project]
+                name = "foo"
+                description = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+                exclude = ["*.no-existe"]
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .file(".cargo_vcs_info.json", "foo")
         .build();
@@ -263,16 +263,16 @@ fn path_dependency_no_version() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -299,38 +299,38 @@ fn exclude() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            exclude = [
-                "*.txt",
-                # file in root
-                "file_root_1",       # NO_CHANGE (ignored)
-                "/file_root_2",      # CHANGING (packaged -> ignored)
-                "file_root_3/",      # NO_CHANGE (packaged)
-                "file_root_4/*",     # NO_CHANGE (packaged)
-                "file_root_5/**",    # NO_CHANGE (packaged)
-                # file in sub-dir
-                "file_deep_1",       # CHANGING (packaged -> ignored)
-                "/file_deep_2",      # NO_CHANGE (packaged)
-                "file_deep_3/",      # NO_CHANGE (packaged)
-                "file_deep_4/*",     # NO_CHANGE (packaged)
-                "file_deep_5/**",    # NO_CHANGE (packaged)
-                # dir in root
-                "dir_root_1",        # CHANGING (packaged -> ignored)
-                "/dir_root_2",       # CHANGING (packaged -> ignored)
-                "dir_root_3/",       # CHANGING (packaged -> ignored)
-                "dir_root_4/*",      # NO_CHANGE (ignored)
-                "dir_root_5/**",     # NO_CHANGE (ignored)
-                # dir in sub-dir
-                "dir_deep_1",        # CHANGING (packaged -> ignored)
-                "/dir_deep_2",       # NO_CHANGE
-                "dir_deep_3/",       # CHANGING (packaged -> ignored)
-                "dir_deep_4/*",      # CHANGING (packaged -> ignored)
-                "dir_deep_5/**",     # CHANGING (packaged -> ignored)
-            ]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                exclude = [
+                    "*.txt",
+                    # file in root
+                    "file_root_1",       # NO_CHANGE (ignored)
+                    "/file_root_2",      # CHANGING (packaged -> ignored)
+                    "file_root_3/",      # NO_CHANGE (packaged)
+                    "file_root_4/*",     # NO_CHANGE (packaged)
+                    "file_root_5/**",    # NO_CHANGE (packaged)
+                    # file in sub-dir
+                    "file_deep_1",       # CHANGING (packaged -> ignored)
+                    "/file_deep_2",      # NO_CHANGE (packaged)
+                    "file_deep_3/",      # NO_CHANGE (packaged)
+                    "file_deep_4/*",     # NO_CHANGE (packaged)
+                    "file_deep_5/**",    # NO_CHANGE (packaged)
+                    # dir in root
+                    "dir_root_1",        # CHANGING (packaged -> ignored)
+                    "/dir_root_2",       # CHANGING (packaged -> ignored)
+                    "dir_root_3/",       # CHANGING (packaged -> ignored)
+                    "dir_root_4/*",      # NO_CHANGE (ignored)
+                    "dir_root_5/**",     # NO_CHANGE (ignored)
+                    # dir in sub-dir
+                    "dir_deep_1",        # CHANGING (packaged -> ignored)
+                    "/dir_deep_2",       # NO_CHANGE
+                    "dir_deep_3/",       # CHANGING (packaged -> ignored)
+                    "dir_deep_4/*",      # CHANGING (packaged -> ignored)
+                    "dir_deep_5/**",     # CHANGING (packaged -> ignored)
+                ]
+            "#,
         )
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .file("bar.txt", "")
@@ -421,13 +421,13 @@ fn include() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            exclude = ["*.txt"]
-            include = ["foo.txt", "**/*.rs", "Cargo.toml", ".dotfile"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                exclude = ["*.txt"]
+                include = ["foo.txt", "**/*.rs", "Cargo.toml", ".dotfile"]
+            "#,
         )
         .file("foo.txt", "")
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
@@ -710,16 +710,16 @@ fn broken_symlink() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = 'foo'
-            documentation = 'foo'
-            homepage = 'foo'
-            repository = 'foo'
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = 'foo'
+                documentation = 'foo'
+                homepage = 'foo'
+                repository = 'foo'
+            "#,
         )
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .build();
@@ -770,15 +770,15 @@ fn do_not_package_if_repository_is_dirty() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -825,25 +825,25 @@ fn generated_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            exclude = ["*.txt"]
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                exclude = ["*.txt"]
+                license = "MIT"
+                description = "foo"
 
-            [project.metadata]
-            foo = 'bar'
+                [project.metadata]
+                foo = 'bar'
 
-            [workspace]
+                [workspace]
 
-            [dependencies]
-            bar = { path = "bar", version = "0.1" }
-            def = { version = "1.0", registry = "alternative" }
-            ghi = "1.0"
-            abc = "1.0"
-        "#,
+                [dependencies]
+                bar = { path = "bar", version = "0.1" }
+                def = { version = "1.0", registry = "alternative" }
+                ghi = "1.0"
+                abc = "1.0"
+            "#,
         )
         .file("src/main.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -896,28 +896,28 @@ fn ignore_workspace_specifier() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
+                [project]
+                name = "foo"
+                version = "0.0.1"
 
-            authors = []
+                authors = []
 
-            [workspace]
+                [workspace]
 
-            [dependencies]
-            bar = { path = "bar", version = "0.1" }
-        "#,
+                [dependencies]
+                bar = { path = "bar", version = "0.1" }
+            "#,
         )
         .file("src/main.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -950,15 +950,15 @@ fn package_two_kinds_of_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            other = "1.0"
-            other1 = { version = "1.0" }
-        "#,
+                [dependencies]
+                other = "1.0"
+                other1 = { version = "1.0" }
+            "#,
         )
         .file("src/main.rs", "")
         .build();
@@ -972,13 +972,13 @@ fn test_edition() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["edition"]
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            edition = "2018"
-        "#,
+                cargo-features = ["edition"]
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                edition = "2018"
+            "#,
         )
         .file("src/lib.rs", r#" "#)
         .build();
@@ -1089,18 +1089,18 @@ fn do_not_package_if_src_was_modified() {
         .file(
             "build.rs",
             r#"
-            use std::fs;
+                use std::fs;
 
-            fn main() {
-                fs::write("src/generated.txt",
-                    "Hello, world of generated files."
-                ).expect("failed to create file");
-                fs::remove_file("dir/foo.txt").expect("failed to remove file");
-                fs::remove_dir("dir").expect("failed to remove dir");
-                fs::write("bar.txt", "updated content").expect("failed to update");
-                fs::create_dir("new-dir").expect("failed to create dir");
-            }
-        "#,
+                fn main() {
+                    fs::write("src/generated.txt",
+                        "Hello, world of generated files."
+                    ).expect("failed to create file");
+                    fs::remove_file("dir/foo.txt").expect("failed to remove file");
+                    fs::remove_dir("dir").expect("failed to remove dir");
+                    fs::write("bar.txt", "updated content").expect("failed to update");
+                    fs::create_dir("new-dir").expect("failed to create dir");
+                }
+            "#,
         )
         .build();
 
@@ -1132,17 +1132,17 @@ fn package_with_select_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [features]
-            required = []
-            optional = []
-        "#,
+                [features]
+                required = []
+                optional = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1161,17 +1161,17 @@ fn package_with_all_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [features]
-            required = []
-            optional = []
-        "#,
+                [features]
+                required = []
+                optional = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1190,17 +1190,17 @@ fn package_no_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [features]
-            default = ["required"]
-            required = []
-        "#,
+                [features]
+                default = ["required"]
+                required = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1757,16 +1757,16 @@ fn reserved_windows_name() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [dependencies]
-            bar = "1.0.0"
-        "#,
+                [dependencies]
+                bar = "1.0.0"
+            "#,
         )
         .file("src/main.rs", "extern crate bar;\nfn main() {  }")
         .build();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -21,18 +21,18 @@ fn replace() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-            baz = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
+                baz = "0.1.0"
 
-            [patch.crates-io]
-            bar = { path = "bar" }
-        "#,
+                [patch.crates-io]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -74,17 +74,17 @@ fn nonexistent() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [patch.crates-io]
-            bar = { path = "bar" }
-        "#,
+                [patch.crates-io]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -119,17 +119,17 @@ fn patch_git() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = {{ git = '{}' }}
+                    [dependencies]
+                    bar = {{ git = '{}' }}
 
-            [patch.'{0}']
-            bar = {{ path = "bar" }}
-        "#,
+                    [patch.'{0}']
+                    bar = {{ path = "bar" }}
+                "#,
                 bar.url()
             ),
         )
@@ -168,17 +168,17 @@ fn patch_to_git() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1"
+                    [dependencies]
+                    bar = "0.1"
 
-            [patch.crates-io]
-            bar = {{ git = '{}' }}
-        "#,
+                    [patch.crates-io]
+                    bar = {{ git = '{}' }}
+                "#,
                 bar.url()
             ),
         )
@@ -210,17 +210,17 @@ fn unused() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [patch.crates-io]
-            bar = { path = "bar" }
-        "#,
+                [patch.crates-io]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.2.0"))
@@ -282,17 +282,17 @@ fn unused_git() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1"
+                    [dependencies]
+                    bar = "0.1"
 
-            [patch.crates-io]
-            bar = {{ git = '{}' }}
-        "#,
+                    [patch.crates-io]
+                    bar = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -339,14 +339,14 @@ fn add_patch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -403,14 +403,14 @@ fn add_ignored_patch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
@@ -492,24 +492,24 @@ fn no_warn_ws_patch() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b", "c"]
+                [workspace]
+                members = ["a", "b", "c"]
 
-            [patch.crates-io]
-            c = { path = "c" }
-        "#,
+                [patch.crates-io]
+                c = { path = "c" }
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.1.0"
-            [dependencies]
-            c = "0.1.0"
-        "#,
+                [package]
+                name = "b"
+                version = "0.1.0"
+                [dependencies]
+                c = "0.1.0"
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file("c/Cargo.toml", &basic_manifest("c", "0.1.0"))
@@ -534,17 +534,17 @@ fn new_minor() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [patch.crates-io]
-            bar = { path = 'bar' }
-        "#,
+                [patch.crates-io]
+                bar = { path = 'bar' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
@@ -571,30 +571,30 @@ fn transitive_new_minor() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = 'bar' }
+                [dependencies]
+                bar = { path = 'bar' }
 
-            [patch.crates-io]
-            baz = { path = 'baz' }
-        "#,
+                [patch.crates-io]
+                baz = { path = 'baz' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = '0.1.0'
-        "#,
+                [dependencies]
+                baz = '0.1.0'
+            "#,
         )
         .file("bar/src/lib.rs", r#""#)
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.1"))
@@ -622,17 +622,17 @@ fn new_major() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.2.0"
+                [dependencies]
+                bar = "0.2.0"
 
-            [patch.crates-io]
-            bar = { path = 'bar' }
-        "#,
+                [patch.crates-io]
+                bar = { path = 'bar' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.2.0"))
@@ -690,30 +690,30 @@ fn transitive_new_major() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = 'bar' }
+                [dependencies]
+                bar = { path = 'bar' }
 
-            [patch.crates-io]
-            baz = { path = 'baz' }
-        "#,
+                [patch.crates-io]
+                baz = { path = 'baz' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = '0.2.0'
-        "#,
+                [dependencies]
+                baz = '0.2.0'
+            "#,
         )
         .file("bar/src/lib.rs", r#""#)
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.2.0"))
@@ -799,18 +799,18 @@ fn remove_patch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
+                [dependencies]
+                bar = "0.1"
 
-            [patch.crates-io]
-            foo = { path = 'foo' }
-            bar = { path = 'bar' }
-        "#,
+                [patch.crates-io]
+                foo = { path = 'foo' }
+                bar = { path = 'bar' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -860,14 +860,14 @@ fn non_crates_io() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [patch.some-other-source]
-            bar = { path = 'bar' }
-        "#,
+                [patch.some-other-source]
+                bar = { path = 'bar' }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -898,14 +898,14 @@ fn replace_with_crates_io() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [patch.crates-io]
-            bar = "0.1"
-        "#,
+                [patch.crates-io]
+                bar = "0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -935,26 +935,26 @@ fn patch_in_virtual() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo"]
+                [workspace]
+                members = ["foo"]
 
-            [patch.crates-io]
-            bar = { path = "bar" }
-        "#,
+                [patch.crates-io]
+                bar = { path = "bar" }
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", r#""#)
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
-        "#,
+                [dependencies]
+                bar = "0.1"
+            "#,
         )
         .file("foo/src/lib.rs", r#""#)
         .build();
@@ -978,19 +978,19 @@ fn patch_depends_on_another_patch() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.1.0"
 
-            [dependencies]
-            bar = "0.1"
-            baz = "0.1"
+                [dependencies]
+                bar = "0.1"
+                baz = "0.1"
 
-            [patch.crates-io]
-            bar = { path = "bar" }
-            baz = { path = "baz" }
-        "#,
+                [patch.crates-io]
+                bar = { path = "bar" }
+                baz = { path = "baz" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
@@ -998,14 +998,14 @@ fn patch_depends_on_another_patch() {
         .file(
             "baz/Cargo.toml",
             r#"
-            [package]
-            name = "baz"
-            version = "0.1.1"
-            authors = []
+                [package]
+                name = "baz"
+                version = "0.1.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
-        "#,
+                [dependencies]
+                bar = "0.1"
+            "#,
         )
         .file("baz/src/lib.rs", r#""#)
         .build();
@@ -1023,24 +1023,24 @@ fn replace_prerelease() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
+                [workspace]
+                members = ["bar"]
 
-            [patch.crates-io]
-            baz = { path = "./baz" }
-        "#,
+                [patch.crates-io]
+                baz = { path = "./baz" }
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            baz = "1.1.0-pre.1"
-        "#,
+                [dependencies]
+                baz = "1.1.0-pre.1"
+            "#,
         )
         .file(
             "bar/src/main.rs",
@@ -1049,12 +1049,12 @@ fn replace_prerelease() {
         .file(
             "baz/Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            version = "1.1.0-pre.1"
-            authors = []
-            [workspace]
-        "#,
+                [project]
+                name = "baz"
+                version = "1.1.0-pre.1"
+                authors = []
+                [workspace]
+            "#,
         )
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
@@ -1236,15 +1236,15 @@ fn patch_same_version() {
             "Cargo.toml",
             &format!(
                 r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                [dependencies]
-                bar = "0.1"
-                [patch.crates-io]
-                bar = {{ path = "bar" }}
-                bar2 = {{ git = '{}', package = 'bar' }}
-            "#,
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    [dependencies]
+                    bar = "0.1"
+                    [patch.crates-io]
+                    bar = {{ path = "bar" }}
+                    bar2 = {{ git = '{}', package = 'bar' }}
+                "#,
                 bar.url(),
             ),
         )
@@ -1285,15 +1285,15 @@ fn two_semver_compatible() {
             "Cargo.toml",
             &format!(
                 r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                [dependencies]
-                bar = "0.1"
-                [patch.crates-io]
-                bar = {{ path = "bar" }}
-                bar2 = {{ git = '{}', package = 'bar' }}
-            "#,
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    [dependencies]
+                    bar = "0.1"
+                    [patch.crates-io]
+                    bar = {{ path = "bar" }}
+                    bar2 = {{ git = '{}', package = 'bar' }}
+                "#,
                 bar.url(),
             ),
         )
@@ -1340,15 +1340,15 @@ fn multipatch_select_big() {
             "Cargo.toml",
             &format!(
                 r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                [dependencies]
-                bar = "*"
-                [patch.crates-io]
-                bar = {{ path = "bar" }}
-                bar2 = {{ git = '{}', package = 'bar' }}
-            "#,
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    [dependencies]
+                    bar = "*"
+                    [patch.crates-io]
+                    bar = {{ path = "bar" }}
+                    bar2 = {{ git = '{}', package = 'bar' }}
+                "#,
                 bar.url(),
             ),
         )
@@ -1593,16 +1593,16 @@ fn no_matches() {
         .file(
             "Cargo.toml",
             r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
+                 [package]
+                 name = "foo"
+                 version = "0.1.0"
 
-                [dependencies]
-                bar = "0.1"
+                 [dependencies]
+                 bar = "0.1"
 
-                [patch.crates-io]
-                bar = { path = "bar" }
-           "#,
+                 [patch.crates-io]
+                 bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("abc", "0.1.0"))
@@ -1632,16 +1632,16 @@ fn mismatched_version() {
         .file(
             "Cargo.toml",
             r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
+                 [package]
+                 name = "foo"
+                 version = "0.1.0"
 
-                [dependencies]
-                bar = "0.1.1"
+                 [dependencies]
+                 bar = "0.1.1"
 
-                [patch.crates-io]
-                bar = { path = "bar", version = "0.1.1" }
-           "#,
+                 [patch.crates-io]
+                 bar = { path = "bar", version = "0.1.1" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -15,56 +15,56 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                [dependencies.bar]
 
-            version = "0.5.0"
-            path = "bar"
-        "#,
+                version = "0.5.0"
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.baz]
+                [dependencies.baz]
 
-            version = "0.5.0"
-            path = "baz"
+                version = "0.5.0"
+                path = "baz"
 
-            [lib]
+                [lib]
 
-            name = "bar"
-        "#,
+                name = "bar"
+            "#,
         )
         .file(
             "bar/src/bar.rs",
             r#"
-            extern crate baz;
+                extern crate baz;
 
-            pub fn gimme() -> String {
-                baz::gimme()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    baz::gimme()
+                }
+            "#,
         )
         .file("bar/baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file(
             "bar/baz/src/baz.rs",
             r#"
-            pub fn gimme() -> String {
-                "test passed".to_string()
-            }
-        "#,
+                pub fn gimme() -> String {
+                    "test passed".to_string()
+                }
+            "#,
         )
         .build();
 
@@ -109,20 +109,20 @@ fn cargo_compile_with_root_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dev-dependencies.bar]
+                [dev-dependencies.bar]
 
-            version = "0.5.0"
-            path = "../bar"
+                version = "0.5.0"
+                path = "../bar"
 
-            [[bin]]
-            name = "foo"
-        "#,
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .build();
@@ -132,10 +132,10 @@ fn cargo_compile_with_root_dev_deps() {
         .file(
             "src/lib.rs",
             r#"
-            pub fn gimme() -> &'static str {
-                "zoidberg"
-            }
-        "#,
+                pub fn gimme() -> &'static str {
+                    "zoidberg"
+                }
+            "#,
         )
         .build();
 
@@ -151,20 +151,20 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dev-dependencies.bar]
+                [dev-dependencies.bar]
 
-            version = "0.5.0"
-            path = "../bar"
+                version = "0.5.0"
+                path = "../bar"
 
-            [[bin]]
-            name = "foo"
-        "#,
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .build();
@@ -174,10 +174,10 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         .file(
             "src/lib.rs",
             r#"
-            pub fn gimme() -> &'static str {
-                "zoidberg"
-            }
-        "#,
+                pub fn gimme() -> &'static str {
+                    "zoidberg"
+                }
+            "#,
         )
         .build();
 
@@ -199,44 +199,44 @@ fn cargo_compile_with_transitive_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                [dependencies.bar]
 
-            version = "0.5.0"
-            path = "bar"
-        "#,
+                version = "0.5.0"
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dev-dependencies.baz]
+                [dev-dependencies.baz]
 
-            git = "git://example.com/path/to/nowhere"
+                git = "git://example.com/path/to/nowhere"
 
-            [lib]
+                [lib]
 
-            name = "bar"
-        "#,
+                name = "bar"
+            "#,
         )
         .file(
             "bar/src/bar.rs",
             r#"
-            pub fn gimme() -> &'static str {
-                "zoidberg"
-            }
-        "#,
+                pub fn gimme() -> &'static str {
+                    "zoidberg"
+                }
+            "#,
         )
         .build();
 
@@ -260,15 +260,15 @@ fn no_rebuild_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::bar() }")
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -288,9 +288,9 @@ fn no_rebuild_dependency() {
     p.change_file(
         "src/main.rs",
         r#"
-        extern crate bar;
-        fn main() { bar::bar(); }
-    "#,
+            extern crate bar;
+            fn main() { bar::bar(); }
+        "#,
     );
     // Don't compile bar, but do recompile foo.
     p.cargo("build")
@@ -308,31 +308,31 @@ fn deep_dependencies_trigger_rebuild() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::bar() }")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [lib]
-            name = "bar"
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [lib]
+                name = "bar"
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file(
             "bar/src/bar.rs",
@@ -395,33 +395,33 @@ fn no_rebuild_two_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
-            [dependencies.baz]
-            path = "baz"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+                [dependencies.baz]
+                path = "baz"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::bar() }")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [lib]
-            name = "bar"
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [lib]
+                name = "bar"
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file("bar/src/bar.rs", "pub fn bar() {}")
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
@@ -447,17 +447,17 @@ fn nested_deps_recompile() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                [dependencies.bar]
 
-            version = "0.5.0"
-            path = "src/bar"
-        "#,
+                version = "0.5.0"
+                path = "src/bar"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file("src/bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -492,16 +492,16 @@ fn error_message_for_missing_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                [dependencies.bar]
 
-            path = "src/bar"
-        "#,
+                path = "src/bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/bar/not-a-manifest", "")
@@ -545,15 +545,15 @@ fn override_relative() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
+                    [package]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = '{}'
-        "#,
+                    [dependencies.bar]
+                    path = '{}'
+                "#,
                 bar.root().display()
             ),
         )
@@ -578,16 +578,16 @@ fn override_self() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
+                    [package]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.bar]
-            path = '{}'
+                    [dependencies.bar]
+                    path = '{}'
 
-        "#,
+                "#,
                 bar.root().display()
             ),
         )
@@ -605,14 +605,14 @@ fn override_path_dep() {
         .file(
             "p1/Cargo.toml",
             r#"
-            [package]
-            name = "p1"
-            version = "0.5.0"
-            authors = []
+                 [package]
+                 name = "p1"
+                 version = "0.5.0"
+                 authors = []
 
-            [dependencies.p2]
-            path = "../p2"
-       "#,
+                 [dependencies.p2]
+                 path = "../p2"
+            "#,
         )
         .file("p1/src/lib.rs", "")
         .file("p2/Cargo.toml", &basic_manifest("p2", "0.5.0"))
@@ -632,16 +632,16 @@ fn override_path_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
+                    [package]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = ["wycats@example.com"]
 
-            [dependencies.p2]
-            path = '{}'
+                    [dependencies.p2]
+                    path = '{}'
 
-        "#,
+                "#,
                 bar.root().join("p2").display()
             ),
         )
@@ -657,42 +657,42 @@ fn path_dep_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "foo"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
 
-            [dependencies.bar]
+                [dependencies.bar]
 
-            version = "0.5.0"
-            path = "bar"
-        "#,
+                version = "0.5.0"
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", &main_file(r#""{}", bar::gimme()"#, &["bar"]))
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+                [project]
 
-            name = "bar"
-            version = "0.5.0"
-            authors = ["wycats@example.com"]
-            build = "build.rs"
+                name = "bar"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
 
-            [lib]
-            name = "bar"
-            path = "src/bar.rs"
-        "#,
+                [lib]
+                name = "bar"
+                path = "src/bar.rs"
+            "#,
         )
         .file(
             "bar/build.rs",
             r#"
-            use std::fs;
-            fn main() {
-                fs::copy("src/bar.rs.in", "src/bar.rs").unwrap();
-            }
-        "#,
+                use std::fs;
+                fn main() {
+                    fs::copy("src/bar.rs.in", "src/bar.rs").unwrap();
+                }
+            "#,
         )
         .file("bar/src/bar.rs.in", "pub fn gimme() -> i32 { 0 }")
         .build();
@@ -732,25 +732,25 @@ fn dev_deps_no_rebuild_lib() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-                name = "foo"
-                version = "0.5.0"
-                authors = []
+                [project]
+                    name = "foo"
+                    version = "0.5.0"
+                    authors = []
 
-            [dev-dependencies.bar]
-                path = "bar"
+                [dev-dependencies.bar]
+                    path = "bar"
 
-            [lib]
-                name = "foo"
-                doctest = false
-        "#,
+                [lib]
+                    name = "foo"
+                    doctest = false
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #[cfg(test)] #[allow(unused_extern_crates)] extern crate bar;
-            #[cfg(not(test))] pub fn foo() { env!("FOO"); }
-        "#,
+                #[cfg(test)] #[allow(unused_extern_crates)] extern crate bar;
+                #[cfg(not(test))] pub fn foo() { env!("FOO"); }
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.5.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -782,15 +782,15 @@ fn custom_target_no_rebuild() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            a = { path = "a" }
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                a = { path = "a" }
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.5.0"))
@@ -798,13 +798,13 @@ fn custom_target_no_rebuild() {
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            a = { path = "../a" }
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                a = { path = "../a" }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .build();
@@ -840,13 +840,13 @@ fn override_and_depend() {
         .file(
             "a/a1/Cargo.toml",
             r#"
-            [project]
-            name = "a1"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            a2 = { path = "../a2" }
-        "#,
+                [project]
+                name = "a1"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                a2 = { path = "../a2" }
+            "#,
         )
         .file("a/a1/src/lib.rs", "")
         .file("a/a2/Cargo.toml", &basic_manifest("a2", "0.5.0"))
@@ -854,14 +854,14 @@ fn override_and_depend() {
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.5.0"
-            authors = []
-            [dependencies]
-            a1 = { path = "../a/a1" }
-            a2 = { path = "../a/a2" }
-        "#,
+                [project]
+                name = "b"
+                version = "0.5.0"
+                authors = []
+                [dependencies]
+                a1 = { path = "../a/a1" }
+                a2 = { path = "../a/a2" }
+            "#,
         )
         .file("b/src/lib.rs", "")
         .file("b/.cargo/config", r#"paths = ["../a"]"#)
@@ -914,29 +914,29 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "top"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "top"
+                version = "0.5.0"
+                authors = []
 
-            [workspace]
+                [workspace]
 
-            [dependencies]
-            foo = { path = "foo" }
-        "#,
+                [dependencies]
+                foo = { path = "foo" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "foo/Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .build();
@@ -979,16 +979,16 @@ fn workspace_produces_rlib() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "top"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "top"
+                version = "0.5.0"
+                authors = []
 
-            [workspace]
+                [workspace]
 
-            [dependencies]
-            foo = { path = "foo" }
-        "#,
+                [dependencies]
+                foo = { path = "foo" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.5.0"))
@@ -1019,23 +1019,23 @@ fn deep_path_error() {
         .file(
             "a/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.1.0"
-            [dependencies]
-            b = {path="../b"}
-           "#,
+             [package]
+             name = "a"
+             version = "0.1.0"
+             [dependencies]
+             b = {path="../b"}
+            "#,
         )
         .file("a/src/lib.rs", "")
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.1.0"
-            [dependencies]
-            c = {path="../c"}
-           "#,
+             [package]
+             name = "b"
+             version = "0.1.0"
+             [dependencies]
+             c = {path="../c"}
+            "#,
         )
         .file("b/src/lib.rs", "")
         .build();

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -12,40 +12,40 @@ fn broken_path_override_warns() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a1" }
-        "#,
+                [dependencies]
+                a = { path = "a1" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "a1/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
-        "#,
+                [dependencies]
+                bar = "0.1"
+            "#,
         )
         .file("a1/src/lib.rs", "")
         .file(
             "a2/Cargo.toml",
             r#"
-            [package]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.2"
-        "#,
+                [dependencies]
+                bar = "0.2"
+            "#,
         )
         .file("a2/src/lib.rs", "")
         .file(".cargo/config", r#"paths = ["a2"]"#)
@@ -90,27 +90,27 @@ fn override_to_path_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                baz = { path = "baz" }
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .file("bar/baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
@@ -129,40 +129,40 @@ fn paths_ok_with_optional() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = { version = "0.1", optional = true }
-        "#,
+                [dependencies]
+                baz = { version = "0.1", optional = true }
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .file(
             "bar2/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = { version = "0.1", optional = true }
-        "#,
+                [dependencies]
+                baz = { version = "0.1", optional = true }
+            "#,
         )
         .file("bar2/src/lib.rs", "")
         .file(".cargo/config", r#"paths = ["bar2"]"#)
@@ -187,14 +187,14 @@ fn paths_add_optional_bad() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -202,14 +202,14 @@ fn paths_add_optional_bad() {
         .file(
             "bar2/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = { version = "0.1", optional = true }
-        "#,
+                [dependencies]
+                baz = { version = "0.1", optional = true }
+            "#,
         )
         .file("bar2/src/lib.rs", "")
         .file(".cargo/config", r#"paths = ["bar2"]"#)

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -10,14 +10,14 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            edition = "2018"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2018"
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -14,36 +14,36 @@ fn plugin_to_the_max() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo_lib"
+                [lib]
+                name = "foo_lib"
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #![feature(plugin)]
-            #![plugin(bar)]
-            extern crate foo_lib;
+                #![feature(plugin)]
+                #![plugin(bar)]
+                extern crate foo_lib;
 
-            fn main() { foo_lib::foo(); }
-        "#,
+                fn main() { foo_lib::foo(); }
+            "#,
         )
         .file(
             "src/foo_lib.rs",
             r#"
-            #![feature(plugin)]
-            #![plugin(bar)]
+                #![feature(plugin)]
+                #![plugin(bar)]
 
-            pub fn foo() {}
-        "#,
+                pub fn foo() {}
+            "#,
         )
         .build();
     let _bar = project()
@@ -51,34 +51,34 @@ fn plugin_to_the_max() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            plugin = true
+                [lib]
+                name = "bar"
+                plugin = true
 
-            [dependencies.baz]
-            path = "../baz"
-        "#,
+                [dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(plugin_registrar, rustc_private)]
+                #![feature(plugin_registrar, rustc_private)]
 
-            extern crate baz;
-            extern crate rustc_driver;
+                extern crate baz;
+                extern crate rustc_driver;
 
-            use rustc_driver::plugin::Registry;
+                use rustc_driver::plugin::Registry;
 
-            #[plugin_registrar]
-            pub fn foo(_reg: &mut Registry) {
-                println!("{}", baz::baz());
-            }
-        "#,
+                #[plugin_registrar]
+                pub fn foo(_reg: &mut Registry) {
+                    println!("{}", baz::baz());
+                }
+            "#,
         )
         .build();
     let _baz = project()
@@ -86,15 +86,15 @@ fn plugin_to_the_max() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "baz"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "baz"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "baz"
-            crate_type = ["dylib"]
-        "#,
+                [lib]
+                name = "baz"
+                crate_type = ["dylib"]
+            "#,
         )
         .file("src/lib.rs", "pub fn baz() -> i32 { 1 }")
         .build();
@@ -115,15 +115,15 @@ fn plugin_with_dynamic_native_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "builder"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "builder"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "builder"
-            crate-type = ["dylib"]
-        "#,
+                [lib]
+                name = "builder"
+                crate-type = ["dylib"]
+            "#,
         )
         .file("src/lib.rs", "#[no_mangle] pub extern fn foo() {}")
         .build();
@@ -132,79 +132,79 @@ fn plugin_with_dynamic_native_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #![feature(plugin)]
-            #![plugin(bar)]
+                #![feature(plugin)]
+                #![plugin(bar)]
 
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-            build = 'build.rs'
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+                build = 'build.rs'
 
-            [lib]
-            name = "bar"
-            plugin = true
-        "#,
+                [lib]
+                name = "bar"
+                plugin = true
+            "#,
         )
         .file(
             "bar/build.rs",
             r#"
-            use std::env;
-            use std::fs;
-            use std::path::PathBuf;
+                use std::env;
+                use std::fs;
+                use std::path::PathBuf;
 
-            fn main() {
-                let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-                let root = PathBuf::from(env::var("BUILDER_ROOT").unwrap());
-                let file = format!("{}builder{}",
-                    env::consts::DLL_PREFIX,
-                    env::consts::DLL_SUFFIX);
-                let src = root.join(&file);
-                let dst = out_dir.join(&file);
-                fs::copy(src, dst).unwrap();
-                if cfg!(target_env = "msvc") {
-                    fs::copy(root.join("builder.dll.lib"),
-                             out_dir.join("builder.dll.lib")).unwrap();
+                fn main() {
+                    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+                    let root = PathBuf::from(env::var("BUILDER_ROOT").unwrap());
+                    let file = format!("{}builder{}",
+                        env::consts::DLL_PREFIX,
+                        env::consts::DLL_SUFFIX);
+                    let src = root.join(&file);
+                    let dst = out_dir.join(&file);
+                    fs::copy(src, dst).unwrap();
+                    if cfg!(target_env = "msvc") {
+                        fs::copy(root.join("builder.dll.lib"),
+                                 out_dir.join("builder.dll.lib")).unwrap();
+                    }
+                    println!("cargo:rustc-flags=-L {}", out_dir.display());
                 }
-                println!("cargo:rustc-flags=-L {}", out_dir.display());
-            }
-        "#,
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #![feature(plugin_registrar, rustc_private)]
+                #![feature(plugin_registrar, rustc_private)]
 
-            extern crate rustc_driver;
-            use rustc_driver::plugin::Registry;
+                extern crate rustc_driver;
+                use rustc_driver::plugin::Registry;
 
-            #[cfg_attr(not(target_env = "msvc"), link(name = "builder"))]
-            #[cfg_attr(target_env = "msvc", link(name = "builder.dll"))]
-            extern { fn foo(); }
+                #[cfg_attr(not(target_env = "msvc"), link(name = "builder"))]
+                #[cfg_attr(target_env = "msvc", link(name = "builder.dll"))]
+                extern { fn foo(); }
 
-            #[plugin_registrar]
-            pub fn bar(_reg: &mut Registry) {
-                unsafe { foo() }
-            }
-        "#,
+                #[plugin_registrar]
+                pub fn bar(_reg: &mut Registry) {
+                    unsafe { foo() }
+                }
+            "#,
         )
         .build();
 
@@ -220,17 +220,17 @@ fn plugin_integration() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
 
-            [lib]
-            name = "foo"
-            plugin = true
-            doctest = false
-        "#,
+                [lib]
+                name = "foo"
+                plugin = true
+                doctest = false
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "")
@@ -246,28 +246,28 @@ fn doctest_a_plugin() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "#[macro_use] extern crate bar;")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            plugin = true
-        "#,
+                [lib]
+                name = "bar"
+                plugin = true
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
@@ -284,14 +284,14 @@ fn native_plugin_dependency_with_custom_linker() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            plugin = true
-        "#,
+                [lib]
+                plugin = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -301,23 +301,23 @@ fn native_plugin_dependency_with_custom_linker() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.foo]
-            path = "../foo"
-        "#,
+                [dependencies.foo]
+                path = "../foo"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}]
-            linker = "nonexistent-linker"
-        "#,
+                    [target.{}]
+                    linker = "nonexistent-linker"
+                "#,
                 target
             ),
         )
@@ -346,37 +346,37 @@ fn panic_abort_plugins() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.dev]
-            panic = 'abort'
+                [profile.dev]
+                panic = 'abort'
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            plugin = true
-        "#,
+                [lib]
+                plugin = true
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #![feature(rustc_private)]
-            extern crate rustc_ast;
-        "#,
+                #![feature(rustc_private)]
+                extern crate rustc_ast;
+            "#,
         )
         .build();
 
@@ -394,42 +394,42 @@ fn shared_panic_abort_plugins() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.dev]
-            panic = 'abort'
+                [profile.dev]
+                panic = 'abort'
 
-            [dependencies]
-            bar = { path = "bar" }
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+                baz = { path = "baz" }
+            "#,
         )
         .file("src/lib.rs", "extern crate baz;")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            plugin = true
+                [lib]
+                plugin = true
 
-            [dependencies]
-            baz = { path = "../baz" }
-        "#,
+                [dependencies]
+                baz = { path = "../baz" }
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #![feature(rustc_private)]
-            extern crate rustc_ast;
-            extern crate baz;
-        "#,
+                #![feature(rustc_private)]
+                extern crate rustc_ast;
+                extern crate baz;
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("baz/src/lib.rs", "")

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -9,26 +9,26 @@ fn probe_cfg_before_crate_type_discovery() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [target.'cfg(not(stage300))'.dependencies.noop]
-            path = "../noop"
-        "#,
+                [target.'cfg(not(stage300))'.dependencies.noop]
+                path = "../noop"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[macro_use]
-            extern crate noop;
+                #[macro_use]
+                extern crate noop;
 
-            #[derive(Noop)]
-            struct X;
+                #[derive(Noop)]
+                struct X;
 
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .build();
     let _noop = project()
@@ -36,26 +36,26 @@ fn probe_cfg_before_crate_type_discovery() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "noop"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "noop"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            proc-macro = true
-        "#,
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[proc_macro_derive(Noop)]
-            pub fn noop(_input: TokenStream) -> TokenStream {
-                "".parse().unwrap()
-            }
-        "#,
+                #[proc_macro_derive(Noop)]
+                pub fn noop(_input: TokenStream) -> TokenStream {
+                    "".parse().unwrap()
+                }
+            "#,
         )
         .build();
 
@@ -68,26 +68,26 @@ fn noop() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.noop]
-            path = "../noop"
-        "#,
+                [dependencies.noop]
+                path = "../noop"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[macro_use]
-            extern crate noop;
+                #[macro_use]
+                extern crate noop;
 
-            #[derive(Noop)]
-            struct X;
+                #[derive(Noop)]
+                struct X;
 
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .build();
     let _noop = project()
@@ -95,26 +95,26 @@ fn noop() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "noop"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "noop"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            proc-macro = true
-        "#,
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[proc_macro_derive(Noop)]
-            pub fn noop(_input: TokenStream) -> TokenStream {
-                "".parse().unwrap()
-            }
-        "#,
+                #[proc_macro_derive(Noop)]
+                pub fn noop(_input: TokenStream) -> TokenStream {
+                    "".parse().unwrap()
+                }
+            "#,
         )
         .build();
 
@@ -128,34 +128,34 @@ fn impl_and_derive() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.transmogrify]
-            path = "../transmogrify"
-        "#,
+                [dependencies.transmogrify]
+                path = "../transmogrify"
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[macro_use]
-            extern crate transmogrify;
+                #[macro_use]
+                extern crate transmogrify;
 
-            trait ImplByTransmogrify {
-                fn impl_by_transmogrify(&self) -> bool;
-            }
+                trait ImplByTransmogrify {
+                    fn impl_by_transmogrify(&self) -> bool;
+                }
 
-            #[derive(Transmogrify, Debug)]
-            struct X { success: bool }
+                #[derive(Transmogrify, Debug)]
+                struct X { success: bool }
 
-            fn main() {
-                let x = X::new();
-                assert!(x.impl_by_transmogrify());
-                println!("{:?}", x);
-            }
-        "#,
+                fn main() {
+                    let x = X::new();
+                    assert!(x.impl_by_transmogrify());
+                    println!("{:?}", x);
+                }
+            "#,
         )
         .build();
     let _transmogrify = project()
@@ -163,39 +163,39 @@ fn impl_and_derive() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "transmogrify"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "transmogrify"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            proc-macro = true
-        "#,
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[proc_macro_derive(Transmogrify)]
-            #[doc(hidden)]
-            pub fn transmogrify(input: TokenStream) -> TokenStream {
-                "
-                    impl X {
-                        fn new() -> Self {
-                            X { success: true }
+                #[proc_macro_derive(Transmogrify)]
+                #[doc(hidden)]
+                pub fn transmogrify(input: TokenStream) -> TokenStream {
+                    "
+                        impl X {
+                            fn new() -> Self {
+                                X { success: true }
+                            }
                         }
-                    }
 
-                    impl ImplByTransmogrify for X {
-                        fn impl_by_transmogrify(&self) -> bool {
-                            true
+                        impl ImplByTransmogrify for X {
+                            fn impl_by_transmogrify(&self) -> bool {
+                                true
+                            }
                         }
-                    }
-                ".parse().unwrap()
-            }
-        "#,
+                    ".parse().unwrap()
+                }
+            "#,
         )
         .build();
 
@@ -214,36 +214,36 @@ fn plugin_and_proc_macro() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            plugin = true
-            proc-macro = true
-        "#,
+                [lib]
+                plugin = true
+                proc-macro = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #![feature(plugin_registrar, rustc_private)]
-            #![feature(proc_macro, proc_macro_lib)]
+                #![feature(plugin_registrar, rustc_private)]
+                #![feature(proc_macro, proc_macro_lib)]
 
-            extern crate rustc_driver;
-            use rustc_driver::plugin::Registry;
+                extern crate rustc_driver;
+                use rustc_driver::plugin::Registry;
 
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[plugin_registrar]
-            pub fn plugin_registrar(reg: &mut Registry) {}
+                #[plugin_registrar]
+                pub fn plugin_registrar(reg: &mut Registry) {}
 
-            #[proc_macro_derive(Questionable)]
-            pub fn questionable(input: TokenStream) -> TokenStream {
-                input
-            }
-        "#,
+                #[proc_macro_derive(Questionable)]
+                pub fn questionable(input: TokenStream) -> TokenStream {
+                    input
+                }
+            "#,
         )
         .build();
 
@@ -260,36 +260,36 @@ fn proc_macro_doctest() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            [lib]
-            proc-macro = true
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                [lib]
+                proc-macro = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-#![crate_type = "proc-macro"]
+            #![crate_type = "proc-macro"]
 
-extern crate proc_macro;
+            extern crate proc_macro;
 
-use proc_macro::TokenStream;
+            use proc_macro::TokenStream;
 
-/// ```
-/// assert!(true);
-/// ```
-#[proc_macro_derive(Bar)]
-pub fn derive(_input: TokenStream) -> TokenStream {
-    "".parse().unwrap()
-}
+            /// ```
+            /// assert!(true);
+            /// ```
+            #[proc_macro_derive(Bar)]
+            pub fn derive(_input: TokenStream) -> TokenStream {
+                "".parse().unwrap()
+            }
 
-#[test]
-fn a() {
-  assert!(true);
-}
-"#,
+            #[test]
+            fn a() {
+              assert!(true);
+            }
+            "#,
         )
         .build();
 
@@ -307,55 +307,55 @@ fn proc_macro_crate_type() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [dependencies]
-            pm = { path = "pm" }
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [dependencies]
+                pm = { path = "pm" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            //! ```
-            //! use foo::THING;
-            //! assert_eq!(THING, 123);
-            //! ```
-            #[macro_use]
-            extern crate pm;
-            #[derive(MkItem)]
-            pub struct S;
-            #[cfg(test)]
-            mod tests {
-                use super::THING;
-                #[test]
-                fn it_works() {
-                    assert_eq!(THING, 123);
+                //! ```
+                //! use foo::THING;
+                //! assert_eq!(THING, 123);
+                //! ```
+                #[macro_use]
+                extern crate pm;
+                #[derive(MkItem)]
+                pub struct S;
+                #[cfg(test)]
+                mod tests {
+                    use super::THING;
+                    #[test]
+                    fn it_works() {
+                        assert_eq!(THING, 123);
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file(
             "pm/Cargo.toml",
             r#"
-            [package]
-            name = "pm"
-            version = "0.1.0"
-            [lib]
-            crate-type = ["proc-macro"]
-        "#,
+                [package]
+                name = "pm"
+                version = "0.1.0"
+                [lib]
+                crate-type = ["proc-macro"]
+            "#,
         )
         .file(
             "pm/src/lib.rs",
             r#"
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[proc_macro_derive(MkItem)]
-            pub fn mk_item(_input: TokenStream) -> TokenStream {
-                "pub const THING: i32 = 123;".parse().unwrap()
-            }
-        "#,
+                #[proc_macro_derive(MkItem)]
+                pub fn mk_item(_input: TokenStream) -> TokenStream {
+                    "pub const THING: i32 = 123;".parse().unwrap()
+                }
+            "#,
         )
         .build();
 
@@ -371,12 +371,12 @@ fn proc_macro_crate_type_warning() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [lib]
-            crate-type = ["proc-macro"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [lib]
+                crate-type = ["proc-macro"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -393,13 +393,13 @@ fn proc_macro_crate_type_warning_plugin() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [lib]
-            crate-type = ["proc-macro"]
-            plugin = true
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [lib]
+                crate-type = ["proc-macro"]
+                plugin = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -418,12 +418,12 @@ fn proc_macro_crate_type_multiple() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            [lib]
-            crate-type = ["proc-macro", "rlib"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                [lib]
+                crate-type = ["proc-macro", "rlib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -42,21 +42,21 @@ fn profile_config_validate_warnings() {
         .file(
             ".cargo/config",
             r#"
-            [profile.test]
-            opt-level = 3
+                [profile.test]
+                opt-level = 3
 
-            [profile.asdf]
-            opt-level = 3
+                [profile.asdf]
+                opt-level = 3
 
-            [profile.dev]
-            bad-key = true
+                [profile.dev]
+                bad-key = true
 
-            [profile.dev.build-override]
-            bad-key-bo = true
+                [profile.dev.build-override]
+                bad-key-bo = true
 
-            [profile.dev.package.bar]
-            bad-key-bar = true
-        "#,
+                [profile.dev.package.bar]
+                bad-key-bar = true
+            "#,
         )
         .build();
 
@@ -82,9 +82,9 @@ fn profile_config_error_paths() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev]
-            opt-level = 3
-        "#,
+                [profile.dev]
+                opt-level = 3
+            "#,
         )
         .file(
             paths::home().join(".cargo/config"),
@@ -116,9 +116,9 @@ fn profile_config_validate_errors() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.package.foo]
-            panic = "abort"
-        "#,
+                [profile.dev.package.foo]
+                panic = "abort"
+            "#,
         )
         .build();
 
@@ -143,9 +143,9 @@ fn profile_config_syntax_errors() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev]
-            codegen-units = "foo"
-        "#,
+                [profile.dev]
+                codegen-units = "foo"
+            "#,
         )
         .build();
 
@@ -179,12 +179,12 @@ fn profile_config_override_spec_multiple() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.package.bar]
-            opt-level = 3
+                [profile.dev.package.bar]
+                opt-level = 3
 
-            [profile.dev.package."bar:0.5.0"]
-            opt-level = 3
-        "#,
+                [profile.dev.package."bar:0.5.0"]
+                opt-level = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -211,17 +211,17 @@ fn profile_config_all_options() {
         .file(
             ".cargo/config",
             r#"
-        [profile.release]
-        opt-level = 1
-        debug = true
-        debug-assertions = true
-        overflow-checks = false
-        rpath = true
-        lto = true
-        codegen-units = 2
-        panic = "abort"
-        incremental = true
-        "#,
+            [profile.release]
+            opt-level = 1
+            debug = true
+            debug-assertions = true
+            overflow-checks = false
+            rpath = true
+            lto = true
+            codegen-units = 2
+            panic = "abort"
+            incremental = true
+            "#,
         )
         .build();
 
@@ -253,19 +253,19 @@ fn profile_config_override_precedence() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = {path = "bar"}
+                [dependencies]
+                bar = {path = "bar"}
 
-            [profile.dev]
-            codegen-units = 2
+                [profile.dev]
+                codegen-units = 2
 
-            [profile.dev.package.bar]
-            opt-level = 3
-        "#,
+                [profile.dev.package.bar]
+                opt-level = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -273,9 +273,9 @@ fn profile_config_override_precedence() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.package.bar]
-            opt-level = 2
-        "#,
+                [profile.dev.package.bar]
+                opt-level = 2
+            "#,
         )
         .build();
 
@@ -299,9 +299,9 @@ fn profile_config_no_warn_unknown_override() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev.package.bar]
-            codegen-units = 4
-        "#,
+                [profile.dev.package.bar]
+                codegen-units = 4
+            "#,
         )
         .build();
 
@@ -318,9 +318,9 @@ fn profile_config_mixed_types() {
         .file(
             ".cargo/config",
             r#"
-            [profile.dev]
-            opt-level = 3
-        "#,
+                [profile.dev]
+                opt-level = 3
+            "#,
         )
         .file(
             paths::home().join(".cargo/config"),

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -8,16 +8,16 @@ fn inherits_on_release() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.release]
-            inherits = "dev"
-        "#,
+                [profile.release]
+                inherits = "dev"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -39,16 +39,16 @@ fn missing_inherits() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.release-lto]
-            codegen-units = 7
-        "#,
+                [profile.release-lto]
+                codegen-units = 7
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -71,17 +71,17 @@ fn invalid_profile_name() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.'.release-lto']
-            inherits = "release"
-            codegen-units = 7
-        "#,
+                [profile.'.release-lto']
+                inherits = "release"
+                codegen-units = 7
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -105,18 +105,18 @@ fn invalid_dir_name() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.'release-lto']
-            inherits = "release"
-            dir-name = ".subdir"
-            codegen-units = 7
-        "#,
+                [profile.'release-lto']
+                inherits = "release"
+                dir-name = ".subdir"
+                codegen-units = 7
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -140,17 +140,17 @@ fn invalid_inherits() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.'release-lto']
-            inherits = ".release"
-            codegen-units = 7
-        "#,
+                [profile.'release-lto']
+                inherits = ".release"
+                codegen-units = 7
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -174,17 +174,17 @@ fn non_existent_inherits() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.release-lto]
-            codegen-units = 7
-            inherits = "non-existent"
-        "#,
+                [profile.release-lto]
+                codegen-units = 7
+                inherits = "non-existent"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -206,17 +206,17 @@ fn self_inherits() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.release-lto]
-            codegen-units = 7
-            inherits = "release-lto"
-        "#,
+                [profile.release-lto]
+                codegen-units = 7
+                inherits = "release-lto"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -238,21 +238,21 @@ fn inherits_loop() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.release-lto]
-            codegen-units = 7
-            inherits = "release-lto2"
+                [profile.release-lto]
+                codegen-units = 7
+                inherits = "release-lto2"
 
-            [profile.release-lto2]
-            codegen-units = 7
-            inherits = "release-lto"
-        "#,
+                [profile.release-lto2]
+                codegen-units = 7
+                inherits = "release-lto"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -274,32 +274,32 @@ fn overrides_with_custom() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            xxx = {path = "xxx"}
-            yyy = {path = "yyy"}
+                [dependencies]
+                xxx = {path = "xxx"}
+                yyy = {path = "yyy"}
 
-            [profile.dev]
-            codegen-units = 7
+                [profile.dev]
+                codegen-units = 7
 
-            [profile.dev.package.xxx]
-            codegen-units = 5
-            [profile.dev.package.yyy]
-            codegen-units = 3
+                [profile.dev.package.xxx]
+                codegen-units = 5
+                [profile.dev.package.yyy]
+                codegen-units = 3
 
-            [profile.other]
-            inherits = "dev"
-            codegen-units = 2
+                [profile.other]
+                inherits = "dev"
+                codegen-units = 2
 
-            [profile.other.package.yyy]
-            codegen-units = 6
-        "#,
+                [profile.other.package.yyy]
+                codegen-units = 6
+            "#,
         )
         .file("src/lib.rs", "")
         .file("xxx/Cargo.toml", &basic_lib_manifest("xxx"))
@@ -348,11 +348,11 @@ fn conflicting_usage() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -376,16 +376,16 @@ fn clean_custom_dirname() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["named-profiles"]
+                cargo-features = ["named-profiles"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.other]
-            inherits = "release"
-        "#,
+                [profile.other]
+                inherits = "release"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -9,20 +9,20 @@ fn profile_override_basic() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = {path = "bar"}
+                [dependencies]
+                bar = {path = "bar"}
 
-            [profile.dev]
-            opt-level = 1
+                [profile.dev]
+                opt-level = 1
 
-            [profile.dev.package.bar]
-            opt-level = 3
-        "#,
+                [profile.dev.package.bar]
+                opt-level = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -46,22 +46,22 @@ fn profile_override_warnings() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = {path = "bar"}
+                [dependencies]
+                bar = {path = "bar"}
 
-            [profile.dev.package.bart]
-            opt-level = 3
+                [profile.dev.package.bart]
+                opt-level = 3
 
-            [profile.dev.package.no-suggestion]
-            opt-level = 3
+                [profile.dev.package.no-suggestion]
+                opt-level = 3
 
-            [profile.dev.package."bar:1.2.3"]
-            opt-level = 3
-        "#,
+                [profile.dev.package."bar:1.2.3"]
+                opt-level = 3
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
@@ -107,16 +107,16 @@ fn profile_override_bad_settings() {
                 "Cargo.toml",
                 &format!(
                     r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
+                        [package]
+                        name = "foo"
+                        version = "0.0.1"
 
-                [dependencies]
-                bar = {{path = "bar"}}
+                        [dependencies]
+                        bar = {{path = "bar"}}
 
-                [profile.dev.package.bar]
-                {}
-            "#,
+                        [profile.dev.package.bar]
+                        {}
+                    "#,
                     snippet
                 ),
             )

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -12,33 +12,33 @@ fn all_target_project() -> Project {
             "Cargo.toml",
             &format!(
                 r#"
-            cargo-features = [{named_profiles}]
+                    cargo-features = [{named_profiles}]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
 
-            [dependencies]
-            bar = {{ path = "bar" }}
+                    [dependencies]
+                    bar = {{ path = "bar" }}
 
-            [build-dependencies]
-            bdep = {{ path = "bdep" }}
+                    [build-dependencies]
+                    bdep = {{ path = "bdep" }}
 
-            [profile.dev]
-            codegen-units = 1
-            panic = "abort"
-            [profile.release]
-            codegen-units = 2
-            panic = "abort"
-            [profile.test]
-            codegen-units = 3
-            [profile.bench]
-            codegen-units = 4
-            [profile.dev.build-override]
-            codegen-units = 5
-            [profile.release.build-override]
-            codegen-units = 6
-        "#,
+                    [profile.dev]
+                    codegen-units = 1
+                    panic = "abort"
+                    [profile.release]
+                    codegen-units = 2
+                    panic = "abort"
+                    [profile.test]
+                    codegen-units = 3
+                    [profile.bench]
+                    codegen-units = 4
+                    [profile.dev.build-override]
+                    codegen-units = 5
+                    [profile.release.build-override]
+                    codegen-units = 6
+                "#,
                 named_profiles = if is_nightly() {
                     "\"named-profiles\", "
                 } else {
@@ -54,15 +54,15 @@ fn all_target_project() -> Project {
         .file(
             "build.rs",
             r#"
-            extern crate bdep;
-            fn main() {
-                eprintln!("foo custom build PROFILE={} DEBUG={} OPT_LEVEL={}",
-                    std::env::var("PROFILE").unwrap(),
-                    std::env::var("DEBUG").unwrap(),
-                    std::env::var("OPT_LEVEL").unwrap(),
-                );
-            }
-        "#,
+                extern crate bdep;
+                fn main() {
+                    eprintln!("foo custom build PROFILE={} DEBUG={} OPT_LEVEL={}",
+                        std::env::var("PROFILE").unwrap(),
+                        std::env::var("DEBUG").unwrap(),
+                        std::env::var("OPT_LEVEL").unwrap(),
+                    );
+                }
+            "#,
         )
         // `bar` package.
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -71,13 +71,13 @@ fn all_target_project() -> Project {
         .file(
             "bdep/Cargo.toml",
             r#"
-            [package]
-            name = "bdep"
-            version = "0.0.1"
+                [package]
+                name = "bdep"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { path = "../bar" }
-        "#,
+                [dependencies]
+                bar = { path = "../bar" }
+            "#,
         )
         .file("bdep/src/lib.rs", "extern crate bar;")
         .build()

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -10,17 +10,17 @@ fn profile_overrides() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [profile.dev]
-            opt-level = 1
-            debug = false
-            rpath = true
-        "#,
+                [profile.dev]
+                opt-level = 1
+                debug = false
+                rpath = true
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -48,15 +48,15 @@ fn opt_level_override_0() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [profile.dev]
-            opt-level = 0
-        "#,
+                [profile.dev]
+                opt-level = 0
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -82,14 +82,14 @@ fn debug_override_1() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                [package]
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [profile.dev]
-            debug = 1
-        "#,
+                [profile.dev]
+                debug = 1
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -115,15 +115,15 @@ fn check_opt_level_override(profile_level: &str, rustc_level: &str) {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
+                    [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                    name = "test"
+                    version = "0.0.0"
+                    authors = []
 
-            [profile.dev]
-            opt-level = {level}
-        "#,
+                    [profile.dev]
+                    opt-level = {level}
+                "#,
                 level = profile_level
             ),
         )
@@ -167,38 +167,38 @@ fn top_level_overrides_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "test"
-            version = "0.0.0"
-            authors = []
+                name = "test"
+                version = "0.0.0"
+                authors = []
 
-            [profile.release]
-            opt-level = 1
-            debug = true
+                [profile.release]
+                opt-level = 1
+                debug = true
 
-            [dependencies.foo]
-            path = "foo"
-        "#,
+                [dependencies.foo]
+                path = "foo"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
+                [package]
 
-            name = "foo"
-            version = "0.0.0"
-            authors = []
+                name = "foo"
+                version = "0.0.0"
+                authors = []
 
-            [profile.release]
-            opt-level = 0
-            debug = false
+                [profile.release]
+                opt-level = 0
+                debug = false
 
-            [lib]
-            name = "foo"
-            crate_type = ["dylib", "rlib"]
-        "#,
+                [lib]
+                name = "foo"
+                crate_type = ["dylib", "rlib"]
+            "#,
         )
         .file("foo/src/lib.rs", "")
         .build();
@@ -240,31 +240,31 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
+                [workspace]
+                members = ["bar"]
 
-            [profile.dev]
-            debug = false
-        "#,
+                [profile.dev]
+                debug = false
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
 
-            [profile.dev]
-            opt-level = 1
-        "#,
+                [profile.dev]
+                opt-level = 1
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .build();
@@ -289,24 +289,24 @@ fn profile_in_virtual_manifest_works() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
+                [workspace]
+                members = ["bar"]
 
-            [profile.dev]
-            opt-level = 1
-            debug = false
-        "#,
+                [profile.dev]
+                opt-level = 1
+                debug = false
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .build();
@@ -328,16 +328,16 @@ fn profile_panic_test_bench() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [profile.test]
-            panic = "abort"
+                [profile.test]
+                panic = "abort"
 
-            [profile.bench]
-            panic = "abort"
-        "#,
+                [profile.bench]
+                panic = "abort"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -358,13 +358,13 @@ fn profile_doc_deprecated() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [profile.doc]
-            opt-level = 0
-        "#,
+                [profile.doc]
+                opt-level = 0
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -446,14 +446,14 @@ fn thin_lto_works() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "top"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "top"
+                version = "0.5.0"
+                authors = []
 
-            [profile.release]
-            lto = 'thin'
-        "#,
+                [profile.release]
+                lto = 'thin'
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -481,15 +481,15 @@ fn strip_works() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["strip"]
+                cargo-features = ["strip"]
 
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [profile.release]
-            strip = 'symbols'
-        "#,
+                [profile.release]
+                strip = 'symbols'
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -516,13 +516,13 @@ fn strip_requires_cargo_feature() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [profile.release]
-            strip = 'symbols'
-        "#,
+                [profile.release]
+                strip = 'symbols'
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -552,15 +552,15 @@ fn strip_rejects_invalid_option() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["strip"]
+                cargo-features = ["strip"]
 
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [profile.release]
-            strip = 'wrong'
-        "#,
+                [profile.release]
+                strip = 'wrong'
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -97,13 +97,13 @@ fn always_shows_progress() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            {}
-            "#,
+                [dependencies]
+                {}
+                "#,
                 deps
             ),
         )
@@ -138,13 +138,13 @@ fn never_progress() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            {}
-            "#,
+                [dependencies]
+                {}
+                "#,
                 deps
             ),
         )

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -16,15 +16,15 @@ fn exported_priv_warning() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["public-dependency"]
+                cargo-features = ["public-dependency"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            priv_dep = "0.1.0"
-        "#,
+                [dependencies]
+                priv_dep = "0.1.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -58,15 +58,15 @@ fn exported_pub_dep() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["public-dependency"]
+                cargo-features = ["public-dependency"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            pub_dep = {version = "0.1.0", public = true}
-        "#,
+                [dependencies]
+                pub_dep = {version = "0.1.0", public = true}
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -98,8 +98,8 @@ pub fn requires_nightly_cargo() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["public-dependency"]
-        "#,
+                cargo-features = ["public-dependency"]
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -129,13 +129,13 @@ fn requires_feature() {
             "Cargo.toml",
             r#"
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            pub_dep = { version = "0.1.0", public = true }
-        "#,
+                [dependencies]
+                pub_dep = { version = "0.1.0", public = true }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -166,15 +166,15 @@ fn pub_dev_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            cargo-features = ["public-dependency"]
+                cargo-features = ["public-dependency"]
 
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dev-dependencies]
-            pub_dep = {version = "0.1.0", public = true}
-        "#,
+                [dev-dependencies]
+                pub_dep = {version = "0.1.0", public = true}
+            "#,
         )
         .file(
             "src/lib.rs",

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -78,13 +78,13 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -115,13 +115,13 @@ fn old_token_location() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -169,13 +169,13 @@ fn simple_with_host() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -216,13 +216,13 @@ fn simple_with_index_and_host() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -263,16 +263,16 @@ fn git_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [dependencies.foo]
-            git = "git://path/to/nowhere"
-        "#,
+                [dependencies.foo]
+                git = "git://path/to/nowhere"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -299,16 +299,16 @@ fn path_dependency_no_version() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
@@ -337,14 +337,14 @@ fn unpublishable_crate() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            publish = false
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                publish = false
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -370,16 +370,16 @@ fn dont_publish_dirty() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -410,16 +410,16 @@ fn publish_clean() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -439,16 +439,16 @@ fn publish_in_sub_repo() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .build();
@@ -468,16 +468,16 @@ fn publish_when_ignored() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(".gitignore", "baz")
@@ -510,16 +510,16 @@ fn ignore_when_crate_ignored() {
         .nocommit_file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .nocommit_file("bar/src/main.rs", "fn main() {}");
     p.cargo("publish --token sekrit").cwd("bar").run();
@@ -547,16 +547,16 @@ fn new_crate_rejected() {
         .nocommit_file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
         )
         .nocommit_file("src/main.rs", "fn main() {}");
     p.cargo("publish --token sekrit")
@@ -576,13 +576,13 @@ fn dry_run() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -617,16 +617,16 @@ fn registry_not_in_publish_list() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            publish = [
-                "test"
-            ]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                publish = [
+                    "test"
+                ]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -652,14 +652,14 @@ fn publish_empty_list() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            publish = []
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                publish = []
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -685,17 +685,17 @@ fn publish_allowed_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-            publish = ["alternative"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+                publish = ["alternative"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -725,17 +725,17 @@ fn publish_implicitly_to_only_allowed_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-            publish = ["alternative"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+                publish = ["alternative"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -765,17 +765,17 @@ fn publish_fail_with_no_registry_specified() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            documentation = "foo"
-            homepage = "foo"
-            repository = "foo"
-            publish = ["alternative", "test"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+                publish = ["alternative", "test"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -799,14 +799,14 @@ fn block_publish_no_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            publish = []
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                publish = []
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -831,14 +831,14 @@ fn publish_with_crates_io_explicit() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            publish = ["crates-io"]
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                publish = ["crates-io"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -864,17 +864,17 @@ fn publish_with_select_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [features]
-            required = []
-            optional = []
-        "#,
+                [features]
+                required = []
+                optional = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -897,17 +897,17 @@ fn publish_with_all_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [features]
-            required = []
-            optional = []
-        "#,
+                [features]
+                required = []
+                optional = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -930,17 +930,17 @@ fn publish_with_no_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
 
-            [features]
-            default = ["required"]
-            required = []
-        "#,
+                [features]
+                default = ["required"]
+                required = []
+            "#,
         )
         .file(
             "src/main.rs",
@@ -964,17 +964,17 @@ fn publish_with_patch() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            [dependencies]
-            bar = "1.0"
-            [patch.crates-io]
-            bar = { path = "bar" }
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                [dependencies]
+                bar = "1.0"
+                [patch.crates-io]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1050,13 +1050,13 @@ fn publish_checks_for_token_before_verify() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1325,13 +1325,13 @@ fn credentials_ambiguous_filename() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1391,13 +1391,13 @@ fn registry_token_with_source_replacement() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -162,9 +162,9 @@ fn lock_file_and_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo"]
-        "#,
+                [workspace]
+                members = ["foo"]
+            "#,
         )
         .file("foo/Cargo.toml", &pl_manifest("foo", "0.0.1", ""))
         .file("foo/src/main.rs", "fn main() {}")

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -48,17 +48,17 @@ fn manifest_output_no_readme() -> String {
 pub fn basic_bin_manifest_with_readme(name: &str, readme_filename: &str) -> String {
     format!(
         r#"
-        [package]
+            [package]
 
-        name = "{}"
-        version = "0.5.0"
-        authors = ["wycats@example.com"]
-        readme = {}
+            name = "{}"
+            version = "0.5.0"
+            authors = ["wycats@example.com"]
+            readme = {}
 
-        [[bin]]
+            [[bin]]
 
-        name = "{}"
-    "#,
+            name = "{}"
+        "#,
         name, readme_filename, name
     )
 }

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -15,14 +15,14 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = ">= 0.0.0"
-        "#,
+                [dependencies]
+                bar = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -63,14 +63,14 @@ fn deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = ">= 0.0.0"
-        "#,
+                [dependencies]
+                bar = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -103,14 +103,14 @@ fn nonexistent() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            nonexistent = ">= 0.0.0"
-        "#,
+                [dependencies]
+                nonexistent = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -136,14 +136,14 @@ fn wrong_case() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            Init = ">= 0.0.0"
-        "#,
+                [dependencies]
+                Init = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -171,14 +171,14 @@ fn mis_hyphenated() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            mis_hyphenated = ">= 0.0.0"
-        "#,
+                [dependencies]
+                mis_hyphenated = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -204,14 +204,14 @@ fn wrong_version() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            foo = ">= 1.0.0"
-        "#,
+                [dependencies]
+                foo = ">= 1.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -253,14 +253,14 @@ fn bad_cksum() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bad-cksum = ">= 0.0.0"
-        "#,
+                [dependencies]
+                bad-cksum = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -293,14 +293,14 @@ fn update_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            notyet = ">= 0.0.0"
-        "#,
+                [dependencies]
+                notyet = ">= 0.0.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -341,18 +341,18 @@ fn package_with_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-            repository = "bar"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                repository = "bar"
 
-            [dependencies.notyet]
-            version = "0.0.1"
-            path = "notyet"
-        "#,
+                [dependencies.notyet]
+                version = "0.0.1"
+                path = "notyet"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("notyet/Cargo.toml", &basic_manifest("notyet", "0.0.1"))
@@ -399,14 +399,14 @@ fn lockfile_locks() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -438,14 +438,14 @@ fn lockfile_locks_transitively() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -481,14 +481,14 @@ fn yanks_are_not_used() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -523,14 +523,14 @@ fn relying_on_a_yank_is_bad() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -559,14 +559,14 @@ fn yanks_in_lockfiles_are_ok() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -599,15 +599,15 @@ fn yanks_in_lockfiles_are_ok_for_other_update() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-            baz = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+                baz = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -653,14 +653,14 @@ fn yanks_in_lockfiles_are_ok_with_new_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -697,14 +697,14 @@ fn update_with_lockfile_if_packages_missing() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -732,14 +732,14 @@ fn update_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -829,14 +829,14 @@ fn dev_dependency_not_used() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -890,14 +890,14 @@ fn bad_license_file() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license-file = "foo"
-            description = "bar"
-            repository = "baz"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license-file = "foo"
+                description = "bar"
+                repository = "baz"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -913,27 +913,27 @@ fn updating_a_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.a]
-            path = "a"
-        "#,
+                [dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "a"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("a/src/lib.rs", "")
         .build();
@@ -990,14 +990,14 @@ fn git_and_registry_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "b"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "b"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = "0.0.1"
-        "#,
+                [dependencies]
+                a = "0.0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -1006,17 +1006,17 @@ fn git_and_registry_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [project]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            a = "0.0.1"
+                    [dependencies]
+                    a = "0.0.1"
 
-            [dependencies.b]
-            git = '{}'
-        "#,
+                    [dependencies.b]
+                    git = '{}'
+                "#,
                 b.url()
             ),
         )
@@ -1054,14 +1054,14 @@ fn update_publish_then_update() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = "0.1.0"
-        "#,
+                [dependencies]
+                a = "0.1.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1082,14 +1082,14 @@ fn update_publish_then_update() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = "0.1.1"
-        "#,
+                [dependencies]
+                a = "0.1.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1124,14 +1124,14 @@ fn fetch_downloads() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = "0.1.0"
-        "#,
+                [dependencies]
+                a = "0.1.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1155,14 +1155,14 @@ fn update_transitive_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = "0.1.0"
-        "#,
+                [dependencies]
+                a = "0.1.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1203,14 +1203,14 @@ fn update_backtracking_ok() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            webdriver = "0.1"
-        "#,
+                [dependencies]
+                webdriver = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1252,16 +1252,16 @@ fn update_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            a = "*"
-            b = "*"
-            c = "*"
-        "#,
+                [dependencies]
+                a = "*"
+                b = "*"
+                c = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1312,15 +1312,15 @@ fn bundled_crate_in_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
-            baz = "0.1"
-        "#,
+                [dependencies]
+                bar = "0.1"
+                baz = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1331,14 +1331,14 @@ fn bundled_crate_in_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "baz"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar", version = "0.1.0" }
-        "#,
+                [dependencies]
+                bar = { path = "bar", version = "0.1.0" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -1354,14 +1354,14 @@ fn update_same_prefix_oh_my_how_was_this_a_bug() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "ugh"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "ugh"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.1"
-        "#,
+                [dependencies]
+                foo = "0.1"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1381,14 +1381,14 @@ fn use_semver() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "1.2.3-alpha.0"
-        "#,
+                [dependencies]
+                foo = "1.2.3-alpha.0"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1453,18 +1453,18 @@ fn only_download_relevant() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [target.foo.dependencies]
-            foo = "*"
-            [dev-dependencies]
-            bar = "*"
-            [dependencies]
-            baz = "*"
-        "#,
+                [target.foo.dependencies]
+                foo = "*"
+                [dev-dependencies]
+                bar = "*"
+                [dependencies]
+                baz = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1493,14 +1493,14 @@ fn resolve_and_backtracking() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "*"
-        "#,
+                [dependencies]
+                foo = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1519,14 +1519,14 @@ fn upstream_warnings_on_extra_verbose() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "*"
-        "#,
+                [dependencies]
+                foo = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1546,14 +1546,14 @@ fn disallow_network() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "*"
-        "#,
+                [dependencies]
+                foo = "*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1583,27 +1583,27 @@ fn add_dep_dont_update_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                baz = { path = "baz" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "baz/Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "baz"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            remote = "0.3"
-        "#,
+                [dependencies]
+                remote = "0.3"
+            "#,
         )
         .file("baz/src/lib.rs", "")
         .build();
@@ -1642,27 +1642,27 @@ fn bump_version_dont_update_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                baz = { path = "baz" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "baz/Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "baz"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            remote = "0.3"
-        "#,
+                [dependencies]
+                remote = "0.3"
+            "#,
         )
         .file("baz/src/lib.rs", "")
         .build();
@@ -1700,14 +1700,14 @@ fn old_version_req() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            remote = "0.2*"
-        "#,
+                [dependencies]
+                remote = "0.2*"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1754,14 +1754,14 @@ fn old_version_req_upstream() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            remote = "0.3"
-        "#,
+                [dependencies]
+                remote = "0.3"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1831,14 +1831,14 @@ fn toml_lies_but_index_is_truth() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            bar = "0.3"
-        "#,
+                [dependencies]
+                bar = "0.3"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1859,14 +1859,14 @@ fn vv_prints_warnings() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "fo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "fo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.2"
-        "#,
+                [dependencies]
+                foo = "0.2"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -1884,14 +1884,14 @@ fn bad_and_or_malicious_packages_rejected() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "fo"
-            version = "0.5.0"
-            authors = []
+                [project]
+                name = "fo"
+                version = "0.5.0"
+                authors = []
 
-            [dependencies]
-            foo = "0.2"
-        "#,
+                [dependencies]
+                foo = "0.2"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -14,15 +14,15 @@ fn rename_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { version = "0.1.0" }
-            baz = { version = "0.2.0", package = "bar" }
-        "#,
+                [dependencies]
+                bar = { version = "0.1.0" }
+                baz = { version = "0.2.0", package = "bar" }
+            "#,
         )
         .file("src/lib.rs", "extern crate bar; extern crate baz;")
         .build();
@@ -36,27 +36,27 @@ fn rename_with_different_names() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            baz = { path = "bar", package = "bar" }
-        "#,
+                [dependencies]
+                baz = { path = "bar", package = "bar" }
+            "#,
         )
         .file("src/lib.rs", "extern crate baz;")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "random_name"
-        "#,
+                [lib]
+                name = "random_name"
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -87,18 +87,18 @@ fn lots_of_names() {
             "Cargo.toml",
             &format!(
                 r#"
-                [package]
-                name = "test"
-                version = "0.1.0"
-                authors = []
+                    [package]
+                    name = "test"
+                    version = "0.1.0"
+                    authors = []
 
-                [dependencies]
-                foo = "0.2"
-                foo1 = {{ version = "0.1", package = "foo" }}
-                foo2 = {{ version = "0.1", registry = "alternative", package = "foo" }}
-                foo3 = {{ git = '{}', package = "foo" }}
-                foo4 = {{ path = "foo", package = "foo" }}
-            "#,
+                    [dependencies]
+                    foo = "0.2"
+                    foo1 = {{ version = "0.1", package = "foo" }}
+                    foo2 = {{ version = "0.1", registry = "alternative", package = "foo" }}
+                    foo3 = {{ git = '{}', package = "foo" }}
+                    foo4 = {{ path = "foo", package = "foo" }}
+                "#,
                 g.url()
             ),
         )
@@ -243,14 +243,14 @@ fn can_run_doc_tests() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
+                [project]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { version = "0.1.0" }
-            baz = { version = "0.2.0", package = "bar" }
-        "#,
+                [dependencies]
+                bar = { version = "0.1.0" }
+                baz = { version = "0.2.0", package = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -19,17 +19,17 @@ fn override_simple() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                    [dependencies]
+                    bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{}' }}
+                "#,
                 bar.url()
             ),
         )
@@ -58,17 +58,17 @@ fn missing_version() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [replace]
-            bar = { git = 'https://example.com' }
-        "#,
+                [replace]
+                bar = { git = 'https://example.com' }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -92,17 +92,17 @@ fn invalid_semver_version() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
+                [dependencies]
+                bar = "*"
 
-            [replace]
-            "bar:*" = { git = 'https://example.com' }
-        "#,
+                [replace]
+                "bar:*" = { git = 'https://example.com' }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -129,17 +129,17 @@ fn different_version() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = "0.2.0"
-        "#,
+                [replace]
+                "bar:0.1.0" = "0.2.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -175,17 +175,17 @@ fn transitive() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            baz = "0.2.0"
+                    [dependencies]
+                    baz = "0.2.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -224,17 +224,17 @@ fn persists_across_rebuilds() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                    [dependencies]
+                    bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -273,17 +273,17 @@ fn replace_registry_with_path() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = { path = "../bar" }
-        "#,
+                [replace]
+                "bar:0.1.0" = { path = "../bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -327,18 +327,18 @@ fn use_a_spec_to_select() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1"
-            baz = "0.1"
+                    [dependencies]
+                    bar = "0.1"
+                    baz = "0.1"
 
-            [replace]
-            "baz:0.2.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "baz:0.2.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -383,14 +383,14 @@ fn override_adds_some_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = "0.1"
-        "#,
+                [dependencies]
+                baz = "0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -400,17 +400,17 @@ fn override_adds_some_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1"
+                    [dependencies]
+                    bar = "0.1"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -466,14 +466,14 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = "*"
-        "#,
+                [dependencies]
+                baz = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -483,18 +483,18 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1"
-            baz = "0.1"
+                    [dependencies]
+                    bar = "0.1"
+                    baz = "0.1"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -521,17 +521,17 @@ fn override_wrong_name() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            baz = "0.1"
+                    [dependencies]
+                    baz = "0.1"
 
-            [replace]
-            "baz:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "baz:0.1.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -568,17 +568,17 @@ fn override_with_nothing() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1"
+                    [dependencies]
+                    bar = "0.1"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{}' }}
+                "#,
                 foo.url()
             ),
         )
@@ -612,14 +612,14 @@ fn override_wrong_version() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [replace]
-            "bar:0.1.0" = { git = 'https://example.com', version = '0.2.0' }
-        "#,
+                [replace]
+                "bar:0.1.0" = { git = 'https://example.com', version = '0.2.0' }
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -651,20 +651,20 @@ fn multiple_specs() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                    [dependencies]
+                    bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{0}' }}
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{0}' }}
 
-            [replace."https://github.com/rust-lang/crates.io-index#bar:0.1.0"]
-            git = '{0}'
-        "#,
+                    [replace."https://github.com/rust-lang/crates.io-index#bar:0.1.0"]
+                    git = '{0}'
+                "#,
                 bar.url()
             ),
         )
@@ -705,17 +705,17 @@ fn test_override_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                    [dependencies]
+                    bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{0}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{0}' }}
+                "#,
                 bar.url()
             ),
         )
@@ -749,17 +749,17 @@ fn update() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                    [dependencies]
+                    bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{0}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{0}' }}
+                "#,
                 bar.url()
             ),
         )
@@ -787,14 +787,14 @@ fn no_override_self() {
         .file(
             "near/Cargo.toml",
             r#"
-            [package]
-            name = "near"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "near"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            far = { path = "../far" }
-        "#,
+                [dependencies]
+                far = { path = "../far" }
+            "#,
         )
         .file("near/src/lib.rs", "#![no_std] pub extern crate far;")
         .build();
@@ -804,17 +804,17 @@ fn no_override_self() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            near = {{ git = '{0}' }}
+                    [dependencies]
+                    near = {{ git = '{0}' }}
 
-            [replace]
-            "near:0.1.0" = {{ git = '{0}' }}
-        "#,
+                    [replace]
+                    "near:0.1.0" = {{ git = '{0}' }}
+                "#,
                 deps.url()
             ),
         )
@@ -840,59 +840,59 @@ fn override_an_override() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            chrono = "0.2"
-            serde = "0.8"
+                [dependencies]
+                chrono = "0.2"
+                serde = "0.8"
 
-            [replace]
-            "chrono:0.2.0" = { path = "chrono" }
-            "serde:0.8.0" = { path = "serde" }
-        "#,
+                [replace]
+                "chrono:0.2.0" = { path = "chrono" }
+                "serde:0.8.0" = { path = "serde" }
+            "#,
         )
         .file(
             "Cargo.lock",
             r#"
-            [[package]]
-            name = "foo"
-            version = "0.0.1"
-            dependencies = [
-             "chrono 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-             "serde 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            ]
+                [[package]]
+                name = "foo"
+                version = "0.0.1"
+                dependencies = [
+                 "chrono 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                 "serde 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                ]
 
-            [[package]]
-            name = "chrono"
-            version = "0.2.0"
-            source = "registry+https://github.com/rust-lang/crates.io-index"
-            replace = "chrono 0.2.0"
+                [[package]]
+                name = "chrono"
+                version = "0.2.0"
+                source = "registry+https://github.com/rust-lang/crates.io-index"
+                replace = "chrono 0.2.0"
 
-            [[package]]
-            name = "chrono"
-            version = "0.2.0"
-            dependencies = [
-             "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-            ]
+                [[package]]
+                name = "chrono"
+                version = "0.2.0"
+                dependencies = [
+                 "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                ]
 
-            [[package]]
-            name = "serde"
-            version = "0.7.0"
-            source = "registry+https://github.com/rust-lang/crates.io-index"
+                [[package]]
+                name = "serde"
+                version = "0.7.0"
+                source = "registry+https://github.com/rust-lang/crates.io-index"
 
-            [[package]]
-            name = "serde"
-            version = "0.8.0"
-            source = "registry+https://github.com/rust-lang/crates.io-index"
-            replace = "serde 0.8.0"
+                [[package]]
+                name = "serde"
+                version = "0.8.0"
+                source = "registry+https://github.com/rust-lang/crates.io-index"
+                replace = "serde 0.8.0"
 
-            [[package]]
-            name = "serde"
-            version = "0.8.0"
-        "#,
+                [[package]]
+                name = "serde"
+                version = "0.8.0"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -909,14 +909,14 @@ fn override_an_override() {
         .file(
             "chrono/Cargo.toml",
             r#"
-            [package]
-            name = "chrono"
-            version = "0.2.0"
-            authors = []
+                [package]
+                name = "chrono"
+                version = "0.2.0"
+                authors = []
 
-            [dependencies]
-            serde = "< 0.9"
-        "#,
+                [dependencies]
+                serde = "< 0.9"
+            "#,
         )
         .file(
             "chrono/src/lib.rs",
@@ -943,14 +943,14 @@ fn overriding_nonexistent_no_spurious() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                baz = { path = "baz" }
+            "#,
         )
         .file("src/lib.rs", "pub fn bar() {}")
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
@@ -962,18 +962,18 @@ fn overriding_nonexistent_no_spurious() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                    [dependencies]
+                    bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = {{ git = '{url}' }}
-            "baz:0.1.0" = {{ git = '{url}' }}
-        "#,
+                    [replace]
+                    "bar:0.1.0" = {{ git = '{url}' }}
+                    "baz:0.1.0" = {{ git = '{url}' }}
+                "#,
                 url = bar.url()
             ),
         )
@@ -1005,18 +1005,19 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
             members = [ "first_crate", "second_crate"]
 
             [replace]
-            "bar:0.1.0" = { path = "local_bar" }"#,
+            "bar:0.1.0" = { path = "local_bar" }
+            "#,
         )
         .file(
             "first_crate/Cargo.toml",
             r#"
-            [package]
-            name = "first_crate"
-            version = "0.1.0"
+                [package]
+                name = "first_crate"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = "0.1.0"
-        "#,
+                [dependencies]
+                bar = "0.1.0"
+            "#,
         )
         .file("first_crate/src/lib.rs", "")
         .file(
@@ -1060,30 +1061,30 @@ fn replace_to_path_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1.0"
+                [dependencies]
+                bar = "0.1.0"
 
-            [replace]
-            "bar:0.1.0" = { path = "bar" }
-        "#,
+                [replace]
+                "bar:0.1.0" = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "extern crate bar;")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = { path = "baz" }
-        "#,
+                [dependencies]
+                baz = { path = "baz" }
+            "#,
         )
         .file(
             "bar/src/lib.rs",
@@ -1106,51 +1107,51 @@ fn override_with_default_feature() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar", default-features = false }
-            another = "0.1"
-            another2 = { path = "another2" }
+                [dependencies]
+                bar = { path = "bar", default-features = false }
+                another = "0.1"
+                another2 = { path = "another2" }
 
-            [replace]
-            'bar:0.1.0' = { path = "bar" }
-        "#,
+                [replace]
+                'bar:0.1.0' = { path = "bar" }
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::bar(); }")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            default = []
-        "#,
+                [features]
+                default = []
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #[cfg(feature = "default")]
-            pub fn bar() {}
-        "#,
+                #[cfg(feature = "default")]
+                pub fn bar() {}
+            "#,
         )
         .file(
             "another2/Cargo.toml",
             r#"
-            [package]
-            name = "another2"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "another2"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { version = "0.1", default-features = false }
-        "#,
+                [dependencies]
+                bar = { version = "0.1", default-features = false }
+            "#,
         )
         .file("another2/src/lib.rs", "")
         .build();
@@ -1166,30 +1167,30 @@ fn override_plus_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "0.1"
+                [dependencies]
+                bar = "0.1"
 
-            [replace]
-            'bar:0.1.0' = { path = "bar" }
-        "#,
+                [replace]
+                'bar:0.1.0' = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = ".." }
-        "#,
+                [dependencies]
+                foo = { path = ".." }
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -13,32 +13,32 @@ fn build_bin_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a"]
-            a = []
+                [features]
+                default = ["a"]
+                a = []
 
-            [[bin]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            #[cfg(feature = "a")]
-            fn test() {
-                foo::foo();
-            }
+                #[cfg(feature = "a")]
+                fn test() {
+                    foo::foo();
+                }
 
-            fn main() {}
-        "#,
+                fn main() {}
+            "#,
         )
         .file("src/lib.rs", r#"#[cfg(feature = "a")] pub fn foo() {}"#)
         .build();
@@ -68,18 +68,18 @@ fn build_bin_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
+                [features]
+                a = []
 
-            [[bin]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -94,27 +94,27 @@ fn build_bin_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a", "b"]
-            a = []
-            b = ["a"]
-            c = []
+                [features]
+                default = ["a", "b"]
+                a = []
+                b = ["a"]
+                c = []
 
-            [[bin]]
-            name = "foo_1"
-            path = "src/foo_1.rs"
-            required-features = ["b", "c"]
+                [[bin]]
+                name = "foo_1"
+                path = "src/foo_1.rs"
+                required-features = ["b", "c"]
 
-            [[bin]]
-            name = "foo_2"
-            path = "src/foo_2.rs"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "foo_2"
+                path = "src/foo_2.rs"
+                required-features = ["a"]
+            "#,
         )
         .file("src/foo_1.rs", "fn main() {}")
         .file("src/foo_2.rs", "fn main() {}")
@@ -139,19 +139,19 @@ fn build_example_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a"]
-            a = []
+                [features]
+                default = ["a"]
+                a = []
 
-            [[example]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[example]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("examples/foo.rs", "fn main() {}")
         .build();
@@ -176,18 +176,18 @@ fn build_example_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
+                [features]
+                a = []
 
-            [[example]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[example]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("examples/foo.rs", "fn main() {}")
         .build();
@@ -202,25 +202,25 @@ fn build_example_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a", "b"]
-            a = []
-            b = ["a"]
-            c = []
+                [features]
+                default = ["a", "b"]
+                a = []
+                b = ["a"]
+                c = []
 
-            [[example]]
-            name = "foo_1"
-            required-features = ["b", "c"]
+                [[example]]
+                name = "foo_1"
+                required-features = ["b", "c"]
 
-            [[example]]
-            name = "foo_2"
-            required-features = ["a"]
-        "#,
+                [[example]]
+                name = "foo_2"
+                required-features = ["a"]
+            "#,
         )
         .file("examples/foo_1.rs", "fn main() {}")
         .file("examples/foo_2.rs", "fn main() {}")
@@ -272,19 +272,19 @@ fn test_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a"]
-            a = []
+                [features]
+                default = ["a"]
+                a = []
 
-            [[test]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[test]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("tests/foo.rs", "#[test]\nfn test() {}")
         .build();
@@ -330,18 +330,18 @@ fn test_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
+                [features]
+                a = []
 
-            [[test]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[test]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("tests/foo.rs", "#[test]\nfn test() {}")
         .build();
@@ -363,25 +363,25 @@ fn test_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a", "b"]
-            a = []
-            b = ["a"]
-            c = []
+                [features]
+                default = ["a", "b"]
+                a = []
+                b = ["a"]
+                c = []
 
-            [[test]]
-            name = "foo_1"
-            required-features = ["b", "c"]
+                [[test]]
+                name = "foo_1"
+                required-features = ["b", "c"]
 
-            [[test]]
-            name = "foo_2"
-            required-features = ["a"]
-        "#,
+                [[test]]
+                name = "foo_2"
+                required-features = ["a"]
+            "#,
         )
         .file("tests/foo_1.rs", "#[test]\nfn test() {}")
         .file("tests/foo_2.rs", "#[test]\nfn test() {}")
@@ -424,19 +424,19 @@ fn bench_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a"]
-            a = []
+                [features]
+                default = ["a"]
+                a = []
 
-            [[bench]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[bench]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file(
             "benches/foo.rs",
@@ -446,7 +446,8 @@ fn bench_default_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -495,18 +496,18 @@ fn bench_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
+                [features]
+                a = []
 
-            [[bench]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[bench]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file(
             "benches/foo.rs",
@@ -516,7 +517,8 @@ fn bench_arg_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -541,25 +543,25 @@ fn bench_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a", "b"]
-            a = []
-            b = ["a"]
-            c = []
+                [features]
+                default = ["a", "b"]
+                a = []
+                b = ["a"]
+                c = []
 
-            [[bench]]
-            name = "foo_1"
-            required-features = ["b", "c"]
+                [[bench]]
+                name = "foo_1"
+                required-features = ["b", "c"]
 
-            [[bench]]
-            name = "foo_2"
-            required-features = ["a"]
-        "#,
+                [[bench]]
+                name = "foo_2"
+                required-features = ["a"]
+            "#,
         )
         .file(
             "benches/foo_1.rs",
@@ -569,7 +571,8 @@ fn bench_multiple_required_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#,
+            }
+            "#,
         )
         .file(
             "benches/foo_2.rs",
@@ -579,7 +582,8 @@ fn bench_multiple_required_features() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -616,23 +620,23 @@ fn install_default_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a"]
-            a = []
+                [features]
+                default = ["a"]
+                a = []
 
-            [[bin]]
-            name = "foo"
-            required-features = ["a"]
+                [[bin]]
+                name = "foo"
+                required-features = ["a"]
 
-            [[example]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[example]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("examples/foo.rs", "fn main() {}")
@@ -701,18 +705,18 @@ fn install_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
+                [features]
+                a = []
 
-            [[bin]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -728,27 +732,27 @@ fn install_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a", "b"]
-            a = []
-            b = ["a"]
-            c = []
+                [features]
+                default = ["a", "b"]
+                a = []
+                b = ["a"]
+                c = []
 
-            [[bin]]
-            name = "foo_1"
-            path = "src/foo_1.rs"
-            required-features = ["b", "c"]
+                [[bin]]
+                name = "foo_1"
+                path = "src/foo_1.rs"
+                required-features = ["b", "c"]
 
-            [[bin]]
-            name = "foo_2"
-            path = "src/foo_2.rs"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "foo_2"
+                path = "src/foo_2.rs"
+                required-features = ["a"]
+            "#,
         )
         .file("src/foo_1.rs", "fn main() {}")
         .file("src/foo_2.rs", "fn main() {}")
@@ -784,30 +788,30 @@ fn dep_feature_in_toml() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar", features = ["a"] }
+                [dependencies]
+                bar = { path = "bar", features = ["a"] }
 
-            [[bin]]
-            name = "foo"
-            required-features = ["bar/a"]
+                [[bin]]
+                name = "foo"
+                required-features = ["bar/a"]
 
-            [[example]]
-            name = "foo"
-            required-features = ["bar/a"]
+                [[example]]
+                name = "foo"
+                required-features = ["bar/a"]
 
-            [[test]]
-            name = "foo"
-            required-features = ["bar/a"]
+                [[test]]
+                name = "foo"
+                required-features = ["bar/a"]
 
-            [[bench]]
-            name = "foo"
-            required-features = ["bar/a"]
-        "#,
+                [[bench]]
+                name = "foo"
+                required-features = ["bar/a"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("examples/foo.rs", "fn main() {}")
@@ -820,19 +824,20 @@ fn dep_feature_in_toml() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#,
+            }
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
-        "#,
+                [features]
+                a = []
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -884,30 +889,30 @@ fn dep_feature_in_cmd_line() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [[bin]]
-            name = "foo"
-            required-features = ["bar/a"]
+                [[bin]]
+                name = "foo"
+                required-features = ["bar/a"]
 
-            [[example]]
-            name = "foo"
-            required-features = ["bar/a"]
+                [[example]]
+                name = "foo"
+                required-features = ["bar/a"]
 
-            [[test]]
-            name = "foo"
-            required-features = ["bar/a"]
+                [[test]]
+                name = "foo"
+                required-features = ["bar/a"]
 
-            [[bench]]
-            name = "foo"
-            required-features = ["bar/a"]
-        "#,
+                [[bench]]
+                name = "foo"
+                required-features = ["bar/a"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("examples/foo.rs", "fn main() {}")
@@ -930,19 +935,20 @@ fn dep_feature_in_cmd_line() {
 
             #[bench]
             fn bench(_: &mut test::Bencher) {
-            }"#,
+            }
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
-        "#,
+                [features]
+                a = []
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -1042,19 +1048,19 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            a = []
+                [features]
+                a = []
 
-            [[bin]]
-            name = "bin_foo"
-            path = "src/bin/foo.rs"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "bin_foo"
+                path = "src/bin/foo.rs"
+                required-features = ["a"]
+            "#,
         )
         .file("src/bin/foo.rs", "extern crate bar; fn main() {}")
         .file("tests/foo.rs", "")
@@ -1108,19 +1114,19 @@ fn run_default() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = []
-            a = []
+                [features]
+                default = []
+                a = []
 
-            [[bin]]
-            name = "foo"
-            required-features = ["a"]
-        "#,
+                [[bin]]
+                name = "foo"
+                required-features = ["a"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/main.rs", "extern crate foo; fn main() {}")
@@ -1145,26 +1151,26 @@ fn run_default_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            default = ["a"]
-            a = []
-            b = []
+                [features]
+                default = ["a"]
+                a = []
+                b = []
 
-            [[bin]]
-            name = "foo1"
-            path = "src/foo1.rs"
-            required-features = ["a"]
+                [[bin]]
+                name = "foo1"
+                path = "src/foo1.rs"
+                required-features = ["a"]
 
-            [[bin]]
-            name = "foo2"
-            path = "src/foo2.rs"
-            required-features = ["b"]
-        "#,
+                [[bin]]
+                name = "foo2"
+                path = "src/foo2.rs"
+                required-features = ["b"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/foo1.rs", "extern crate foo; fn main() {}")
@@ -1235,13 +1241,13 @@ fn renamed_required_features() {
         .file(
             "a2/Cargo.toml",
             r#"
-             [package]
-            name = "a"
-            version = "0.2.0"
+              [package]
+             name = "a"
+             version = "0.2.0"
 
-            [features]
-            f2 = []
-           "#,
+             [features]
+             f2 = []
+            "#,
         )
         .file(
             "a2/src/lib.rs",

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -50,9 +50,9 @@ fn quiet_and_verbose_config() {
         .file(
             ".cargo/config",
             r#"
-            [term]
-            verbose = true
-        "#,
+                [term]
+                verbose = true
+            "#,
         )
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .build();
@@ -66,11 +66,11 @@ fn simple_with_args() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                assert_eq!(std::env::args().nth(1).unwrap(), "hello");
-                assert_eq!(std::env::args().nth(2).unwrap(), "world");
-            }
-        "#,
+                fn main() {
+                    assert_eq!(std::env::args().nth(1).unwrap(), "hello");
+                    assert_eq!(std::env::args().nth(2).unwrap(), "world");
+                }
+            "#,
         )
         .build();
 
@@ -86,14 +86,14 @@ fn simple_with_non_utf8_args() {
         .file(
             "src/main.rs",
             r#"
-            use std::ffi::OsStr;
-            use std::os::unix::ffi::OsStrExt;
+                use std::ffi::OsStr;
+                use std::os::unix::ffi::OsStrExt;
 
-            fn main() {
-                assert_eq!(std::env::args_os().nth(1).unwrap(), OsStr::from_bytes(b"hello"));
-                assert_eq!(std::env::args_os().nth(2).unwrap(), OsStr::from_bytes(b"ab\xffcd"));
-            }
-        "#,
+                fn main() {
+                    assert_eq!(std::env::args_os().nth(1).unwrap(), OsStr::from_bytes(b"hello"));
+                    assert_eq!(std::env::args_os().nth(2).unwrap(), OsStr::from_bytes(b"ab\xffcd"));
+                }
+            "#,
         )
         .build();
 
@@ -187,18 +187,18 @@ fn specify_name() {
         .file(
             "src/bin/a.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-            fn main() { println!("hello a.rs"); }
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+                fn main() { println!("hello a.rs"); }
+            "#,
         )
         .file(
             "src/bin/b.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-            fn main() { println!("hello b.rs"); }
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+                fn main() { println!("hello b.rs"); }
+            "#,
         )
         .build();
 
@@ -232,12 +232,12 @@ fn specify_default_run() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            default-run = "a"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                default-run = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", r#"fn main() { println!("hello A"); }"#)
@@ -255,12 +255,12 @@ fn bogus_default_run() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            default-run = "b"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                default-run = "b"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("src/bin/a.rs", r#"fn main() { println!("hello A"); }"#)
@@ -306,14 +306,14 @@ fn run_library_example() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            [[example]]
-            name = "bar"
-            crate_type = ["lib"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                [[example]]
+                name = "bar"
+                crate_type = ["lib"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/bar.rs", "fn foo() {}")
@@ -331,13 +331,13 @@ fn run_bin_example() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            [[example]]
-            name = "bar"
-            crate_type = ["bin"]
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                [[example]]
+                name = "bar"
+                crate_type = ["bin"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/bar.rs", r#"fn main() { println!("example"); }"#)
@@ -502,9 +502,9 @@ fn run_with_filename() {
         .file(
             "src/bin/a.rs",
             r#"
-            extern crate foo;
-            fn main() { println!("hello a.rs"); }
-        "#,
+                extern crate foo;
+                fn main() { println!("hello a.rs"); }
+            "#,
         )
         .file("examples/a.rs", r#"fn main() { println!("example"); }"#)
         .build();
@@ -586,43 +586,43 @@ fn example_with_release_flag() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            version = "*"
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                version = "*"
+                path = "bar"
+            "#,
         )
         .file(
             "examples/a.rs",
             r#"
-            extern crate bar;
+                extern crate bar;
 
-            fn main() {
-                if cfg!(debug_assertions) {
-                    println!("slow1")
-                } else {
-                    println!("fast1")
+                fn main() {
+                    if cfg!(debug_assertions) {
+                        println!("slow1")
+                    } else {
+                        println!("fast1")
+                    }
+                    bar::baz();
                 }
-                bar::baz();
-            }
-        "#,
+            "#,
         )
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "bar/src/bar.rs",
             r#"
-            pub fn baz() {
-                if cfg!(debug_assertions) {
-                    println!("slow2")
-                } else {
-                    println!("fast2")
+                pub fn baz() {
+                    if cfg!(debug_assertions) {
+                        println!("slow2")
+                    } else {
+                        println!("fast2")
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
 
@@ -691,14 +691,14 @@ fn run_dylib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/main.rs",
@@ -707,15 +707,15 @@ fn run_dylib_dep() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            crate-type = ["dylib"]
-        "#,
+                [lib]
+                name = "bar"
+                crate-type = ["dylib"]
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
@@ -729,8 +729,8 @@ fn release_works() {
         .file(
             "src/main.rs",
             r#"
-            fn main() { if cfg!(debug_assertions) { panic!() } }
-        "#,
+                fn main() { if cfg!(debug_assertions) { panic!() } }
+            "#,
         )
         .build();
 
@@ -752,14 +752,14 @@ fn run_bin_different_name() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name = "bar"
-        "#,
+                [[bin]]
+                name = "bar"
+            "#,
         )
         .file("src/bar.rs", "fn main() {}")
         .build();
@@ -773,14 +773,14 @@ fn dashes_are_forwarded() {
         .file(
             "src/bin/bar.rs",
             r#"
-            fn main() {
-                let s: Vec<String> = std::env::args().collect();
-                assert_eq!(s[1], "--");
-                assert_eq!(s[2], "a");
-                assert_eq!(s[3], "--");
-                assert_eq!(s[4], "b");
-            }
-        "#,
+                fn main() {
+                    let s: Vec<String> = std::env::args().collect();
+                    assert_eq!(s[1], "--");
+                    assert_eq!(s[2], "a");
+                    assert_eq!(s[3], "--");
+                    assert_eq!(s[4], "b");
+                }
+            "#,
         )
         .build();
 
@@ -822,22 +822,22 @@ fn run_with_library_paths() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
             &format!(
                 r##"
-            fn main() {{
-                println!(r#"cargo:rustc-link-search=native={}"#);
-                println!(r#"cargo:rustc-link-search={}"#);
-            }}
-        "##,
+                    fn main() {{
+                        println!(r#"cargo:rustc-link-search=native={}"#);
+                        println!(r#"cargo:rustc-link-search={}"#);
+                    }}
+                "##,
                 dir1.display(),
                 dir2.display()
             ),
@@ -846,14 +846,14 @@ fn run_with_library_paths() {
             "src/main.rs",
             &format!(
                 r##"
-            fn main() {{
-                let search_path = std::env::var_os("{}").unwrap();
-                let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
-                println!("{{:#?}}", paths);
-                assert!(paths.contains(&r#"{}"#.into()));
-                assert!(paths.contains(&r#"{}"#.into()));
-            }}
-        "##,
+                    fn main() {{
+                        let search_path = std::env::var_os("{}").unwrap();
+                        let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
+                        println!("{{:#?}}", paths);
+                        assert!(paths.contains(&r#"{}"#.into()));
+                        assert!(paths.contains(&r#"{}"#.into()));
+                    }}
+                "##,
                 dylib_path_envvar(),
                 dir1.display(),
                 dir2.display()
@@ -881,23 +881,23 @@ fn library_paths_sorted_alphabetically() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
             &format!(
                 r##"
-            fn main() {{
-                println!(r#"cargo:rustc-link-search=native={}"#);
-                println!(r#"cargo:rustc-link-search=native={}"#);
-                println!(r#"cargo:rustc-link-search=native={}"#);
-            }}
-        "##,
+                    fn main() {{
+                        println!(r#"cargo:rustc-link-search=native={}"#);
+                        println!(r#"cargo:rustc-link-search=native={}"#);
+                        println!(r#"cargo:rustc-link-search=native={}"#);
+                    }}
+                "##,
                 dir1.display(),
                 dir2.display(),
                 dir3.display()
@@ -907,15 +907,15 @@ fn library_paths_sorted_alphabetically() {
             "src/main.rs",
             &format!(
                 r##"
-            fn main() {{
-                let search_path = std::env::var_os("{}").unwrap();
-                let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
-                // ASCII case-sensitive sort
-                assert_eq!("BBBBBBB", paths[0].file_name().unwrap().to_string_lossy());
-                assert_eq!("aaaaaaa", paths[1].file_name().unwrap().to_string_lossy());
-                assert_eq!("zzzzzzz", paths[2].file_name().unwrap().to_string_lossy());
-            }}
-        "##,
+                    fn main() {{
+                        let search_path = std::env::var_os("{}").unwrap();
+                        let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
+                        // ASCII case-sensitive sort
+                        assert_eq!("BBBBBBB", paths[0].file_name().unwrap().to_string_lossy());
+                        assert_eq!("aaaaaaa", paths[1].file_name().unwrap().to_string_lossy());
+                        assert_eq!("zzzzzzz", paths[2].file_name().unwrap().to_string_lossy());
+                    }}
+                "##,
                 dylib_path_envvar()
             ),
         )
@@ -944,21 +944,21 @@ fn run_multiple_packages() {
         .file(
             "foo/Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [workspace]
+                [workspace]
 
-            [dependencies]
-            d1 = { path = "d1" }
-            d2 = { path = "d2" }
-            d3 = { path = "../d3" } # outside of the workspace
+                [dependencies]
+                d1 = { path = "d1" }
+                d2 = { path = "d2" }
+                d3 = { path = "../d3" } # outside of the workspace
 
-            [[bin]]
-            name = "foo"
-        "#,
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file("foo/src/foo.rs", "fn main() { println!(\"foo\"); }")
         .file("foo/d1/Cargo.toml", &basic_bin_manifest("d1"))
@@ -1006,11 +1006,11 @@ fn explicit_bin_with_args() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                assert_eq!(std::env::args().nth(1).unwrap(), "hello");
-                assert_eq!(std::env::args().nth(2).unwrap(), "world");
-            }
-        "#,
+                fn main() {
+                    assert_eq!(std::env::args().nth(1).unwrap(), "hello");
+                    assert_eq!(std::env::args().nth(2).unwrap(), "world");
+                }
+            "#,
         )
         .build();
 
@@ -1023,9 +1023,9 @@ fn run_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_bin_manifest("a"))
         .file("a/src/main.rs", r#"fn main() {println!("run-a");}"#)
@@ -1050,18 +1050,18 @@ fn default_run_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.0.1"
-            default-run = "a"
-        "#,
+                [project]
+                name = "a"
+                version = "0.0.1"
+                default-run = "a"
+            "#,
         )
         .file("a/src/main.rs", r#"fn main() {println!("run-a");}"#)
         .file("b/Cargo.toml", &basic_bin_manifest("b"))
@@ -1132,11 +1132,11 @@ fn run_link_system_path_macos() {
             "build.rs",
             &format!(
                 r#"
-            fn main() {{
-                println!("cargo:rustc-link-lib=foo");
-                println!("cargo:rustc-link-search={}");
-            }}
-            "#,
+                fn main() {{
+                    println!("cargo:rustc-link-lib=foo");
+                    println!("cargo:rustc-link-search={}");
+                }}
+                "#,
                 p.target_debug_dir().display()
             ),
         )

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -164,14 +164,14 @@ fn build_foo_with_bar_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::baz() }")
         .build();
@@ -200,14 +200,14 @@ fn build_only_bar_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::baz() }")
         .build();
@@ -273,17 +273,17 @@ fn fail_with_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-                path = "../bar"
+                [dependencies.bar]
+                    path = "../bar"
 
-            [dependencies.baz]
-                path = "../baz"
-        "#,
+                [dependencies.baz]
+                    path = "../baz"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();
@@ -294,10 +294,10 @@ fn fail_with_multiple_packages() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                if cfg!(flag = "1") { println!("Yeah from bar!"); }
-            }
-        "#,
+                fn main() {
+                    if cfg!(flag = "1") { println!("Yeah from bar!"); }
+                }
+            "#,
         )
         .build();
 
@@ -307,10 +307,10 @@ fn fail_with_multiple_packages() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                if cfg!(flag = "1") { println!("Yeah from baz!"); }
-            }
-        "#,
+                fn main() {
+                    if cfg!(flag = "1") { println!("Yeah from baz!"); }
+                }
+            "#,
         )
         .build();
 
@@ -331,23 +331,23 @@ fn rustc_with_other_profile() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies]
-            a = { path = "a" }
-        "#,
+                [dev-dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            #[cfg(test)] extern crate a;
+                #[cfg(test)] extern crate a;
 
-            #[test]
-            fn foo() {}
-        "#,
+                #[test]
+                fn foo() {}
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "")
@@ -411,16 +411,17 @@ fn rustc_test_with_implicit_bin() {
         .file(
             "src/main.rs",
             r#"
-            #[cfg(foo)]
-            fn f() { compile_fail!("Foo shouldn't be set."); }
-            fn main() {}
-        "#,
+                #[cfg(foo)]
+                fn f() { compile_fail!("Foo shouldn't be set."); }
+                fn main() {}
+            "#,
         )
         .file(
             "tests/test1.rs",
             r#"
-            #[cfg(not(foo))]
-            fn f() { compile_fail!("Foo should be set."); } "#,
+                #[cfg(not(foo))]
+                fn f() { compile_fail!("Foo should be set."); }
+            "#,
         )
         .build();
 

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -44,17 +44,17 @@ fn rustc_info_cache() {
             .file(
                 "src/main.rs",
                 r#"
-            use std::process::Command;
-            use std::env;
+                    use std::process::Command;
+                    use std::env;
 
-            fn main() {
-                let mut cmd = Command::new("rustc");
-                for arg in env::args_os().skip(1) {
-                    cmd.arg(arg);
-                }
-                std::process::exit(cmd.status().unwrap().code().unwrap());
-            }
-        "#,
+                    fn main() {
+                        let mut cmd = Command::new("rustc");
+                        for arg in env::args_os().skip(1) {
+                            cmd.arg(arg);
+                        }
+                        std::process::exit(cmd.status().unwrap().code().unwrap());
+                    }
+                "#,
             )
             .build();
         p.cargo("build").run();

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -56,14 +56,14 @@ fn rustdoc_foo_with_bar_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "extern crate bar; pub fn foo() {}")
         .build();
@@ -97,14 +97,14 @@ fn rustdoc_only_bar_dependency() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/main.rs", "extern crate bar; fn main() { bar::baz() }")
         .build();
@@ -157,14 +157,14 @@ fn features() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [features]
-            quux = []
-        "#,
+                [features]
+                quux = []
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -180,15 +180,15 @@ fn proc_macro_crate_type() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            proc-macro = true
+                [lib]
+                proc-macro = true
 
-        "#,
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -19,9 +19,9 @@ fn parses_config() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            rustdocflags = ["--cfg", "foo"]
-        "#,
+                [build]
+                rustdocflags = ["--cfg", "foo"]
+            "#,
         )
         .build();
 
@@ -67,10 +67,10 @@ fn rustdocflags_passed_to_rustdoc_through_cargo_test() {
         .file(
             "src/lib.rs",
             r#"
-            //! ```
-            //! assert!(cfg!(do_not_choke));
-            //! ```
-        "#,
+                //! ```
+                //! assert!(cfg!(do_not_choke));
+                //! ```
+            "#,
         )
         .build();
 

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -18,7 +18,8 @@ fn env_rustflags_normal_source() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .build();
 
@@ -59,20 +60,20 @@ fn env_rustflags_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() { }
-            #[cfg(not(foo))]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(not(foo))]
+                fn main() { }
+            "#,
         )
         .build();
 
@@ -88,14 +89,14 @@ fn env_rustflags_build_script_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
 
-            [build-dependencies.bar]
-            path = "../bar"
-        "#,
+                [build-dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -106,10 +107,10 @@ fn env_rustflags_build_script_dep() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(not(foo))]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(not(foo))]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -125,22 +126,22 @@ fn env_rustflags_plugin() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
-        "#,
+                [lib]
+                name = "foo"
+                plugin = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            fn main() { }
-            #[cfg(not(foo))]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(not(foo))]
+                fn main() { }
+            "#,
         )
         .build();
 
@@ -156,17 +157,17 @@ fn env_rustflags_plugin_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
+                [lib]
+                name = "foo"
+                plugin = true
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "fn foo() {}")
         .build();
@@ -176,10 +177,10 @@ fn env_rustflags_plugin_dep() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(not(foo))]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(not(foo))]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -198,7 +199,8 @@ fn env_rustflags_normal_source_with_target() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .build();
 
@@ -246,20 +248,20 @@ fn env_rustflags_build_script_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() { }
-            #[cfg(foo)]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(foo)]
+                fn main() { }
+            "#,
         )
         .build();
 
@@ -279,14 +281,14 @@ fn env_rustflags_build_script_dep_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
 
-            [build-dependencies.bar]
-            path = "../bar"
-        "#,
+                [build-dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -297,10 +299,10 @@ fn env_rustflags_build_script_dep_with_target() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(foo)]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(foo)]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -320,22 +322,22 @@ fn env_rustflags_plugin_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
-        "#,
+                [lib]
+                name = "foo"
+                plugin = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            fn main() { }
-            #[cfg(foo)]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(foo)]
+                fn main() { }
+            "#,
         )
         .build();
 
@@ -355,17 +357,17 @@ fn env_rustflags_plugin_dep_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
+                [lib]
+                name = "foo"
+                plugin = true
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "fn foo() {}")
         .build();
@@ -375,10 +377,10 @@ fn env_rustflags_plugin_dep_with_target() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(foo)]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(foo)]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -438,7 +440,8 @@ fn build_rustflags_normal_source() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -480,20 +483,20 @@ fn build_rustflags_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() { }
-            #[cfg(not(foo))]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(not(foo))]
+                fn main() { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -516,14 +519,14 @@ fn build_rustflags_build_script_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
 
-            [build-dependencies.bar]
-            path = "../bar"
-        "#,
+                [build-dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -541,10 +544,10 @@ fn build_rustflags_build_script_dep() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(not(foo))]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(not(foo))]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -560,22 +563,22 @@ fn build_rustflags_plugin() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
-        "#,
+                [lib]
+                name = "foo"
+                plugin = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            fn main() { }
-            #[cfg(not(foo))]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(not(foo))]
+                fn main() { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -598,17 +601,17 @@ fn build_rustflags_plugin_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
+                [lib]
+                name = "foo"
+                plugin = true
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "fn foo() {}")
         .file(
@@ -625,10 +628,10 @@ fn build_rustflags_plugin_dep() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(not(foo))]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(not(foo))]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -647,7 +650,8 @@ fn build_rustflags_normal_source_with_target() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -697,20 +701,20 @@ fn build_rustflags_build_script_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "build.rs",
             r#"
-            fn main() { }
-            #[cfg(foo)]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(foo)]
+                fn main() { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -734,14 +738,14 @@ fn build_rustflags_build_script_dep_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
 
-            [build-dependencies.bar]
-            path = "../bar"
-        "#,
+                [build-dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
@@ -759,10 +763,10 @@ fn build_rustflags_build_script_dep_with_target() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(foo)]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(foo)]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -779,22 +783,22 @@ fn build_rustflags_plugin_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
-        "#,
+                [lib]
+                name = "foo"
+                plugin = true
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            fn main() { }
-            #[cfg(foo)]
-            fn main() { }
-        "#,
+                fn main() { }
+                #[cfg(foo)]
+                fn main() { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -818,17 +822,17 @@ fn build_rustflags_plugin_dep_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [lib]
-            name = "foo"
-            plugin = true
+                [lib]
+                name = "foo"
+                plugin = true
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file("src/lib.rs", "fn foo() {}")
         .file(
@@ -845,10 +849,10 @@ fn build_rustflags_plugin_dep_with_target() {
         .file(
             "src/lib.rs",
             r#"
-            fn bar() { }
-            #[cfg(foo)]
-            fn bar() { }
-        "#,
+                fn bar() { }
+                #[cfg(foo)]
+                fn bar() { }
+            "#,
         )
         .build();
 
@@ -952,7 +956,8 @@ fn target_rustflags_normal_source() {
             r#"
             #![feature(test)]
             extern crate test;
-            #[bench] fn run1(_ben: &mut test::Bencher) { }"#,
+            #[bench] fn run1(_ben: &mut test::Bencher) { }
+            "#,
         )
         .file(
             ".cargo/config",
@@ -1044,9 +1049,9 @@ fn cfg_rustflags_normal_source() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.'cfg({})']
-            rustflags = ["--cfg", "bar"]
-            "#,
+                [target.'cfg({})']
+                rustflags = ["--cfg", "bar"]
+                "#,
                 if rustc_host().contains("-windows-") {
                     "windows"
                 } else {
@@ -1123,12 +1128,12 @@ fn cfg_rustflags_precedence() {
             ".cargo/config",
             &format!(
                 r#"
-            [build]
-            rustflags = ["--cfg", "foo"]
+                [build]
+                rustflags = ["--cfg", "foo"]
 
-            [target.'cfg({})']
-            rustflags = ["--cfg", "bar"]
-            "#,
+                [target.'cfg({})']
+                rustflags = ["--cfg", "bar"]
+                "#,
                 if rustc_host().contains("-windows-") {
                     "windows"
                 } else {
@@ -1245,9 +1250,9 @@ fn target_rustflags_string_and_array_form2() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}]
-            rustflags = ["--cfg", "foo"]
-        "#,
+                    [target.{}]
+                    rustflags = ["--cfg", "foo"]
+                "#,
                 rustc_host()
             ),
         )
@@ -1269,9 +1274,9 @@ fn target_rustflags_string_and_array_form2() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}]
-            rustflags = "--cfg foo"
-        "#,
+                    [target.{}]
+                    rustflags = "--cfg foo"
+                "#,
                 rustc_host()
             ),
         )
@@ -1295,29 +1300,29 @@ fn two_matching_in_config() {
         .file(
             ".cargo/config",
             r#"
-            [target.'cfg(unix)']
-            rustflags = ["--cfg", 'foo="a"']
-            [target.'cfg(windows)']
-            rustflags = ["--cfg", 'foo="a"']
-            [target.'cfg(target_pointer_width = "32")']
-            rustflags = ["--cfg", 'foo="b"']
-            [target.'cfg(target_pointer_width = "64")']
-            rustflags = ["--cfg", 'foo="b"']
-        "#,
+                [target.'cfg(unix)']
+                rustflags = ["--cfg", 'foo="a"']
+                [target.'cfg(windows)']
+                rustflags = ["--cfg", 'foo="a"']
+                [target.'cfg(target_pointer_width = "32")']
+                rustflags = ["--cfg", 'foo="b"']
+                [target.'cfg(target_pointer_width = "64")']
+                rustflags = ["--cfg", 'foo="b"']
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {
-                if cfg!(foo = "a") {
-                    println!("a");
-                } else if cfg!(foo = "b") {
-                    println!("b");
-                } else {
-                    panic!()
+                fn main() {
+                    if cfg!(foo = "a") {
+                        println!("a");
+                    } else if cfg!(foo = "b") {
+                        println!("b");
+                    } else {
+                        panic!()
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .build();
 
@@ -1343,11 +1348,11 @@ fn env_rustflags_misspelled_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                build = "build.rs"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() { }")

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -121,13 +121,13 @@ fn set_cargo_config() {
         &config,
         format!(
             r#"
-[source.crates-io]
-registry = 'https://wut'
-replace-with = 'dummy-registry'
+            [source.crates-io]
+            registry = 'https://wut'
+            replace-with = 'dummy-registry'
 
-[source.dummy-registry]
-registry = '{reg}'
-"#,
+            [source.dummy-registry]
+            registry = '{reg}'
+            "#,
             reg = registry_url(),
         ),
     )

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -27,7 +27,8 @@ fn cargo_test_simple() {
             #[test]
             fn test_hello() {
                 assert_eq!(hello(), "hello")
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -53,33 +54,33 @@ fn cargo_test_release() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            authors = []
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                authors = []
+                version = "0.1.0"
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
-            pub fn foo() { bar::bar(); }
+                extern crate bar;
+                pub fn foo() { bar::bar(); }
 
-            #[test]
-            fn test() { foo(); }
-        "#,
+                #[test]
+                fn test() { foo(); }
+            "#,
         )
         .file(
             "tests/test.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            #[test]
-            fn test() { foo::foo(); }
-        "#,
+                #[test]
+                fn test() { foo::foo(); }
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -132,7 +133,8 @@ fn cargo_test_overflow_checks() {
                     [1, i32::MAX].iter().sum::<i32>();
                 });
                 assert!(r.is_err());
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -148,23 +150,23 @@ fn cargo_test_quiet_with_harness() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [[test]]
-            name = "foo"
-            path = "src/foo.rs"
-            harness = true
-        "#,
+                [[test]]
+                name = "foo"
+                path = "src/foo.rs"
+                harness = true
+            "#,
         )
         .file(
             "src/foo.rs",
             r#"
-            fn main() {}
-            #[test] fn test_hello() {}
-        "#,
+                fn main() {}
+                #[test] fn test_hello() {}
+            "#,
         )
         .build();
 
@@ -187,27 +189,27 @@ fn cargo_test_quiet_no_harness() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [[bin]]
-            name = "foo"
-            test = false
+                [[bin]]
+                name = "foo"
+                test = false
 
-            [[test]]
-            name = "foo"
-            path = "src/main.rs"
-            harness = false
-        "#,
+                [[test]]
+                name = "foo"
+                path = "src/main.rs"
+                harness = false
+            "#,
         )
         .file(
             "src/main.rs",
             r#"
-            fn main() {}
-            #[test] fn test_hello() {}
-        "#,
+                fn main() {}
+                #[test] fn test_hello() {}
+            "#,
         )
         .build();
 
@@ -221,9 +223,9 @@ fn cargo_test_verbose() {
         .file(
             "src/main.rs",
             r#"
-            fn main() {}
-            #[test] fn test_hello() {}
-        "#,
+                fn main() {}
+                #[test] fn test_hello() {}
+            "#,
         )
         .build();
 
@@ -261,9 +263,9 @@ fn many_similar_names() {
         .file(
             "tests/foo.rs",
             r#"
-            extern crate foo;
-            #[test] fn test_test() { foo::foo() }
-        "#,
+                extern crate foo;
+                #[test] fn test_test() { foo::foo() }
+            "#,
         )
         .build();
 
@@ -292,7 +294,8 @@ fn cargo_test_failing_test_in_bin() {
             #[test]
             fn test_hello() {
                 assert_eq!(hello(), "nope")
-            }"#,
+            }
+            "#,
         )
         .build();
 
@@ -423,30 +426,30 @@ fn test_with_lib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name = "baz"
-            path = "src/main.rs"
-        "#,
+                [[bin]]
+                name = "baz"
+                path = "src/main.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            ///
-            /// ```rust
-            /// extern crate foo;
-            /// fn main() {
-            ///     println!("{:?}", foo::foo());
-            /// }
-            /// ```
-            ///
-            pub fn foo(){}
-            #[test] fn lib_test() {}
-        "#,
+                ///
+                /// ```rust
+                /// extern crate foo;
+                /// fn main() {
+                ///     println!("{:?}", foo::foo());
+                /// }
+                /// ```
+                ///
+                pub fn foo(){}
+                #[test] fn lib_test() {}
+            "#,
         )
         .file(
             "src/main.rs",
@@ -483,14 +486,14 @@ fn test_with_deep_lib_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.bar]
-            path = "../bar"
-        "#,
+                [dependencies.bar]
+                path = "../bar"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -535,33 +538,33 @@ fn external_test_explicit() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[test]]
-            name = "test"
-            path = "src/test.rs"
-        "#,
+                [[test]]
+                name = "test"
+                path = "src/test.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn get_hello() -> &'static str { "Hello" }
+                pub fn get_hello() -> &'static str { "Hello" }
 
-            #[test]
-            fn internal_test() {}
-        "#,
+                #[test]
+                fn internal_test() {}
+            "#,
         )
         .file(
             "src/test.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            #[test]
-            fn external_test() { assert_eq!(foo::get_hello(), "Hello") }
-        "#,
+                #[test]
+                fn external_test() { assert_eq!(foo::get_hello(), "Hello") }
+            "#,
         )
         .build();
 
@@ -586,14 +589,14 @@ fn external_test_named_test() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[test]]
-            name = "test"
-        "#,
+                [[test]]
+                name = "test"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("tests/test.rs", "#[test] fn foo() {}")
@@ -608,20 +611,20 @@ fn external_test_implicit() {
         .file(
             "src/lib.rs",
             r#"
-            pub fn get_hello() -> &'static str { "Hello" }
+                pub fn get_hello() -> &'static str { "Hello" }
 
-            #[test]
-            fn internal_test() {}
-        "#,
+                #[test]
+                fn internal_test() {}
+            "#,
         )
         .file(
             "tests/external.rs",
             r#"
-            extern crate foo;
+                extern crate foo;
 
-            #[test]
-            fn external_test() { assert_eq!(foo::get_hello(), "Hello") }
-        "#,
+                #[test]
+                fn external_test() { assert_eq!(foo::get_hello(), "Hello") }
+            "#,
         )
         .build();
 
@@ -647,8 +650,8 @@ fn dont_run_examples() {
         .file(
             "examples/dont-run-me-i-will-fail.rs",
             r#"
-            fn main() { panic!("Examples should not be run by 'cargo test'"); }
-        "#,
+                fn main() { panic!("Examples should not be run by 'cargo test'"); }
+            "#,
         )
         .build();
     p.cargo("test").run();
@@ -718,16 +721,16 @@ fn lib_bin_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            [[bin]]
-            name = "foo"
-        "#,
+                [lib]
+                name = "foo"
+                [[bin]]
+                name = "foo"
+            "#,
         )
         .file("src/lib.rs", "#[test] fn lib_test() {}")
         .file(
@@ -804,16 +807,16 @@ fn lib_with_standard_name2() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "syntax"
-            test = false
-            doctest = false
-        "#,
+                [lib]
+                name = "syntax"
+                test = false
+                doctest = false
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
@@ -846,15 +849,15 @@ fn lib_without_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            test = false
-            doctest = false
-        "#,
+                [lib]
+                test = false
+                doctest = false
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
@@ -887,18 +890,18 @@ fn bin_without_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            test = false
-            doctest = false
+                [lib]
+                test = false
+                doctest = false
 
-            [[bin]]
-            path = "src/main.rs"
-        "#,
+                [[bin]]
+                path = "src/main.rs"
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
@@ -932,18 +935,18 @@ fn bench_without_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            test = false
-            doctest = false
+                [lib]
+                test = false
+                doctest = false
 
-            [[bench]]
-            path = "src/bench.rs"
-        "#,
+                [[bench]]
+                path = "src/bench.rs"
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
@@ -988,25 +991,25 @@ fn test_without_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            test = false
-            doctest = false
+                [lib]
+                test = false
+                doctest = false
 
-            [[test]]
-            path = "src/test.rs"
-        "#,
+                [[test]]
+                path = "src/test.rs"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn foo() {}
-            pub fn get_hello() -> &'static str { "Hello" }
-        "#,
+                pub fn foo() {}
+                pub fn get_hello() -> &'static str { "Hello" }
+            "#,
         )
         .file(
             "src/main.rs",
@@ -1022,11 +1025,11 @@ fn test_without_name() {
         .file(
             "src/test.rs",
             r#"
-            extern crate syntax;
+                extern crate syntax;
 
-            #[test]
-            fn external_test() { assert_eq!(syntax::get_hello(), "Hello") }
-        "#,
+                #[test]
+                fn external_test() { assert_eq!(syntax::get_hello(), "Hello") }
+            "#,
         )
         .build();
 
@@ -1048,18 +1051,18 @@ fn example_without_name() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "syntax"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "syntax"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            test = false
-            doctest = false
+                [lib]
+                test = false
+                doctest = false
 
-            [[example]]
-            path = "examples/example.rs"
-        "#,
+                [[example]]
+                path = "examples/example.rs"
+            "#,
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .file(
@@ -1076,12 +1079,12 @@ fn example_without_name() {
         .file(
             "examples/example.rs",
             r#"
-            extern crate syntax;
+                extern crate syntax;
 
-            fn main() {
-                println!("example1");
-            }
-        "#,
+                fn main() {
+                    println!("example1");
+                }
+            "#,
         )
         .build();
 
@@ -1110,13 +1113,13 @@ fn bin_there_for_integration() {
         .file(
             "tests/foo.rs",
             r#"
-            use std::process::Command;
-            #[test]
-            fn test_test() {
-                let status = Command::new("target/debug/foo").status().unwrap();
-                assert_eq!(status.code(), Some(101));
-            }
-        "#,
+                use std::process::Command;
+                #[test]
+                fn test_test() {
+                    let status = Command::new("target/debug/foo").status().unwrap();
+                    assert_eq!(status.code(), Some(101));
+                }
+            "#,
         )
         .build();
 
@@ -1132,51 +1135,51 @@ fn test_dylib() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate_type = ["dylib"]
+                [lib]
+                name = "foo"
+                crate_type = ["dylib"]
 
-            [dependencies.bar]
-            path = "bar"
-        "#,
+                [dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar as the_bar;
+                extern crate bar as the_bar;
 
-            pub fn bar() { the_bar::baz(); }
+                pub fn bar() { the_bar::baz(); }
 
-            #[test]
-            fn foo() { bar(); }
-        "#,
+                #[test]
+                fn foo() { bar(); }
+            "#,
         )
         .file(
             "tests/test.rs",
             r#"
-            extern crate foo as the_foo;
+                extern crate foo as the_foo;
 
-            #[test]
-            fn foo() { the_foo::bar(); }
-        "#,
+                #[test]
+                fn foo() { the_foo::bar(); }
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "bar"
-            crate_type = ["dylib"]
-        "#,
+                [lib]
+                name = "bar"
+                crate_type = ["dylib"]
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn baz() {}")
         .build();
@@ -1211,12 +1214,12 @@ fn test_twice_with_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("build.rs", "fn main() {}")
         .file("src/lib.rs", "#[test] fn foo() {}")
@@ -1287,19 +1290,19 @@ fn test_run_specific_bin_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name="bin1"
-            path="src/bin1.rs"
+                [[bin]]
+                name="bin1"
+                path="src/bin1.rs"
 
-            [[bin]]
-            name="bin2"
-            path="src/bin2.rs"
-        "#,
+                [[bin]]
+                name="bin2"
+                path="src/bin2.rs"
+            "#,
         )
         .file("src/bin1.rs", "#[test] fn test1() { }")
         .file("src/bin2.rs", "#[test] fn test2() { }")
@@ -1322,15 +1325,15 @@ fn test_run_implicit_bin_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name="mybin"
-            path="src/mybin.rs"
-        "#,
+                [[bin]]
+                name="mybin"
+                path="src/mybin.rs"
+            "#,
         )
         .file(
             "src/mybin.rs",
@@ -1383,15 +1386,15 @@ fn test_run_implicit_test_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name="mybin"
-            path="src/mybin.rs"
-        "#,
+                [[bin]]
+                name="mybin"
+                path="src/mybin.rs"
+            "#,
         )
         .file(
             "src/mybin.rs",
@@ -1424,15 +1427,15 @@ fn test_run_implicit_bench_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name="mybin"
-            path="src/mybin.rs"
-        "#,
+                [[bin]]
+                name="mybin"
+                path="src/mybin.rs"
+            "#,
         )
         .file(
             "src/mybin.rs",
@@ -1465,22 +1468,22 @@ fn test_run_implicit_example_target() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name = "mybin"
-            path = "src/mybin.rs"
+                [[bin]]
+                name = "mybin"
+                path = "src/mybin.rs"
 
-            [[example]]
-            name = "myexm1"
+                [[example]]
+                name = "myexm1"
 
-            [[example]]
-            name = "myexm2"
-            test = true
-        "#,
+                [[example]]
+                name = "myexm2"
+                test = true
+            "#,
         )
         .file(
             "src/mybin.rs",
@@ -1571,20 +1574,20 @@ fn test_no_harness() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [[bin]]
-            name = "foo"
-            test = false
+                [[bin]]
+                name = "foo"
+                test = false
 
-            [[test]]
-            name = "bar"
-            path = "foo.rs"
-            harness = false
-        "#,
+                [[test]]
+                name = "bar"
+                path = "foo.rs"
+                harness = false
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("foo.rs", "fn main() {}")
@@ -1607,34 +1610,34 @@ fn selective_testing() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies.d1]
-                path = "d1"
-            [dependencies.d2]
-                path = "d2"
-
-            [lib]
+                [package]
                 name = "foo"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.d1]
+                    path = "d1"
+                [dependencies.d2]
+                    path = "d2"
+
+                [lib]
+                    name = "foo"
+                    doctest = false
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
+                [package]
                 name = "d1"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [lib]
+                    name = "d1"
+                    doctest = false
+            "#,
         )
         .file("d1/src/lib.rs", "")
         .file(
@@ -1644,15 +1647,15 @@ fn selective_testing() {
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
+                [package]
                 name = "d2"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [lib]
+                    name = "d2"
+                    doctest = false
+            "#,
         )
         .file("d2/src/lib.rs", "")
         .file(
@@ -1703,42 +1706,42 @@ fn almost_cyclic_but_not_quite() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies.b]
-            path = "b"
-            [dev-dependencies.c]
-            path = "c"
-        "#,
+                [dev-dependencies.b]
+                path = "b"
+                [dev-dependencies.c]
+                path = "c"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #[cfg(test)] extern crate b;
-            #[cfg(test)] extern crate c;
-        "#,
+                #[cfg(test)] extern crate b;
+                #[cfg(test)] extern crate c;
+            "#,
         )
         .file(
             "b/Cargo.toml",
             r#"
-            [package]
-            name = "b"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "b"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.foo]
-            path = ".."
-        "#,
+                [dependencies.foo]
+                path = ".."
+            "#,
         )
         .file(
             "b/src/lib.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+            "#,
         )
         .file("c/Cargo.toml", &basic_manifest("c", "0.0.1"))
         .file("c/src/lib.rs", "")
@@ -1754,14 +1757,14 @@ fn build_then_selective_test() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.b]
-            path = "b"
-        "#,
+                [dependencies.b]
+                path = "b"
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -1770,12 +1773,12 @@ fn build_then_selective_test() {
         .file(
             "src/main.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate b;
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-            fn main() {}
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate b;
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+                fn main() {}
+            "#,
         )
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
@@ -1792,14 +1795,14 @@ fn example_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies.bar]
-            path = "bar"
-        "#,
+                [dev-dependencies.bar]
+                path = "bar"
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/e1.rs", "extern crate bar; fn main() {}")
@@ -1807,20 +1810,20 @@ fn example_dev_dep() {
         .file(
             "bar/src/lib.rs",
             r#"
-            // make sure this file takes awhile to compile
-            macro_rules! f0( () => (1) );
-            macro_rules! f1( () => ({(f0!()) + (f0!())}) );
-            macro_rules! f2( () => ({(f1!()) + (f1!())}) );
-            macro_rules! f3( () => ({(f2!()) + (f2!())}) );
-            macro_rules! f4( () => ({(f3!()) + (f3!())}) );
-            macro_rules! f5( () => ({(f4!()) + (f4!())}) );
-            macro_rules! f6( () => ({(f5!()) + (f5!())}) );
-            macro_rules! f7( () => ({(f6!()) + (f6!())}) );
-            macro_rules! f8( () => ({(f7!()) + (f7!())}) );
-            pub fn bar() {
-                f8!();
-            }
-        "#,
+                // make sure this file takes awhile to compile
+                macro_rules! f0( () => (1) );
+                macro_rules! f1( () => ({(f0!()) + (f0!())}) );
+                macro_rules! f2( () => ({(f1!()) + (f1!())}) );
+                macro_rules! f3( () => ({(f2!()) + (f2!())}) );
+                macro_rules! f4( () => ({(f3!()) + (f3!())}) );
+                macro_rules! f5( () => ({(f4!()) + (f4!())}) );
+                macro_rules! f6( () => ({(f5!()) + (f5!())}) );
+                macro_rules! f7( () => ({(f6!()) + (f6!())}) );
+                macro_rules! f8( () => ({(f7!()) + (f7!())}) );
+                pub fn bar() {
+                    f8!();
+                }
+            "#,
         )
         .build();
     p.cargo("test").run();
@@ -1833,36 +1836,36 @@ fn selective_testing_with_docs() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies.d1]
-                path = "d1"
-        "#,
+                [dependencies.d1]
+                    path = "d1"
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// not valid rust
-            /// ```
-            pub fn foo() {}
-        "#,
+                /// ```
+                /// not valid rust
+                /// ```
+                pub fn foo() {}
+            "#,
         )
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "d1"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "d1"
-            path = "d1.rs"
-        "#,
+                [lib]
+                name = "d1"
+                path = "d1.rs"
+            "#,
         )
         .file("d1/d1.rs", "");
     let p = p.build();
@@ -1937,19 +1940,19 @@ fn example_with_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            test = false
-            doctest = false
+                [lib]
+                name = "foo"
+                test = false
+                doctest = false
 
-            [dev-dependencies.a]
-            path = "a"
-        "#,
+                [dev-dependencies.a]
+                path = "a"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
@@ -2010,23 +2013,23 @@ fn doctest_feature() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            [features]
-            bar = []
-        "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                [features]
+                bar = []
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            /// ```rust
-            /// assert_eq!(foo::foo(), 1);
-            /// ```
-            #[cfg(feature = "bar")]
-            pub fn foo() -> i32 { 1 }
-        "#,
+                /// ```rust
+                /// assert_eq!(foo::foo(), 1);
+                /// ```
+                #[cfg(feature = "bar")]
+                pub fn foo() -> i32 { 1 }
+            "#,
         )
         .build();
 
@@ -2050,11 +2053,11 @@ fn dashes_to_underscores() {
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// assert_eq!(foo_bar::foo(), 1);
-            /// ```
-            pub fn foo() -> i32 { 1 }
-        "#,
+                /// ```
+                /// assert_eq!(foo_bar::foo(), 1);
+                /// ```
+                pub fn foo() -> i32 { 1 }
+            "#,
         )
         .build();
 
@@ -2067,23 +2070,23 @@ fn doctest_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies]
-            b = { path = "b" }
-        "#,
+                [dev-dependencies]
+                b = { path = "b" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// extern crate b;
-            /// ```
-            pub fn foo() {}
-        "#,
+                /// ```
+                /// extern crate b;
+                /// ```
+                pub fn foo() {}
+            "#,
         )
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
@@ -2098,11 +2101,11 @@ fn filter_no_doc_tests() {
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// extern crate b;
-            /// ```
-            pub fn foo() {}
-        "#,
+                /// ```
+                /// extern crate b;
+                /// ```
+                pub fn foo() {}
+            "#,
         )
         .file("tests/foo.rs", "")
         .build();
@@ -2124,25 +2127,25 @@ fn dylib_doctest() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate-type = ["rlib", "dylib"]
-            test = false
-        "#,
+                [lib]
+                name = "foo"
+                crate-type = ["rlib", "dylib"]
+                test = false
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// foo::foo();
-            /// ```
-            pub fn foo() {}
-        "#,
+                /// ```
+                /// foo::foo();
+                /// ```
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -2164,25 +2167,25 @@ fn dylib_doctest2() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            name = "foo"
-            crate-type = ["dylib"]
-            test = false
-        "#,
+                [lib]
+                name = "foo"
+                crate-type = ["dylib"]
+                test = false
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// foo::foo();
-            /// ```
-            pub fn foo() {}
-        "#,
+                /// ```
+                /// foo::foo();
+                /// ```
+                pub fn foo() {}
+            "#,
         )
         .build();
 
@@ -2195,41 +2198,41 @@ fn cyclic_dev_dep_doc_test() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dev-dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            //! ```
-            //! extern crate bar;
-            //! ```
-        "#,
+                //! ```
+                //! extern crate bar;
+                //! ```
+            "#,
         )
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            foo = { path = ".." }
-        "#,
+                [dependencies]
+                foo = { path = ".." }
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            #[allow(unused_extern_crates)]
-            extern crate foo;
-        "#,
+                #[allow(unused_extern_crates)]
+                extern crate foo;
+            "#,
         )
         .build();
     p.cargo("test")
@@ -2252,26 +2255,26 @@ fn dev_dep_with_build_script() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dev-dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dev-dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("examples/foo.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
-            authors = []
-            build = "build.rs"
-        "#,
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+                build = "build.rs"
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .file("bar/build.rs", "fn main() {}")
@@ -2285,47 +2288,47 @@ fn no_fail_fast() {
         .file(
             "src/lib.rs",
             r#"
-        pub fn add_one(x: i32) -> i32{
-            x + 1
-        }
+            pub fn add_one(x: i32) -> i32{
+                x + 1
+            }
 
-        /// ```rust
-        /// use foo::sub_one;
-        /// assert_eq!(sub_one(101), 100);
-        /// ```
-        pub fn sub_one(x: i32) -> i32{
-            x - 1
-        }
-        "#,
+            /// ```rust
+            /// use foo::sub_one;
+            /// assert_eq!(sub_one(101), 100);
+            /// ```
+            pub fn sub_one(x: i32) -> i32{
+                x - 1
+            }
+            "#,
         )
         .file(
             "tests/test_add_one.rs",
             r#"
-        extern crate foo;
-        use foo::*;
+            extern crate foo;
+            use foo::*;
 
-        #[test]
-        fn add_one_test() {
-            assert_eq!(add_one(1), 2);
-        }
+            #[test]
+            fn add_one_test() {
+                assert_eq!(add_one(1), 2);
+            }
 
-        #[test]
-        fn fail_add_one_test() {
-            assert_eq!(add_one(1), 1);
-        }
-        "#,
+            #[test]
+            fn fail_add_one_test() {
+                assert_eq!(add_one(1), 1);
+            }
+            "#,
         )
         .file(
             "tests/test_sub_one.rs",
             r#"
-        extern crate foo;
-        use foo::*;
+            extern crate foo;
+            use foo::*;
 
-        #[test]
-        fn sub_one_test() {
-            assert_eq!(sub_one(1), 0);
-        }
-        "#,
+            #[test]
+            fn sub_one_test() {
+                assert_eq!(sub_one(1), 0);
+            }
+            "#,
         )
         .build();
     p.cargo("test --no-fail-fast")
@@ -2355,48 +2358,48 @@ fn test_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-
-            [dependencies.d1]
-                path = "d1"
-            [dependencies.d2]
-                path = "d2"
-
-            [lib]
+                [package]
                 name = "foo"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.d1]
+                    path = "d1"
+                [dependencies.d2]
+                    path = "d2"
+
+                [lib]
+                    name = "foo"
+                    doctest = false
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "d1/Cargo.toml",
             r#"
-            [package]
-            name = "d1"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
+                [package]
                 name = "d1"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [lib]
+                    name = "d1"
+                    doctest = false
+            "#,
         )
         .file("d1/src/lib.rs", "")
         .file(
             "d2/Cargo.toml",
             r#"
-            [package]
-            name = "d2"
-            version = "0.0.1"
-            authors = []
-
-            [lib]
+                [package]
                 name = "d2"
-                doctest = false
-        "#,
+                version = "0.0.1"
+                authors = []
+
+                [lib]
+                    name = "d2"
+                    doctest = false
+            "#,
         )
         .file("d2/src/lib.rs", "");
     let p = p.build();
@@ -2439,17 +2442,17 @@ fn selective_test_wonky_profile() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.release]
-            opt-level = 2
+                [profile.release]
+                opt-level = 2
 
-            [dependencies]
-            a = { path = "a" }
-        "#,
+                [dependencies]
+                a = { path = "a" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -2465,14 +2468,14 @@ fn selective_test_optional_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a", optional = true }
-        "#,
+                [dependencies]
+                a = { path = "a", optional = true }
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -2497,18 +2500,18 @@ fn only_test_docs() {
         .file(
             "src/lib.rs",
             r#"
-            #[test]
-            fn foo() {
-                let a: u32 = "hello";
-            }
+                #[test]
+                fn foo() {
+                    let a: u32 = "hello";
+                }
 
-            /// ```
-            /// foo::bar();
-            /// println!("ok");
-            /// ```
-            pub fn bar() {
-            }
-        "#,
+                /// ```
+                /// foo::bar();
+                /// println!("ok");
+                /// ```
+                pub fn bar() {
+                }
+            "#,
         )
         .file("tests/foo.rs", "this is not rust");
     let p = p.build();
@@ -2530,26 +2533,26 @@ fn test_panic_abort_with_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [profile.dev]
-            panic = 'abort'
-        "#,
+                [profile.dev]
+                panic = 'abort'
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            extern crate bar;
+                extern crate bar;
 
-            #[test]
-            fn foo() {}
-        "#,
+                #[test]
+                fn foo() {}
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
@@ -2563,15 +2566,15 @@ fn cfg_test_even_with_no_harness() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [lib]
-            harness = false
-            doctest = false
-        "#,
+                [lib]
+                harness = false
+                doctest = false
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -2597,17 +2600,17 @@ fn panic_abort_multiple() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
+                [dependencies]
+                a = { path = "a" }
 
-            [profile.release]
-            panic = 'abort'
-        "#,
+                [profile.release]
+                panic = 'abort'
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -2625,64 +2628,64 @@ fn pass_correct_cfgs_flags_to_rustdoc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            default = ["feature_a/default"]
-            nightly = ["feature_a/nightly"]
+                [features]
+                default = ["feature_a/default"]
+                nightly = ["feature_a/nightly"]
 
-            [dependencies.feature_a]
-            path = "libs/feature_a"
-            default-features = false
-        "#,
+                [dependencies.feature_a]
+                path = "libs/feature_a"
+                default-features = false
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            #[cfg(test)]
-            mod tests {
-                #[test]
-                fn it_works() {
-                  assert!(true);
+                #[cfg(test)]
+                mod tests {
+                    #[test]
+                    fn it_works() {
+                      assert!(true);
+                    }
                 }
-            }
-        "#,
+            "#,
         )
         .file(
             "libs/feature_a/Cargo.toml",
             r#"
-            [package]
-            name = "feature_a"
-            version = "0.1.0"
-            authors = []
+                [package]
+                name = "feature_a"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            default = ["mock_serde_codegen"]
-            nightly = ["mock_serde_derive"]
+                [features]
+                default = ["mock_serde_codegen"]
+                nightly = ["mock_serde_derive"]
 
-            [dependencies]
-            mock_serde_derive = { path = "../mock_serde_derive", optional = true }
+                [dependencies]
+                mock_serde_derive = { path = "../mock_serde_derive", optional = true }
 
-            [build-dependencies]
-            mock_serde_codegen = { path = "../mock_serde_codegen", optional = true }
-        "#,
+                [build-dependencies]
+                mock_serde_codegen = { path = "../mock_serde_codegen", optional = true }
+            "#,
         )
         .file(
             "libs/feature_a/src/lib.rs",
             r#"
-            #[cfg(feature = "mock_serde_derive")]
-            const MSG: &'static str = "This is safe";
+                #[cfg(feature = "mock_serde_derive")]
+                const MSG: &'static str = "This is safe";
 
-            #[cfg(feature = "mock_serde_codegen")]
-            const MSG: &'static str = "This is risky";
+                #[cfg(feature = "mock_serde_codegen")]
+                const MSG: &'static str = "This is risky";
 
-            pub fn get() -> &'static str {
-                MSG
-            }
-        "#,
+                pub fn get() -> &'static str {
+                    MSG
+                }
+            "#,
         )
         .file(
             "libs/mock_serde_derive/Cargo.toml",
@@ -2719,19 +2722,19 @@ fn test_release_ignore_panic() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
+                [dependencies]
+                a = { path = "a" }
 
-            [profile.test]
-            panic = 'abort'
-            [profile.release]
-            panic = 'abort'
-        "#,
+                [profile.test]
+                panic = 'abort'
+                [profile.release]
+                panic = 'abort'
+            "#,
         )
         .file(
             "src/lib.rs",
@@ -2752,19 +2755,19 @@ fn test_many_with_features() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            a = { path = "a" }
+                [dependencies]
+                a = { path = "a" }
 
-            [features]
-            foo = []
+                [features]
+                foo = []
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.0.1"))
@@ -2780,15 +2783,15 @@ fn test_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "#[test] fn foo_test() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -2807,13 +2810,13 @@ fn test_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -2836,9 +2839,9 @@ fn test_all_virtual_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "#[test] fn a() {}")
@@ -2858,9 +2861,9 @@ fn test_virtual_manifest_all_implied() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "#[test] fn a() {}")
@@ -2880,20 +2883,20 @@ fn test_all_member_dependency_same_name() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a"]
-        "#,
+                [workspace]
+                members = ["a"]
+            "#,
         )
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
+                [project]
+                name = "a"
+                version = "0.1.0"
 
-            [dependencies]
-            a = "0.1.0"
-        "#,
+                [dependencies]
+                a = "0.1.0"
+            "#,
         )
         .file("a/src/lib.rs", "#[test] fn a() {}")
         .build();
@@ -2911,24 +2914,24 @@ fn doctest_only_with_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
+                [project]
+                name = "a"
+                version = "0.1.0"
 
-            [dev-dependencies]
-            b = { path = "b" }
-        "#,
+                [dev-dependencies]
+                b = { path = "b" }
+            "#,
         )
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// extern crate b;
-            ///
-            /// b::b();
-            /// ```
-            pub fn a() {}
-        "#,
+                /// ```
+                /// extern crate b;
+                ///
+                /// b::b();
+                /// ```
+                pub fn a() {}
+            "#,
         )
         .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
         .file("b/src/lib.rs", "pub fn b() {}")
@@ -2943,37 +2946,37 @@ fn test_many_targets() {
         .file(
             "src/bin/a.rs",
             r#"
-            fn main() {}
-            #[test] fn bin_a() {}
-        "#,
+                fn main() {}
+                #[test] fn bin_a() {}
+            "#,
         )
         .file(
             "src/bin/b.rs",
             r#"
-            fn main() {}
-            #[test] fn bin_b() {}
-        "#,
+                fn main() {}
+                #[test] fn bin_b() {}
+            "#,
         )
         .file(
             "src/bin/c.rs",
             r#"
-            fn main() {}
-            #[test] fn bin_c() { panic!(); }
-        "#,
+                fn main() {}
+                #[test] fn bin_c() { panic!(); }
+            "#,
         )
         .file(
             "examples/a.rs",
             r#"
-            fn main() {}
-            #[test] fn example_a() {}
-        "#,
+                fn main() {}
+                #[test] fn example_a() {}
+            "#,
         )
         .file(
             "examples/b.rs",
             r#"
-            fn main() {}
-            #[test] fn example_b() {}
-        "#,
+                fn main() {}
+                #[test] fn example_b() {}
+            "#,
         )
         .file("examples/c.rs", "#[test] fn example_c() { panic!(); }")
         .file("tests/a.rs", "#[test] fn test_a() {}")
@@ -2997,16 +3000,16 @@ fn doctest_and_registry() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "a"
-            version = "0.1.0"
+                [project]
+                name = "a"
+                version = "0.1.0"
 
-            [dependencies]
-            b = { path = "b" }
-            c = { path = "c" }
+                [dependencies]
+                b = { path = "b" }
+                c = { path = "c" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("b/Cargo.toml", &basic_manifest("b", "0.1.0"))
@@ -3022,13 +3025,13 @@ fn doctest_and_registry() {
         .file(
             "c/Cargo.toml",
             r#"
-            [project]
-            name = "c"
-            version = "0.1.0"
+                [project]
+                name = "c"
+                version = "0.1.0"
 
-            [dependencies]
-            b = "0.1"
-        "#,
+                [dependencies]
+                b = "0.1"
+            "#,
         )
         .file("c/src/lib.rs", "")
         .build();
@@ -3103,13 +3106,13 @@ fn cyclic_dev() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dev-dependencies]
-            foo = { path = "." }
-        "#,
+                [dev-dependencies]
+                foo = { path = "." }
+            "#,
         )
         .file("src/lib.rs", "#[test] fn test_lib() {}")
         .file("tests/foo.rs", "extern crate foo;")
@@ -3124,14 +3127,14 @@ fn publish_a_crate_without_tests() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "testless"
-            version = "0.1.0"
-            exclude = ["tests/*"]
+                [project]
+                name = "testless"
+                version = "0.1.0"
+                exclude = ["tests/*"]
 
-            [[test]]
-            name = "a_test"
-        "#,
+                [[test]]
+                name = "a_test"
+            "#,
         )
         .file("src/lib.rs", "")
         // In real life, the package will have a test,
@@ -3145,13 +3148,13 @@ fn publish_a_crate_without_tests() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            testless = "0.1.0"
-        "#,
+                [dependencies]
+                testless = "0.1.0"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3166,59 +3169,59 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["root", "proc_macro_dep"]
-        "#,
+                [workspace]
+                members = ["root", "proc_macro_dep"]
+            "#,
         )
         .file(
             "root/Cargo.toml",
             r#"
-            [project]
-            name = "root"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "root"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            proc_macro_dep = { path = "../proc_macro_dep" }
-        "#,
+                [dependencies]
+                proc_macro_dep = { path = "../proc_macro_dep" }
+            "#,
         )
         .file(
             "root/src/lib.rs",
             r#"
-            #[macro_use]
-            extern crate proc_macro_dep;
+                #[macro_use]
+                extern crate proc_macro_dep;
 
-            #[derive(Noop)]
-            pub struct X;
-        "#,
+                #[derive(Noop)]
+                pub struct X;
+            "#,
         )
         .file(
             "proc_macro_dep/Cargo.toml",
             r#"
-            [project]
-            name = "proc_macro_dep"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "proc_macro_dep"
+                version = "0.1.0"
+                authors = []
 
-            [lib]
-            proc-macro = true
+                [lib]
+                proc-macro = true
 
-            [dependencies]
-            baz = "^0.1"
-        "#,
+                [dependencies]
+                baz = "^0.1"
+            "#,
         )
         .file(
             "proc_macro_dep/src/lib.rs",
             r#"
-            extern crate baz;
-            extern crate proc_macro;
-            use proc_macro::TokenStream;
+                extern crate baz;
+                extern crate proc_macro;
+                use proc_macro::TokenStream;
 
-            #[proc_macro_derive(Noop)]
-            pub fn noop(_input: TokenStream) -> TokenStream {
-                "".parse().unwrap()
-            }
-        "#,
+                #[proc_macro_derive(Noop)]
+                pub fn noop(_input: TokenStream) -> TokenStream {
+                    "".parse().unwrap()
+                }
+            "#,
         )
         .build();
     Package::new("bar", "0.1.0").publish();
@@ -3235,20 +3238,20 @@ fn test_hint_not_masked_by_doctest() {
         .file(
             "src/lib.rs",
             r#"
-            /// ```
-            /// assert_eq!(1, 1);
-            /// ```
-            pub fn this_works() {}
-        "#,
+                /// ```
+                /// assert_eq!(1, 1);
+                /// ```
+                pub fn this_works() {}
+            "#,
         )
         .file(
             "tests/integ.rs",
             r#"
-            #[test]
-            fn this_fails() {
-                panic!();
-            }
-        "#,
+                #[test]
+                fn this_fails() {
+                    panic!();
+                }
+            "#,
         )
         .build();
     p.cargo("test --no-fail-fast")
@@ -3268,9 +3271,9 @@ fn test_hint_workspace_virtual() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a", "b"]
-        "#,
+                [workspace]
+                members = ["a", "b"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/lib.rs", "#[test] fn t1() {}")
@@ -3325,14 +3328,14 @@ fn json_artifact_includes_test_flag() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [profile.test]
-            opt-level = 1
-        "#,
+                [profile.test]
+                opt-level = 1
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -3340,33 +3343,33 @@ fn json_artifact_includes_test_flag() {
     p.cargo("test --lib -v --message-format=json")
         .with_json(
             r#"
-    {
-        "reason":"compiler-artifact",
-        "profile": {
-            "debug_assertions": true,
-            "debuginfo": 2,
-            "opt_level": "1",
-            "overflow_checks": true,
-            "test": true
-        },
-        "executable": "[..]/foo-[..]",
-        "features": [],
-        "package_id":"foo 0.0.1 ([..])",
-        "target":{
-            "kind":["lib"],
-            "crate_types":["lib"],
-            "doctest": true,
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]lib.rs",
-            "test": true
-        },
-        "filenames":"{...}",
-        "fresh": false
-    }
+                {
+                    "reason":"compiler-artifact",
+                    "profile": {
+                        "debug_assertions": true,
+                        "debuginfo": 2,
+                        "opt_level": "1",
+                        "overflow_checks": true,
+                        "test": true
+                    },
+                    "executable": "[..]/foo-[..]",
+                    "features": [],
+                    "package_id":"foo 0.0.1 ([..])",
+                    "target":{
+                        "kind":["lib"],
+                        "crate_types":["lib"],
+                        "doctest": true,
+                        "edition": "2015",
+                        "name":"foo",
+                        "src_path":"[..]lib.rs",
+                        "test": true
+                    },
+                    "filenames":"{...}",
+                    "fresh": false
+                }
 
-    {"reason": "build-finished", "success": true}
-"#,
+                {"reason": "build-finished", "success": true}
+            "#,
         )
         .run();
 }
@@ -3381,27 +3384,27 @@ fn json_artifact_includes_executable_for_library_tests() {
     p.cargo("test --lib -v --no-run --message-format=json")
         .with_json(
             r#"
-            {
-                "executable": "[..]/foo/target/debug/deps/foo-[..][EXE]",
-                "features": [],
-                "filenames": "{...}",
-                "fresh": false,
-                "package_id": "foo 0.0.1 ([..])",
-                "profile": "{...}",
-                "reason": "compiler-artifact",
-                "target": {
-                    "crate_types": [ "lib" ],
-                    "kind": [ "lib" ],
-                    "doctest": true,
-                    "edition": "2015",
-                    "name": "foo",
-                    "src_path": "[..]/foo/src/lib.rs",
-                    "test": true
+                {
+                    "executable": "[..]/foo/target/debug/deps/foo-[..][EXE]",
+                    "features": [],
+                    "filenames": "{...}",
+                    "fresh": false,
+                    "package_id": "foo 0.0.1 ([..])",
+                    "profile": "{...}",
+                    "reason": "compiler-artifact",
+                    "target": {
+                        "crate_types": [ "lib" ],
+                        "kind": [ "lib" ],
+                        "doctest": true,
+                        "edition": "2015",
+                        "name": "foo",
+                        "src_path": "[..]/foo/src/lib.rs",
+                        "test": true
+                    }
                 }
-            }
 
-            {"reason": "build-finished", "success": true}
-        "#,
+                {"reason": "build-finished", "success": true}
+            "#,
         )
         .run();
 }
@@ -3418,27 +3421,27 @@ fn json_artifact_includes_executable_for_integration_tests() {
     p.cargo("test -v --no-run --message-format=json --test integration_test")
         .with_json(
             r#"
-            {
-                "executable": "[..]/foo/target/debug/deps/integration_test-[..][EXE]",
-                "features": [],
-                "filenames": "{...}",
-                "fresh": false,
-                "package_id": "foo 0.0.1 ([..])",
-                "profile": "{...}",
-                "reason": "compiler-artifact",
-                "target": {
-                    "crate_types": [ "bin" ],
-                    "kind": [ "test" ],
-                    "doctest": false,
-                    "edition": "2015",
-                    "name": "integration_test",
-                    "src_path": "[..]/foo/tests/integration_test.rs",
-                    "test": true
+                {
+                    "executable": "[..]/foo/target/debug/deps/integration_test-[..][EXE]",
+                    "features": [],
+                    "filenames": "{...}",
+                    "fresh": false,
+                    "package_id": "foo 0.0.1 ([..])",
+                    "profile": "{...}",
+                    "reason": "compiler-artifact",
+                    "target": {
+                        "crate_types": [ "bin" ],
+                        "kind": [ "test" ],
+                        "doctest": false,
+                        "edition": "2015",
+                        "name": "integration_test",
+                        "src_path": "[..]/foo/tests/integration_test.rs",
+                        "test": true
+                    }
                 }
-            }
 
-            {"reason": "build-finished", "success": true}
-        "#,
+                {"reason": "build-finished", "success": true}
+            "#,
         )
         .run();
 }
@@ -3598,11 +3601,11 @@ fn can_not_no_run_doc_tests() {
         .file(
             "src/lib.rs",
             r#"
-/// ```
-/// let _x = 1 + "foo";
-/// ```
-pub fn foo() -> u8 { 1 }
-"#,
+            /// ```
+            /// let _x = 1 + "foo";
+            /// ```
+            pub fn foo() -> u8 { 1 }
+            "#,
         )
         .build();
 
@@ -3634,25 +3637,25 @@ fn test_dep_with_dev() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
+                [package]
+                name = "foo"
+                version = "0.0.1"
 
-            [dependencies]
-            bar = { path = "bar" }
-        "#,
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            version = "0.0.1"
+                [package]
+                name = "bar"
+                version = "0.0.1"
 
-            [dev-dependencies]
-            devdep = "0.1"
-        "#,
+                [dev-dependencies]
+                devdep = "0.1"
+            "#,
         )
         .file("bar/src/lib.rs", "")
         .build();
@@ -3799,9 +3802,9 @@ fn cargo_test_doctest_xcompile_runner() {
         config,
         format!(
             r#"
-[target.'cfg(target_arch = "{}")']
-runner = "{}"
-"#,
+            [target.'cfg(target_arch = "{}")']
+            runner = "{}"
+            "#,
             cross_compile::alternate_arch(),
             runner_str
         ),

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -13,9 +13,9 @@ fn pathless_tools() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}]
-            linker = "nonexistent-linker"
-        "#,
+                    [target.{}]
+                    linker = "nonexistent-linker"
+                "#,
                 target
             ),
         )
@@ -50,9 +50,9 @@ fn absolute_tools() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{target}]
-            linker = "{linker}"
-        "#,
+                    [target.{target}]
+                    linker = "{linker}"
+                "#,
                 target = target,
                 linker = linker
             ),
@@ -91,9 +91,9 @@ fn relative_tools() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{target}]
-            linker = "{linker}"
-        "#,
+                    [target.{target}]
+                    linker = "{linker}"
+                "#,
                 target = target,
                 linker = linker
             ),
@@ -127,9 +127,9 @@ fn custom_runner() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.{}]
-            runner = "nonexistent-runner -r"
-        "#,
+                    [target.{}]
+                    runner = "nonexistent-runner -r"
+                "#,
                 target
             ),
         )
@@ -209,12 +209,12 @@ fn custom_runner_cfg_precedence() {
             ".cargo/config",
             &format!(
                 r#"
-            [target.'cfg(not(target_os = "none"))']
-            runner = "ignored-runner"
+                    [target.'cfg(not(target_os = "none"))']
+                    runner = "ignored-runner"
 
-            [target.{}]
-            runner = "nonexistent-runner -r"
-        "#,
+                    [target.{}]
+                    runner = "nonexistent-runner -r"
+                "#,
                 target
             ),
         )
@@ -297,9 +297,9 @@ fn custom_runner_env_overrides_config() {
             ".cargo/config.toml",
             &format!(
                 r#"
-        [target.{}]
-        runner = "should-not-run -r"
-    "#,
+                    [target.{}]
+                    runner = "should-not-run -r"
+                "#,
                 target
             ),
         )

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -230,15 +230,15 @@ fn source_kinds() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [dependencies]
-            regdep = "1.0"
-            pathdep = {{ path = "pathdep" }}
-            gitdep = {{ git = "{}" }}
-            "#,
+                [dependencies]
+                regdep = "1.0"
+                pathdep = {{ path = "pathdep" }}
+                gitdep = {{ git = "{}" }}
+                "#,
                 git_project.url()
             ),
         )
@@ -345,27 +345,27 @@ fn filters_target() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [target.'{alt}'.dependencies]
-            targetdep = "1.0"
-            pm_target = "1.0"
+                [target.'{alt}'.dependencies]
+                targetdep = "1.0"
+                pm_target = "1.0"
 
-            [target.'{host}'.dependencies]
-            hostdep = "1.0"
-            pm_host = "1.0"
+                [target.'{host}'.dependencies]
+                hostdep = "1.0"
+                pm_host = "1.0"
 
-            [target.'{alt}'.dev-dependencies]
-            devdep = "1.0"
+                [target.'{alt}'.dev-dependencies]
+                devdep = "1.0"
 
-            [target.'{alt}'.build-dependencies]
-            build_target_dep = "1.0"
+                [target.'{alt}'.build-dependencies]
+                build_target_dep = "1.0"
 
-            [target.'{host}'.build-dependencies]
-            build_host_dep = "1.0"
-            "#,
+                [target.'{host}'.build-dependencies]
+                build_host_dep = "1.0"
+                "#,
                 alt = alternate(),
                 host = rustc_host()
             ),

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -49,171 +49,171 @@ fn simple() {
         .masquerade_as_nightly_cargo()
         .with_json(
             r#"{
-  "version": 1,
-  "units": [
-    {
-      "pkg_id": "a 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "target": {
-        "kind": [
-          "lib"
-        ],
-        "crate_types": [
-          "lib"
-        ],
-        "name": "a",
-        "src_path": "[..]/a-1.0.0/src/lib.rs",
-        "edition": "2015",
-        "doctest": true,
-        "test": true
-      },
-      "profile": {
-        "name": "dev",
-        "opt_level": "0",
-        "lto": "false",
-        "codegen_units": null,
-        "debuginfo": 2,
-        "debug_assertions": true,
-        "overflow_checks": true,
-        "rpath": false,
-        "incremental": false,
-        "panic": "unwind",
-        "strip": "none"
-      },
-      "platform": null,
-      "mode": "build",
-      "features": [
-        "feata"
-      ],
-      "dependencies": [
-        {
-          "index": 1,
-          "extern_crate_name": "b",
-          "public": false,
-          "noprelude": false
-        }
-      ]
-    },
-    {
-      "pkg_id": "b 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "target": {
-        "kind": [
-          "lib"
-        ],
-        "crate_types": [
-          "lib"
-        ],
-        "name": "b",
-        "src_path": "[..]/b-1.0.0/src/lib.rs",
-        "edition": "2015",
-        "doctest": true,
-        "test": true
-      },
-      "profile": {
-        "name": "dev",
-        "opt_level": "0",
-        "lto": "false",
-        "codegen_units": null,
-        "debuginfo": 2,
-        "debug_assertions": true,
-        "overflow_checks": true,
-        "rpath": false,
-        "incremental": false,
-        "panic": "unwind",
-        "strip": "none"
-      },
-      "platform": null,
-      "mode": "build",
-      "features": [
-        "featb"
-      ],
-      "dependencies": [
-        {
-          "index": 2,
-          "extern_crate_name": "c",
-          "public": false,
-          "noprelude": false
-        }
-      ]
-    },
-    {
-      "pkg_id": "c 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-      "target": {
-        "kind": [
-          "lib"
-        ],
-        "crate_types": [
-          "lib"
-        ],
-        "name": "c",
-        "src_path": "[..]/c-1.0.0/src/lib.rs",
-        "edition": "2015",
-        "test": true,
-        "doctest": true
-      },
-      "profile": {
-        "name": "dev",
-        "opt_level": "0",
-        "lto": "false",
-        "codegen_units": null,
-        "debuginfo": 2,
-        "debug_assertions": true,
-        "overflow_checks": true,
-        "rpath": false,
-        "incremental": false,
-        "panic": "unwind",
-        "strip": "none"
-      },
-      "platform": null,
-      "mode": "build",
-      "features": [
-        "featc"
-      ],
-      "dependencies": []
-    },
-    {
-      "pkg_id": "foo 0.1.0 (path+file://[..]/foo)",
-      "target": {
-        "kind": [
-          "lib"
-        ],
-        "crate_types": [
-          "lib"
-        ],
-        "name": "foo",
-        "src_path": "[..]/foo/src/lib.rs",
-        "edition": "2015",
-        "test": true,
-        "doctest": true
-      },
-      "profile": {
-        "name": "dev",
-        "opt_level": "0",
-        "lto": "false",
-        "codegen_units": null,
-        "debuginfo": 2,
-        "debug_assertions": true,
-        "overflow_checks": true,
-        "rpath": false,
-        "incremental": false,
-        "panic": "unwind",
-        "strip": "none"
-      },
-      "platform": null,
-      "mode": "build",
-      "features": [],
-      "dependencies": [
-        {
-          "index": 0,
-          "extern_crate_name": "a",
-          "public": false,
-          "noprelude": false
-        }
-      ]
-    }
-  ],
-  "roots": [3]
-}
-"#,
+              "version": 1,
+              "units": [
+                {
+                  "pkg_id": "a 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "target": {
+                    "kind": [
+                      "lib"
+                    ],
+                    "crate_types": [
+                      "lib"
+                    ],
+                    "name": "a",
+                    "src_path": "[..]/a-1.0.0/src/lib.rs",
+                    "edition": "2015",
+                    "doctest": true,
+                    "test": true
+                  },
+                  "profile": {
+                    "name": "dev",
+                    "opt_level": "0",
+                    "lto": "false",
+                    "codegen_units": null,
+                    "debuginfo": 2,
+                    "debug_assertions": true,
+                    "overflow_checks": true,
+                    "rpath": false,
+                    "incremental": false,
+                    "panic": "unwind",
+                    "strip": "none"
+                  },
+                  "platform": null,
+                  "mode": "build",
+                  "features": [
+                    "feata"
+                  ],
+                  "dependencies": [
+                    {
+                      "index": 1,
+                      "extern_crate_name": "b",
+                      "public": false,
+                      "noprelude": false
+                    }
+                  ]
+                },
+                {
+                  "pkg_id": "b 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "target": {
+                    "kind": [
+                      "lib"
+                    ],
+                    "crate_types": [
+                      "lib"
+                    ],
+                    "name": "b",
+                    "src_path": "[..]/b-1.0.0/src/lib.rs",
+                    "edition": "2015",
+                    "doctest": true,
+                    "test": true
+                  },
+                  "profile": {
+                    "name": "dev",
+                    "opt_level": "0",
+                    "lto": "false",
+                    "codegen_units": null,
+                    "debuginfo": 2,
+                    "debug_assertions": true,
+                    "overflow_checks": true,
+                    "rpath": false,
+                    "incremental": false,
+                    "panic": "unwind",
+                    "strip": "none"
+                  },
+                  "platform": null,
+                  "mode": "build",
+                  "features": [
+                    "featb"
+                  ],
+                  "dependencies": [
+                    {
+                      "index": 2,
+                      "extern_crate_name": "c",
+                      "public": false,
+                      "noprelude": false
+                    }
+                  ]
+                },
+                {
+                  "pkg_id": "c 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "target": {
+                    "kind": [
+                      "lib"
+                    ],
+                    "crate_types": [
+                      "lib"
+                    ],
+                    "name": "c",
+                    "src_path": "[..]/c-1.0.0/src/lib.rs",
+                    "edition": "2015",
+                    "test": true,
+                    "doctest": true
+                  },
+                  "profile": {
+                    "name": "dev",
+                    "opt_level": "0",
+                    "lto": "false",
+                    "codegen_units": null,
+                    "debuginfo": 2,
+                    "debug_assertions": true,
+                    "overflow_checks": true,
+                    "rpath": false,
+                    "incremental": false,
+                    "panic": "unwind",
+                    "strip": "none"
+                  },
+                  "platform": null,
+                  "mode": "build",
+                  "features": [
+                    "featc"
+                  ],
+                  "dependencies": []
+                },
+                {
+                  "pkg_id": "foo 0.1.0 (path+file://[..]/foo)",
+                  "target": {
+                    "kind": [
+                      "lib"
+                    ],
+                    "crate_types": [
+                      "lib"
+                    ],
+                    "name": "foo",
+                    "src_path": "[..]/foo/src/lib.rs",
+                    "edition": "2015",
+                    "test": true,
+                    "doctest": true
+                  },
+                  "profile": {
+                    "name": "dev",
+                    "opt_level": "0",
+                    "lto": "false",
+                    "codegen_units": null,
+                    "debuginfo": 2,
+                    "debug_assertions": true,
+                    "overflow_checks": true,
+                    "rpath": false,
+                    "incremental": false,
+                    "panic": "unwind",
+                    "strip": "none"
+                  },
+                  "platform": null,
+                  "mode": "build",
+                  "features": [],
+                  "dependencies": [
+                    {
+                      "index": 0,
+                      "extern_crate_name": "a",
+                      "public": false,
+                      "noprelude": false
+                    }
+                  ]
+                }
+              ],
+              "roots": [3]
+            }
+            "#,
         )
         .run();
 }

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -51,12 +51,12 @@ fn cargo_verify_project_honours_unstable_features() {
         .file(
             "Cargo.toml",
             r#"
-        cargo-features = ["test-dummy-unstable"]
+                cargo-features = ["test-dummy-unstable"]
 
-        [package]
-        name = "foo"
-        version = "0.0.1"
-    "#,
+                [package]
+                name = "foo"
+                version = "0.0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -34,9 +34,9 @@ fn version_works_with_bad_target_dir() {
         .file(
             ".cargo/config",
             r#"
-            [build]
-            target-dir = 4
-        "#,
+                [build]
+                target-dir = 4
+            "#,
         )
         .build();
     p.cargo("version").run();

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -11,25 +11,25 @@ fn make_lib(lib_src: &str) {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "bar"
-            authors = []
-            version = "0.0.1"
-            build = "build.rs"
-        "#,
+                [package]
+                name = "bar"
+                authors = []
+                version = "0.0.1"
+                build = "build.rs"
+            "#,
         )
         .file(
             "build.rs",
             &format!(
                 r#"
-            fn main() {{
-                use std::io::Write;
-                println!("cargo:warning={{}}", "{}");
-                println!("hidden stdout");
-                write!(&mut ::std::io::stderr(), "hidden stderr");
-                println!("cargo:warning={{}}", "{}");
-            }}
-        "#,
+                    fn main() {{
+                        use std::io::Write;
+                        println!("cargo:warning={{}}", "{}");
+                        println!("hidden stdout");
+                        write!(&mut ::std::io::stderr(), "hidden stderr");
+                        println!("cargo:warning={{}}", "{}");
+                    }}
+                "#,
                 WARNING1, WARNING2
             ),
         )
@@ -42,14 +42,14 @@ fn make_upstream(main_src: &str) -> Project {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("src/main.rs", &format!("fn main() {{ {} }}", main_src))
         .build()

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -11,25 +11,25 @@ fn simple_explicit() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -52,26 +52,26 @@ fn simple_explicit_default_members() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-            default-members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+                default-members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -87,15 +87,15 @@ fn non_virtual_default_members_build_other_member() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = [".", "bar", "baz"]
-            default-members = ["baz"]
-        "#,
+                [workspace]
+                members = [".", "bar", "baz"]
+                default-members = ["baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -125,14 +125,14 @@ fn inferred_root() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -157,16 +157,16 @@ fn inferred_path_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -192,29 +192,29 @@ fn transitive_path_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "bar" }
+                [dependencies]
+                bar = { path = "bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            baz = { path = "../baz" }
-        "#,
+                [dependencies]
+                baz = { path = "../baz" }
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "")
@@ -249,27 +249,27 @@ fn parent_pointer_works() {
         .file(
             "foo/Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "../bar" }
+                [dependencies]
+                bar = { path = "../bar" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("foo/src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = "../foo"
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = "../foo"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .file("bar/src/lib.rs", "");
@@ -287,25 +287,25 @@ fn same_names_in_workspace() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -328,13 +328,13 @@ fn parent_doesnt_point_to_child() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -363,12 +363,12 @@ fn invalid_parent_pointer() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                workspace = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
@@ -392,14 +392,14 @@ fn invalid_members() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["foo"]
-        "#,
+                [workspace]
+                members = ["foo"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
@@ -423,13 +423,13 @@ fn bare_workspace_ok() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
@@ -443,27 +443,27 @@ fn two_roots() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = [".."]
-        "#,
+                [workspace]
+                members = [".."]
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -486,12 +486,12 @@ fn workspace_isnt_root() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = "bar"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                workspace = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -510,36 +510,36 @@ fn dangling_member() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = "../baz"
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = "../baz"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
         .file(
             "baz/Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-            workspace = "../baz"
-        "#,
+                [project]
+                name = "baz"
+                version = "0.1.0"
+                authors = []
+                workspace = "../baz"
+            "#,
         )
         .file("baz/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -562,23 +562,23 @@ fn cycle() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
-            workspace = "bar"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+                workspace = "bar"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = ".."
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = ".."
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -597,30 +597,30 @@ fn share_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            dep1 = "0.1"
+                [dependencies]
+                dep1 = "0.1"
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            dep1 = "< 0.1.5"
-        "#,
+                [dependencies]
+                dep1 = "< 0.1.5"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -648,27 +648,27 @@ fn fetch_fetches_all() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            dep1 = "*"
-        "#,
+                [dependencies]
+                dep1 = "*"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -692,30 +692,30 @@ fn lock_works_for_everyone() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            dep2 = "0.1"
+                [dependencies]
+                dep2 = "0.1"
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            dep1 = "0.1"
-        "#,
+                [dependencies]
+                dep1 = "0.1"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -762,9 +762,9 @@ fn virtual_works() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -781,9 +781,9 @@ fn explicit_package_argument_works_with_virtual_manifest() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -800,8 +800,8 @@ fn virtual_misconfigure() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -829,9 +829,9 @@ fn virtual_build_all_implied() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -845,10 +845,10 @@ fn virtual_default_members() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-            default-members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+                default-members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
@@ -866,10 +866,10 @@ fn virtual_default_member_is_not_a_member() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-            default-members = ["something-else"]
-        "#,
+                [workspace]
+                members = ["bar"]
+                default-members = ["something-else"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -891,10 +891,10 @@ fn virtual_default_members_build_other_member() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-            default-members = ["baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+                default-members = ["baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -936,20 +936,20 @@ fn include_virtual() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            [workspace]
-            members = ["bar"]
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "")
         .file(
             "bar/Cargo.toml",
             r#"
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         );
     let p = p.build();
     p.cargo("build")
@@ -970,30 +970,30 @@ fn members_include_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["p1"]
+                [workspace]
+                members = ["p1"]
 
-            [dependencies]
-            p3 = { path = "p3" }
-        "#,
+                [dependencies]
+                p3 = { path = "p3" }
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "p1/Cargo.toml",
             r#"
-            [project]
-            name = "p1"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "p1"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            p2 = { path = "../p2" }
-        "#,
+                [dependencies]
+                p2 = { path = "../p2" }
+            "#,
         )
         .file("p1/src/lib.rs", "")
         .file("p2/Cargo.toml", &basic_manifest("p2", "0.1.0"))
@@ -1019,13 +1019,13 @@ fn new_warns_you_this_will_not_work() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/lib.rs", "");
     let p = p.build();
@@ -1077,30 +1077,30 @@ fn lock_doesnt_change_depending_on_crate() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ['baz']
+                [workspace]
+                members = ['baz']
 
-            [dependencies]
-            foo = "*"
-        "#,
+                [dependencies]
+                foo = "*"
+            "#,
         )
         .file("src/lib.rs", "")
         .file(
             "baz/Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "baz"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = "*"
-        "#,
+                [dependencies]
+                bar = "*"
+            "#,
         )
         .file("baz/src/lib.rs", "");
     let p = p.build();
@@ -1125,37 +1125,37 @@ fn rebuild_please() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ['lib', 'bin']
-        "#,
+                [workspace]
+                members = ['lib', 'bin']
+            "#,
         )
         .file("lib/Cargo.toml", &basic_manifest("lib", "0.1.0"))
         .file(
             "lib/src/lib.rs",
             r#"
-            pub fn foo() -> u32 { 0 }
-        "#,
+                pub fn foo() -> u32 { 0 }
+            "#,
         )
         .file(
             "bin/Cargo.toml",
             r#"
-            [package]
-            name = "bin"
-            version = "0.1.0"
+                [package]
+                name = "bin"
+                version = "0.1.0"
 
-            [dependencies]
-            lib = { path = "../lib" }
-        "#,
+                [dependencies]
+                lib = { path = "../lib" }
+            "#,
         )
         .file(
             "bin/src/main.rs",
             r#"
-            extern crate lib;
+                extern crate lib;
 
-            fn main() {
-                assert_eq!(lib::foo(), 0);
-            }
-        "#,
+                fn main() {
+                    assert_eq!(lib::foo(), 0);
+                }
+            "#,
         );
     let p = p.build();
 
@@ -1181,9 +1181,9 @@ fn workspace_in_git() {
             .file(
                 "Cargo.toml",
                 r#"
-                [workspace]
-                members = ["foo"]
-            "#,
+                    [workspace]
+                    members = ["foo"]
+                "#,
             )
             .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
             .file("foo/src/lib.rs", "")
@@ -1193,21 +1193,21 @@ fn workspace_in_git() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "lib"
-            version = "0.1.0"
+                    [package]
+                    name = "lib"
+                    version = "0.1.0"
 
-            [dependencies.foo]
-            git = '{}'
-        "#,
+                    [dependencies.foo]
+                    git = '{}'
+                "#,
                 git_project.url()
             ),
         )
         .file(
             "src/lib.rs",
             r#"
-            pub fn foo() -> u32 { 0 }
-        "#,
+                pub fn foo() -> u32 { 0 }
+            "#,
         );
     let p = p.build();
 
@@ -1220,23 +1220,23 @@ fn lockfile_can_specify_nonexistant_members() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a"]
-        "#,
+                [workspace]
+                members = ["a"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
         .file("a/src/main.rs", "fn main() {}")
         .file(
             "Cargo.lock",
             r#"
-            [[package]]
-            name = "a"
-            version = "0.1.0"
+                [[package]]
+                name = "a"
+                version = "0.1.0"
 
-            [[package]]
-            name = "b"
-            version = "0.1.0"
-        "#,
+                [[package]]
+                name = "b"
+                version = "0.1.0"
+            "#,
         );
 
     let p = p.build();
@@ -1250,8 +1250,8 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
@@ -1269,43 +1269,43 @@ fn workspace_with_transitive_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.5.0"
-            authors = ["mbrubeck@example.com"]
+                [project]
+                name = "foo"
+                version = "0.5.0"
+                authors = ["mbrubeck@example.com"]
 
-            [dependencies.bar]
-            path = "bar"
+                [dependencies.bar]
+                path = "bar"
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
         .file("src/main.rs", r#"fn main() {}"#)
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.5.0"
-            authors = ["mbrubeck@example.com"]
+                [project]
+                name = "bar"
+                version = "0.5.0"
+                authors = ["mbrubeck@example.com"]
 
-            [dev-dependencies.baz]
-            path = "../baz"
-        "#,
+                [dev-dependencies.baz]
+                path = "../baz"
+            "#,
         )
         .file(
             "bar/src/lib.rs",
             r#"
-            pub fn init() {}
+                pub fn init() {}
 
-            #[cfg(test)]
+                #[cfg(test)]
 
-            #[test]
-            fn test() {
-                extern crate baz;
-                baz::do_stuff();
-            }
-        "#,
+                #[test]
+                fn test() {
+                    extern crate baz;
+                    baz::do_stuff();
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.5.0"))
         .file("baz/src/lib.rs", r#"pub fn do_stuff() {}"#);
@@ -1335,25 +1335,25 @@ fn relative_path_for_member_works() {
         .file(
             "foo/Cargo.toml",
             r#"
-        [project]
-        name = "foo"
-        version = "0.1.0"
-        authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-        [workspace]
-        members = ["../bar"]
-    "#,
+                [workspace]
+                members = ["../bar"]
+            "#,
         )
         .file("foo/src/main.rs", "fn main() {}")
         .file(
             "bar/Cargo.toml",
             r#"
-        [project]
-        name = "bar"
-        version = "0.1.0"
-        authors = []
-        workspace = "../foo"
-    "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = "../foo"
+            "#,
         )
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -1368,16 +1368,16 @@ fn relative_path_for_root_works() {
         .file(
             "Cargo.toml",
             r#"
-        [project]
-        name = "foo"
-        version = "0.1.0"
-        authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-        [workspace]
+                [workspace]
 
-        [dependencies]
-        subproj = { path = "./subproj" }
-    "#,
+                [dependencies]
+                subproj = { path = "./subproj" }
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("subproj/Cargo.toml", &basic_manifest("subproj", "0.1.0"))
@@ -1398,18 +1398,18 @@ fn path_dep_outside_workspace_is_not_member() {
         .file(
             "ws/Cargo.toml",
             r#"
-            [project]
-            name = "ws"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = "../foo" }
+                [dependencies]
+                foo = { path = "../foo" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
-        .file("ws/src/lib.rs", r"extern crate foo;")
+        .file("ws/src/lib.rs", "extern crate foo;")
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "");
     let p = p.build();
@@ -1424,33 +1424,30 @@ fn test_in_and_out_of_workspace() {
         .file(
             "ws/Cargo.toml",
             r#"
-            [project]
-            name = "ws"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = "../foo" }
+                [dependencies]
+                foo = { path = "../foo" }
 
-            [workspace]
-            members = [ "../bar" ]
-        "#,
+                [workspace]
+                members = [ "../bar" ]
+            "#,
         )
-        .file(
-            "ws/src/lib.rs",
-            r"extern crate foo; pub fn f() { foo::f() }",
-        )
+        .file("ws/src/lib.rs", "extern crate foo; pub fn f() { foo::f() }")
         .file(
             "foo/Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "../bar" }
-        "#,
+                [dependencies]
+                bar = { path = "../bar" }
+            "#,
         )
         .file(
             "foo/src/lib.rs",
@@ -1459,12 +1456,12 @@ fn test_in_and_out_of_workspace() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
-            workspace = "../ws"
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-        "#,
+                [project]
+                workspace = "../ws"
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+            "#,
         )
         .file("bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
@@ -1491,33 +1488,30 @@ fn test_path_dependency_under_member() {
         .file(
             "ws/Cargo.toml",
             r#"
-            [project]
-            name = "ws"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            foo = { path = "../foo" }
+                [dependencies]
+                foo = { path = "../foo" }
 
-            [workspace]
-        "#,
+                [workspace]
+            "#,
         )
-        .file(
-            "ws/src/lib.rs",
-            r"extern crate foo; pub fn f() { foo::f() }",
-        )
+        .file("ws/src/lib.rs", "extern crate foo; pub fn f() { foo::f() }")
         .file(
             "foo/Cargo.toml",
             r#"
-            [project]
-            workspace = "../ws"
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                workspace = "../ws"
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "./bar" }
-        "#,
+                [dependencies]
+                bar = { path = "./bar" }
+            "#,
         )
         .file(
             "foo/src/lib.rs",
@@ -1544,14 +1538,14 @@ fn excluded_simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "ws"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            exclude = ["foo"]
-        "#,
+                [workspace]
+                exclude = ["foo"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -1570,15 +1564,15 @@ fn exclude_members_preferred() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "ws"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["foo/bar"]
-            exclude = ["foo"]
-        "#,
+                [workspace]
+                members = ["foo/bar"]
+                exclude = ["foo"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -1601,17 +1595,17 @@ fn exclude_but_also_depend() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "ws"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            bar = { path = "foo/bar" }
+                [dependencies]
+                bar = { path = "foo/bar" }
 
-            [workspace]
-            exclude = ["foo"]
-        "#,
+                [workspace]
+                exclude = ["foo"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
@@ -1634,11 +1628,11 @@ fn excluded_default_members_still_must_be_members() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo"]
-            default-members = ["foo", "bar"]
-            exclude = ["bar"]
-        "#,
+                [workspace]
+                members = ["foo"]
+                default-members = ["foo", "bar"]
+                exclude = ["bar"]
+            "#,
         )
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/lib.rs", "")
@@ -1661,11 +1655,11 @@ fn excluded_default_members_crate_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar/*"]
-            default-members = ["bar/*"]
-            exclude = ["bar/quux"]
-        "#,
+                [workspace]
+                members = ["foo", "bar/*"]
+                default-members = ["bar/*"]
+                exclude = ["bar/quux"]
+            "#,
         )
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/main.rs", "fn main() {}")
@@ -1697,11 +1691,11 @@ fn excluded_default_members_not_crate_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["foo", "bar/*"]
-            default-members = ["bar/*"]
-            exclude = ["bar/docs"]
-        "#,
+                [workspace]
+                members = ["foo", "bar/*"]
+                default-members = ["bar/*"]
+                exclude = ["bar/docs"]
+            "#,
         )
         .file("foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("foo/src/main.rs", "fn main() {}")
@@ -1724,47 +1718,47 @@ fn glob_syntax() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["crates/*"]
-            exclude = ["crates/qux"]
-        "#,
+                [workspace]
+                members = ["crates/*"]
+                exclude = ["crates/qux"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file(
             "crates/bar/Cargo.toml",
             r#"
-            [project]
-            name = "bar"
-            version = "0.1.0"
-            authors = []
-            workspace = "../.."
-        "#,
+                [project]
+                name = "bar"
+                version = "0.1.0"
+                authors = []
+                workspace = "../.."
+            "#,
         )
         .file("crates/bar/src/main.rs", "fn main() {}")
         .file(
             "crates/baz/Cargo.toml",
             r#"
-            [project]
-            name = "baz"
-            version = "0.1.0"
-            authors = []
-            workspace = "../.."
-        "#,
+                [project]
+                name = "baz"
+                version = "0.1.0"
+                authors = []
+                workspace = "../.."
+            "#,
         )
         .file("crates/baz/src/main.rs", "fn main() {}")
         .file(
             "crates/qux/Cargo.toml",
             r#"
-            [project]
-            name = "qux"
-            version = "0.1.0"
-            authors = []
-        "#,
+                [project]
+                name = "qux"
+                version = "0.1.0"
+                authors = []
+            "#,
         )
         .file("crates/qux/src/main.rs", "fn main() {}");
     let p = p.build();
@@ -1860,14 +1854,14 @@ fn glob_syntax_invalid_members() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
 
-            [workspace]
-            members = ["crates/*"]
-        "#,
+                [workspace]
+                members = ["crates/*"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("crates/bar/src/main.rs", "fn main() {}");
@@ -1900,49 +1894,49 @@ fn dep_used_with_separate_features() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["feat_lib", "caller1", "caller2"]
-        "#,
+                [workspace]
+                members = ["feat_lib", "caller1", "caller2"]
+            "#,
         )
         .file(
             "feat_lib/Cargo.toml",
             r#"
-            [project]
-            name = "feat_lib"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "feat_lib"
+                version = "0.1.0"
+                authors = []
 
-            [features]
-            myfeature = []
-        "#,
+                [features]
+                myfeature = []
+            "#,
         )
         .file("feat_lib/src/lib.rs", "")
         .file(
             "caller1/Cargo.toml",
             r#"
-            [project]
-            name = "caller1"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "caller1"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            feat_lib = { path = "../feat_lib" }
-        "#,
+                [dependencies]
+                feat_lib = { path = "../feat_lib" }
+            "#,
         )
         .file("caller1/src/main.rs", "fn main() {}")
         .file("caller1/src/lib.rs", "")
         .file(
             "caller2/Cargo.toml",
             r#"
-            [project]
-            name = "caller2"
-            version = "0.1.0"
-            authors = []
+                [project]
+                name = "caller2"
+                version = "0.1.0"
+                authors = []
 
-            [dependencies]
-            feat_lib = { path = "../feat_lib", features = ["myfeature"] }
-            caller1 = { path = "../caller1" }
-        "#,
+                [dependencies]
+                feat_lib = { path = "../feat_lib", features = ["myfeature"] }
+                caller1 = { path = "../caller1" }
+            "#,
         )
         .file("caller2/src/main.rs", "fn main() {}")
         .file("caller2/src/lib.rs", "");
@@ -2002,24 +1996,24 @@ fn dont_recurse_out_of_cargo_home() {
             .file(
                 "build.rs",
                 r#"
-                use std::env;
-                use std::path::Path;
-                use std::process::{self, Command};
+                    use std::env;
+                    use std::path::Path;
+                    use std::process::{self, Command};
 
-                fn main() {
-                    let cargo = env::var_os("CARGO").unwrap();
-                    let cargo_manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
-                    let output = Command::new(cargo)
-                        .args(&["metadata", "--format-version", "1", "--manifest-path"])
-                        .arg(&Path::new(&cargo_manifest_dir).join("Cargo.toml"))
-                        .output()
-                        .unwrap();
-                    if !output.status.success() {
-                        eprintln!("{}", String::from_utf8(output.stderr).unwrap());
-                        process::exit(1);
+                    fn main() {
+                        let cargo = env::var_os("CARGO").unwrap();
+                        let cargo_manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap();
+                        let output = Command::new(cargo)
+                            .args(&["metadata", "--format-version", "1", "--manifest-path"])
+                            .arg(&Path::new(&cargo_manifest_dir).join("Cargo.toml"))
+                            .output()
+                            .unwrap();
+                        if !output.status.success() {
+                            eprintln!("{}", String::from_utf8(output.stderr).unwrap());
+                            process::exit(1);
+                        }
                     }
-                }
-            "#,
+                "#,
             )
     });
     let p = project()
@@ -2027,15 +2021,15 @@ fn dont_recurse_out_of_cargo_home() {
             "Cargo.toml",
             &format!(
                 r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
 
-            [dependencies.dep]
-            git = "{}"
+                    [dependencies.dep]
+                    git = "{}"
 
-            [workspace]
-        "#,
+                    [workspace]
+                "#,
                 git_project.url()
             ),
         )
@@ -2077,13 +2071,13 @@ fn cargo_home_at_root_works() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "foo"
-            version = "0.1.0"
+                [package]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["a"]
-        "#,
+                [workspace]
+                members = ["a"]
+            "#,
         )
         .file("src/lib.rs", "")
         .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
@@ -2100,17 +2094,17 @@ fn relative_rustc() {
         .file(
             "src/main.rs",
             r#"
-            use std::process::Command;
-            use std::env;
+                use std::process::Command;
+                use std::env;
 
-            fn main() {
-                let mut cmd = Command::new("rustc");
-                for arg in env::args_os().skip(1) {
-                    cmd.arg(arg);
+                fn main() {
+                    let mut cmd = Command::new("rustc");
+                    for arg in env::args_os().skip(1) {
+                        cmd.arg(arg);
+                    }
+                    std::process::exit(cmd.status().unwrap().code().unwrap());
                 }
-                std::process::exit(cmd.status().unwrap().code().unwrap());
-            }
-        "#,
+            "#,
         )
         .build();
     p.cargo("build").run();
@@ -2127,13 +2121,13 @@ fn relative_rustc() {
         .file(
             "Cargo.toml",
             r#"
-            [package]
-            name = "lib"
-            version = "0.1.0"
+                [package]
+                name = "lib"
+                version = "0.1.0"
 
-            [dependencies]
-            a = "0.1"
-        "#,
+                [dependencies]
+                a = "0.1"
+            "#,
         )
         .file("src/lib.rs", "")
         .build();
@@ -2150,9 +2144,9 @@ fn ws_rustc_err() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["a"]
-        "#,
+                [workspace]
+                members = ["a"]
+            "#,
         )
         .file("a/Cargo.toml", &basic_lib_manifest("a"))
         .file("a/src/lib.rs", "")

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -21,13 +21,13 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.0.1"
-            authors = []
-            license = "MIT"
-            description = "foo"
-        "#,
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .build();


### PR DESCRIPTION
It has always slightly bugged me how strings were indented after rustfmt was run across the repo (#5176). This attempts to normalize the strings so that they open and close on the same column.  This only touches the `tests` directory.