### PR TITLE
Fix man page links inside `option` blocks.

### DIFF
--- a/ci/validate-man.sh
+++ b/ci/validate-man.sh
@@ -5,7 +5,7 @@ set -e
 
 cd src/doc
 
-changes=$(git status --porcelain .)
+changes=$(git status --porcelain)
 if [ -n "$changes" ]
 then
     echo "git directory must be clean before running this script."
@@ -14,7 +14,7 @@ fi
 
 ./build-man.sh
 
-changes=$(git status --porcelain .)
+changes=$(git status --porcelain)
 if [ -n "$changes" ]
 then
     echo "Detected changes in man pages:"

--- a/crates/mdman/src/format/md.rs
+++ b/crates/mdman/src/format/md.rs
@@ -4,22 +4,20 @@ use crate::util::unwrap;
 use crate::ManMap;
 use anyhow::{bail, format_err, Error};
 use std::fmt::Write;
-use url::Url;
 
 pub struct MdFormatter {
-    url: Option<Url>,
     man_map: ManMap,
 }
 
 impl MdFormatter {
-    pub fn new(url: Option<Url>, man_map: ManMap) -> MdFormatter {
-        MdFormatter { url, man_map }
+    pub fn new(man_map: ManMap) -> MdFormatter {
+        MdFormatter { man_map }
     }
 }
 
 impl MdFormatter {
     fn render_html(&self, input: &str) -> Result<String, Error> {
-        let parser = crate::md_parser(input, self.url.clone());
+        let parser = crate::md_parser(input, None);
         let mut html_output: String = String::with_capacity(input.len() * 3 / 2);
         pulldown_cmark::html::push_html(&mut html_output, parser.map(|(e, _r)| e));
         Ok(html_output)
@@ -78,7 +76,7 @@ impl super::Formatter for MdFormatter {
     fn linkify_man_to_md(&self, name: &str, section: u8) -> Result<String, Error> {
         let s = match self.man_map.get(&(name.to_string(), section)) {
             Some(link) => format!("[{}({})]({})", name, section, link),
-            None => format!("[{}({})]({}.md)", name, section, name),
+            None => format!("[{}({})]({}.html)", name, section, name),
         };
         Ok(s)
     }

--- a/crates/mdman/src/lib.rs
+++ b/crates/mdman/src/lib.rs
@@ -50,7 +50,7 @@ pub fn convert(
 ) -> Result<String, Error> {
     let formatter: Box<dyn Formatter + Send + Sync> = match format {
         Format::Man => Box::new(format::man::ManFormatter::new(url)),
-        Format::Md => Box::new(format::md::MdFormatter::new(url, man_map)),
+        Format::Md => Box::new(format::md::MdFormatter::new(man_map)),
         Format::Text => Box::new(format::text::TextFormatter::new(url)),
     };
     let expanded = hbs::expand(file, &*formatter)?;

--- a/crates/mdman/tests/compare/expected/links.1
+++ b/crates/mdman/tests/compare/expected/links.1
@@ -29,3 +29,17 @@ Shortcut unknown: [shortcut unknown]
 \fBother\-cmd\fR(1)
 .sp
 \fBlocal\-cmd\fR(1)
+.sp
+\fISome link\fR <https://example.org/foo.html>
+.sp
+\fB\-\-include\fR
+.RS 4
+Testing an \fIincluded link\fR <https://example.org/included_link.html>\&.
+.RE
+.SH "OPTIONS"
+.sp
+\fB\-\-foo\-bar\fR
+.RS 4
+Example \fIlink\fR <https://example.org/bar.html>\&.
+See \fBother\-cmd\fR(1), \fBlocal\-cmd\fR(1)
+.RE

--- a/crates/mdman/tests/compare/expected/links.md
+++ b/crates/mdman/tests/compare/expected/links.md
@@ -28,7 +28,28 @@ Shortcut unknown: [shortcut unknown]
 
 [other-cmd(1)](https://example.org/commands/other-cmd.html)
 
-[local-cmd(1)](local-cmd.md)
+[local-cmd(1)](local-cmd.html)
+
+[Some link](foo.html)
+
+<dl>
+<dt class="option-term" id="option-links---include"><a class="option-anchor" href="#option-links---include"></a><code>--include</code></dt>
+<dd class="option-desc">Testing an <a href="included_link.html">included link</a>.</dd>
+
+</dl>
+
+
+## OPTIONS
+
+<dl>
+
+<dt class="option-term" id="option-links---foo-bar"><a class="option-anchor" href="#option-links---foo-bar"></a><code>--foo-bar</code></dt>
+<dd class="option-desc">Example <a href="bar.html">link</a>.
+See <a href="https://example.org/commands/other-cmd.html">other-cmd(1)</a>, <a href="local-cmd.html">local-cmd(1)</a></dd>
+
+
+</dl>
+
 
 [bar]: https://example.com/bar
 [collapsed]: https://example.com/collapsed

--- a/crates/mdman/tests/compare/expected/links.txt
+++ b/crates/mdman/tests/compare/expected/links.txt
@@ -28,3 +28,13 @@ DESCRIPTION
 
        local-cmd(1)
 
+       Some link <https://example.org/foo.html>
+
+       --include
+           Testing an included link <https://example.org/included_link.html>.
+
+OPTIONS
+       --foo-bar
+           Example link <https://example.org/bar.html>. See other-cmd(1),
+           local-cmd(1)
+

--- a/crates/mdman/tests/compare/expected/options.md
+++ b/crates/mdman/tests/compare/expected/options.md
@@ -74,4 +74,4 @@ A description of the command.
        my-command --xyz
 
 ## SEE ALSO
-[other-command(1)](other-command.md) [abc(7)](abc.md)
+[other-command(1)](other-command.html) [abc(7)](abc.html)

--- a/crates/mdman/tests/compare/includes/links-include.md
+++ b/crates/mdman/tests/compare/includes/links-include.md
@@ -1,0 +1,7 @@
+[Some link](foo.html)
+
+{{#options}}
+{{#option "`--include`"}}
+Testing an [included link](included_link.html).
+{{/option}}
+{{/options}}

--- a/crates/mdman/tests/compare/links.md
+++ b/crates/mdman/tests/compare/links.md
@@ -30,6 +30,20 @@ Shortcut unknown: [shortcut unknown]
 
 {{man "local-cmd" 1}}
 
+{{> links-include}}
+
+## OPTIONS
+
+{{#options}}
+
+{{#option "`--foo-bar`"}}
+Example [link](bar.html).
+See {{man "other-cmd" 1}}, {{man "local-cmd" 1}}
+{{/option}}
+
+{{/options}}
+
+
 [bar]: https://example.com/bar
 [collapsed]: https://example.com/collapsed
 [shortcut]: https://example.com/shortcut

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -57,7 +57,7 @@ config files](../reference/config.html). If not specified, and there is a
 [`package.publish`](../reference/manifest.html#the-publish-field) field in
 `Cargo.toml` with a single registry, then it will publish to that registry.
 Otherwise it will use the default registry, which is defined by the
-[`registry.default`](../reference/config.html#registry-default) config key
+[`registry.default`](../reference/config.html#registrydefault) config key
 which defaults to `crates-io`.
 {{/option}}
 

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -64,7 +64,7 @@ OPTIONS
            field in Cargo.toml with a single registry, then it will publish to
            that registry. Otherwise it will use the default registry, which is
            defined by the registry.default
-           <https://doc.rust-lang.org/cargo/reference/config.html#registry-default>
+           <https://doc.rust-lang.org/cargo/reference/config.html#registrydefault>
            config key which defaults to crates-io.
 
    Compilation Options

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -80,7 +80,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-bench--p"><a class="option-anchor" href="#option-cargo-bench--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-bench---package"><a class="option-anchor" href="#option-cargo-bench---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Benchmark only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Benchmark only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -224,10 +224,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -239,7 +239,7 @@ target artifacts are placed in a separate directory. See the
 <dt class="option-term" id="option-cargo-bench---target-dir"><a class="option-anchor" href="#option-cargo-bench---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -260,7 +260,7 @@ passing `--nocapture` to the benchmark binaries:
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench--q"><a class="option-anchor" href="#option-cargo-bench--q"></a><code>-q</code></dt>
@@ -277,7 +277,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -288,7 +288,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -333,9 +333,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -374,7 +374,7 @@ Rust test harness runs benchmarks serially in a single thread.
 <dt class="option-term" id="option-cargo-bench--j"><a class="option-anchor" href="#option-cargo-bench--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-bench---jobs"><a class="option-anchor" href="#option-cargo-bench---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -393,7 +393,7 @@ are built with the `release` profiles when linked to binaries and benchmarks.
 Dependencies use the `release` profile.
 
 If you need a debug build of a benchmark, try building it with
-[cargo-build(1)](cargo-build.md) which will use the `test` profile which is by default
+[cargo-build(1)](cargo-build.html) which will use the `test` profile which is by default
 unoptimized and includes debug information. You can then run the debug-enabled
 benchmark manually.
 
@@ -420,4 +420,4 @@ details on environment variables that Cargo reads.
        cargo bench --bench bench_name -- modname::some_benchmark
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-test(1)](cargo-test.md)
+[cargo(1)](cargo.html), [cargo-test(1)](cargo-test.html)

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -32,7 +32,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-build--p"><a class="option-anchor" href="#option-cargo-build--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-build---package"><a class="option-anchor" href="#option-cargo-build---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Build only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Build only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -163,10 +163,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -185,7 +185,7 @@ selection.</dd>
 <dt class="option-term" id="option-cargo-build---target-dir"><a class="option-anchor" href="#option-cargo-build---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -208,7 +208,7 @@ See https://github.com/rust-lang/cargo/issues/6790 for more information.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-build--q"><a class="option-anchor" href="#option-cargo-build--q"></a><code>-q</code></dt>
@@ -225,7 +225,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -236,7 +236,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -289,9 +289,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -326,7 +326,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-build--j"><a class="option-anchor" href="#option-cargo-build--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-build---jobs"><a class="option-anchor" href="#option-cargo-build---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -373,4 +373,4 @@ details on environment variables that Cargo reads.
        cargo build --release
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-rustc(1)](cargo-rustc.md)
+[cargo(1)](cargo.html), [cargo-rustc(1)](cargo-rustc.html)

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -37,7 +37,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-check--p"><a class="option-anchor" href="#option-cargo-check--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-check---package"><a class="option-anchor" href="#option-cargo-check---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Check only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Check only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -168,10 +168,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -199,7 +199,7 @@ used.</dd>
 <dt class="option-term" id="option-cargo-check---target-dir"><a class="option-anchor" href="#option-cargo-check---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -213,7 +213,7 @@ to <code>target</code> in the root of the workspace.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-check--q"><a class="option-anchor" href="#option-cargo-check--q"></a><code>-q</code></dt>
@@ -230,7 +230,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -241,7 +241,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -285,9 +285,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -322,7 +322,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-check--j"><a class="option-anchor" href="#option-cargo-check--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-check---jobs"><a class="option-anchor" href="#option-cargo-check---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -369,4 +369,4 @@ details on environment variables that Cargo reads.
        cargo check --all-targets --profile=test
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-build(1)](cargo-build.md)
+[cargo(1)](cargo.html), [cargo-build(1)](cargo-build.html)

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -27,7 +27,7 @@ workspace are cleaned.
 <dt class="option-term" id="option-cargo-clean--p"><a class="option-anchor" href="#option-cargo-clean--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-clean---package"><a class="option-anchor" href="#option-cargo-clean---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Clean only the specified packages. This flag may be specified
-multiple times. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the SPEC format.</dd>
+multiple times. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC format.</dd>
 
 </dl>
 
@@ -47,7 +47,7 @@ the target directory.</dd>
 <dt class="option-term" id="option-cargo-clean---target-dir"><a class="option-anchor" href="#option-cargo-clean---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -58,10 +58,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -75,7 +75,7 @@ target artifacts are placed in a separate directory. See the
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-clean--q"><a class="option-anchor" href="#option-cargo-clean--q"></a><code>-q</code></dt>
@@ -92,7 +92,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -125,9 +125,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -179,4 +179,4 @@ details on environment variables that Cargo reads.
        cargo clean --release
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-build(1)](cargo-build.md)
+[cargo(1)](cargo.html), [cargo-build(1)](cargo-build.html)

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -52,7 +52,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-doc--p"><a class="option-anchor" href="#option-cargo-doc--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-doc---package"><a class="option-anchor" href="#option-cargo-doc---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Document only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Document only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -141,10 +141,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -163,7 +163,7 @@ selection.</dd>
 <dt class="option-term" id="option-cargo-doc---target-dir"><a class="option-anchor" href="#option-cargo-doc---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -177,7 +177,7 @@ to <code>target</code> in the root of the workspace.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-doc--q"><a class="option-anchor" href="#option-cargo-doc--q"></a><code>-q</code></dt>
@@ -194,7 +194,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -205,7 +205,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -249,9 +249,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -286,7 +286,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-doc--j"><a class="option-anchor" href="#option-cargo-doc--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-doc---jobs"><a class="option-anchor" href="#option-cargo-doc---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -330,4 +330,4 @@ details on environment variables that Cargo reads.
        cargo doc
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-rustdoc(1)](cargo-rustdoc.md), [rustdoc(1)](https://doc.rust-lang.org/rustdoc/index.html)
+[cargo(1)](cargo.html), [cargo-rustdoc(1)](cargo-rustdoc.html), [rustdoc(1)](https://doc.rust-lang.org/rustdoc/index.html)

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -36,10 +36,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 </dl>
@@ -52,7 +52,7 @@ target artifacts are placed in a separate directory. See the
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-fetch--q"><a class="option-anchor" href="#option-cargo-fetch--q"></a><code>-q</code></dt>
@@ -69,7 +69,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -102,9 +102,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -152,4 +152,4 @@ details on environment variables that Cargo reads.
        cargo fetch
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-update(1)](cargo-update.md), [cargo-generate-lockfile(1)](cargo-generate-lockfile.md)
+[cargo(1)](cargo.html), [cargo-update(1)](cargo-update.html), [cargo-generate-lockfile(1)](cargo-generate-lockfile.html)

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -18,7 +18,7 @@ The `cargo fix` subcommand is also being developed for the Rust 2018 edition
 to provide code the ability to easily opt-in to the new edition without having
 to worry about any breakage.
 
-Executing `cargo fix` will under the hood execute [cargo-check(1)](cargo-check.md). Any warnings
+Executing `cargo fix` will under the hood execute [cargo-check(1)](cargo-check.html). Any warnings
 applicable to your crate will be automatically fixed (if possible) and all
 remaining warnings will be displayed when the check process is finished. For
 example if you'd like to prepare for the 2018 edition, you can do so by
@@ -97,7 +97,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-fix--p"><a class="option-anchor" href="#option-cargo-fix--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-fix---package"><a class="option-anchor" href="#option-cargo-fix---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Fix only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Fix only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -228,10 +228,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -259,7 +259,7 @@ used.</dd>
 <dt class="option-term" id="option-cargo-fix---target-dir"><a class="option-anchor" href="#option-cargo-fix---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -273,7 +273,7 @@ to <code>target</code> in the root of the workspace.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix--q"><a class="option-anchor" href="#option-cargo-fix--q"></a><code>-q</code></dt>
@@ -290,7 +290,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -301,7 +301,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -345,9 +345,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -382,7 +382,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-fix--j"><a class="option-anchor" href="#option-cargo-fix--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-fix---jobs"><a class="option-anchor" href="#option-cargo-fix---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -433,4 +433,4 @@ details on environment variables that Cargo reads.
        cargo fix --edition-idioms
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-check(1)](cargo-check.md)
+[cargo(1)](cargo.html), [cargo-check(1)](cargo-check.html)

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -14,7 +14,7 @@ This command will create the `Cargo.lock` lockfile for the current package or
 workspace. If the lockfile already exists, it will be rebuilt with the latest
 available version of every package.
 
-See also [cargo-update(1)](cargo-update.md) which is also capable of creating a `Cargo.lock`
+See also [cargo-update(1)](cargo-update.html) which is also capable of creating a `Cargo.lock`
 lockfile and has more options for controlling update behavior.
 
 ## OPTIONS
@@ -27,7 +27,7 @@ lockfile and has more options for controlling update behavior.
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-generate-lockfile--q"><a class="option-anchor" href="#option-cargo-generate-lockfile--q"></a><code>-q</code></dt>
@@ -44,7 +44,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -77,9 +77,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -127,4 +127,4 @@ details on environment variables that Cargo reads.
        cargo generate-lockfile
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-update(1)](cargo-update.md)
+[cargo(1)](cargo.html), [cargo-update(1)](cargo-update.html)

--- a/src/doc/src/commands/cargo-help.md
+++ b/src/doc/src/commands/cargo-help.md
@@ -23,4 +23,4 @@ Prints a help message for the given command.
        cargo build --help
 
 ## SEE ALSO
-[cargo(1)](cargo.md)
+[cargo(1)](cargo.html)

--- a/src/doc/src/commands/cargo-init.md
+++ b/src/doc/src/commands/cargo-init.md
@@ -46,7 +46,7 @@ See [the reference](../reference/config.html) for more information about
 configuration files.
 
 
-See [cargo-new(1)](cargo-new.md) for a similar command which will create a new package in
+See [cargo-new(1)](cargo-new.html) for a similar command which will create a new package in
 a new directory.
 
 ## OPTIONS
@@ -83,7 +83,7 @@ hg, pijul, or fossil) or do not initialize any version control at all
 <dt class="option-term" id="option-cargo-init---registry"><a class="option-anchor" href="#option-cargo-init---registry"></a><code>--registry</code> <em>registry</em></dt>
 <dd class="option-desc">This sets the <code>publish</code> field in <code>Cargo.toml</code> to the given registry name
 which will restrict publishing only to that registry.</p>
-<p>Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config files</a>.
+<p>Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry defined by the <code>registry.default</code>
 config key is used. If the default registry is not set and <code>--registry</code> is not
 used, the <code>publish</code> field will not be set which means that publishing will not
@@ -101,7 +101,7 @@ be restricted.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-init--q"><a class="option-anchor" href="#option-cargo-init--q"></a><code>-q</code></dt>
@@ -118,7 +118,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -166,4 +166,4 @@ details on environment variables that Cargo reads.
        cargo init
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-new(1)](cargo-new.md)
+[cargo(1)](cargo.html), [cargo-new(1)](cargo-new.html)

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -83,7 +83,7 @@ available.
 
 <dt class="option-term" id="option-cargo-install---vers"><a class="option-anchor" href="#option-cargo-install---vers"></a><code>--vers</code> <em>version</em></dt>
 <dt class="option-term" id="option-cargo-install---version"><a class="option-anchor" href="#option-cargo-install---version"></a><code>--version</code> <em>version</em></dt>
-<dd class="option-desc">Specify a version to install. This may be a <a href="https://doc.rust-lang.org/cargo/reference/specifying-dependencies.md">version
+<dd class="option-desc">Specify a version to install. This may be a <a href="../reference/specifying-dependencies.md">version
 requirement</a>, like <code>~1.2</code>, to have Cargo
 select the newest version from the given requirement. If the version does not
 have a requirement operator (such as <code>^</code> or <code>~</code>), then it must be in the form
@@ -153,7 +153,7 @@ same time.</dd>
 
 
 <dt class="option-term" id="option-cargo-install---registry"><a class="option-anchor" href="#option-cargo-install---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config
+<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config
 files</a>. If not specified, the default registry is used,
 which is defined by the <code>registry.default</code> config key which defaults to
 <code>crates-io</code>.</dd>
@@ -208,17 +208,17 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
 <dt class="option-term" id="option-cargo-install---target-dir"><a class="option-anchor" href="#option-cargo-install---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -251,9 +251,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -264,7 +264,7 @@ offline.</p>
 <dt class="option-term" id="option-cargo-install--j"><a class="option-anchor" href="#option-cargo-install--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-install---jobs"><a class="option-anchor" href="#option-cargo-install---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -278,7 +278,7 @@ the number of CPUs.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-install--q"><a class="option-anchor" href="#option-cargo-install--q"></a><code>-q</code></dt>
@@ -295,7 +295,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -351,4 +351,4 @@ details on environment variables that Cargo reads.
        cargo install --list
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-uninstall(1)](cargo-uninstall.md), [cargo-search(1)](cargo-search.md), [cargo-publish(1)](cargo-publish.md)
+[cargo(1)](cargo.html), [cargo-uninstall(1)](cargo-uninstall.html), [cargo-search(1)](cargo-search.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo-locate-project.md
+++ b/src/doc/src/commands/cargo-locate-project.md
@@ -41,7 +41,7 @@ workspace member.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-locate-project--q"><a class="option-anchor" href="#option-cargo-locate-project--q"></a><code>-q</code></dt>
@@ -58,7 +58,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -116,4 +116,4 @@ details on environment variables that Cargo reads.
        cargo locate-project
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-metadata(1)](cargo-metadata.md)
+[cargo(1)](cargo.html), [cargo-metadata(1)](cargo-metadata.html)

--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -11,7 +11,7 @@ cargo-login - Save an API token from the registry locally
 ## DESCRIPTION
 
 This command will save the API token to disk so that commands that require
-authentication, such as [cargo-publish(1)](cargo-publish.md), will be automatically
+authentication, such as [cargo-publish(1)](cargo-publish.html), will be automatically
 authenticated. The token is saved in `$CARGO_HOME/credentials.toml`. `CARGO_HOME`
 defaults to `.cargo` in your home directory.
 
@@ -27,7 +27,7 @@ Take care to keep the token secret, it should not be shared with anyone else.
 
 <dl>
 <dt class="option-term" id="option-cargo-login---registry"><a class="option-anchor" href="#option-cargo-login---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config
+<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config
 files</a>. If not specified, the default registry is used,
 which is defined by the <code>registry.default</code> config key which defaults to
 <code>crates-io</code>.</dd>
@@ -43,7 +43,7 @@ which is defined by the <code>registry.default</code> config key which defaults 
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-login--q"><a class="option-anchor" href="#option-cargo-login--q"></a><code>-q</code></dt>
@@ -60,7 +60,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -108,4 +108,4 @@ details on environment variables that Cargo reads.
        cargo login
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-publish(1)](cargo-publish.md)
+[cargo(1)](cargo.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -348,7 +348,7 @@ specified multiple times, which enables all specified features.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-metadata--q"><a class="option-anchor" href="#option-cargo-metadata--q"></a><code>-q</code></dt>
@@ -365,7 +365,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -398,9 +398,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -448,4 +448,4 @@ details on environment variables that Cargo reads.
        cargo metadata --format-version=1
 
 ## SEE ALSO
-[cargo(1)](cargo.md)
+[cargo(1)](cargo.html)

--- a/src/doc/src/commands/cargo-new.md
+++ b/src/doc/src/commands/cargo-new.md
@@ -41,7 +41,7 @@ See [the reference](../reference/config.html) for more information about
 configuration files.
 
 
-See [cargo-init(1)](cargo-init.md) for a similar command which will create a new manifest
+See [cargo-init(1)](cargo-init.html) for a similar command which will create a new manifest
 in an existing directory.
 
 ## OPTIONS
@@ -78,7 +78,7 @@ hg, pijul, or fossil) or do not initialize any version control at all
 <dt class="option-term" id="option-cargo-new---registry"><a class="option-anchor" href="#option-cargo-new---registry"></a><code>--registry</code> <em>registry</em></dt>
 <dd class="option-desc">This sets the <code>publish</code> field in <code>Cargo.toml</code> to the given registry name
 which will restrict publishing only to that registry.</p>
-<p>Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config files</a>.
+<p>Registry names are defined in <a href="../reference/config.html">Cargo config files</a>.
 If not specified, the default registry defined by the <code>registry.default</code>
 config key is used. If the default registry is not set and <code>--registry</code> is not
 used, the <code>publish</code> field will not be set which means that publishing will not
@@ -96,7 +96,7 @@ be restricted.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-new--q"><a class="option-anchor" href="#option-cargo-new--q"></a><code>-q</code></dt>
@@ -113,7 +113,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -161,4 +161,4 @@ details on environment variables that Cargo reads.
        cargo new foo
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-init(1)](cargo-init.md)
+[cargo(1)](cargo.html), [cargo-init(1)](cargo-init.html)

--- a/src/doc/src/commands/cargo-owner.md
+++ b/src/doc/src/commands/cargo-owner.md
@@ -17,7 +17,7 @@ crate can upload new versions and yank old versions. Non-team owners can also
 modify the set of owners, so take care!
 
 This command requires you to be authenticated with either the `--token` option
-or using [cargo-login(1)](cargo-login.md).
+or using [cargo-login(1)](cargo-login.html).
 
 If the crate name is not specified, it will use the package name from the
 current directory.
@@ -48,8 +48,8 @@ information about owners and publishing.
 
 <dt class="option-term" id="option-cargo-owner---token"><a class="option-anchor" href="#option-cargo-owner---token"></a><code>--token</code> <em>token</em></dt>
 <dd class="option-desc">API token to use when authenticating. This overrides the token stored in
-the credentials file (which is created by <a href="https://doc.rust-lang.org/cargo/commands/cargo-login.md">cargo-login(1)</a>).</p>
-<p><a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config</a> environment variables can be
+the credentials file (which is created by <a href="cargo-login.html">cargo-login(1)</a>).</p>
+<p><a href="../reference/config.html">Cargo config</a> environment variables can be
 used to override the tokens stored in the credentials file. The token for
 crates.io may be specified with the <code>CARGO_REGISTRY_TOKEN</code> environment
 variable. Tokens for other registries may be specified with environment
@@ -64,7 +64,7 @@ of the registry in all capital letters.</dd>
 
 
 <dt class="option-term" id="option-cargo-owner---registry"><a class="option-anchor" href="#option-cargo-owner---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config
+<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config
 files</a>. If not specified, the default registry is used,
 which is defined by the <code>registry.default</code> config key which defaults to
 <code>crates-io</code>.</dd>
@@ -81,7 +81,7 @@ which is defined by the <code>registry.default</code> config key which defaults 
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-owner--q"><a class="option-anchor" href="#option-cargo-owner--q"></a><code>-q</code></dt>
@@ -98,7 +98,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -154,4 +154,4 @@ details on environment variables that Cargo reads.
        cargo owner --remove username foo
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-login(1)](cargo-login.md), [cargo-publish(1)](cargo-publish.md)
+[cargo(1)](cargo.html), [cargo-login(1)](cargo-login.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -25,7 +25,7 @@ steps:
     - `[patch]`, `[replace]`, and `[workspace]` sections are removed from the
       manifest.
     - `Cargo.lock` is automatically included if the package contains an
-      executable binary or example target. [cargo-install(1)](cargo-install.md) will use the
+      executable binary or example target. [cargo-install(1)](cargo-install.html) will use the
       packaged lock file if the `--locked` flag is used.
     - A `.cargo_vcs_info.json` file is included that contains information
       about the current VCS checkout hash if available (not included with
@@ -78,17 +78,17 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
 <dt class="option-term" id="option-cargo-package---target-dir"><a class="option-anchor" href="#option-cargo-package---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -155,9 +155,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -169,7 +169,7 @@ offline.</p>
 <dt class="option-term" id="option-cargo-package--j"><a class="option-anchor" href="#option-cargo-package--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-package---jobs"><a class="option-anchor" href="#option-cargo-package---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -183,7 +183,7 @@ the number of CPUs.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-package--q"><a class="option-anchor" href="#option-cargo-package--q"></a><code>-q</code></dt>
@@ -200,7 +200,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -248,4 +248,4 @@ details on environment variables that Cargo reads.
        cargo package
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-publish(1)](cargo-publish.md)
+[cargo(1)](cargo.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -54,7 +54,7 @@ _url_`#`_name_`:`_version_ | `https://github.com/rust-lang/cargo#crates-io:0.21.
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-pkgid--q"><a class="option-anchor" href="#option-cargo-pkgid--q"></a><code>-q</code></dt>
@@ -71,7 +71,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -105,9 +105,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -164,4 +164,4 @@ details on environment variables that Cargo reads.
        cargo pkgid https://github.com/rust-lang/crates.io-index#foo
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-generate-lockfile(1)](cargo-generate-lockfile.md), [cargo-metadata(1)](cargo-metadata.md)
+[cargo(1)](cargo.html), [cargo-generate-lockfile(1)](cargo-generate-lockfile.html), [cargo-metadata(1)](cargo-metadata.html)

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -19,12 +19,12 @@ following steps:
 1. Performs a few checks, including:
    - Checks the `package.publish` key in the manifest for restrictions on
      which registries you are allowed to publish to.
-2. Create a `.crate` file by following the steps in [cargo-package(1)](cargo-package.md).
+2. Create a `.crate` file by following the steps in [cargo-package(1)](cargo-package.html).
 3. Upload the crate to the registry. Note that the server will perform
    additional checks on the crate.
 
 This command requires you to be authenticated with either the `--token` option
-or using [cargo-login(1)](cargo-login.md).
+or using [cargo-login(1)](cargo-login.html).
 
 See [the reference](../reference/publishing.html) for more details about
 packaging and publishing.
@@ -41,8 +41,8 @@ packaging and publishing.
 
 <dt class="option-term" id="option-cargo-publish---token"><a class="option-anchor" href="#option-cargo-publish---token"></a><code>--token</code> <em>token</em></dt>
 <dd class="option-desc">API token to use when authenticating. This overrides the token stored in
-the credentials file (which is created by <a href="https://doc.rust-lang.org/cargo/commands/cargo-login.md">cargo-login(1)</a>).</p>
-<p><a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config</a> environment variables can be
+the credentials file (which is created by <a href="cargo-login.html">cargo-login(1)</a>).</p>
+<p><a href="../reference/config.html">Cargo config</a> environment variables can be
 used to override the tokens stored in the credentials file. The token for
 crates.io may be specified with the <code>CARGO_REGISTRY_TOKEN</code> environment
 variable. Tokens for other registries may be specified with environment
@@ -65,12 +65,12 @@ of the registry in all capital letters.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---registry"><a class="option-anchor" href="#option-cargo-publish---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to publish to. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo
+<dd class="option-desc">Name of the registry to publish to. Registry names are defined in <a href="../reference/config.html">Cargo
 config files</a>. If not specified, and there is a
-<a href="https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field"><code>package.publish</code></a> field in
+<a href="../reference/manifest.html#the-publish-field"><code>package.publish</code></a> field in
 <code>Cargo.toml</code> with a single registry, then it will publish to that registry.
 Otherwise it will use the default registry, which is defined by the
-<a href="https://doc.rust-lang.org/cargo/reference/config.html#registry-default"><code>registry.default</code></a> config key
+<a href="../reference/config.html#registrydefault"><code>registry.default</code></a> config key
 which defaults to <code>crates-io</code>.</dd>
 
 
@@ -86,17 +86,17 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
 <dt class="option-term" id="option-cargo-publish---target-dir"><a class="option-anchor" href="#option-cargo-publish---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -163,9 +163,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -177,7 +177,7 @@ offline.</p>
 <dt class="option-term" id="option-cargo-publish--j"><a class="option-anchor" href="#option-cargo-publish--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-publish---jobs"><a class="option-anchor" href="#option-cargo-publish---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -191,7 +191,7 @@ the number of CPUs.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish--q"><a class="option-anchor" href="#option-cargo-publish--q"></a><code>-q</code></dt>
@@ -208,7 +208,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -256,4 +256,4 @@ details on environment variables that Cargo reads.
        cargo publish
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-package(1)](cargo-package.md), [cargo-login(1)](cargo-login.md)
+[cargo(1)](cargo.html), [cargo-package(1)](cargo-package.html), [cargo-login(1)](cargo-login.html)

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -28,7 +28,7 @@ flag can be used to choose a different package in a workspace.
 
 <dt class="option-term" id="option-cargo-run--p"><a class="option-anchor" href="#option-cargo-run--p"></a><code>-p</code> <em>spec</em></dt>
 <dt class="option-term" id="option-cargo-run---package"><a class="option-anchor" href="#option-cargo-run---package"></a><code>--package</code> <em>spec</em></dt>
-<dd class="option-desc">The package to run. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the SPEC
+<dd class="option-desc">The package to run. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC
 format.</dd>
 
 
@@ -95,10 +95,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -117,7 +117,7 @@ selection.</dd>
 <dt class="option-term" id="option-cargo-run---target-dir"><a class="option-anchor" href="#option-cargo-run---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -132,7 +132,7 @@ to <code>target</code> in the root of the workspace.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-run--q"><a class="option-anchor" href="#option-cargo-run--q"></a><code>-q</code></dt>
@@ -149,7 +149,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -160,7 +160,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -206,9 +206,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -244,7 +244,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-run--j"><a class="option-anchor" href="#option-cargo-run--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-run---jobs"><a class="option-anchor" href="#option-cargo-run---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -291,4 +291,4 @@ details on environment variables that Cargo reads.
        cargo run --example exname -- --exoption exarg1 exarg2
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-build(1)](cargo-build.md)
+[cargo(1)](cargo.html), [cargo-build(1)](cargo-build.html)

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -41,7 +41,7 @@ flag can be used to choose a different package in a workspace.
 
 <dt class="option-term" id="option-cargo-rustc--p"><a class="option-anchor" href="#option-cargo-rustc--p"></a><code>-p</code> <em>spec</em></dt>
 <dt class="option-term" id="option-cargo-rustc---package"><a class="option-anchor" href="#option-cargo-rustc---package"></a><code>--package</code> <em>spec</em></dt>
-<dd class="option-desc">The package to build. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the SPEC
+<dd class="option-desc">The package to build. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC
 format.</dd>
 
 
@@ -156,10 +156,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -178,7 +178,7 @@ selection.</dd>
 <dt class="option-term" id="option-cargo-rustc---target-dir"><a class="option-anchor" href="#option-cargo-rustc---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -193,7 +193,7 @@ to <code>target</code> in the root of the workspace.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc--q"><a class="option-anchor" href="#option-cargo-rustc--q"></a><code>-q</code></dt>
@@ -210,7 +210,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -221,7 +221,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -267,9 +267,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -305,7 +305,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-rustc--j"><a class="option-anchor" href="#option-cargo-rustc--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-rustc---jobs"><a class="option-anchor" href="#option-cargo-rustc---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -353,4 +353,4 @@ details on environment variables that Cargo reads.
        cargo rustc --lib -- -Z print-type-sizes
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-build(1)](cargo-build.md), [rustc(1)](https://doc.rust-lang.org/rustc/index.html)
+[cargo(1)](cargo.html), [cargo-build(1)](cargo-build.html), [rustc(1)](https://doc.rust-lang.org/rustc/index.html)

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -52,7 +52,7 @@ flag can be used to choose a different package in a workspace.
 
 <dt class="option-term" id="option-cargo-rustdoc--p"><a class="option-anchor" href="#option-cargo-rustdoc--p"></a><code>-p</code> <em>spec</em></dt>
 <dt class="option-term" id="option-cargo-rustdoc---package"><a class="option-anchor" href="#option-cargo-rustdoc---package"></a><code>--package</code> <em>spec</em></dt>
-<dd class="option-desc">The package to document. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the SPEC
+<dd class="option-desc">The package to document. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC
 format.</dd>
 
 
@@ -169,10 +169,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -191,7 +191,7 @@ selection.</dd>
 <dt class="option-term" id="option-cargo-rustdoc---target-dir"><a class="option-anchor" href="#option-cargo-rustdoc---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -205,7 +205,7 @@ to <code>target</code> in the root of the workspace.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc--q"><a class="option-anchor" href="#option-cargo-rustdoc--q"></a><code>-q</code></dt>
@@ -222,7 +222,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -233,7 +233,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -277,9 +277,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -314,7 +314,7 @@ for more information about how toolchain overrides work.</dd>
 <dt class="option-term" id="option-cargo-rustdoc--j"><a class="option-anchor" href="#option-cargo-rustdoc--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-rustdoc---jobs"><a class="option-anchor" href="#option-cargo-rustdoc---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -357,4 +357,4 @@ details on environment variables that Cargo reads.
        cargo rustdoc --lib -- --extend-css extra.css
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-doc(1)](cargo-doc.md), [rustdoc(1)](https://doc.rust-lang.org/rustdoc/index.html)
+[cargo(1)](cargo.html), [cargo-doc(1)](cargo-doc.html), [rustdoc(1)](https://doc.rust-lang.org/rustdoc/index.html)

--- a/src/doc/src/commands/cargo-search.md
+++ b/src/doc/src/commands/cargo-search.md
@@ -30,7 +30,7 @@ for copying into a `Cargo.toml` manifest.
 
 
 <dt class="option-term" id="option-cargo-search---registry"><a class="option-anchor" href="#option-cargo-search---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config
+<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config
 files</a>. If not specified, the default registry is used,
 which is defined by the <code>registry.default</code> config key which defaults to
 <code>crates-io</code>.</dd>
@@ -47,7 +47,7 @@ which is defined by the <code>registry.default</code> config key which defaults 
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-search--q"><a class="option-anchor" href="#option-cargo-search--q"></a><code>-q</code></dt>
@@ -64,7 +64,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -112,4 +112,4 @@ details on environment variables that Cargo reads.
        cargo search serde
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-install(1)](cargo-install.md), [cargo-publish(1)](cargo-publish.md)
+[cargo(1)](cargo.html), [cargo-install(1)](cargo-install.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -78,7 +78,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-test--p"><a class="option-anchor" href="#option-cargo-test--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-test---package"><a class="option-anchor" href="#option-cargo-test---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Test only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Test only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -243,10 +243,10 @@ architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</p>
+<a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the
 target artifacts are placed in a separate directory. See the
-<a href="https://doc.rust-lang.org/cargo/guide/build-cache.html">build cache</a> documentation for more details.</dd>
+<a href="../guide/build-cache.html">build cache</a> documentation for more details.</dd>
 
 
 
@@ -265,7 +265,7 @@ selection.</dd>
 <dt class="option-term" id="option-cargo-test---target-dir"><a class="option-anchor" href="#option-cargo-test---target-dir"></a><code>--target-dir</code> <em>directory</em></dt>
 <dd class="option-desc">Directory for all generated artifacts and intermediate files. May also be
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
-<code>build.target-dir</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults
+<code>build.target-dir</code> <a href="../reference/config.html">config value</a>. Defaults
 to <code>target</code> in the root of the workspace.</dd>
 
 
@@ -286,7 +286,7 @@ results readable. Test output can be recovered (e.g., for debugging) by passing
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-test--q"><a class="option-anchor" href="#option-cargo-test--q"></a><code>-q</code></dt>
@@ -303,7 +303,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -314,7 +314,7 @@ and consists of comma-separated values. Valid values:</p>
 <li><code>human</code> (default): Display in a human-readable text format.</li>
 <li><code>short</code>: Emit shorter, human-readable text messages.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
-<a href="https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages">the reference</a>
+<a href="../reference/external-tools.html#json-messages">the reference</a>
 for more details.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
 the &quot;short&quot; rendering from rustc.</li>
@@ -360,9 +360,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -405,7 +405,7 @@ includes an option to control the number of threads used:
 <dt class="option-term" id="option-cargo-test--j"><a class="option-anchor" href="#option-cargo-test--j"></a><code>-j</code> <em>N</em></dt>
 <dt class="option-term" id="option-cargo-test---jobs"><a class="option-anchor" href="#option-cargo-test---jobs"></a><code>--jobs</code> <em>N</em></dt>
 <dd class="option-desc">Number of parallel jobs to run. May also be specified with the
-<code>build.jobs</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>. Defaults to
+<code>build.jobs</code> <a href="../reference/config.html">config value</a>. Defaults to
 the number of CPUs.</dd>
 
 
@@ -465,4 +465,4 @@ details on environment variables that Cargo reads.
        cargo test --test int_test_name -- modname::test_name
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-bench(1)](cargo-bench.md)
+[cargo(1)](cargo.html), [cargo-bench(1)](cargo-bench.html)

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -165,7 +165,7 @@ virtual workspace will include all workspace members (equivalent to passing
 
 <dt class="option-term" id="option-cargo-tree--p"><a class="option-anchor" href="#option-cargo-tree--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-tree---package"><a class="option-anchor" href="#option-cargo-tree---package"></a><code>--package</code> <em>spec</em>...</dt>
-<dd class="option-desc">Display only the specified packages. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the
+<dd class="option-desc">Display only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times.</dd>
 
 
@@ -212,9 +212,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -260,7 +260,7 @@ specified multiple times, which enables all specified features.</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-tree--q"><a class="option-anchor" href="#option-cargo-tree--q"></a><code>-q</code></dt>
@@ -277,7 +277,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -381,4 +381,4 @@ details on environment variables that Cargo reads.
    entries, try with the `--no-dedupe` flag to get the full output.
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-metadata(1)](cargo-metadata.md)
+[cargo(1)](cargo.html), [cargo-metadata(1)](cargo-metadata.html)

--- a/src/doc/src/commands/cargo-uninstall.md
+++ b/src/doc/src/commands/cargo-uninstall.md
@@ -10,9 +10,9 @@ cargo-uninstall - Remove a Rust binary
 
 ## DESCRIPTION
 
-This command removes a package installed with [cargo-install(1)](cargo-install.md). The _spec_
+This command removes a package installed with [cargo-install(1)](cargo-install.html). The _spec_
 argument is a package ID specification of the package to remove (see
-[cargo-pkgid(1)](cargo-pkgid.md)).
+[cargo-pkgid(1)](cargo-pkgid.html)).
 
 By default all binaries are removed for a crate but the `--bin` and
 `--example` flags can be used to only remove particular binaries.
@@ -56,7 +56,7 @@ The installation root is determined, in order of precedence:
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-uninstall--q"><a class="option-anchor" href="#option-cargo-uninstall--q"></a><code>-q</code></dt>
@@ -73,7 +73,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -122,4 +122,4 @@ details on environment variables that Cargo reads.
        cargo uninstall ripgrep
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-install(1)](cargo-install.md)
+[cargo(1)](cargo.html), [cargo-install(1)](cargo-install.html)

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -23,7 +23,7 @@ latest available versions.
 <dt class="option-term" id="option-cargo-update--p"><a class="option-anchor" href="#option-cargo-update--p"></a><code>-p</code> <em>spec</em>...</dt>
 <dt class="option-term" id="option-cargo-update---package"><a class="option-anchor" href="#option-cargo-update---package"></a><code>--package</code> <em>spec</em>...</dt>
 <dd class="option-desc">Update only the specified packages. This flag may be specified
-multiple times. See <a href="https://doc.rust-lang.org/cargo/commands/cargo-pkgid.md">cargo-pkgid(1)</a> for the SPEC format.</p>
+multiple times. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC format.</p>
 <p>If packages are specified with the <code>-p</code> flag, then a conservative update of
 the lockfile will be performed. This means that only the dependency specified
 by SPEC will be updated. Its transitive dependencies will be updated only if
@@ -57,7 +57,7 @@ revision (such as a SHA hash or tag).</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-update--q"><a class="option-anchor" href="#option-cargo-update--q"></a><code>-q</code></dt>
@@ -74,7 +74,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -108,9 +108,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -167,4 +167,4 @@ details on environment variables that Cargo reads.
        cargo update -p foo --precise 1.2.3
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-generate-lockfile(1)](cargo-generate-lockfile.md)
+[cargo(1)](cargo.html), [cargo-generate-lockfile(1)](cargo-generate-lockfile.html)

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -80,9 +80,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -97,7 +97,7 @@ offline.</p>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-vendor--q"><a class="option-anchor" href="#option-cargo-vendor--q"></a><code>-q</code></dt>
@@ -114,7 +114,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -171,5 +171,5 @@ details on environment variables that Cargo reads.
        cargo vendor -s ../path/to/Cargo.toml
 
 ## SEE ALSO
-[cargo(1)](cargo.md)
+[cargo(1)](cargo.html)
 

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -30,7 +30,7 @@ An invalid workspace will display:
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-verify-project--q"><a class="option-anchor" href="#option-cargo-verify-project--q"></a><code>-q</code></dt>
@@ -47,7 +47,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -82,9 +82,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -132,4 +132,4 @@ details on environment variables that Cargo reads.
        cargo verify-project
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-package(1)](cargo-package.md)
+[cargo(1)](cargo.html), [cargo-package(1)](cargo-package.html)

--- a/src/doc/src/commands/cargo-version.md
+++ b/src/doc/src/commands/cargo-version.md
@@ -39,4 +39,4 @@ Displays the version of Cargo.
        cargo -Vv
 
 ## SEE ALSO
-[cargo(1)](cargo.md)
+[cargo(1)](cargo.html)

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -19,7 +19,7 @@ download the yanked version to use it. Cargo will, however, not allow any new
 crates to be locked to any yanked version.
 
 This command requires you to be authenticated with either the `--token` option
-or using [cargo-login(1)](cargo-login.md).
+or using [cargo-login(1)](cargo-login.html).
 
 If the crate name is not specified, it will use the package name from the
 current directory.
@@ -40,8 +40,8 @@ current directory.
 
 <dt class="option-term" id="option-cargo-yank---token"><a class="option-anchor" href="#option-cargo-yank---token"></a><code>--token</code> <em>token</em></dt>
 <dd class="option-desc">API token to use when authenticating. This overrides the token stored in
-the credentials file (which is created by <a href="https://doc.rust-lang.org/cargo/commands/cargo-login.md">cargo-login(1)</a>).</p>
-<p><a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config</a> environment variables can be
+the credentials file (which is created by <a href="cargo-login.html">cargo-login(1)</a>).</p>
+<p><a href="../reference/config.html">Cargo config</a> environment variables can be
 used to override the tokens stored in the credentials file. The token for
 crates.io may be specified with the <code>CARGO_REGISTRY_TOKEN</code> environment
 variable. Tokens for other registries may be specified with environment
@@ -56,7 +56,7 @@ of the registry in all capital letters.</dd>
 
 
 <dt class="option-term" id="option-cargo-yank---registry"><a class="option-anchor" href="#option-cargo-yank---registry"></a><code>--registry</code> <em>registry</em></dt>
-<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="https://doc.rust-lang.org/cargo/reference/config.html">Cargo config
+<dd class="option-desc">Name of the registry to use. Registry names are defined in <a href="../reference/config.html">Cargo config
 files</a>. If not specified, the default registry is used,
 which is defined by the <code>registry.default</code> config key which defaults to
 <code>crates-io</code>.</dd>
@@ -74,7 +74,7 @@ which is defined by the <code>registry.default</code> config key which defaults 
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo-yank--q"><a class="option-anchor" href="#option-cargo-yank--q"></a><code>-q</code></dt>
@@ -91,7 +91,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -140,4 +140,4 @@ details on environment variables that Cargo reads.
        cargo yank --vers 1.0.7 foo
 
 ## SEE ALSO
-[cargo(1)](cargo.md), [cargo-login(1)](cargo-login.md), [cargo-publish(1)](cargo-publish.md)
+[cargo(1)](cargo.html), [cargo-login(1)](cargo-login.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo.md
+++ b/src/doc/src/commands/cargo.md
@@ -21,105 +21,105 @@ available at <https://rust-lang.org>.
 
 ### Build Commands
 
-[cargo-bench(1)](cargo-bench.md)\
+[cargo-bench(1)](cargo-bench.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Execute benchmarks of a package.
 
-[cargo-build(1)](cargo-build.md)\
+[cargo-build(1)](cargo-build.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Compile a package.
 
-[cargo-check(1)](cargo-check.md)\
+[cargo-check(1)](cargo-check.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Check a local package and all of its dependencies for errors.
 
-[cargo-clean(1)](cargo-clean.md)\
+[cargo-clean(1)](cargo-clean.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Remove artifacts that Cargo has generated in the past.
 
-[cargo-doc(1)](cargo-doc.md)\
+[cargo-doc(1)](cargo-doc.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Build a package's documentation.
 
-[cargo-fetch(1)](cargo-fetch.md)\
+[cargo-fetch(1)](cargo-fetch.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Fetch dependencies of a package from the network.
 
-[cargo-fix(1)](cargo-fix.md)\
+[cargo-fix(1)](cargo-fix.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Automatically fix lint warnings reported by rustc.
 
-[cargo-run(1)](cargo-run.md)\
+[cargo-run(1)](cargo-run.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Run a binary or example of the local package.
 
-[cargo-rustc(1)](cargo-rustc.md)\
+[cargo-rustc(1)](cargo-rustc.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Compile a package, and pass extra options to the compiler.
 
-[cargo-rustdoc(1)](cargo-rustdoc.md)\
+[cargo-rustdoc(1)](cargo-rustdoc.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Build a package's documentation, using specified custom flags.
 
-[cargo-test(1)](cargo-test.md)\
+[cargo-test(1)](cargo-test.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Execute unit and integration tests of a package.
 
 ### Manifest Commands
 
-[cargo-generate-lockfile(1)](cargo-generate-lockfile.md)\
+[cargo-generate-lockfile(1)](cargo-generate-lockfile.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Generate `Cargo.lock` for a project.
 
-[cargo-locate-project(1)](cargo-locate-project.md)\
+[cargo-locate-project(1)](cargo-locate-project.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Print a JSON representation of a `Cargo.toml` file's location.
 
-[cargo-metadata(1)](cargo-metadata.md)\
+[cargo-metadata(1)](cargo-metadata.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Output the resolved dependencies of a package in machine-readable format.
 
-[cargo-pkgid(1)](cargo-pkgid.md)\
+[cargo-pkgid(1)](cargo-pkgid.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Print a fully qualified package specification.
 
-[cargo-tree(1)](cargo-tree.md)\
+[cargo-tree(1)](cargo-tree.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Display a tree visualization of a dependency graph.
 
-[cargo-update(1)](cargo-update.md)\
+[cargo-update(1)](cargo-update.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Update dependencies as recorded in the local lock file.
 
-[cargo-vendor(1)](cargo-vendor.md)\
+[cargo-vendor(1)](cargo-vendor.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Vendor all dependencies locally.
 
-[cargo-verify-project(1)](cargo-verify-project.md)\
+[cargo-verify-project(1)](cargo-verify-project.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Check correctness of crate manifest.
 
 ### Package Commands
 
-[cargo-init(1)](cargo-init.md)\
+[cargo-init(1)](cargo-init.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Create a new Cargo package in an existing directory.
 
-[cargo-install(1)](cargo-install.md)\
+[cargo-install(1)](cargo-install.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Build and install a Rust binary.
 
-[cargo-new(1)](cargo-new.md)\
+[cargo-new(1)](cargo-new.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Create a new Cargo package.
 
-[cargo-search(1)](cargo-search.md)\
+[cargo-search(1)](cargo-search.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Search packages in crates.io.
 
-[cargo-uninstall(1)](cargo-uninstall.md)\
+[cargo-uninstall(1)](cargo-uninstall.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Remove a Rust binary.
 
 ### Publishing Commands
 
-[cargo-login(1)](cargo-login.md)\
+[cargo-login(1)](cargo-login.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Save an API token from the registry locally.
 
-[cargo-owner(1)](cargo-owner.md)\
+[cargo-owner(1)](cargo-owner.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Manage the owners of a crate on the registry.
 
-[cargo-package(1)](cargo-package.md)\
+[cargo-package(1)](cargo-package.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Assemble the local package into a distributable tarball.
 
-[cargo-publish(1)](cargo-publish.md)\
+[cargo-publish(1)](cargo-publish.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Upload a package to the registry.
 
-[cargo-yank(1)](cargo-yank.md)\
+[cargo-yank(1)](cargo-yank.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Remove a pushed crate from the index.
 
 ### General Commands
 
-[cargo-help(1)](cargo-help.md)\
+[cargo-help(1)](cargo-help.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Display help information about Cargo.
 
-[cargo-version(1)](cargo-version.md)\
+[cargo-version(1)](cargo-version.html)\
 &nbsp;&nbsp;&nbsp;&nbsp;Show version information.
 
 ## OPTIONS
@@ -155,7 +155,7 @@ error message (for example, <code>E0004</code>).</dd>
 <dd class="option-desc">Use verbose output. May be specified twice for &quot;very verbose&quot; output which
 includes extra output such as dependency warnings and build script output.
 May also be specified with the <code>term.verbose</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 <dt class="option-term" id="option-cargo--q"><a class="option-anchor" href="#option-cargo--q"></a><code>-q</code></dt>
@@ -172,7 +172,7 @@ terminal.</li>
 <li><code>never</code>: Never display colors.</li>
 </ul>
 <p>May also be specified with the <code>term.color</code>
-<a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<a href="../reference/config.html">config value</a>.</dd>
 
 
 
@@ -200,9 +200,9 @@ proceed without the network if possible.</p>
 <p>Beware that this may result in different dependency resolution than online
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
-See the <a href="https://doc.rust-lang.org/cargo/commands/cargo-fetch.md">cargo-fetch(1)</a> command to download dependencies before going
+See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
-<p>May also be specified with the <code>net.offline</code> <a href="https://doc.rust-lang.org/cargo/reference/config.html">config value</a>.</dd>
+<p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
 
 
 </dl>
@@ -251,7 +251,7 @@ stores various files. The location can be changed with the `CARGO_HOME`
 environment variable.
 
 `$CARGO_HOME/bin/`\
-&nbsp;&nbsp;&nbsp;&nbsp;Binaries installed by [cargo-install(1)](cargo-install.md) will be located here. If using
+&nbsp;&nbsp;&nbsp;&nbsp;Binaries installed by [cargo-install(1)](cargo-install.html) will be located here. If using
 [rustup], executables distributed with Rust are also located here.
 
 `$CARGO_HOME/config.toml`\

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -180,9 +180,9 @@ The output has the following format:
             /* The repository value from the manifest or null if not specified. */
             "repository": "https://github.com/rust\-lang/cargo",
             /* The homepage value from the manifest or null if not specified. */
-            "homepage": "https://rust-lang.org",
+            "homepage": "https://rust\-lang.org",
             /* The documentation value from the manifest or null if not specified. */
-            "documentation": "https://doc.rust-lang.org/stable/std",
+            "documentation": "https://doc.rust\-lang.org/stable/std",
             /* The default edition of the package.
                Note that individual targets may have different editions.
             */
@@ -333,7 +333,7 @@ Do not activate the \fBdefault\fR feature of the current directory's package.
 .RE
 .SS "Display Options"
 .sp
-\fB\-v\fR,
+\fB\-v\fR, 
 \fB\-\-verbose\fR
 .RS 4
 Use verbose output. May be specified twice for "very verbose" output which
@@ -342,7 +342,7 @@ May also be specified with the \fBterm.verbose\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
 .RE
 .sp
-\fB\-q\fR,
+\fB\-q\fR, 
 \fB\-\-quiet\fR
 .RS 4
 No output printed to stdout.
@@ -376,7 +376,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR,
+\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
 Either of these flags requires that the \fBCargo.lock\fR file is
@@ -415,7 +415,7 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-h\fR,
+\fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4
 Prints help information.

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -79,7 +79,7 @@ config files\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&. If n
 \fI\f(BIpackage.publish\fI\fR <https://doc.rust\-lang.org/cargo/reference/manifest.html#the\-publish\-field> field in
 \fBCargo.toml\fR with a single registry, then it will publish to that registry.
 Otherwise it will use the default registry, which is defined by the
-\fI\f(BIregistry.default\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#registry\-default> config key
+\fI\f(BIregistry.default\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#registrydefault> config key
 which defaults to \fBcrates\-io\fR\&.
 .RE
 .SS "Compilation Options"


### PR DESCRIPTION
Links inside `{{#option}}` blocks were erroneously being converted to absolute links when emitting the `md` format because they were being rendered as HTML.  This wasn't intended and caused some links to fail. It also causes problems for offline viewing (since the links are to an external website).

Also, man-page links like `{{man "cargo-foo" 1}}` were linking to `.md` extension, but since they are processed as markdown into HTML, mdbook's `.md` to `.html` translation wasn't getting applied. The simple fix is to always use `.html`.

This revealed a legitimate error in a link in `cargo-publish.md` which had the wrong anchor link (`#registrydefault`).

This also revealed that the CI check that the man pages are in sync wasn't working quite right (it was not checking the `etc/man` directory for changes).
