### PR TITLE
Bump `anyhow` dependency to `1.0.34` in `crates-io` crate

### DIFF
--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 curl = "0.4"
-anyhow = "1.0.0"
+anyhow = "1.0.34"
 percent-encoding = "2.0"
 serde = { version = "1.0", features = ['derive'] }
 serde_json = "1.0"


### PR DESCRIPTION
This will keep `crates-io` compiling if https://github.com/rust-lang/rust/issues/33953
is fixed. See https://github.com/dtolnay/anyhow/pull/120