### PR TITLE
cargo-tree: mention special target `all` in CLI help text

### DIFF
--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -26,7 +26,8 @@ pub fn cli() -> App {
         )
         .arg_features()
         .arg_target_triple(
-            "Filter dependencies matching the given target-triple (default host platform)",
+            "Filter dependencies matching the given target-triple (default host platform). \
+            Pass `all` to include all targets.",
         )
         .arg(
             Arg::with_name("no-dev-dependencies")


### PR DESCRIPTION
Fixes #8567

Actually, `cargo help tree` has already got a [description about `--target=all`](https://github.com/rust-lang/cargo/blob/3045228ee139f970ccc892aa5c34c0f3cb70ee06/src/doc/man/cargo-tree.md#tree-options) in tree options:

```console
$ cargo help tree
...
OPTIONS
   Tree Options
        ...
       --target triple
           Filter dependencies matching the given target-triple. The default is the host platform. Use the value all to include all targets.
...
