### PR TITLE
Add --check for rustdoc

### DIFF
--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -1,5 +1,7 @@
 use crate::command_prelude::*;
+use crate::commands::doc;
 
+use cargo::core::features;
 use cargo::ops;
 
 pub fn cli() -> App {
@@ -55,5 +57,15 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let compile_opts = args.compile_options(config, mode, Some(&ws), ProfileChecking::Unchecked)?;
 
     ops::compile(&ws, &compile_opts)?;
+
+    if features::nightly_features_allowed() {
+        doc::exec_doc(
+            config,
+            args,
+            CompileMode::DocCheck,
+            ProfileChecking::Checked,
+        )?;
+    }
+
     Ok(())
 }

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -132,6 +132,8 @@ pub enum CompileMode {
     /// Building a target with `rustc` to emit `rmeta` metadata only. If
     /// `test` is true, then it is also compiled with `--test` to check it like
     /// a test.
+    ///
+    /// It then runs `rustdoc --check`.
     Check { test: bool },
     /// Used to indicate benchmarks should be built. This is not used in
     /// `Unit`, because it is essentially the same as `Test` (indicating
@@ -143,6 +145,8 @@ pub enum CompileMode {
     Doc { deps: bool },
     /// A target that will be tested with `rustdoc`.
     Doctest,
+    /// Runs `rustdoc --check`.
+    DocCheck,
     /// A marker for Units that represent the execution of a `build.rs` script.
     RunCustomBuild,
 }
@@ -160,6 +164,7 @@ impl ser::Serialize for CompileMode {
             Bench => "bench".serialize(s),
             Doc { .. } => "doc".serialize(s),
             Doctest => "doctest".serialize(s),
+            DocCheck => "doccheck".serialize(s),
             RunCustomBuild => "run-custom-build".serialize(s),
         }
     }
@@ -168,12 +173,12 @@ impl ser::Serialize for CompileMode {
 impl CompileMode {
     /// Returns `true` if the unit is being checked.
     pub fn is_check(self) -> bool {
-        matches!(self, CompileMode::Check { .. })
+        matches!(self, CompileMode::Check { .. } | CompileMode::DocCheck)
     }
 
     /// Returns `true` if this is generating documentation.
     pub fn is_doc(self) -> bool {
-        matches!(self, CompileMode::Doc { .. })
+        matches!(self, CompileMode::Doc { .. } | CompileMode::DocCheck)
     }
 
     /// Returns `true` if this a doc test.

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -436,7 +436,10 @@ impl TargetInfo {
                 }
             }
             CompileMode::Check { .. } => Ok((vec![FileType::new_rmeta()], Vec::new())),
-            CompileMode::Doc { .. } | CompileMode::Doctest | CompileMode::RunCustomBuild => {
+            CompileMode::Doc { .. }
+            | CompileMode::Doctest
+            | CompileMode::RunCustomBuild
+            | CompileMode::DocCheck => {
                 panic!("asked for rustc output for non-rustc mode")
             }
         }

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -395,7 +395,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
                 // outputs.
                 vec![]
             }
