### PR TITLE
Add an unstable `--no-config` flag and an equivalent environment variable

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -1,6 +1,7 @@
 use cargo::core::features;
 use cargo::{self, drop_print, drop_println, CliResult, Config};
 use clap::{AppSettings, Arg, ArgMatches};
+use std::env;
 
 use super::commands;
 use super::list_commands;
@@ -218,7 +219,11 @@ fn execute_subcommand(
     cmd: &str,
     subcommand_args: &ArgMatches<'_>,
 ) -> CliResult {
-    if subcommand_args.is_present("no-config") {
+    if subcommand_args.is_present("no-config")
+        || env::var_os("CARGO_NO_CONFIG_UNSTABLE")
+            .map(|v| v == "1")
+            .unwrap_or(false)
+    {
         config.ignore_config_files()?;
     }
 

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -218,6 +218,10 @@ fn execute_subcommand(
     cmd: &str,
     subcommand_args: &ArgMatches<'_>,
 ) -> CliResult {
+    if subcommand_args.is_present("no-config") {
+        config.ignore_config_files()?;
+    }
+
     if let Some(exec) = commands::builtin_exec(cmd) {
         return exec(config, subcommand_args);
     }
@@ -326,6 +330,11 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(opt("offline", "Run without accessing the network").global(true))
         .arg(
             multi_opt("config", "KEY=VALUE", "Override a configuration value")
+                .global(true)
+                .hidden(true),
+        )
+        .arg(
+            opt("no-config", "Ignore `.cargo/config` files")
                 .global(true)
                 .hidden(true),
         )

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -37,6 +37,8 @@ pub struct BuildConfig {
     // Note that, although the cmd-line flag name is `out-dir`, in code we use
     // `export_dir`, to avoid confusion with out dir at `target/debug/deps`.
     pub export_dir: Option<PathBuf>,
+    /// Ignore `.cargo/config` files.
+    pub no_config: bool,
 }
 
 impl BuildConfig {
@@ -80,6 +82,7 @@ impl BuildConfig {
             primary_unit_rustc: None,
             rustfix_diagnostic_server: RefCell::new(None),
             export_dir: None,
+            no_config: false,
         })
     }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -163,6 +163,13 @@ pub trait AppExt: Sized {
         ))
     }
 
+    fn arg_no_config(self) -> Self {
+        self._arg(opt(
+            "no-config",
+            "Ignore `.cargo/config.toml` files (unstable)",
+        ))
+    }
+
     fn arg_unit_graph(self) -> Self {
         self._arg(opt("unit-graph", "Output build graph in JSON (unstable)").hidden(true))
     }
@@ -459,6 +466,7 @@ pub trait ArgMatchesExt {
         build_config.requested_profile = self.get_profile_name(config, "dev", profile_checking)?;
         build_config.build_plan = self._is_present("build-plan");
         build_config.unit_graph = self._is_present("unit-graph");
+        build_config.no_config = self._is_present("no-config");
         if build_config.build_plan {
             config
                 .cli_unstable()
@@ -468,6 +476,11 @@ pub trait ArgMatchesExt {
             config
                 .cli_unstable()
                 .fail_if_stable_opt("--unit-graph", 8002)?;
+        }
+        if build_config.no_config {
+            config
+                .cli_unstable()
+                .fail_if_stable_opt("--no-config", 0000)?;
         }
 
         let opts = CompileOptions {

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -436,6 +436,14 @@ impl Config {
         Ok(())
     }
 
+    /// Ignores all values specified in config files, leaving only CLI arguments in place.
+    pub fn ignore_config_files(&mut self) -> CargoResult<()> {
+        self.values.replace(HashMap::default());
+        self.merge_cli_args()?;
+        self.load_unstable_flags_from_config()?;
+        Ok(())
+    }
+
     /// The current working directory.
     pub fn cwd(&self) -> &Path {
         &self.cwd

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1514,7 +1514,7 @@ See [..]
 }
 
 #[cargo_test]
-fn no_config_basic() {
+fn no_config_cli() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -1526,6 +1526,24 @@ fn no_config_basic() {
         )
         .build();
     p.cargo("build -v --no-config -Z unstable-options")
+        .masquerade_as_nightly_cargo()
+        .run();
+}
+
+#[cargo_test]
+fn no_config_env() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+            [build]
+            target = "non-existent"
+        "#,
+        )
+        .build();
+    p.cargo("build -v")
+        .env("CARGO_NO_CONFIG_UNSTABLE", "1")
         .masquerade_as_nightly_cargo()
         .run();
 }


### PR DESCRIPTION
This provides a way to ignore configuration values set in `.cargo/config` files.

This PR implements both an unstable command line flag named `--no-config` and a `CARGO_NO_CONFIG_UNSTABLE` environment variable for this, which can be set to "1". Note that the environment variable does not have a feature gate yet since I wasn't sure how to make an environment variable unstable (hence the the `UNSTABLE` suffix).

Discussed in https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Opt-out.20for.20config.20file.20values/near/212360029