### PR TITLE
Specify a different target when running unit tests

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -56,7 +56,8 @@ impl BuildConfig {
         mode: CompileMode,
     ) -> CargoResult<BuildConfig> {
         let cfg = config.build_config()?;
-        let requested_kinds = CompileKind::from_requested_targets(config, requested_targets, Some(mode))?;
+        let requested_kinds =
+            CompileKind::from_requested_targets(config, requested_targets, Some(mode))?;
         if jobs == Some(0) {
             anyhow::bail!("jobs must be at least 1")
         }

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -54,11 +54,11 @@ impl BuildConfig {
         requested_targets: &[String],
         mode: CompileMode,
     ) -> CargoResult<BuildConfig> {
-        let cfg = match mode {
-            CompileMode::Test | CompileMode::Bench => config.test_config().or_else(|_| config.build_config())?,
-            _ => config.build_config()?,
-        };
+        println!("requested_targets: {:?}", requested_targets);
+        println!("mode: {:?}", mode);
+        let cfg = config.build_config()?;
         let requested_kinds = CompileKind::from_requested_targets(config, requested_targets)?;
+        println!("request_kinds: {:?}", requested_kinds);
         if jobs == Some(0) {
             anyhow::bail!("jobs must be at least 1")
         }
@@ -71,7 +71,7 @@ impl BuildConfig {
         }
         let jobs = jobs.or(cfg.jobs).unwrap_or(::num_cpus::get() as u32);
 
-        Ok(BuildConfig {
+        let build_config = Ok(BuildConfig {
             requested_kinds,
             jobs,
             requested_profile: InternedString::new("dev"),
@@ -83,7 +83,11 @@ impl BuildConfig {
             primary_unit_rustc: None,
             rustfix_diagnostic_server: RefCell::new(None),
             export_dir: None,
-        })
+        });
+
+        println!("build_config: {:?}", build_config);
+
+        build_config
     }
 
     /// Whether or not the *user* wants JSON output. Whether or not rustc

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -54,7 +54,10 @@ impl BuildConfig {
         requested_targets: &[String],
         mode: CompileMode,
     ) -> CargoResult<BuildConfig> {
-        let cfg = config.build_config()?;
+        let cfg = match mode {
+            CompileMode::Test | CompileMode::Bench => config.test_config().or_else(|_| config.build_config())?,
+            _ => config.build_config()?,
+        };
         let requested_kinds = CompileKind::from_requested_targets(config, requested_targets)?;
         if jobs == Some(0) {
             anyhow::bail!("jobs must be at least 1")

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -45,6 +45,7 @@ impl BuildConfig {
     ///
     /// * `build.jobs`
     /// * `build.target`
+    /// * `build.test-target`
     /// * `target.$target.ar`
     /// * `target.$target.linker`
     /// * `target.$target.libfoo.metadata`
@@ -54,11 +55,8 @@ impl BuildConfig {
         requested_targets: &[String],
         mode: CompileMode,
     ) -> CargoResult<BuildConfig> {
-        println!("requested_targets: {:?}", requested_targets);
-        println!("mode: {:?}", mode);
         let cfg = config.build_config()?;
-        let requested_kinds = CompileKind::from_requested_targets(config, requested_targets)?;
-        println!("request_kinds: {:?}", requested_kinds);
+        let requested_kinds = CompileKind::from_requested_targets(config, requested_targets, Some(mode))?;
         if jobs == Some(0) {
             anyhow::bail!("jobs must be at least 1")
         }
@@ -71,7 +69,7 @@ impl BuildConfig {
         }
         let jobs = jobs.or(cfg.jobs).unwrap_or(::num_cpus::get() as u32);
 
-        let build_config = Ok(BuildConfig {
+        Ok(BuildConfig {
             requested_kinds,
             jobs,
             requested_profile: InternedString::new("dev"),
@@ -83,11 +81,7 @@ impl BuildConfig {
             primary_unit_rustc: None,
             rustfix_diagnostic_server: RefCell::new(None),
             export_dir: None,
-        });
-
-        println!("build_config: {:?}", build_config);
-
-        build_config
+        })
     }
 
     /// Whether or not the *user* wants JSON output. Whether or not rustc

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -50,6 +50,7 @@ impl CompileKind {
         config: &Config,
         targets: &[String],
     ) -> CargoResult<Vec<CompileKind>> {
+        println!("targets: {:?}", targets);
         if targets.len() > 1 && !config.cli_unstable().multitarget {
             bail!("specifying multiple `--target` flags requires `-Zmultitarget`")
         }

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -1,5 +1,5 @@
-use crate::core::Target;
 use crate::core::compiler::CompileMode;
+use crate::core::Target;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::interning::InternedString;
 use crate::util::Config;
@@ -52,8 +52,6 @@ impl CompileKind {
         targets: &[String],
         compile_mode: Option<CompileMode>,
     ) -> CargoResult<Vec<CompileKind>> {
-        println!("compile_mode: {:?}", compile_mode);
-        println!("config: {:?}", config);
         if targets.len() > 1 && !config.cli_unstable().multitarget {
             bail!("specifying multiple `--target` flags requires `-Zmultitarget`")
         }
@@ -68,15 +66,17 @@ impl CompileKind {
                 .into_iter()
                 .collect());
         }
-        
+
         let build_configs = config.build_config()?;
         let target = match compile_mode {
-            Some(CompileMode::Test) => if build_configs.test_target.is_some() {
-                &build_configs.test_target
-            } else {
-                &build_configs.target
-            },
-            _ => &build_configs.target
+            Some(CompileMode::Test) => {
+                if build_configs.test_target.is_some() {
+                    &build_configs.test_target
+                } else {
+                    &build_configs.target
+                }
+            }
+            _ => &build_configs.target,
         };
 
         let kind = match &target {

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -52,6 +52,8 @@ impl CompileKind {
         targets: &[String],
         compile_mode: Option<CompileMode>,
     ) -> CargoResult<Vec<CompileKind>> {
+        println!("compile_mode: {:?}", compile_mode);
+        println!("config: {:?}", config);
         if targets.len() > 1 && !config.cli_unstable().multitarget {
             bail!("specifying multiple `--target` flags requires `-Zmultitarget`")
         }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -54,7 +54,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     }
 
     // Clean specific packages.
-    let requested_kinds = CompileKind::from_requested_targets(config, &opts.targets)?;
+    let requested_kinds = CompileKind::from_requested_targets(config, &opts.targets, None)?;
     let target_data = RustcTargetData::new(ws, &requested_kinds)?;
     let (pkg_set, resolve) = ops::resolve_ws(ws)?;
     let prof_dir_name = profiles.get_dir_name();

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -109,7 +109,7 @@ fn build_resolve_graph(
     // TODO: Without --filter-platform, features are being resolved for `host` only.
     // How should this work?
     let requested_kinds =
-        CompileKind::from_requested_targets(ws.config(), &metadata_opts.filter_platforms)?;
+        CompileKind::from_requested_targets(ws.config(), &metadata_opts.filter_platforms, None)?;
     let target_data = RustcTargetData::new(ws, &requested_kinds)?;
     // Resolve entire workspace.
     let specs = Packages::All.to_package_id_specs(ws)?;

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -133,7 +133,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     };
     // TODO: Target::All is broken with -Zfeatures=itarget. To handle that properly,
     // `FeatureResolver` will need to be taught what "all" means.
-    let requested_kinds = CompileKind::from_requested_targets(ws.config(), &requested_targets)?;
+    let requested_kinds = CompileKind::from_requested_targets(ws.config(), &requested_targets, None)?;
     let target_data = RustcTargetData::new(ws, &requested_kinds)?;
     let specs = opts.packages.to_package_id_specs(ws)?;
     let resolve_opts = ResolveOpts::new(

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -133,7 +133,8 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     };
     // TODO: Target::All is broken with -Zfeatures=itarget. To handle that properly,
     // `FeatureResolver` will need to be taught what "all" means.
-    let requested_kinds = CompileKind::from_requested_targets(ws.config(), &requested_targets, None)?;
+    let requested_kinds =
+        CompileKind::from_requested_targets(ws.config(), &requested_targets, None)?;
     let target_data = RustcTargetData::new(ws, &requested_kinds)?;
     let specs = opts.packages.to_package_id_specs(ws)?;
     let resolve_opts = ResolveOpts::new(

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -174,7 +174,6 @@ pub struct Config {
     http_config: LazyCell<CargoHttpConfig>,
     net_config: LazyCell<CargoNetConfig>,
     build_config: LazyCell<CargoBuildConfig>,
-    test_config: LazyCell<CargoTestConfig>,
     target_cfgs: LazyCell<Vec<(String, TargetCfgConfig)>>,
     doc_extern_map: LazyCell<RustdocExternMap>,
 }
@@ -246,7 +245,6 @@ impl Config {
             http_config: LazyCell::new(),
             net_config: LazyCell::new(),
             build_config: LazyCell::new(),
-            test_config: LazyCell::new(),
             target_cfgs: LazyCell::new(),
             doc_extern_map: LazyCell::new(),
         }
@@ -1194,11 +1192,6 @@ impl Config {
             .try_borrow_with(|| Ok(self.get::<CargoBuildConfig>("build")?))
     }
 
-    pub fn test_config(&self) -> CargoResult<&CargoTestConfig> {
-        self.test_config
-            .try_borrow_with(|| Ok(self.get::<CargoTestConfig>("test")?))
-    }
-
     /// Returns a list of [target.'cfg()'] tables.
     ///
     /// The list is sorted by the table name.
@@ -1784,8 +1777,6 @@ pub struct CargoBuildConfig {
     pub rustdoc: Option<PathBuf>,
     pub out_dir: Option<ConfigRelativePath>,
 }
-
-type CargoTestConfig = CargoBuildConfig;
 
 /// A type to deserialize a list of strings from a toml file.
 ///

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -174,6 +174,7 @@ pub struct Config {
     http_config: LazyCell<CargoHttpConfig>,
     net_config: LazyCell<CargoNetConfig>,
     build_config: LazyCell<CargoBuildConfig>,
+    test_config: LazyCell<CargoTestConfig>,
     target_cfgs: LazyCell<Vec<(String, TargetCfgConfig)>>,
     doc_extern_map: LazyCell<RustdocExternMap>,
 }
@@ -245,6 +246,7 @@ impl Config {
             http_config: LazyCell::new(),
             net_config: LazyCell::new(),
             build_config: LazyCell::new(),
+            test_config: LazyCell::new(),
             target_cfgs: LazyCell::new(),
             doc_extern_map: LazyCell::new(),
         }
@@ -1192,6 +1194,11 @@ impl Config {
             .try_borrow_with(|| Ok(self.get::<CargoBuildConfig>("build")?))
     }
 
+    pub fn test_config(&self) -> CargoResult<&CargoTestConfig> {
+        self.test_config
+            .try_borrow_with(|| Ok(self.get::<CargoTestConfig>("test")?))
+    }
+
     /// Returns a list of [target.'cfg()'] tables.
     ///
     /// The list is sorted by the table name.
@@ -1777,6 +1784,8 @@ pub struct CargoBuildConfig {
     pub rustdoc: Option<PathBuf>,
     pub out_dir: Option<ConfigRelativePath>,
 }
+
+type CargoTestConfig = CargoBuildConfig;
 
 /// A type to deserialize a list of strings from a toml file.
 ///

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1768,6 +1768,7 @@ pub struct CargoBuildConfig {
     pub target_dir: Option<ConfigRelativePath>,
     pub incremental: Option<bool>,
     pub target: Option<ConfigRelativePath>,
+    pub test_target: Option<ConfigRelativePath>,
     pub jobs: Option<u32>,
     pub rustflags: Option<StringList>,
     pub rustdocflags: Option<StringList>,

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -52,7 +52,10 @@ t = "test"
 r = "run"
 rr = "run --release"
 space_example = ["run", "--release", "--", "\"command list\""]
+```
 
+You can specify `[build]` and/or `[test]` configurations.
+```toml
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs
 rustc = "rustc"           # the rust compiler tool
@@ -78,7 +81,11 @@ rustdocflags = ["…", "…"] # custom flags to pass to rustdoc
 incremental = true        # whether or not to enable incremental compilation
 dep-info-basedir = "…"    # path for the base directory for targets in depfiles
 pipelining = true         # rustc pipelining
+```
+> **Note:** If `cargo test` is invoked, and no `[test]` configuration is specified, 
+> the `[build]` configuation will be used if specified.
 
+```toml
 [cargo-new]
 name = "Your Name"        # name to use in `authors` field
 email = "you@example.com" # email address to use in `authors` field

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -66,6 +66,19 @@ incremental = true        # whether or not to enable incremental compilation
 dep-info-basedir = "…"    # path for the base directory for targets in depfiles
 pipelining = true         # rustc pipelining
 
+[test]
+jobs = 1                  # number of parallel jobs, defaults to # of CPUs
+rustc = "rustc"           # the rust compiler tool
+rustc-wrapper = "…"       # run this wrapper instead of `rustc`
+rustdoc = "rustdoc"       # the doc generator tool
+target = "triple"         # build for the target triple (ignored by `cargo install`)
+target-dir = "target"     # path of where to place all generated artifacts
+rustflags = ["…", "…"]    # custom flags to pass to all compiler invocations
+rustdocflags = ["…", "…"] # custom flags to pass to rustdoc
+incremental = true        # whether or not to enable incremental compilation
+dep-info-basedir = "…"    # path for the base directory for targets in depfiles
+pipelining = true         # rustc pipelining
+
 [cargo-new]
 name = "Your Name"        # name to use in `authors` field
 email = "you@example.com" # email address to use in `authors` field

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -52,16 +52,14 @@ t = "test"
 r = "run"
 rr = "run --release"
 space_example = ["run", "--release", "--", "\"command list\""]
-```
 
-You can specify `[build]` and/or `[test]` configurations.
-```toml
 [build]
 jobs = 1                  # number of parallel jobs, defaults to # of CPUs
 rustc = "rustc"           # the rust compiler tool
 rustc-wrapper = "…"       # run this wrapper instead of `rustc`
 rustdoc = "rustdoc"       # the doc generator tool
-target = "triple"         # build for the target triple (ignored by `cargo install`)
+target = "triple"         # default build for the target triple (ignored by `cargo install`)
+test-target = "triple"    # build target triple when `cargo test` is invoked (overrides `build.target` option)
 target-dir = "target"     # path of where to place all generated artifacts
 rustflags = ["…", "…"]    # custom flags to pass to all compiler invocations
 rustdocflags = ["…", "…"] # custom flags to pass to rustdoc
@@ -69,23 +67,6 @@ incremental = true        # whether or not to enable incremental compilation
 dep-info-basedir = "…"    # path for the base directory for targets in depfiles
 pipelining = true         # rustc pipelining
 
-[test]
-jobs = 1                  # number of parallel jobs, defaults to # of CPUs
-rustc = "rustc"           # the rust compiler tool
-rustc-wrapper = "…"       # run this wrapper instead of `rustc`
-rustdoc = "rustdoc"       # the doc generator tool
-target = "triple"         # build for the target triple (ignored by `cargo install`)
-target-dir = "target"     # path of where to place all generated artifacts
-rustflags = ["…", "…"]    # custom flags to pass to all compiler invocations
-rustdocflags = ["…", "…"] # custom flags to pass to rustdoc
-incremental = true        # whether or not to enable incremental compilation
-dep-info-basedir = "…"    # path for the base directory for targets in depfiles
-pipelining = true         # rustc pipelining
-```
-> **Note:** If `cargo test` is invoked, and no `[test]` configuration is specified, 
-> the `[build]` configuation will be used if specified.
-
-```toml
 [cargo-new]
 name = "Your Name"        # name to use in `authors` field
 email = "you@example.com" # email address to use in `authors` field

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -168,7 +168,7 @@ fn simple_cross_test_config() {
         .build();
 
     p.cargo("build -v").run();
-    
+
     if cross_compile::can_run_on_host() {
         p.cargo("test").run();
     }

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -170,7 +170,7 @@ fn simple_cross_test_config() {
         .build();
 
     let target = cross_compile::alternate();
-    p.cargo("build -v").run();
+    p.cargo("build --tests -v").run();
     assert!(p.target_bin(target, "foo").is_file());
 
     if cross_compile::can_run_on_host() {

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -168,8 +168,10 @@ fn simple_cross_test_config() {
         .build();
 
     p.cargo("build -v").run();
-
-    p.cargo("test").run();
+    
+    if cross_compile::can_run_on_host() {
+        p.cargo("test").run();
+    }
 }
 
 #[cargo_test]


### PR DESCRIPTION
When working with bare metal embedded systems, it would be nice to be able to run unit tests on your host machine using `cargo test` and then deploy to the target device using `cargo run`. Currently, to build different targets between tests and regular builds, your only option is to explicitly use the `--target` flag when invoking cargo.

The purpose of this pull request is have different targets between `cargo build` and `cargo test`  without the need for the `--target` flag.

This was achieved by changing the `.cargo/config.toml` options.

Closes #6784