### PR TITLE
Allow resolver="1" to explicitly use the old resolver behavior.

### DIFF
--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -110,9 +110,10 @@ pub enum ResolveBehavior {
 impl ResolveBehavior {
     pub fn from_manifest(resolver: &str) -> CargoResult<ResolveBehavior> {
         match resolver {
+            "1" => Ok(ResolveBehavior::V1),
             "2" => Ok(ResolveBehavior::V2),
             s => anyhow::bail!(
-                "`resolver` setting `{}` is not valid, only valid option is \"2\"",
+                "`resolver` setting `{}` is not valid, valid options are \"1\" or \"2\"",
                 s
             ),
         }

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -661,9 +661,9 @@ version = "1.0.0"
 resolver = "2"
 ```
 
-Currently the only allowed value is `"2"`. This declaration enables all of the
-new feature behavior of [`-Zfeatures=all`](#features) and
-[`-Zpackage-features`](#package-features).
+The value `"1"` is the current resolver behavior on the stable channel. A
+value of `"2"` enables all of the new feature behavior of
+[`-Zfeatures=all`](#features) and [`-Zpackage-features`](#package-features).
 
 This flag is global for a workspace. If using a virtual workspace, the root
 definition should be in the `[workspace]` table like this:

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1367,7 +1367,7 @@ fn resolver_bad_setting() {
             [package]
             name = "foo"
             version = "0.1.0"
-            resolver = "1"
+            resolver = "foo"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1381,10 +1381,65 @@ fn resolver_bad_setting() {
 error: failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  `resolver` setting `1` is not valid, only valid option is \"2\"
+  `resolver` setting `foo` is not valid, valid options are \"1\" or \"2\"
 ",
         )
         .run();
+}
+
+#[cargo_test]
+fn resolver_original() {
+    // resolver="1" uses old unification behavior.
+    Package::new("common", "1.0.0")
+        .feature("f1", &[])
+        .file(
+            "src/lib.rs",
+            r#"
+            #[cfg(feature = "f1")]
+            compile_error!("f1 should not activate");
+            "#,
+        )
+        .publish();
+
+    Package::new("bar", "1.0.0")
+        .add_dep(
+            Dependency::new("common", "1.0")
+                .target("cfg(whatever)")
+                .enable_features(&["f1"]),
+        )
+        .publish();
+
+    let manifest = |resolver| {
+        format!(
+            r#"
+                cargo-features = ["resolver"]
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                resolver = "{}"
+
+                [dependencies]
+                common = "1.0"
+                bar = "1.0"
+            "#,
+            resolver
+        )
+    };
+
+    let p = project()
+        .file("Cargo.toml", &manifest("1"))
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr_contains("[..]f1 should not activate[..]")
+        .run();
+
+    p.change_file("Cargo.toml", &manifest("2"));
+
+    p.cargo("check").masquerade_as_nightly_cargo().run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
A couple people expressed that it was surprising that it was not possible to explicitly specify the old behavior, so this PR adds the ability to specify `resolver = "1"` to explicitly specify the old feature unification behavior.   This is a little more consistent with other options like `edition` which allows an explicit "2015" even though that is the default.
