### PR TITLE
Add `member` table to cargo config

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -42,6 +42,7 @@ Available unstable (nightly-only) flags:
     -Z timings          -- Display concurrency information
     -Z doctest-xcompile -- Compile and run doctests for non-host target using runner config
     -Z terminal-width   -- Provide a terminal width to rustc for error truncation
+    -Z member-configs   -- Configure individual workspace members in cargo config
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -287,7 +287,14 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
         let dest = self.bcx.profiles.get_dir_name();
         let host_layout = Layout::new(self.bcx.ws, None, &dest)?;
         let mut targets = HashMap::new();
+        let mut kinds = HashSet::new();
         for kind in self.bcx.build_config.requested_kinds.iter() {
+            kinds.insert(*kind);
+        }
+        for root in self.bcx.roots.iter() {
+            kinds.insert(root.kind());
+        }
+        for kind in kinds.iter() {
             if let CompileKind::Target(target) = *kind {
                 let layout = Layout::new(self.bcx.ws, Some(target), &dest)?;
                 targets.insert(target, layout);

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -100,6 +100,10 @@ impl Unit {
     pub fn buildkey(&self) -> String {
         format!("{}-{}", self.pkg.name(), short_hash(self))
     }
+
+    pub fn kind(&self) -> CompileKind {
+        self.inner.kind
+    }
 }
 
 // Just hash the pointer for fast hashing

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -360,6 +360,7 @@ pub struct CliUnstable {
     pub multitarget: bool,
     pub rustdoc_map: bool,
     pub terminal_width: Option<Option<usize>>,
+    pub member_configs: bool,
 }
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
@@ -465,6 +466,7 @@ impl CliUnstable {
             "multitarget" => self.multitarget = parse_empty(k, v)?,
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "terminal-width" => self.terminal_width = Some(parse_usize_opt(v)?),
+            "member-configs" => self.member_configs = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 


### PR DESCRIPTION
This PR attempts to fix #7004. While I intend to get this merged eventually I am aware that this implementation is somewhat ugly right now since I avoided major refactorings. Any feedback is appreciated. I have discussed the implementation options [here](https://github.com/rust-lang/cargo/issues/7004#issuecomment-712671190).

This introduces `[member.'name']` tables into `.cargo/config`. The tables right now have the single member `target` which defines the target of a member crate if it is set. For the member crate this key takes precedence over the `build.target` value and the `--target` CLI argument. This is useful for crates where differing targets do not really make sense such as for WASM or UEFI binaries.

I am not sure if this needs an RFC. IIRC past RFCs mainly concern themselves with the manifest format so I assume `.cargo/config.toml` format is not covered by the RFC process. Is this correct?

The new functionality is marked unstable (`-Z member-configs`).