### PR TITLE
Document RUSTFMT environment variable

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -49,7 +49,8 @@ system:
 * `TERM` — If this is set to `dumb`, it disables the progress bar.
 * `BROWSER` — The web browser to execute to open documentation with [`cargo
   doc`]'s' `--open` flag.
-* `RUSTFMT` — Instead of running `rustfmt`, Cargo will execute this specified
+* `RUSTFMT` — Instead of running `rustfmt`, 
+  [`cargo fmt`](https://github.com/rust-lang/rustfmt) will execute this specified
   `rustfmt` instance instead.
 
 #### Configuration environment variables

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -49,6 +49,8 @@ system:
 * `TERM` — If this is set to `dumb`, it disables the progress bar.
 * `BROWSER` — The web browser to execute to open documentation with [`cargo
   doc`]'s' `--open` flag.
+* `RUSTFMT` — Instead of running `rustfmt`, Cargo will execute this specified
+  `rustfmt` instance instead.
 
 #### Configuration environment variables
 


### PR DESCRIPTION
This PR documents the `RUSTFMT` enviorment variable, as specified in [rust-lang/rustfmt/4426](https://github.com/rust-lang/rustfmt/issues/4426) and [rust-lang/rustfmt/4419](https://github.com/rust-lang/rustfmt/pull/4419).