### PR TITLE
Properly set for_host for proc-macro tests.

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -161,7 +161,13 @@ fn deps_of_roots(roots: &[Unit], mut state: &mut State<'_, '_>) -> CargoResult<(
         // without, once for `--test`). In particular, the lib included for
         // Doc tests and examples are `Build` mode here.
         let unit_for = if unit.mode.is_any_test() || state.global_mode.is_rustc_test() {
-            UnitFor::new_test(state.config)
+            if unit.target.proc_macro() {
+                // Special-case for proc-macros, which are forced to for-host
+                // since they need to link with the proc_macro crate.
+                UnitFor::new_host_test(state.config)
+            } else {
+                UnitFor::new_test(state.config)
+            }
         } else if unit.target.is_custom_build() {
             // This normally doesn't happen, except `clean` aggressively
             // generates all units.

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -967,6 +967,16 @@ impl UnitFor {
         }
     }
 
+    /// This is a special case for unit tests of a proc-macro.
+    ///
+    /// Proc-macro unit tests are forced to be run on the host.
+    pub fn new_host_test(config: &Config) -> UnitFor {
+        let mut unit_for = UnitFor::new_test(config);
+        unit_for.host = true;
+        unit_for.host_features = true;
+        unit_for
+    }
+
     /// Returns a new copy based on `for_host` setting.
     ///
     /// When `for_host` is true, this clears `panic_abort_ok` in a sticky


### PR DESCRIPTION
Proc-macro tests are currently forced to run for the host target (by [this line of code](https://github.com/rust-lang/cargo/blob/898ccde7ac867ecdb62184714b379c4328409399/src/cargo/ops/cargo_compile.rs#L819)). However, the code that builds the dependency graph wasn't playing by the same rules, and was building the proc-macro test as-if it was "not for_host".  This would cause the proc-macro test to pull in the wrong set of dependencies/features with the new feature resolver.

Forcing proc-macro tests to run on host isn't 100% required, since most targets have the proc_macro crate available. However, I feel like it simplifies things to build for-host. I was thinking we could relax that requirement, but I'm not really sure.  See also #4336 where there's an bug if you do specify `--target`.

Tested with the wasmtime repo running `cargo test -Zfeatures=all -p wiggle-macro` with `doctest = false` commented out of `crates/wiggle/macro/Cargo.toml`.

Fixes #8563.