-            CompileMode::Doctest => {
+            CompileMode::Doctest | CompileMode::DocCheck => {
                 // Doctests are built in a temporary directory and then
                 // deleted. There is the `--persist-doctests` unstable flag,
                 // but Cargo does not know about that.

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -562,12 +562,14 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
 
     let doc_dir = cx.files().out_dir(unit);
 
-    // Create the documentation directory ahead of time as rustdoc currently has
-    // a bug where concurrent invocations will race to create this directory if
-    // it doesn't already exist.
-    paths::create_dir_all(&doc_dir)?;
+    if !unit.mode.is_check() {
+        // Create the documentation directory ahead of time as rustdoc currently has
+        // a bug where concurrent invocations will race to create this directory if
+        // it doesn't already exist.
+        paths::create_dir_all(&doc_dir)?;
 
-    rustdoc.arg("-o").arg(doc_dir);
+        rustdoc.arg("-o").arg(doc_dir);
+    }
 
     for feat in &unit.features {
         rustdoc.arg("--cfg").arg(&format!("feature=\"{}\"", feat));
@@ -595,6 +597,14 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
     let mut output_options = OutputOptions::new(cx, unit);
     let pkg_id = unit.pkg.package_id();
     let script_metadata = cx.find_build_script_metadata(unit.clone());
+
+    if unit.mode.is_check() {
+        rustdoc.arg("-Z");
+        rustdoc.arg("unstable-options");
+        rustdoc.arg("--check");
+        // rustdoc.arg("--warn");
+        // rustdoc.arg("rustdoc");
+    }
 
     Ok(Work::new(move |state| {
         if let Some(script_metadata) = script_metadata {

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -170,7 +170,9 @@ impl<'cfg> Timings<'cfg> {
             CompileMode::Test => target.push_str(" (test)"),
             CompileMode::Build => {}
             CompileMode::Check { test: true } => target.push_str(" (check-test)"),
-            CompileMode::Check { test: false } => target.push_str(" (check)"),
+            CompileMode::Check { test: false } | CompileMode::DocCheck => {
+                target.push_str(" (check)")
+            }
             CompileMode::Bench => target.push_str(" (bench)"),
             CompileMode::Doc { .. } => target.push_str(" (doc)"),
             CompileMode::Doctest => target.push_str(" (doc test)"),

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -312,7 +312,10 @@ impl Profiles {
                         )
                     }
                 }
-                CompileMode::Build | CompileMode::Check { .. } | CompileMode::RunCustomBuild => {
+                CompileMode::Build
+                | CompileMode::Check { .. }
+                | CompileMode::RunCustomBuild
+                | CompileMode::DocCheck => {
                     // Note: `RunCustomBuild` doesn't normally use this code path.
                     // `build_unit_profiles` normally ensures that it selects the
                     // ancestor's profile. However, `cargo clean -p` can hit this

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -315,7 +315,8 @@ pub fn create_bcx<'a, 'cfg>(
         | CompileMode::Build
         | CompileMode::Check { .. }
         | CompileMode::Bench
-        | CompileMode::RunCustomBuild => {
+        | CompileMode::RunCustomBuild
+        | CompileMode::DocCheck => {
             if std::env::var("RUST_FLAGS").is_ok() {
                 config.shell().warn(
                     "Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?",
@@ -678,17 +679,18 @@ impl CompileFilter {
         match mode {
             CompileMode::Test | CompileMode::Doctest | CompileMode::Bench => true,
             CompileMode::Check { test: true } => true,
-            CompileMode::Build | CompileMode::Doc { .. } | CompileMode::Check { test: false } => {
-                match *self {
-                    CompileFilter::Default { .. } => false,
-                    CompileFilter::Only {
-                        ref examples,
-                        ref tests,
-                        ref benches,
-                        ..
-                    } => examples.is_specific() || tests.is_specific() || benches.is_specific(),
-                }
-            }
+            CompileMode::Build
+            | CompileMode::Doc { .. }
+            | CompileMode::Check { test: false }
+            | CompileMode::DocCheck => match *self {
+                CompileFilter::Default { .. } => false,
+                CompileFilter::Only {
+                    ref examples,
+                    ref tests,
+                    ref benches,
+                    ..
+                } => examples.is_specific() || tests.is_specific() || benches.is_specific(),
+            },
             CompileMode::RunCustomBuild => panic!("Invalid mode"),
         }
     }
@@ -1177,7 +1179,7 @@ fn filter_default_targets(targets: &[Target], mode: CompileMode) -> Vec<&Target>
             .iter()
             .filter(|t| t.tested() || t.is_example())
             .collect(),
-        CompileMode::Build | CompileMode::Check { .. } => targets
+        CompileMode::Build | CompileMode::Check { .. } | CompileMode::DocCheck => targets
             .iter()
             .filter(|t| t.is_bin() || t.is_lib())
             .collect(),


### PR DESCRIPTION
Since https://github.com/rust-lang/rust/pull/78984 has landed, it'd be nice to integrate it into cargo nightly.

Currently, the code seems to be running the checks, but doesn't run `rustdoc`. Any help to help me figure out what's missing would be very appreciated. :)

<details>
As you can see here, the second check is run as expected, but the rustdoc command isn't started for some reason...

```bash
$ ../../cargo/target/release/cargo check -v
warning: /home/imperio/rust/gtk-rs/graphene/sys/Cargo.toml: unused manifest key: package.link
       Fresh unicode-xid v0.2.1
       Fresh unicode-segmentation v1.6.0
       Fresh strum v0.19.5
       Fresh pkg-config v0.3.19
       Fresh version-compare v0.0.11
       Fresh version_check v0.9.2
       Fresh futures-core v0.3.8
       Fresh once_cell v1.5.2
       Fresh pin-utils v0.1.0
       Fresh slab v0.4.2
       Fresh either v1.6.1
       Fresh smallvec v1.4.2
       Fresh heck v0.3.1
       Fresh futures-task v0.3.8
       Fresh itertools v0.9.0
       Fresh futures-channel v0.3.8
       Fresh proc-macro2 v1.0.24
       Fresh serde v1.0.117
       Fresh proc-macro-hack v0.5.19
       Fresh libc v0.2.80
       Fresh quote v1.0.7
       Fresh toml v0.5.7
       Fresh proc-macro-nested v0.1.6
       Fresh anyhow v1.0.34
       Fresh bitflags v1.2.1
       Fresh syn v1.0.48
       Fresh proc-macro-error-attr v1.0.4
       Fresh proc-macro-crate v0.1.5
       Fresh thiserror-impl v1.0.22
       Fresh strum_macros v0.19.4
       Fresh pin-project-internal v1.0.1
       Fresh futures-macro v0.3.8
       Fresh proc-macro-error v1.0.4
       Fresh thiserror v1.0.22
       Fresh pin-project v1.0.1
       Fresh glib-macros v0.13.0 (/home/imperio/rust/gtk-rs/glib-macros)
       Fresh system-deps v2.0.1
       Fresh futures-util v0.3.8
       Fresh futures-executor v0.3.8
       Fresh glib-sys v0.13.0 (/home/imperio/rust/gtk-rs/glib/sys)
       Fresh gobject-sys v0.13.0 (/home/imperio/rust/gtk-rs/glib/gobject-sys)
    Checking glib v0.13.0 (/home/imperio/rust/gtk-rs/glib)
     Running `rustc --crate-name glib glib/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi --crate-type lib --emit=dep-info,metadata -C embed-bitcode=no -C debuginfo=2 -C metadata=70d43c382e683ed1 -C extra-filename=-70d43c382e683ed1 --out-dir /home/imperio/rust/gtk-rs/target/debug/deps -C incremental=/home/imperio/rust/gtk-rs/target/debug/incremental -L dependency=/home/imperio/rust/gtk-rs/target/debug/deps --extern bitflags=/home/imperio/rust/gtk-rs/target/debug/deps/libbitflags-33cf578042896f22.rmeta --extern futures_channel=/home/imperio/rust/gtk-rs/target/debug/deps/libfutures_channel-2e44f97b4af970fb.rmeta --extern futures_core=/home/imperio/rust/gtk-rs/target/debug/deps/libfutures_core-bafe9494a629a15e.rmeta --extern futures_executor=/home/imperio/rust/gtk-rs/target/debug/deps/libfutures_executor-940684229381a4a0.rmeta --extern futures_task=/home/imperio/rust/gtk-rs/target/debug/deps/libfutures_task-bbbcaee922a34b22.rmeta --extern futures_util=/home/imperio/rust/gtk-rs/target/debug/deps/libfutures_util-f73631bfdc9b54d0.rmeta --extern glib_macros=/home/imperio/rust/gtk-rs/target/debug/deps/libglib_macros-acbc09e903b4b734.so --extern glib_sys=/home/imperio/rust/gtk-rs/target/debug/deps/libglib_sys-2712898b600d8a37.rmeta --extern gobject_sys=/home/imperio/rust/gtk-rs/target/debug/deps/libgobject_sys-f753b4fcba7c0d36.rmeta --extern libc=/home/imperio/rust/gtk-rs/target/debug/deps/liblibc-4444037e32c5a7fc.rmeta --extern once_cell=/home/imperio/rust/gtk-rs/target/debug/deps/libonce_cell-d3ff5d109eb6c70d.rmeta --extern smallvec=/home/imperio/rust/gtk-rs/target/debug/deps/libsmallvec-09d6995c1d1a32f6.rmeta`
    Finished dev [unoptimized + debuginfo] target(s) in 1.59s
warning: /home/imperio/rust/gtk-rs/graphene/sys/Cargo.toml: unused manifest key: package.link
       Fresh unicode-xid v0.2.1
       Fresh unicode-segmentation v1.6.0
       Fresh version_check v0.9.2
       Fresh strum v0.19.5
       Fresh pkg-config v0.3.19
       Fresh version-compare v0.0.11
       Fresh futures-core v0.3.8
       Fresh once_cell v1.5.2
       Fresh either v1.6.1
       Fresh pin-utils v0.1.0
       Fresh slab v0.4.2
       Fresh smallvec v1.4.2
       Fresh heck v0.3.1
       Fresh futures-task v0.3.8
       Fresh futures-channel v0.3.8
       Fresh proc-macro2 v1.0.24
       Fresh serde v1.0.117
       Fresh itertools v0.9.0
       Fresh proc-macro-hack v0.5.19
       Fresh libc v0.2.80
       Fresh proc-macro-nested v0.1.6
       Fresh anyhow v1.0.34
       Fresh bitflags v1.2.1
       Fresh quote v1.0.7
       Fresh toml v0.5.7
       Fresh syn v1.0.48
       Fresh proc-macro-error-attr v1.0.4
       Fresh proc-macro-crate v0.1.5
       Fresh thiserror-impl v1.0.22
       Fresh strum_macros v0.19.4
       Fresh pin-project-internal v1.0.1
       Fresh futures-macro v0.3.8
       Fresh proc-macro-error v1.0.4
       Fresh thiserror v1.0.22
       Fresh pin-project v1.0.1
       Fresh glib-macros v0.13.0 (/home/imperio/rust/gtk-rs/glib-macros)
       Fresh system-deps v2.0.1
       Fresh futures-util v0.3.8
       Fresh futures-executor v0.3.8
       Fresh glib-sys v0.13.0 (/home/imperio/rust/gtk-rs/glib/sys)
       Fresh gobject-sys v0.13.0 (/home/imperio/rust/gtk-rs/glib/gobject-sys)
       Fresh glib v0.13.0 (/home/imperio/rust/gtk-rs/glib)
    Finished dev [unoptimized + debuginfo] target(s) in 1.77s
```
</details>

r? @ehuss 