### PR TITLE
vendor: correct the path to cargo config

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -33,7 +33,7 @@ pub fn vendor(ws: &Workspace<'_>, opts: &VendorOptions<'_>) -> CargoResult<()> {
     if config.shell().verbosity() != Verbosity::Quiet {
         crate::drop_eprint!(
             config,
-            "To use vendored sources, add this to your .cargo/config for this project:\n\n"
+            "To use vendored sources, add this to your .cargo/config.toml for this project:\n\n"
         );
         crate::drop_print!(config, "{}", &toml::to_string(&vendor_config).unwrap());
     }


### PR DESCRIPTION
When running `cargo vendor`, users are prompted to add the configuration to their cargo config.  Unfortunately, the path named is not correct, as it's lacking the correct suffix.