### PR TITLE
Add Zsh completion for target triples

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -56,7 +56,7 @@ _cargo() {
     )
 
     msgfmt='--message-format=[specify error format]:error format [human]:(human json short)'
-    triple='--target=[specify target triple]:target triple'
+    triple='--target=[specify target triple]:target triple:_cargo_target_triple'
     target='--target-dir=[specify directory for all generated artifacts]:directory:_directories'
     manifest='--manifest-path=[specify path to manifest]:path:_directories'
     registry='--registry=[specify registry to use]:registry'
@@ -359,6 +359,11 @@ _cargo_cmds() {
     _describe -t commands 'command' commands
 }
 
+_cargo_target_triple() {
+    local -a targets
+	targets=( ${(f)"$(rustc --print target-list)"} )
+	_describe 'target triple' targets
+}
 
 #FIXME: Disabled until fixed
 #gets package names from the manifest file


### PR DESCRIPTION
Target triples are used for specifying targets for e.g. `cargo build --target thumbv7em-none-eabihf` where `thumbv7em-none-eabihf` is the target triplet.
For more information on target triples, see <https://doc.rust-lang.org/cargo/appendix/glossary.html#target>.