### PR TITLE
Reproducible crate builds

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -472,6 +472,13 @@ fn check_repo_state(
     }
 }
 
+fn timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
 fn tar(
     ws: &Workspace<'_>,
     ar_files: Vec<ArchiveFile>,
@@ -491,6 +498,7 @@ fn tar(
 
     let base_name = format!("{}-{}", pkg.name(), pkg.version());
     let base_path = Path::new(&base_name);
+    let time = timestamp();
     for ar_file in ar_files {
         let ArchiveFile {
             rel_path,
@@ -525,12 +533,7 @@ fn tar(
                 };
                 header.set_entry_type(EntryType::file());
                 header.set_mode(0o644);
-                header.set_mtime(
-                    SystemTime::now()
-                        .duration_since(SystemTime::UNIX_EPOCH)
-                        .unwrap()
-                        .as_secs(),
-                );
+                header.set_mtime(time);
                 header.set_size(contents.len() as u64);
                 header.set_cksum();
                 ar.append_data(&mut header, &ar_path, contents.as_bytes())

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -473,6 +473,11 @@ fn check_repo_state(
 }
 
 fn timestamp() -> u64 {
+    if let Ok(var) = std::env::var("SOURCE_DATE_EPOCH") {
+        if let Ok(stamp) = var.parse() {
+            return stamp;
+        }
+    }
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .unwrap()

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -6,8 +6,10 @@ use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, git, path2url, paths, project, symlink_supported, t,
 };
+use flate2::read::GzDecoder;
 use std::fs::{self, read_to_string, File};
 use std::path::Path;
+use tar::Archive;
 
 #[cargo_test]
 fn simple() {
@@ -1916,4 +1918,45 @@ src/main.rs
             long_name
         ))
         .run();
+}
+
+#[cargo_test]
+fn reproducible_output() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                exclude = ["*.txt"]
+                license = "MIT"
+                description = "foo"
+            "#,
+        )
+        .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .build();
+
+    // Timestamp is arbitrary and is the same used by git format-patch.
+    p.cargo("package")
+        .env("SOURCE_DATE_EPOCH", "1000684800")
+        .run();
+    assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
+
+    let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
+    let decoder = GzDecoder::new(f);
+    let mut archive = Archive::new(decoder);
+    for ent in archive.entries().unwrap() {
+        let ent = ent.unwrap();
+        let header = ent.header();
+        assert_eq!(header.mode().unwrap(), 0o644);
+        assert_eq!(header.uid().unwrap(), 0);
+        assert_eq!(header.gid().unwrap(), 0);
+        assert_eq!(header.mtime().unwrap(), 1000684800);
+        assert_eq!(header.username().unwrap().unwrap(), "root");
+        assert_eq!(header.groupname().unwrap().unwrap(), "root");
+        assert_eq!(header.device_major().unwrap().unwrap(), 0);
+        assert_eq!(header.device_minor().unwrap().unwrap(), 0);
+    }
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1938,10 +1938,7 @@ fn reproducible_output() {
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .build();
 
-    // Timestamp is arbitrary and is the same used by git format-patch.
-    p.cargo("package")
-        .env("SOURCE_DATE_EPOCH", "1000684800")
-        .run();
+    p.cargo("package").run();
     assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
@@ -1951,12 +1948,8 @@ fn reproducible_output() {
         let ent = ent.unwrap();
         let header = ent.header();
         assert_eq!(header.mode().unwrap(), 0o644);
-        assert_eq!(header.uid().unwrap(), 0);
-        assert_eq!(header.gid().unwrap(), 0);
-        assert_eq!(header.mtime().unwrap(), 1000684800);
-        assert_eq!(header.username().unwrap().unwrap(), "root");
-        assert_eq!(header.groupname().unwrap().unwrap(), "root");
-        assert_eq!(header.device_major().unwrap().unwrap(), 0);
-        assert_eq!(header.device_minor().unwrap().unwrap(), 0);
+        assert_eq!(header.mtime().unwrap(), 0);
+        assert_eq!(header.username().unwrap().unwrap(), "");
+        assert_eq!(header.groupname().unwrap().unwrap(), "");
     }
 }


### PR DESCRIPTION
This series introduces reproducible crate builds.  Since crates are essentially gzipped tar archives, we canonicalize the fields such that they don't contain extraneous and potentially privacy-leaking data such as user and group names and IDs, device major and minor, and system timestamps.  Outside of the timestamps, the user probably did not intend to share information about their user or system, so this also improves developer privacy somewhat.

The individual commit messages include copious details about the individual changes involved and the rationale for this change, but roughly, the idea is that by setting the environment variable `SOURCE_DATE_EPOCH`, which is [the preferred way to specify a fixed timestamp by the Reproducible Builds project](https://reproducible-builds.org/docs/source-date-epoch/), we will produce a fully reproducible archive.  In any event, we will now produce consistent timestamps throughout the archive and avoid looking up the system time repeatedly.

If desired, I could hash the produced crate in the tests, but I feel that would be a little overkill, especially since it's possible that one of our dependencies (e.g., flate2) might change and result in us producing an equivalent but different archive.  Since reproducible builds use a consistent toolchain, that's not a problem here.

Fixes #8612