### PR TITLE
Update deprecated GitHub add-path in workflows.

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -15,7 +15,7 @@ jobs:
       run: |
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.3/mdbook-v0.4.3-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        echo ::add-path::`pwd`/mdbook
+        echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Deploy docs
       run: |
         cd src/doc/contrib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
     - run: |
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.3.7/mdbook-v0.3.7-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-        echo ::add-path::`pwd`/mdbook
+        echo `pwd`/mdbook >> $GITHUB_PATH
     - run: cargo doc --no-deps
     - run: cd src/doc && mdbook build --dest-dir ../../target/doc
     - run: |


### PR DESCRIPTION
The old method of using `::` commands is being deprecated, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.
