### PR TITLE
Use u32/64::to/from_le_bytes instead of bit fiddling

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -172,27 +172,9 @@ impl Registry {
         let stat = tarball.metadata()?;
         let header = {
             let mut w = Vec::new();
-            w.extend(
-                [
-                    (json.len() >> 0) as u8,
-                    (json.len() >> 8) as u8,
-                    (json.len() >> 16) as u8,
-                    (json.len() >> 24) as u8,
-                ]
-                .iter()
-                .cloned(),
-            );
+            w.extend(&(json.len() as u32).to_le_bytes());
             w.extend(json.as_bytes().iter().cloned());
-            w.extend(
-                [
-                    (stat.len() >> 0) as u8,
-                    (stat.len() >> 8) as u8,
-                    (stat.len() >> 16) as u8,
-                    (stat.len() >> 24) as u8,
-                ]
-                .iter()
-                .cloned(),
-            );
+            w.extend(&(stat.len() as u32).to_le_bytes());
             w
         };
         let size = stat.len() as usize + header.len();

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -313,6 +313,7 @@
 //! <https://github.com/rust-lang/cargo/issues?q=is%3Aissue+is%3Aopen+label%3AA-rebuild-detection>
 
 use std::collections::hash_map::{Entry, HashMap};
+use std::convert::TryInto;
 use std::env;
 use std::hash::{self, Hasher};
 use std::path::{Path, PathBuf};
@@ -1906,12 +1907,7 @@ impl EncodedDepInfo {
         fn read_usize(bytes: &mut &[u8]) -> Option<usize> {
             let ret = bytes.get(..4)?;
             *bytes = &bytes[4..];
-            Some(
-                ((ret[0] as usize) << 0)
-                    | ((ret[1] as usize) << 8)
-                    | ((ret[2] as usize) << 16)
-                    | ((ret[3] as usize) << 24),
-            )
+            Some(u32::from_le_bytes(ret.try_into().unwrap()) as usize)
         }
 
         fn read_u8(bytes: &mut &[u8]) -> Option<u8> {
@@ -1960,10 +1956,7 @@ impl EncodedDepInfo {
         }
 
         fn write_usize(dst: &mut Vec<u8>, val: usize) {
-            dst.push(val as u8);
-            dst.push((val >> 8) as u8);
-            dst.push((val >> 16) as u8);
-            dst.push((val >> 24) as u8);
+            dst.extend(&u32::to_le_bytes(val as u32));
         }
     }
 }

--- a/src/cargo/util/hex.rs
+++ b/src/cargo/util/hex.rs
@@ -4,16 +4,7 @@ use std::hash::{Hash, Hasher};
 use std::io::Read;
 
 pub fn to_hex(num: u64) -> String {
-    hex::encode(&[
-        (num >> 0) as u8,
-        (num >> 8) as u8,
-        (num >> 16) as u8,
-        (num >> 24) as u8,
-        (num >> 32) as u8,
-        (num >> 40) as u8,
-        (num >> 48) as u8,
-        (num >> 56) as u8,
-    ])
+    hex::encode(num.to_le_bytes())
 }
 
 pub fn hash_u64<H: Hash>(hashable: H) -> u64 {

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -7,6 +7,7 @@ use cargo_test_support::{
     basic_bin_manifest, basic_manifest, is_nightly, main_file, project, rustc_host, Project,
 };
 use filetime::FileTime;
+use std::convert::TryInto;
 use std::fs;
 use std::path::Path;
 use std::str;
@@ -37,10 +38,8 @@ fn assert_deps(project: &Project, fingerprint: &str, test_cb: impl Fn(&Path, &[(
     fn read_usize(bytes: &mut &[u8]) -> usize {
         let ret = &bytes[..4];
         *bytes = &bytes[4..];
-        (ret[0] as usize)
-            | ((ret[1] as usize) << 8)
-            | ((ret[2] as usize) << 16)
-            | ((ret[3] as usize) << 24)
+
+        u32::from_le_bytes(ret.try_into().unwrap()) as usize
     }
 
     fn read_u8(bytes: &mut &[u8]) -> u8 {
@@ -50,7 +49,7 @@ fn assert_deps(project: &Project, fingerprint: &str, test_cb: impl Fn(&Path, &[(
     }
 
     fn read_bytes<'a>(bytes: &mut &'a [u8]) -> &'a [u8] {
-        let n = read_usize(bytes) as usize;
+        let n = read_usize(bytes);
         let ret = &bytes[..n];
         *bytes = &bytes[n..];
         ret


### PR DESCRIPTION
What it says on the tin; it's just something I've spotted when browsing through the code and decided to search for other occurrences of casting to/from bytes.