### PR TITLE
Ignore paths that don't exist for dependencies

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1642,9 +1642,23 @@ impl DetailedTomlDependency {
             }
         }
 
+        // Ignore paths that don't exist so as to fallback onto some other
+        // source in that circumstance. This allows specifying dependencies
+        // from crates.io or git as well as a local path for development and
+        // having everything just work.
+        let path = if let Some(path) = &self.path {
+            if Path::new(&path).join("Cargo.toml").exists() {
+                self.path.as_ref()
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         let new_source_id = match (
             self.git.as_ref(),
-            self.path.as_ref(),
+            path,
             self.registry.as_ref(),
             self.registry_index.as_ref(),
         ) {


### PR DESCRIPTION
If a given path is not a valid dependency, just ignore it. This allows falling back to git or the repository automatically while retaining the ability to have the code locally if you need to develop a dependency in tandem with the crate code.

This is an attempt at implementing #8747. At least one test is now failing because of this as it's the test that checks that if you specify both `path` and `git` cargo will abort.

Fixes #8747