### PR TITLE
Fix publishing with optional dependencies.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -267,17 +267,18 @@ fn transmit(
         return Ok(());
     }
 
-    let summary = pkg.summary();
-    let string_features = summary
-        .features()
-        .iter()
-        .map(|(feat, values)| {
-            (
-                feat.to_string(),
-                values.iter().map(|fv| fv.to_string()).collect(),
-            )
-        })
-        .collect::<BTreeMap<String, Vec<String>>>();
+    let string_features = match manifest.original().features() {
+        Some(features) => features
+            .iter()
+            .map(|(feat, values)| {
+                (
+                    feat.to_string(),
+                    values.iter().map(|fv| fv.to_string()).collect(),
+                )
+            })
+            .collect::<BTreeMap<String, Vec<String>>>(),
+        None => BTreeMap::new(),
+    };
 
     let publish = registry.publish(
         &NewCrate {


### PR DESCRIPTION
In #8799, I neglected to update the `publish` code to use the correct features when generating the JSON to upload to the registry. The `Cargo.toml` file was correctly updated, but the JSON was not.  This caused Cargo to send the implicit `dep:` feature syntax in the JSON blob, which crates.io rejects.  The solution here is to use the original feature map before the implicit features have been added.
