### PR TITLE
Support glob patterns for package/target selection

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1637,8 +1637,12 @@ impl ChannelChanger for cargo::util::ProcessBuilder {
 }
 
 fn split_and_add_args(p: &mut ProcessBuilder, s: &str) {
-    for arg in s.split_whitespace() {
-        if arg.contains('"') || arg.contains('\'') {
+    for mut arg in s.split_whitespace() {
+        if (arg.starts_with('"') && arg.ends_with('"'))
+            || (arg.starts_with('\'') && arg.ends_with('\''))
+        {
+            arg = &arg[1..(arg.len() - 1).max(1)];
+        } else if arg.contains(&['"', '\''][..]) {
             panic!("shell-style argument parsing is not supported")
         }
         p.arg(arg);

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -40,17 +40,14 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     )?;
 
     // Disallow `spec` to be an glob pattern
-    match &compile_opts.spec {
-        Packages::Packages(opt_in) => {
-            if let Some(pattern) = opt_in.iter().find(|s| is_glob_pattern(s)) {
-                return Err(anyhow::anyhow!(
-                    "`cargo run` does not support glob pattern `{}` on package selection",
-                    pattern,
-                )
-                .into());
-            }
+    if let Packages::Packages(opt_in) = &compile_opts.spec {
+        if let Some(pattern) = opt_in.iter().find(|s| is_glob_pattern(s)) {
+            return Err(anyhow::anyhow!(
+                "`cargo run` does not support glob pattern `{}` on package selection",
+                pattern,
+            )
+            .into());
         }
-        _ => (),
     }
 
     if !args.is_present("example") && !args.is_present("bin") {

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -1,7 +1,8 @@
 use crate::command_prelude::*;
+use crate::util::restricted_names::is_glob_pattern;
 use crate::util::ProcessError;
 use cargo::core::Verbosity;
-use cargo::ops::{self, CompileFilter};
+use cargo::ops::{self, CompileFilter, Packages};
 
 pub fn cli() -> App {
     subcommand("run")
@@ -37,6 +38,20 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some(&ws),
         ProfileChecking::Checked,
     )?;
+
+    // Disallow `spec` to be an glob pattern
+    match &compile_opts.spec {
+        Packages::Packages(opt_in) => {
+            if let Some(pattern) = opt_in.iter().find(|s| is_glob_pattern(s)) {
+                return Err(anyhow::anyhow!(
+                    "`cargo run` does not support glob pattern `{}` on package selection",
+                    pattern,
+                )
+                .into());
+            }
+        }
+        _ => (),
+    }
 
     if !args.is_present("example") && !args.is_present("bin") {
         let default_runs: Vec<_> = compile_opts

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -158,8 +158,7 @@ impl Packages {
                         .map(PackageIdSpec::from_package_id);
                     specs.extend(matched_pkgs);
                 }
-                emit_pattern_not_found(ws, patterns, false)
-                    .or_else(|e| ws.config().shell().warn(e))?;
+                emit_pattern_not_found(ws, patterns, false)?;
                 specs
             }
             Packages::Default => ws

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -1347,7 +1347,7 @@ fn traverse_and_share(
 
 /// Build `glob::Pattern` with informative context.
 fn build_glob(pat: &str) -> CargoResult<glob::Pattern> {
-    glob::Pattern::new(pat).with_context(|| format!("Cannot build glob pattern from `{}`", pat))
+    glob::Pattern::new(pat).with_context(|| format!("cannot build glob pattern from `{}`", pat))
 }
 
 /// Emits "package not found" error.
@@ -1361,11 +1361,10 @@ fn emit_package_not_found(
 ) -> CargoResult<()> {
     if !opt_names.is_empty() {
         anyhow::bail!(
-            "{}package(s) {} not found in workspace `{}`",
+            "{}package(s) `{}` not found in workspace `{}`",
             if opt_out { "excluded " } else { "" },
             opt_names
-                .iter()
-                .map(|x| x.as_ref())
+                .into_iter()
                 .collect::<Vec<_>>()
                 .join(", "),
             ws.root().display(),
@@ -1390,7 +1389,7 @@ fn emit_pattern_not_found(
         .collect::<Vec<_>>();
     if !not_matched.is_empty() {
         anyhow::bail!(
-            "{}package pattern(s) {} not found in workspace `{}`",
+            "{}package pattern(s) `{}` not found in workspace `{}`",
             if opt_out { "excluded " } else { "" },
             not_matched.join(", "),
             ws.root().display(),

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -1362,10 +1362,7 @@ fn emit_package_not_found(
         anyhow::bail!(
             "{}package(s) `{}` not found in workspace `{}`",
             if opt_out { "excluded " } else { "" },
-            opt_names
-                .into_iter()
-                .collect::<Vec<_>>()
-                .join(", "),
+            opt_names.into_iter().collect::<Vec<_>>().join(", "),
             ws.root().display(),
         )
     }

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -13,6 +13,10 @@ pub fn run(
 ) -> CargoResult<()> {
     let config = ws.config();
 
+    if options.filter.contains_glob_patterns() {
+        anyhow::bail!("`cargo run` does not support glob patterns on target selection")
+    }
+
     // We compute the `bins` here *just for diagnosis*. The actual set of
     // packages to be run is determined by the `ops::compile` call below.
     let packages = options.spec.get_packages(ws)?;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -4,6 +4,7 @@ use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionCon
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::interning::InternedString;
+use crate::util::restricted_names::is_glob_pattern;
 use crate::util::{paths, toml::TomlProfile, validate_package_name};
 use crate::util::{
     print_available_benches, print_available_binaries, print_available_examples,
@@ -509,7 +510,11 @@ pub trait ArgMatchesExt {
         profile_checking: ProfileChecking,
     ) -> CargoResult<CompileOptions> {
         let mut compile_opts = self.compile_options(config, mode, workspace, profile_checking)?;
-        compile_opts.spec = Packages::Packages(self._values_of("package"));
+        let spec = self._values_of("package");
+        if spec.iter().any(is_glob_pattern) {
+            anyhow::bail!("Glob patterns on package selection are not supported.")
+        }
+        compile_opts.spec = Packages::Packages(spec);
         Ok(compile_opts)
     }
 

--- a/src/cargo/util/restricted_names.rs
+++ b/src/cargo/util/restricted_names.rs
@@ -83,7 +83,7 @@ pub fn validate_package_name(name: &str, what: &str, help: &str) -> CargoResult<
     Ok(())
 }
 
-// Check the entire path for names reserved in Windows.
+/// Check the entire path for names reserved in Windows.
 pub fn is_windows_reserved_path(path: &Path) -> bool {
     path.iter()
         .filter_map(|component| component.to_str())
@@ -91,4 +91,9 @@ pub fn is_windows_reserved_path(path: &Path) -> bool {
             let stem = component.split('.').next().unwrap();
             is_windows_reserved(stem)
         })
+}
+
+/// Returns `true` if the name contains any glob pattern wildcards.
+pub fn is_glob_pattern<T: AsRef<str>>(name: T) -> bool {
+    name.as_ref().contains(&['*', '?', '[', ']'][..])
 }

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -65,7 +65,11 @@ OPTIONS
 
        -p spec..., --package spec...
            Benchmark only the specified packages. See cargo-pkgid(1) for the
-           SPEC format. This flag may be specified multiple times.
+           SPEC format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Benchmark all members in the workspace.
@@ -75,7 +79,11 @@ OPTIONS
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Target Selection
        When no target selection options are given, cargo bench will build the
@@ -102,26 +110,31 @@ OPTIONS
        Passing target selection flags will benchmark only the specified
        targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Benchmark the package's library.
 
        --bin name...
            Benchmark the specified binary. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --bins
            Benchmark all binary targets.
 
        --example name...
            Benchmark the specified example. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --examples
            Benchmark all example targets.
 
        --test name...
            Benchmark the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Benchmark all targets in test mode that have the test = true
@@ -134,7 +147,7 @@ OPTIONS
 
        --bench name...
            Benchmark the specified benchmark. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --benches
            Benchmark all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -26,7 +26,11 @@ OPTIONS
 
        -p spec..., --package spec...
            Build only the specified packages. See cargo-pkgid(1) for the SPEC
-           format. This flag may be specified multiple times.
+           format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Build all members in the workspace.
@@ -36,7 +40,11 @@ OPTIONS
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Target Selection
        When no target selection options are given, cargo build will build all
@@ -45,26 +53,31 @@ OPTIONS
 
        Passing target selection flags will build only the specified targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Build the package's library.
 
        --bin name...
            Build the specified binary. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --bins
            Build all binary targets.
 
        --example name...
            Build the specified example. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --examples
            Build all example targets.
 
        --test name...
            Build the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Build all targets in test mode that have the test = true manifest
@@ -77,7 +90,7 @@ OPTIONS
 
        --bench name...
            Build the specified benchmark. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --benches
            Build all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -32,7 +32,11 @@ OPTIONS
 
        -p spec..., --package spec...
            Check only the specified packages. See cargo-pkgid(1) for the SPEC
-           format. This flag may be specified multiple times.
+           format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Check all members in the workspace.
@@ -42,7 +46,11 @@ OPTIONS
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Target Selection
        When no target selection options are given, cargo check will check all
@@ -51,26 +59,31 @@ OPTIONS
 
        Passing target selection flags will check only the specified targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Check the package's library.
 
        --bin name...
            Check the specified binary. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --bins
            Check all binary targets.
 
        --example name...
            Check the specified example. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --examples
            Check all example targets.
 
        --test name...
            Check the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Check all targets in test mode that have the test = true manifest
@@ -83,7 +96,7 @@ OPTIONS
 
        --bench name...
            Check the specified benchmark. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --benches
            Check all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -39,7 +39,11 @@ OPTIONS
 
        -p spec..., --package spec...
            Document only the specified packages. See cargo-pkgid(1) for the
-           SPEC format. This flag may be specified multiple times.
+           SPEC format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Document all members in the workspace.
@@ -49,7 +53,11 @@ OPTIONS
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Target Selection
        When no target selection options are given, cargo doc will document all
@@ -66,7 +74,7 @@ OPTIONS
 
        --bin name...
            Document the specified binary. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --bins
            Document all binary targets.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -81,7 +81,11 @@ OPTIONS
 
        -p spec..., --package spec...
            Fix only the specified packages. See cargo-pkgid(1) for the SPEC
-           format. This flag may be specified multiple times.
+           format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Fix all members in the workspace.
@@ -91,7 +95,11 @@ OPTIONS
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Target Selection
        When no target selection options are given, cargo fix will fix all
@@ -100,25 +108,31 @@ OPTIONS
 
        Passing target selection flags will fix only the specified targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Fix the package's library.
 
        --bin name...
-           Fix the specified binary. This flag may be specified multiple times.
+           Fix the specified binary. This flag may be specified multiple times
+           and supports common Unix glob patterns.
 
        --bins
            Fix all binary targets.
 
        --example name...
-           Fix the specified example. This flag may be specified multiple
-           times.
+           Fix the specified example. This flag may be specified multiple times
+           and supports common Unix glob patterns.
 
        --examples
            Fix all example targets.
 
        --test name...
            Fix the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Fix all targets in test mode that have the test = true manifest flag
@@ -131,7 +145,7 @@ OPTIONS
 
        --bench name...
            Fix the specified benchmark. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --benches
            Fix all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -44,26 +44,31 @@ OPTIONS
 
        Passing target selection flags will build only the specified targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Build the package's library.
 
        --bin name...
            Build the specified binary. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --bins
            Build all binary targets.
 
        --example name...
            Build the specified example. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --examples
            Build all example targets.
 
        --test name...
            Build the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Build all targets in test mode that have the test = true manifest
@@ -76,7 +81,7 @@ OPTIONS
 
        --bench name...
            Build the specified benchmark. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --benches
            Build all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -51,26 +51,31 @@ OPTIONS
 
        Passing target selection flags will document only the specified targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Document the package's library.
 
        --bin name...
            Document the specified binary. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --bins
            Document all binary targets.
 
        --example name...
            Document the specified example. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --examples
            Document all example targets.
 
        --test name...
            Document the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Document all targets in test mode that have the test = true manifest
@@ -83,7 +88,7 @@ OPTIONS
 
        --bench name...
            Document the specified benchmark. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --benches
            Document all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -63,7 +63,11 @@ OPTIONS
 
        -p spec..., --package spec...
            Test only the specified packages. See cargo-pkgid(1) for the SPEC
-           format. This flag may be specified multiple times.
+           format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Test all members in the workspace.
@@ -73,7 +77,11 @@ OPTIONS
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Target Selection
        When no target selection options are given, cargo test will build the
@@ -116,26 +124,31 @@ OPTIONS
 
        Passing target selection flags will test only the specified targets.
 
+       Note that --bin, --example, --test and --bench flags also support common
+       Unix glob patterns like *, ? and []. However, to avoid your shell
+       accidentally expanding glob patterns before Cargo handles them, you must
+       use single quotes or double quotes around each glob pattern.
+
        --lib
            Test the package's library.
 
        --bin name...
-           Test the specified binary. This flag may be specified multiple
-           times.
+           Test the specified binary. This flag may be specified multiple times
+           and supports common Unix glob patterns.
 
        --bins
            Test all binary targets.
 
        --example name...
            Test the specified example. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --examples
            Test all example targets.
 
        --test name...
            Test the specified integration test. This flag may be specified
-           multiple times.
+           multiple times and supports common Unix glob patterns.
 
        --tests
            Test all targets in test mode that have the test = true manifest
@@ -148,7 +161,7 @@ OPTIONS
 
        --bench name...
            Test the specified benchmark. This flag may be specified multiple
-           times.
+           times and supports common Unix glob patterns.
 
        --benches
            Test all targets in benchmark mode that have the bench = true

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -155,14 +155,22 @@ OPTIONS
 
        -p spec..., --package spec...
            Display only the specified packages. See cargo-pkgid(1) for the SPEC
-           format. This flag may be specified multiple times.
+           format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
 
        --workspace
            Display all members in the workspace.
 
        --exclude SPEC...
            Exclude the specified packages. Must be used in conjunction with the
-           --workspace flag. This flag may be specified multiple times.
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/includes/options-targets-lib-bin.md
+++ b/src/doc/man/includes/options-targets-lib-bin.md
@@ -3,7 +3,8 @@
 {{/option}}
 
 {{#option "`--bin` _name_..." }}
-{{actionverb}} the specified binary. This flag may be specified multiple times.
+{{actionverb}} the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 {{/option}}
 
 {{#option "`--bins`" }}

--- a/src/doc/man/includes/options-targets.md
+++ b/src/doc/man/includes/options-targets.md
@@ -1,12 +1,18 @@
 Passing target selection flags will {{lower actionverb}} only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 {{#options}}
 
 {{> options-targets-lib-bin }}
 
 {{#option "`--example` _name_..." }}
-{{actionverb}} the specified example. This flag may be specified multiple times.
+{{actionverb}} the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 {{/option}}
 
 {{#option "`--examples`" }}
@@ -15,7 +21,7 @@ targets.
 
 {{#option "`--test` _name_..." }}
 {{actionverb}} the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 {{/option}}
 
 {{#option "`--tests`" }}
@@ -29,7 +35,8 @@ manifest settings for the target.
 {{/option}}
 
 {{#option "`--bench` _name_..." }}
-{{actionverb}} the specified benchmark. This flag may be specified multiple times.
+{{actionverb}} the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 {{/option}}
 
 {{#option "`--benches`" }}

--- a/src/doc/man/includes/section-package-selection.md
+++ b/src/doc/man/includes/section-package-selection.md
@@ -15,7 +15,10 @@ virtual workspace will include all workspace members (equivalent to passing
 
 {{#option "`-p` _spec_..." "`--package` _spec_..."}}
 {{actionverb}} only the specified packages. See {{man "cargo-pkgid" 1}} for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like `*`, `?` and `[]`. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 {{/option}}
 
 {{#option "`--workspace`" }}
@@ -30,7 +33,10 @@ Deprecated alias for `--workspace`.
 
 {{#option "`--exclude` _SPEC_..." }}
 Exclude the specified packages. Must be used in conjunction with the
-`--workspace` flag. This flag may be specified multiple times.
+`--workspace` flag. This flag may be specified multiple times and supports
+common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 {{/option}}
 
 {{/options}}

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -81,7 +81,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-bench--p"><a class="option-anchor" href="#option-cargo-bench--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-bench---package"><a class="option-anchor" href="#option-cargo-bench---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Benchmark only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---workspace"><a class="option-anchor" href="#option-cargo-bench---workspace"></a><code>--workspace</code></dt>
@@ -96,7 +99,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-bench---exclude"><a class="option-anchor" href="#option-cargo-bench---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>
@@ -122,7 +128,12 @@ target by name ignore the `bench` flag and will always benchmark the given
 target.
 
 Passing target selection flags will benchmark only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -131,7 +142,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-bench---bin"><a class="option-anchor" href="#option-cargo-bench---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Benchmark the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Benchmark the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---bins"><a class="option-anchor" href="#option-cargo-bench---bins"></a><code>--bins</code></dt>
@@ -140,7 +152,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-bench---example"><a class="option-anchor" href="#option-cargo-bench---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Benchmark the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Benchmark the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---examples"><a class="option-anchor" href="#option-cargo-bench---examples"></a><code>--examples</code></dt>
@@ -149,7 +162,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-bench---test"><a class="option-anchor" href="#option-cargo-bench---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Benchmark the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---tests"><a class="option-anchor" href="#option-cargo-bench---tests"></a><code>--tests</code></dt>
@@ -163,7 +176,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---bench"><a class="option-anchor" href="#option-cargo-bench---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Benchmark the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Benchmark the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---benches"><a class="option-anchor" href="#option-cargo-bench---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -33,7 +33,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-build--p"><a class="option-anchor" href="#option-cargo-build--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-build---package"><a class="option-anchor" href="#option-cargo-build---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Build only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---workspace"><a class="option-anchor" href="#option-cargo-build---workspace"></a><code>--workspace</code></dt>
@@ -48,7 +51,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-build---exclude"><a class="option-anchor" href="#option-cargo-build---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>
@@ -61,7 +67,12 @@ binary and library targets of the selected packages. Binaries are skipped if
 they have `required-features` that are missing.
 
 Passing target selection flags will build only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -70,7 +81,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-build---bin"><a class="option-anchor" href="#option-cargo-build---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Build the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Build the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---bins"><a class="option-anchor" href="#option-cargo-build---bins"></a><code>--bins</code></dt>
@@ -79,7 +91,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-build---example"><a class="option-anchor" href="#option-cargo-build---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Build the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Build the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---examples"><a class="option-anchor" href="#option-cargo-build---examples"></a><code>--examples</code></dt>
@@ -88,7 +101,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-build---test"><a class="option-anchor" href="#option-cargo-build---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Build the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---tests"><a class="option-anchor" href="#option-cargo-build---tests"></a><code>--tests</code></dt>
@@ -102,7 +115,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---bench"><a class="option-anchor" href="#option-cargo-build---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Build the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Build the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---benches"><a class="option-anchor" href="#option-cargo-build---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -38,7 +38,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-check--p"><a class="option-anchor" href="#option-cargo-check--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-check---package"><a class="option-anchor" href="#option-cargo-check---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Check only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---workspace"><a class="option-anchor" href="#option-cargo-check---workspace"></a><code>--workspace</code></dt>
@@ -53,7 +56,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-check---exclude"><a class="option-anchor" href="#option-cargo-check---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>
@@ -66,7 +72,12 @@ binary and library targets of the selected packages. Binaries are skipped if
 they have `required-features` that are missing.
 
 Passing target selection flags will check only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -75,7 +86,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-check---bin"><a class="option-anchor" href="#option-cargo-check---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Check the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Check the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---bins"><a class="option-anchor" href="#option-cargo-check---bins"></a><code>--bins</code></dt>
@@ -84,7 +96,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-check---example"><a class="option-anchor" href="#option-cargo-check---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Check the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Check the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---examples"><a class="option-anchor" href="#option-cargo-check---examples"></a><code>--examples</code></dt>
@@ -93,7 +106,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-check---test"><a class="option-anchor" href="#option-cargo-check---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Check the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---tests"><a class="option-anchor" href="#option-cargo-check---tests"></a><code>--tests</code></dt>
@@ -107,7 +120,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---bench"><a class="option-anchor" href="#option-cargo-check---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Check the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Check the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---benches"><a class="option-anchor" href="#option-cargo-check---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -53,7 +53,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-doc--p"><a class="option-anchor" href="#option-cargo-doc--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-doc---package"><a class="option-anchor" href="#option-cargo-doc---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Document only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-doc---workspace"><a class="option-anchor" href="#option-cargo-doc---workspace"></a><code>--workspace</code></dt>
@@ -68,7 +71,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-doc---exclude"><a class="option-anchor" href="#option-cargo-doc---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>
@@ -91,7 +97,8 @@ flag and will always document the given target.
 
 
 <dt class="option-term" id="option-cargo-doc---bin"><a class="option-anchor" href="#option-cargo-doc---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Document the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Document the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-doc---bins"><a class="option-anchor" href="#option-cargo-doc---bins"></a><code>--bins</code></dt>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -98,7 +98,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-fix--p"><a class="option-anchor" href="#option-cargo-fix--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-fix---package"><a class="option-anchor" href="#option-cargo-fix---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Fix only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---workspace"><a class="option-anchor" href="#option-cargo-fix---workspace"></a><code>--workspace</code></dt>
@@ -113,7 +116,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-fix---exclude"><a class="option-anchor" href="#option-cargo-fix---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>
@@ -126,7 +132,12 @@ When no target selection options are given, `cargo fix` will fix all targets
 `required-features` that are missing.
 
 Passing target selection flags will fix only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -135,7 +146,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-fix---bin"><a class="option-anchor" href="#option-cargo-fix---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Fix the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Fix the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---bins"><a class="option-anchor" href="#option-cargo-fix---bins"></a><code>--bins</code></dt>
@@ -144,7 +156,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-fix---example"><a class="option-anchor" href="#option-cargo-fix---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Fix the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Fix the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---examples"><a class="option-anchor" href="#option-cargo-fix---examples"></a><code>--examples</code></dt>
@@ -153,7 +166,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-fix---test"><a class="option-anchor" href="#option-cargo-fix---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Fix the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---tests"><a class="option-anchor" href="#option-cargo-fix---tests"></a><code>--tests</code></dt>
@@ -167,7 +180,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---bench"><a class="option-anchor" href="#option-cargo-fix---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Fix the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Fix the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---benches"><a class="option-anchor" href="#option-cargo-fix---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -54,7 +54,12 @@ When no target selection options are given, `cargo rustc` will build all
 binary and library targets of the selected package.
 
 Passing target selection flags will build only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -63,7 +68,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-rustc---bin"><a class="option-anchor" href="#option-cargo-rustc---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Build the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Build the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---bins"><a class="option-anchor" href="#option-cargo-rustc---bins"></a><code>--bins</code></dt>
@@ -72,7 +78,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-rustc---example"><a class="option-anchor" href="#option-cargo-rustc---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Build the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Build the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---examples"><a class="option-anchor" href="#option-cargo-rustc---examples"></a><code>--examples</code></dt>
@@ -81,7 +88,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-rustc---test"><a class="option-anchor" href="#option-cargo-rustc---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Build the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---tests"><a class="option-anchor" href="#option-cargo-rustc---tests"></a><code>--tests</code></dt>
@@ -95,7 +102,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---bench"><a class="option-anchor" href="#option-cargo-rustc---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Build the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Build the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---benches"><a class="option-anchor" href="#option-cargo-rustc---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -67,7 +67,12 @@ if its name is the same as the lib target. Binaries are skipped if they have
 `required-features` that are missing.
 
 Passing target selection flags will document only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -76,7 +81,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-rustdoc---bin"><a class="option-anchor" href="#option-cargo-rustdoc---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Document the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Document the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---bins"><a class="option-anchor" href="#option-cargo-rustdoc---bins"></a><code>--bins</code></dt>
@@ -85,7 +91,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-rustdoc---example"><a class="option-anchor" href="#option-cargo-rustdoc---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Document the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Document the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---examples"><a class="option-anchor" href="#option-cargo-rustdoc---examples"></a><code>--examples</code></dt>
@@ -94,7 +101,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-rustdoc---test"><a class="option-anchor" href="#option-cargo-rustdoc---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Document the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---tests"><a class="option-anchor" href="#option-cargo-rustdoc---tests"></a><code>--tests</code></dt>
@@ -108,7 +115,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---bench"><a class="option-anchor" href="#option-cargo-rustdoc---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Document the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Document the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---benches"><a class="option-anchor" href="#option-cargo-rustdoc---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -79,7 +79,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-test--p"><a class="option-anchor" href="#option-cargo-test--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-test---package"><a class="option-anchor" href="#option-cargo-test---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Test only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---workspace"><a class="option-anchor" href="#option-cargo-test---workspace"></a><code>--workspace</code></dt>
@@ -94,7 +97,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-test---exclude"><a class="option-anchor" href="#option-cargo-test---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>
@@ -132,7 +138,12 @@ is set when the integration test is built so that it can use the
 executable.
 
 Passing target selection flags will test only the specified
-targets.
+targets. 
+
+Note that `--bin`, `--example`, `--test` and `--bench` flags also 
+support common Unix glob patterns like `*`, `?` and `[]`. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 
 <dl>
 
@@ -141,7 +152,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-test---bin"><a class="option-anchor" href="#option-cargo-test---bin"></a><code>--bin</code> <em>name</em>...</dt>
-<dd class="option-desc">Test the specified binary. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Test the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---bins"><a class="option-anchor" href="#option-cargo-test---bins"></a><code>--bins</code></dt>
@@ -150,7 +162,8 @@ targets.
 
 
 <dt class="option-term" id="option-cargo-test---example"><a class="option-anchor" href="#option-cargo-test---example"></a><code>--example</code> <em>name</em>...</dt>
-<dd class="option-desc">Test the specified example. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Test the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---examples"><a class="option-anchor" href="#option-cargo-test---examples"></a><code>--examples</code></dt>
@@ -159,7 +172,7 @@ targets.
 
 <dt class="option-term" id="option-cargo-test---test"><a class="option-anchor" href="#option-cargo-test---test"></a><code>--test</code> <em>name</em>...</dt>
 <dd class="option-desc">Test the specified integration test. This flag may be specified
-multiple times.</dd>
+multiple times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---tests"><a class="option-anchor" href="#option-cargo-test---tests"></a><code>--tests</code></dt>
@@ -173,7 +186,8 @@ manifest settings for the target.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---bench"><a class="option-anchor" href="#option-cargo-test---bench"></a><code>--bench</code> <em>name</em>...</dt>
-<dd class="option-desc">Test the specified benchmark. This flag may be specified multiple times.</dd>
+<dd class="option-desc">Test the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---benches"><a class="option-anchor" href="#option-cargo-test---benches"></a><code>--benches</code></dt>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -166,7 +166,10 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-tree--p"><a class="option-anchor" href="#option-cargo-tree--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-tree---package"><a class="option-anchor" href="#option-cargo-tree---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Display only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
-SPEC format. This flag may be specified multiple times.</dd>
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-tree---workspace"><a class="option-anchor" href="#option-cargo-tree---workspace"></a><code>--workspace</code></dt>
@@ -177,7 +180,10 @@ SPEC format. This flag may be specified multiple times.</dd>
 
 <dt class="option-term" id="option-cargo-tree---exclude"><a class="option-anchor" href="#option-cargo-tree---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
 <dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
-<code>--workspace</code> flag. This flag may be specified multiple times.</dd>
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
 
 
 </dl>

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -78,7 +78,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Benchmark only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -94,7 +97,10 @@ Deprecated alias for \fB\-\-workspace\fR\&.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Target Selection"
 When no target selection options are given, \fBcargo bench\fR will build the
@@ -129,7 +135,12 @@ target by name ignore the \fBbench\fR flag and will always benchmark the given
 target.
 .sp
 Passing target selection flags will benchmark only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -138,7 +149,8 @@ Benchmark the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Benchmark the specified binary. This flag may be specified multiple times.
+Benchmark the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -148,7 +160,8 @@ Benchmark all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Benchmark the specified example. This flag may be specified multiple times.
+Benchmark the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -159,7 +172,7 @@ Benchmark all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Benchmark the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -175,7 +188,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Benchmark the specified benchmark. This flag may be specified multiple times.
+Benchmark the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -26,7 +26,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Build only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -42,7 +45,10 @@ Deprecated alias for \fB\-\-workspace\fR\&.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Target Selection"
 When no target selection options are given, \fBcargo build\fR will build all
@@ -50,7 +56,12 @@ binary and library targets of the selected packages. Binaries are skipped if
 they have \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will build only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -59,7 +70,8 @@ Build the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Build the specified binary. This flag may be specified multiple times.
+Build the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -69,7 +81,8 @@ Build all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Build the specified example. This flag may be specified multiple times.
+Build the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -80,7 +93,7 @@ Build all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Build the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -96,7 +109,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Build the specified benchmark. This flag may be specified multiple times.
+Build the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -31,7 +31,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Check only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -47,7 +50,10 @@ Deprecated alias for \fB\-\-workspace\fR\&.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Target Selection"
 When no target selection options are given, \fBcargo check\fR will check all
@@ -55,7 +61,12 @@ binary and library targets of the selected packages. Binaries are skipped if
 they have \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will check only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -64,7 +75,8 @@ Check the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Check the specified binary. This flag may be specified multiple times.
+Check the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -74,7 +86,8 @@ Check all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Check the specified example. This flag may be specified multiple times.
+Check the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -85,7 +98,7 @@ Check all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Check the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -101,7 +114,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Check the specified benchmark. This flag may be specified multiple times.
+Check the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -44,7 +44,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Document only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -60,7 +63,10 @@ Deprecated alias for \fB\-\-workspace\fR\&.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Target Selection"
 When no target selection options are given, \fBcargo doc\fR will document all
@@ -79,7 +85,8 @@ Document the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Document the specified binary. This flag may be specified multiple times.
+Document the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -104,7 +104,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Fix only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -120,7 +123,10 @@ Deprecated alias for \fB\-\-workspace\fR\&.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Target Selection"
 When no target selection options are given, \fBcargo fix\fR will fix all targets
@@ -128,7 +134,12 @@ When no target selection options are given, \fBcargo fix\fR will fix all targets
 \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will fix only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -137,7 +148,8 @@ Fix the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Fix the specified binary. This flag may be specified multiple times.
+Fix the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -147,7 +159,8 @@ Fix all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Fix the specified example. This flag may be specified multiple times.
+Fix the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -158,7 +171,7 @@ Fix all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Fix the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -174,7 +187,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Fix the specified benchmark. This flag may be specified multiple times.
+Fix the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -180,9 +180,9 @@ The output has the following format:
             /* The repository value from the manifest or null if not specified. */
             "repository": "https://github.com/rust\-lang/cargo",
             /* The homepage value from the manifest or null if not specified. */
-            "homepage": "https://rust-lang.org",
+            "homepage": "https://rust\-lang.org",
             /* The documentation value from the manifest or null if not specified. */
-            "documentation": "https://doc.rust-lang.org/stable/std",
+            "documentation": "https://doc.rust\-lang.org/stable/std",
             /* The default edition of the package.
                Note that individual targets may have different editions.
             */
@@ -333,7 +333,7 @@ Do not activate the \fBdefault\fR feature of the current directory's package.
 .RE
 .SS "Display Options"
 .sp
-\fB\-v\fR,
+\fB\-v\fR, 
 \fB\-\-verbose\fR
 .RS 4
 Use verbose output. May be specified twice for "very verbose" output which
@@ -342,7 +342,7 @@ May also be specified with the \fBterm.verbose\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
 .RE
 .sp
-\fB\-q\fR,
+\fB\-q\fR, 
 \fB\-\-quiet\fR
 .RS 4
 No output printed to stdout.
@@ -376,7 +376,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR,
+\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
 Either of these flags requires that the \fBCargo.lock\fR file is
@@ -415,7 +415,7 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-h\fR,
+\fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4
 Prints help information.

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -42,7 +42,12 @@ When no target selection options are given, \fBcargo rustc\fR will build all
 binary and library targets of the selected package.
 .sp
 Passing target selection flags will build only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -51,7 +56,8 @@ Build the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Build the specified binary. This flag may be specified multiple times.
+Build the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -61,7 +67,8 @@ Build all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Build the specified example. This flag may be specified multiple times.
+Build the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -72,7 +79,7 @@ Build all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Build the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -88,7 +95,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Build the specified benchmark. This flag may be specified multiple times.
+Build the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -51,7 +51,12 @@ if its name is the same as the lib target. Binaries are skipped if they have
 \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will document only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -60,7 +65,8 @@ Document the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Document the specified binary. This flag may be specified multiple times.
+Document the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -70,7 +76,8 @@ Document all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Document the specified example. This flag may be specified multiple times.
+Document the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -81,7 +88,7 @@ Document all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Document the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -97,7 +104,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Document the specified benchmark. This flag may be specified multiple times.
+Document the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -71,7 +71,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Test only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -87,7 +90,10 @@ Deprecated alias for \fB\-\-workspace\fR\&.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Target Selection"
 When no target selection options are given, \fBcargo test\fR will build the
@@ -140,7 +146,12 @@ is set when the integration test is built so that it can use the
 executable.
 .sp
 Passing target selection flags will test only the specified
-targets.
+targets. 
+.sp
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
+shell accidentally expanding glob patterns before Cargo handles them, you must 
+use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR
 .RS 4
@@ -149,7 +160,8 @@ Test the package's library.
 .sp
 \fB\-\-bin\fR \fIname\fR\&...
 .RS 4
-Test the specified binary. This flag may be specified multiple times.
+Test the specified binary. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-bins\fR
@@ -159,7 +171,8 @@ Test all binary targets.
 .sp
 \fB\-\-example\fR \fIname\fR\&...
 .RS 4
-Test the specified example. This flag may be specified multiple times.
+Test the specified example. This flag may be specified multiple times
+and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-examples\fR
@@ -170,7 +183,7 @@ Test all example targets.
 \fB\-\-test\fR \fIname\fR\&...
 .RS 4
 Test the specified integration test. This flag may be specified
-multiple times.
+multiple times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-tests\fR
@@ -186,7 +199,8 @@ manifest settings for the target.
 .sp
 \fB\-\-bench\fR \fIname\fR\&...
 .RS 4
-Test the specified benchmark. This flag may be specified multiple times.
+Test the specified benchmark. This flag may be specified multiple
+times and supports common Unix glob patterns.
 .RE
 .sp
 \fB\-\-benches\fR

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -204,7 +204,10 @@ virtual workspace will include all workspace members (equivalent to passing
 \fB\-\-package\fR \fIspec\fR\&...
 .RS 4
 Display only the specified packages. See \fBcargo\-pkgid\fR(1) for the
-SPEC format. This flag may be specified multiple times.
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
 .RE
 .sp
 \fB\-\-workspace\fR
@@ -215,7 +218,10 @@ Display all members in the workspace.
 \fB\-\-exclude\fR \fISPEC\fR\&...
 .RS 4
 Exclude the specified packages. Must be used in conjunction with the
-\fB\-\-workspace\fR flag. This flag may be specified multiple times.
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
 .RE
 .SS "Manifest Options"
 .sp

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1468,28 +1468,28 @@ fn bench_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file(
             "bar/src/lib.rs",
             r#"
-            #![feature(test)]
-            #[cfg(test)]
-            extern crate test;
+                #![feature(test)]
+                #[cfg(test)]
+                extern crate test;
 
-            #[bench]
-            pub fn bar(b: &mut test::Bencher) {
-                b.iter(|| {});
-            }
-        "#,
+                #[bench]
+                pub fn bar(b: &mut test::Bencher) {
+                    b.iter(|| {});
+                }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file(
@@ -1570,37 +1570,37 @@ fn bench_virtual_manifest_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() { break_the_build(); }")
         .file(
             "bar/benches/bar.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_bar(_: &mut Bencher) -> () { break_the_build(); }
-        "#,
+                #[bench]
+                fn bench_bar(_: &mut Bencher) -> () { break_the_build(); }
+            "#,
         )
         .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .file(
             "baz/benches/baz.rs",
             r#"
-            #![feature(test)]
-            extern crate test;
+                #![feature(test)]
+                extern crate test;
 
-            use test::Bencher;
+                use test::Bencher;
 
-            #[bench]
-            fn bench_baz(_: &mut Bencher) -> () { () }
-        "#,
+                #[bench]
+                fn bench_baz(_: &mut Bencher) -> () { () }
+            "#,
         )
         .build();
 

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1459,6 +1459,55 @@ test bar ... bench:           [..] ns/iter (+/- [..])",
 }
 
 #[cargo_test]
+fn bench_all_exclude_glob() {
+    if !is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file(
+            "bar/src/lib.rs",
+            r#"
+            #![feature(test)]
+            #[cfg(test)]
+            extern crate test;
+
+            #[bench]
+            pub fn bar(b: &mut test::Bencher) {
+                b.iter(|| {});
+            }
+        "#,
+        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file(
+            "baz/src/lib.rs",
+            "#[test] pub fn baz() { break_the_build(); }",
+        )
+        .build();
+
+    p.cargo("bench --workspace --exclude '*z'")
+        .with_stdout_contains(
+            "\
+running 1 test
+test bar ... bench:           [..] ns/iter (+/- [..])",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn bench_all_virtual_manifest() {
     if !is_nightly() {
         return;
@@ -1508,6 +1557,59 @@ fn bench_all_virtual_manifest() {
         .with_stdout_contains("test bench_baz ... bench: [..]")
         .with_stderr_contains("[RUNNING] target/release/deps/bar-[..][EXE]")
         .with_stdout_contains("test bench_bar ... bench: [..]")
+        .run();
+}
+
+#[cargo_test]
+fn bench_virtual_manifest_glob() {
+    if !is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() { break_the_build(); }")
+        .file(
+            "bar/benches/bar.rs",
+            r#"
+            #![feature(test)]
+            extern crate test;
+
+            use test::Bencher;
+
+            #[bench]
+            fn bench_bar(_: &mut Bencher) -> () { break_the_build(); }
+        "#,
+        )
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .file(
+            "baz/benches/baz.rs",
+            r#"
+            #![feature(test)]
+            extern crate test;
+
+            use test::Bencher;
+
+            #[bench]
+            fn bench_baz(_: &mut Bencher) -> () { () }
+        "#,
+        )
+        .build();
+
+    // The order in which bar and baz are built is not guaranteed
+    p.cargo("bench -p '*z'")
+        .with_stderr_contains("[RUNNING] target/release/deps/baz-[..][EXE]")
+        .with_stdout_contains("test bench_baz ... bench: [..]")
+        .with_stderr_does_not_contain("[RUNNING] target/release/deps/bar-[..][EXE]")
+        .with_stdout_does_not_contain("test bench_bar ... bench: [..]")
         .run();
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3770,13 +3770,8 @@ fn build_virtual_manifest_glob_not_found() {
         .build();
 
     p.cargo("build -p bar -p '*z'")
-        .with_stderr(
-            "\
-[WARNING] package pattern(s) `*z` not found in workspace [..]
-[COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_status(101)
+        .with_stderr("[ERROR] package pattern(s) `*z` not found in workspace [..]")
         .run();
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3500,13 +3500,13 @@ fn build_all_exclude_not_found() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -3534,13 +3534,13 @@ fn build_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -3569,13 +3569,13 @@ fn build_all_exclude_glob_not_found() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -3740,9 +3740,9 @@ fn build_virtual_manifest_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() { break_the_build(); }")
@@ -3767,9 +3767,9 @@ fn build_virtual_manifest_glob_not_found() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -3792,9 +3792,9 @@ fn build_virtual_manifest_broken_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4583,6 +4583,16 @@ fn target_filters_workspace() {
         )
         .run();
 
+    ws.cargo("build -v --example 'ex??'")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] no example target matches pattern `ex??`
+
+<tab>Did you mean `ex1`?",
+        )
+        .run();
+
     ws.cargo("build -v --lib")
         .with_stderr_contains("[RUNNING] `rustc [..]a/src/lib.rs[..]")
         .with_stderr_contains("[RUNNING] `rustc [..]b/src/lib.rs[..]")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3481,13 +3481,11 @@ fn build_all_exclude() {
         .build();
 
     p.cargo("build --workspace --exclude baz")
-        .with_stderr_contains("[COMPILING] foo v0.1.0 [..]")
-        .with_stderr_contains("[COMPILING] bar v0.1.0 [..]")
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
-        .with_stderr(
+        .with_stderr_unordered(
             "\
-[COMPILING] [..] v0.1.0 ([..])
-[COMPILING] [..] v0.1.0 ([..])
+[COMPILING] foo v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -3515,13 +3513,11 @@ fn build_all_exclude_not_found() {
 
     p.cargo("build --workspace --exclude baz")
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
-        .with_stderr_contains("[COMPILING] foo v0.1.0 [..]")
-        .with_stderr_contains("[COMPILING] bar v0.1.0 [..]")
-        .with_stderr(
+        .with_stderr_unordered(
             "\
 [WARNING] excluded package(s) `baz` not found in workspace [..]
-[COMPILING] [..] v0.1.0 ([..])
-[COMPILING] [..] v0.1.0 ([..])
+[COMPILING] foo v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -3551,12 +3547,10 @@ fn build_all_exclude_glob() {
 
     p.cargo("build --workspace --exclude '*z'")
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
-        .with_stderr_contains("[COMPILING] foo v0.1.0 [..]")
-        .with_stderr_contains("[COMPILING] bar v0.1.0 [..]")
-        .with_stderr(
+        .with_stderr_unordered(
             "\
-[COMPILING] [..] v0.1.0 ([..])
-[COMPILING] [..] v0.1.0 ([..])
+[COMPILING] foo v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -3669,12 +3663,12 @@ fn build_all_virtual_manifest() {
 
     // The order in which bar and baz are built is not guaranteed
     p.cargo("build --workspace")
-        .with_stderr_contains("[..] Compiling baz v0.1.0 ([..])")
-        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
-        .with_stderr(
-            "[..] Compiling [..] v0.1.0 ([..])\n\
-             [..] Compiling [..] v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+        .with_stderr_unordered(
+            "\
+[COMPILING] baz v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
         )
         .run();
 }
@@ -3697,12 +3691,12 @@ fn build_virtual_manifest_all_implied() {
 
     // The order in which `bar` and `baz` are built is not guaranteed.
     p.cargo("build")
-        .with_stderr_contains("[..] Compiling baz v0.1.0 ([..])")
-        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
-        .with_stderr(
-            "[..] Compiling [..] v0.1.0 ([..])\n\
-             [..] Compiling [..] v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+        .with_stderr_unordered(
+            "\
+[COMPILING] baz v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
         )
         .run();
 }
@@ -3832,12 +3826,12 @@ fn build_all_virtual_manifest_implicit_examples() {
 
     // The order in which bar and baz are built is not guaranteed
     p.cargo("build --workspace --examples")
-        .with_stderr_contains("[..] Compiling baz v0.1.0 ([..])")
-        .with_stderr_contains("[..] Compiling bar v0.1.0 ([..])")
-        .with_stderr(
-            "[..] Compiling [..] v0.1.0 ([..])\n\
-             [..] Compiling [..] v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+        .with_stderr_unordered(
+            "\
+[COMPILING] baz v0.1.0 ([..])
+[COMPILING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
         )
         .run();
     assert!(!p.bin("a").is_file());

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3519,7 +3519,7 @@ fn build_all_exclude_not_found() {
         .with_stderr_contains("[COMPILING] bar v0.1.0 [..]")
         .with_stderr(
             "\
-[WARNING] excluded package(s) baz not found in workspace [..]
+[WARNING] excluded package(s) `baz` not found in workspace [..]
 [COMPILING] [..] v0.1.0 ([..])
 [COMPILING] [..] v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -3586,7 +3586,7 @@ fn build_all_exclude_glob_not_found() {
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[WARNING] excluded package pattern(s) *z not found in workspace [..]
+[WARNING] excluded package pattern(s) `*z` not found in workspace [..]
 [COMPILING] [..] v0.1.0 ([..])
 [COMPILING] [..] v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -3601,7 +3601,7 @@ fn build_all_exclude_broken_glob() {
 
     p.cargo("build --workspace --exclude '[*z'")
         .with_status(101)
-        .with_stderr_contains("[ERROR] Cannot build glob pattern from `[*z`")
+        .with_stderr_contains("[ERROR] cannot build glob pattern from `[*z`")
         .run();
 }
 
@@ -3778,7 +3778,7 @@ fn build_virtual_manifest_glob_not_found() {
     p.cargo("build -p bar -p '*z'")
         .with_stderr(
             "\
-[WARNING] package pattern(s) *z not found in workspace [..]
+[WARNING] package pattern(s) `*z` not found in workspace [..]
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -3802,7 +3802,7 @@ fn build_virtual_manifest_broken_glob() {
 
     p.cargo("build -p '[*z'")
         .with_status(101)
-        .with_stderr_contains("[ERROR] Cannot build glob pattern from `[*z`")
+        .with_stderr_contains("[ERROR] cannot build glob pattern from `[*z`")
         .run();
 }
 

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -420,9 +420,9 @@ fn check_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -447,9 +447,9 @@ fn check_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -496,9 +496,9 @@ fn check_virtual_manifest_one_project() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -523,9 +523,9 @@ fn check_virtual_manifest_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -415,6 +415,60 @@ fn check_all() {
 }
 
 #[cargo_test]
+fn check_all_exclude() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("check --workspace --exclude baz")
+        .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
+        .with_stderr(
+            "\
+[CHECKING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_all_exclude_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("check --workspace --exclude '*z'")
+        .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
+        .with_stderr(
+            "\
+[CHECKING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn check_virtual_all_implied() {
     let p = project()
         .file(
@@ -433,6 +487,60 @@ fn check_virtual_all_implied() {
     p.cargo("check -v")
         .with_stderr_contains("[..] --crate-name bar bar/src/lib.rs [..]")
         .with_stderr_contains("[..] --crate-name baz baz/src/lib.rs [..]")
+        .run();
+}
+
+#[cargo_test]
+fn check_virtual_manifest_one_project() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("check -p bar")
+        .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
+        .with_stderr(
+            "\
+[CHECKING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_virtual_manifest_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
+
+    p.cargo("check -p '*z'")
+        .with_stderr_does_not_contain("[CHECKING] bar v0.1.0 [..]")
+        .with_stderr(
+            "\
+[CHECKING] baz v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
         .run();
 }
 

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -551,7 +551,7 @@ fn exclude_warns_on_non_existing_package() {
         .with_stdout("")
         .with_stderr(
             "\
-[WARNING] excluded package(s) bar not found in workspace `[CWD]`
+[WARNING] excluded package(s) `bar` not found in workspace `[CWD]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -546,9 +546,9 @@ fn doc_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -573,9 +573,9 @@ fn doc_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -1015,9 +1015,9 @@ fn doc_virtual_manifest_one_project() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {}")
@@ -1042,9 +1042,9 @@ fn doc_virtual_manifest_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -541,6 +541,60 @@ fn doc_dash_p() {
 }
 
 #[cargo_test]
+fn doc_all_exclude() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("doc --workspace --exclude baz")
+        .with_stderr_does_not_contain("[DOCUMENTING] baz v0.1.0 [..]")
+        .with_stderr(
+            "\
+[DOCUMENTING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn doc_all_exclude_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("doc --workspace --exclude '*z'")
+        .with_stderr_does_not_contain("[DOCUMENTING] baz v0.1.0 [..]")
+        .with_stderr(
+            "\
+[DOCUMENTING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn doc_same_name() {
     let p = project()
         .file("src/lib.rs", "")
@@ -952,6 +1006,60 @@ fn doc_virtual_manifest_all_implied() {
     p.cargo("doc")
         .with_stderr_contains("[..] Documenting baz v0.1.0 ([..])")
         .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
+        .run();
+}
+
+#[cargo_test]
+fn doc_virtual_manifest_one_project() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("doc -p bar")
+        .with_stderr_does_not_contain("[DOCUMENTING] baz v0.1.0 [..]")
+        .with_stderr(
+            "\
+[DOCUMENTING] bar v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn doc_virtual_manifest_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() {}")
+        .build();
+
+    p.cargo("doc -p '*z'")
+        .with_stderr_does_not_contain("[DOCUMENTING] bar v0.1.0 [..]")
+        .with_stderr(
+            "\
+[DOCUMENTING] baz v0.1.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
         .run();
 }
 

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -1,0 +1,535 @@
+//! Tests for target filter flags rith glob patterns.
+
+use cargo_test_support::{project, Project};
+
+#[cargo_test]
+fn build_example() {
+    full_project()
+        .cargo("build -v --example 'ex*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name example1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_bin() {
+    full_project()
+        .cargo("build -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_bench() {
+    full_project()
+        .cargo("build -v --bench 'be*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_test() {
+    full_project()
+        .cargo("build -v --test 'te*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_example() {
+    full_project()
+        .cargo("check -v --example 'ex*1'")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name example1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_bin() {
+    full_project()
+        .cargo("check -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_bench() {
+    full_project()
+        .cargo("check -v --bench 'be*1'")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name bench1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_test() {
+    full_project()
+        .cargo("check -v --test 'te*1'")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name test1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn doc_bin() {
+    full_project()
+        .cargo("doc -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-type bin --crate-name bin1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn fix_example() {
+    full_project()
+        .cargo("fix -v --example 'ex*1' --allow-no-vcs")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `[..] rustc --crate-name example1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn fix_bin() {
+    full_project()
+        .cargo("fix -v --bin 'bi*1' --allow-no-vcs")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `[..] rustc --crate-name bin1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn fix_bench() {
+    full_project()
+        .cargo("fix -v --bench 'be*1' --allow-no-vcs")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `[..] rustc --crate-name bench1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn fix_test() {
+    full_project()
+        .cargo("fix -v --test 'te*1' --allow-no-vcs")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[RUNNING] `[..] rustc --crate-name test1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn run_example_and_bin() {
+    let p = full_project();
+    p.cargo("run -v --bin 'bi*1'")
+        .with_status(101)
+        .with_stderr("[ERROR] `cargo run` does not support glob patterns on target selection")
+        .run();
+
+    p.cargo("run -v --example 'ex*1'")
+        .with_status(101)
+        .with_stderr("[ERROR] `cargo run` does not support glob patterns on target selection")
+        .run();
+}
+
+#[cargo_test]
+fn test_example() {
+    full_project()
+        .cargo("test -v --example 'ex*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name example1 [..]`
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] [..]example1[..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_bin() {
+    full_project()
+        .cargo("test -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] [..]bin1[..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_bench() {
+    full_project()
+        .cargo("test -v --bench 'be*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] [..]bench1[..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_test() {
+    full_project()
+        .cargo("test -v --test 'te*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] [..]test1[..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bench_example() {
+    full_project()
+        .cargo("bench -v --example 'ex*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name example1 [..]`
+[FINISHED] bench [optimized] target(s) in [..]
+[RUNNING] `[..]example1[..] --bench`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bench_bin() {
+    full_project()
+        .cargo("bench -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] bench [optimized] target(s) in [..]
+[RUNNING] `[..]bin1[..] --bench`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bench_bench() {
+    full_project()
+        .cargo("bench -v --bench 'be*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] bench [optimized] target(s) in [..]
+[RUNNING] `[..]bench1[..] --bench`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bench_test() {
+    full_project()
+        .cargo("bench -v --test 'te*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] bench [optimized] target(s) in [..]
+[RUNNING] `[..]test1[..] --bench`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn install_example() {
+    full_project()
+        .cargo("install --path . --example 'ex*1'")
+        .with_stderr(
+            "\
+[INSTALLING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] [..]/home/.cargo/bin/example1[EXE]
+[INSTALLED] package `foo v0.0.1 ([CWD])` (executable `example1[EXE]`)
+[WARNING] be sure to add [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn install_bin() {
+    full_project()
+        .cargo("install --path . --bin 'bi*1'")
+        .with_stderr(
+            "\
+[INSTALLING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] [..]/home/.cargo/bin/bin1[EXE]
+[INSTALLED] package `foo v0.0.1 ([CWD])` (executable `bin1[EXE]`)
+[WARNING] be sure to add [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustdoc_example() {
+    full_project()
+        .cargo("rustdoc -v --example 'ex*1'")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-type bin --crate-name example1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustdoc_bin() {
+    full_project()
+        .cargo("rustdoc -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-type bin --crate-name bin1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustdoc_bench() {
+    full_project()
+        .cargo("rustdoc -v --bench 'be*1'")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-type bin --crate-name bench1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustdoc_test() {
+    full_project()
+        .cargo("rustdoc -v --test 'te*1'")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[RUNNING] `rustdoc --crate-type bin --crate-name test1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustc_example() {
+    full_project()
+        .cargo("rustc -v --example 'ex*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name example1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustc_bin() {
+    full_project()
+        .cargo("rustc -v --bin 'bi*1'")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name bin1 [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustc_bench() {
+    full_project()
+        .cargo("rustc -v --bench 'be*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bench1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn rustc_test() {
+    full_project()
+        .cargo("rustc -v --test 'te*1'")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name test1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin2 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bin1 [..]`")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name foo [..]`")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[RUNNING] `rustc --crate-name [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+fn full_project() -> Project {
+    project()
+        .file("examples/example1.rs", "fn main() { }")
+        .file("examples/example2.rs", "fn main() { }")
+        .file("benches/bench1.rs", "")
+        .file("benches/bench2.rs", "")
+        .file("tests/test1.rs", "")
+        .file("tests/test2.rs", "")
+        .file("src/main.rs", "fn main() { }")
+        .file("src/bin/bin1.rs", "fn main() { }")
+        .file("src/bin/bin2.rs", "fn main() { }")
+        .build()
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -52,6 +52,7 @@ mod generate_lockfile;
 mod git;
 mod git_auth;
 mod git_gc;
+mod glob_targets;
 mod help;
 mod init;
 mod install;

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -996,7 +996,16 @@ fn run_multiple_packages() {
         .arg("-p")
         .arg("d3")
         .with_status(101)
-        .with_stderr_contains("[ERROR] package `d3` is not a member of the workspace")
+        .with_stderr_contains("[ERROR] package(s) d3 not found in workspace [..]")
+        .run();
+
+    cargo()
+        .arg("-p")
+        .arg("d*")
+        .with_status(101)
+        .with_stderr_contains(
+            "[ERROR] `cargo run` does not support glob pattern `d*` on package selection",
+        )
         .run();
 }
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -996,7 +996,7 @@ fn run_multiple_packages() {
         .arg("-p")
         .arg("d3")
         .with_status(101)
-        .with_stderr_contains("[ERROR] package(s) d3 not found in workspace [..]")
+        .with_stderr_contains("[ERROR] package(s) `d3` not found in workspace [..]")
         .run();
 
     cargo()

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -331,9 +331,9 @@ fn fail_with_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -326,6 +326,26 @@ error: The argument '--package <SPEC>' was provided more than once, \
 }
 
 #[cargo_test]
+fn fail_with_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")
+        .build();
+
+    p.cargo("rustc -p '*z'")
+        .with_status(101)
+        .with_stderr("[ERROR] Glob patterns on package selection are not supported.")
+        .run();
+}
+
+#[cargo_test]
 fn rustc_with_other_profile() {
     let p = project()
         .file(

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -233,9 +233,9 @@ fn fail_with_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -226,3 +226,23 @@ fn rustdoc_target() {
         ))
         .run();
 }
+
+#[cargo_test]
+fn fail_with_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {  break_the_build(); }")
+        .build();
+
+    p.cargo("rustdoc -p '*z'")
+        .with_status(101)
+        .with_stderr("[ERROR] Glob patterns on package selection are not supported.")
+        .run();
+}

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3033,9 +3033,8 @@ fn test_virtual_manifest_glob_not_found() {
         .build();
 
     p.cargo("test -p bar -p '*z'")
-        .with_stderr_contains("[WARNING] package pattern(s) `*z` not found in workspace [..]")
-        .with_stdout_contains("running 1 test\ntest bar ... ok")
-        .with_stdout_does_not_contain("running 1 test\ntest baz ... ok")
+        .with_status(101)
+        .with_stderr("[ERROR] package pattern(s) `*z` not found in workspace [..]")
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2834,6 +2834,103 @@ test bar ... ok",
 }
 
 #[cargo_test]
+fn test_all_exclude_not_found() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] pub fn bar() {}")
+        .build();
+
+    p.cargo("test --workspace --exclude baz")
+        .with_stderr_contains("[WARNING] excluded package(s) baz not found in workspace [..]")
+        .with_stdout_contains(
+            "running 1 test
+test bar ... ok",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_all_exclude_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "#[test] pub fn baz() { assert!(false); }")
+        .build();
+
+    p.cargo("test --workspace --exclude '*z'")
+        .with_stdout_contains(
+            "running 1 test
+test bar ... ok",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_all_exclude_glob_not_found() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [project]
+            name = "foo"
+            version = "0.1.0"
+
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] pub fn bar() {}")
+        .build();
+
+    p.cargo("test --workspace --exclude '*z'")
+        .with_stderr_contains(
+            "[WARNING] excluded package pattern(s) *z not found in workspace [..]",
+        )
+        .with_stdout_contains(
+            "running 1 test
+test bar ... ok",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_all_exclude_broken_glob() {
+    let p = project().file("src/main.rs", "fn main() {}").build();
+
+    p.cargo("test --workspace --exclude '[*z'")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] Cannot build glob pattern from `[*z`")
+        .run();
+}
+
+#[cargo_test]
 fn test_all_virtual_manifest() {
     let p = project()
         .file(
@@ -2850,8 +2947,8 @@ fn test_all_virtual_manifest() {
         .build();
 
     p.cargo("test --workspace")
-        .with_stdout_contains("test a ... ok")
-        .with_stdout_contains("test b ... ok")
+        .with_stdout_contains("running 1 test\ntest a ... ok")
+        .with_stdout_contains("running 1 test\ntest b ... ok")
         .run();
 }
 
@@ -2872,8 +2969,93 @@ fn test_virtual_manifest_all_implied() {
         .build();
 
     p.cargo("test")
-        .with_stdout_contains("test a ... ok")
-        .with_stdout_contains("test b ... ok")
+        .with_stdout_contains("running 1 test\ntest a ... ok")
+        .with_stdout_contains("running 1 test\ntest b ... ok")
+        .run();
+}
+
+#[cargo_test]
+fn test_virtual_manifest_one_project() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "#[test] fn baz() { assert!(false); }")
+        .build();
+
+    p.cargo("test -p bar")
+        .with_stdout_contains("running 1 test\ntest bar ... ok")
+        .with_stdout_does_not_contain("running 1 test\ntest baz ... ok")
+        .run();
+}
+
+#[cargo_test]
+fn test_virtual_manifest_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar", "baz"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] fn bar() { assert!(false); }")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "#[test] fn baz() {}")
+        .build();
+
+    p.cargo("test -p '*z'")
+        .with_stdout_does_not_contain("running 1 test\ntest bar ... ok")
+        .with_stdout_contains("running 1 test\ntest baz ... ok")
+        .run();
+}
+
+#[cargo_test]
+fn test_virtual_manifest_glob_not_found() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] fn bar() {}")
+        .build();
+
+    p.cargo("test -p bar -p '*z'")
+        .with_stderr_contains("[WARNING] package pattern(s) *z not found in workspace [..]")
+        .with_stdout_contains("running 1 test\ntest bar ... ok")
+        .with_stdout_does_not_contain("running 1 test\ntest baz ... ok")
+        .run();
+}
+
+#[cargo_test]
+fn test_virtual_manifest_broken_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["bar"]
+        "#,
+        )
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "#[test] fn bar() {}")
+        .build();
+
+    p.cargo("test -p '[*z'")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] Cannot build glob pattern from `[*z`")
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2853,7 +2853,7 @@ fn test_all_exclude_not_found() {
         .build();
 
     p.cargo("test --workspace --exclude baz")
-        .with_stderr_contains("[WARNING] excluded package(s) baz not found in workspace [..]")
+        .with_stderr_contains("[WARNING] excluded package(s) `baz` not found in workspace [..]")
         .with_stdout_contains(
             "running 1 test
 test bar ... ok",
@@ -2911,7 +2911,7 @@ fn test_all_exclude_glob_not_found() {
 
     p.cargo("test --workspace --exclude '*z'")
         .with_stderr_contains(
-            "[WARNING] excluded package pattern(s) *z not found in workspace [..]",
+            "[WARNING] excluded package pattern(s) `*z` not found in workspace [..]",
         )
         .with_stdout_contains(
             "running 1 test
@@ -2926,7 +2926,7 @@ fn test_all_exclude_broken_glob() {
 
     p.cargo("test --workspace --exclude '[*z'")
         .with_status(101)
-        .with_stderr_contains("[ERROR] Cannot build glob pattern from `[*z`")
+        .with_stderr_contains("[ERROR] cannot build glob pattern from `[*z`")
         .run();
 }
 
@@ -3033,7 +3033,7 @@ fn test_virtual_manifest_glob_not_found() {
         .build();
 
     p.cargo("test -p bar -p '*z'")
-        .with_stderr_contains("[WARNING] package pattern(s) *z not found in workspace [..]")
+        .with_stderr_contains("[WARNING] package pattern(s) `*z` not found in workspace [..]")
         .with_stdout_contains("running 1 test\ntest bar ... ok")
         .with_stdout_does_not_contain("running 1 test\ntest baz ... ok")
         .run();
@@ -3055,7 +3055,7 @@ fn test_virtual_manifest_broken_glob() {
 
     p.cargo("test -p '[*z'")
         .with_status(101)
-        .with_stderr_contains("[ERROR] Cannot build glob pattern from `[*z`")
+        .with_stderr_contains("[ERROR] cannot build glob pattern from `[*z`")
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2839,13 +2839,13 @@ fn test_all_exclude_not_found() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -2867,13 +2867,13 @@ fn test_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -2896,13 +2896,13 @@ fn test_all_exclude_glob_not_found() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
-            name = "foo"
-            version = "0.1.0"
+                [project]
+                name = "foo"
+                version = "0.1.0"
 
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("src/main.rs", "fn main() {}")
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -2980,9 +2980,9 @@ fn test_virtual_manifest_one_project() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "#[test] fn bar() {}")
@@ -3002,9 +3002,9 @@ fn test_virtual_manifest_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar", "baz"]
-        "#,
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "#[test] fn bar() { assert!(false); }")
@@ -3024,9 +3024,9 @@ fn test_virtual_manifest_glob_not_found() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "#[test] fn bar() {}")
@@ -3045,9 +3045,9 @@ fn test_virtual_manifest_broken_glob() {
         .file(
             "Cargo.toml",
             r#"
-            [workspace]
-            members = ["bar"]
-        "#,
+                [workspace]
+                members = ["bar"]
+            "#,
         )
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/lib.rs", "#[test] fn bar() {}")


### PR DESCRIPTION
Resolves #8582

## What

Commands that supports glob patterns on package/target selection:

- `build`
- `test`
- `bench`
- `doc`
- `check`
- `fix` (run `check` underneath the hood)
- `tree` (no target selection functionalit as same as before)

Commands that supports glob patterns on target selection only:

- `rustdoc` (can only build one package via `-p/--package` option)
- `rustc`  (can only build one package via `-p/--package` option)

Command that _does not_ support any glob patterns for package/target selection:

- `run` (you can only run at most one executable)

## How

By using existing [`glob`](https://crates.io/crates/glob) crate to

1. check whether a target filter is a glob pattern, and then 
1. compare if the target matches the filter.

Also, I loosed some shell-style restriction in cargo-test-support (by adding simple quote arguments support).

## Breaking Changes

Suppose no. 

- No public API introduced.
- All valid glob pattern chars (`*`, `?`, `[`, `]`) characters [are restricted by Cargo](https://github.com/rust-lang/cargo/blob/75615f8e69f748d7ef0df7bc0b064a9b1f5c78b2/src/cargo/util/restricted_names.rs#L70-L82 ) due to not containing in`XID_Continue` character set in [UAX#31](https://docs.rs/unicode-xid/0.2.1/unicode_xid/trait.UnicodeXID.html) and are also restricted 

## Performance Regression

Definitely gets some. 

However, assumed no one would pass lots of package/target selection with glob patterns, so the extra overhead for ordinary use cases are glob pattern existence checks on each target filter. The current implementation is somewhat naive, so if you have any better algorithm, please help me improve it.

## Documentation

I have done my best effort to write the documentation, but as a non-native English speaker I need helps to polish these sentences. Besides, I am not quite sure should we mention glob pattern in CLI help text, which is a bit lengthy at the moment....

