### PR TITLE
Publish target's "doc" setting when emitting metadata

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -259,6 +259,9 @@ struct SerializedTarget<'a> {
     edition: &'a str,
     #[serde(rename = "required-features", skip_serializing_if = "Option::is_none")]
     required_features: Option<Vec<&'a str>>,
+    /// Whether docs should be built for the target via `cargo doc`
+    /// See https://doc.rust-lang.org/cargo/commands/cargo-doc.html#target-selection
+    doc: bool,
     doctest: bool,
     /// Whether tests should be run for the target (`test` field in `Cargo.toml`)
     test: bool,
@@ -281,6 +284,7 @@ impl ser::Serialize for Target {
             required_features: self
                 .required_features()
                 .map(|rf| rf.iter().map(|s| &**s).collect()),
+            doc: self.documented(),
             doctest: self.doctested() && self.doctestable(),
             test: self.tested(),
         }

--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -127,6 +127,8 @@ The output has the following format:
                        This property is not included if no required features are set.
                     */
                     "required-features": ["feat1"],
+                    /* Whether the target should be documented by `cargo doc`. */
+                    "doc": true,
                     /* Whether or not this target has doc tests enabled, and
                        the target is compatible with doc testing.
                     */

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -122,6 +122,8 @@ OUTPUT FORMAT
                                   This property is not included if no required features are set.
                                */
                                "required-features": ["feat1"],
+                               /* Whether the target should be documented by `cargo doc`. */
+                               "doc": true,
                                /* Whether or not this target has doc tests enabled, and
                                   the target is compatible with doc testing.
                                */

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -127,6 +127,8 @@ The output has the following format:
                        This property is not included if no required features are set.
                     */
                     "required-features": ["feat1"],
+                    /* Whether the target should be documented by `cargo doc`. */
+                    "doc": true,
                     /* Whether or not this target has doc tests enabled, and
                        the target is compatible with doc testing.
                     */

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -124,6 +124,8 @@ The output has the following format:
                        This property is not included if no required features are set.
                     */
                     "required\-features": ["feat1"],
+                    /* Whether the target should be documented by `cargo doc`. */
+                    "doc": true,
                     /* Whether or not this target has doc tests enabled, and
                        the target is compatible with doc testing.
                     */

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1741,6 +1741,7 @@ fn json_artifact_includes_executable_for_benchmark() {
                     "target": {
                         "crate_types": [ "bin" ],
                         "kind": [ "bench" ],
+                        "doc": false,
                         "doctest": false,
                         "edition": "2015",
                         "name": "benchmark",

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3144,6 +3144,7 @@ fn compiler_json_error_format() {
                 "target":{
                     "kind":["custom-build"],
                     "crate_types":["bin"],
+                    "doc": false,
                     "doctest": false,
                     "edition": "2015",
                     "name":"build-script-build",
@@ -3169,6 +3170,7 @@ fn compiler_json_error_format() {
                 "target":{
                     "kind":["lib"],
                     "crate_types":["lib"],
+                    "doc": true,
                     "doctest": true,
                     "edition": "2015",
                     "name":"bar",
@@ -3193,6 +3195,7 @@ fn compiler_json_error_format() {
                 "target":{
                     "kind":["lib"],
                     "crate_types":["lib"],
+                    "doc": true,
                     "doctest": true,
                     "edition": "2015",
                     "name":"bar",
@@ -3222,6 +3225,7 @@ fn compiler_json_error_format() {
                 "target":{
                     "kind":["bin"],
                     "crate_types":["bin"],
+                    "doc": true,
                     "doctest": false,
                     "edition": "2015",
                     "name":"foo",
@@ -3237,6 +3241,7 @@ fn compiler_json_error_format() {
                 "target":{
                     "kind":["bin"],
                     "crate_types":["bin"],
+                    "doc": true,
                     "doctest": false,
                     "edition": "2015",
                     "name":"foo",
@@ -3306,6 +3311,7 @@ fn message_format_json_forward_stderr() {
                     "target":{
                         "kind":["bin"],
                         "crate_types":["bin"],
+                        "doc": true,
                         "doctest": false,
                         "edition": "2015",
                         "name":"foo",
@@ -3321,6 +3327,7 @@ fn message_format_json_forward_stderr() {
                     "target":{
                         "kind":["bin"],
                         "crate_types":["bin"],
+                        "doc": true,
                         "doctest": false,
                         "edition": "2015",
                         "name":"foo",

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -697,6 +697,7 @@ fn metabuild_json_artifact() {
                 "crate_types": [
                   "bin"
                 ],
+                "doc": false,
                 "doctest": false,
                 "edition": "2018",
                 "kind": [
@@ -747,6 +748,7 @@ fn metabuild_failed_build_json() {
                 "crate_types": [
                   "bin"
                 ],
+                "doc": false,
                 "doctest": false,
                 "edition": "2018",
                 "kind": [

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -45,6 +45,7 @@ fn cargo_metadata_simple() {
                         "crate_types": [
                             "bin"
                         ],
+                        "doc": true,
                         "doctest": false,
                         "test": true,
                         "edition": "2015",
@@ -141,6 +142,7 @@ crate-type = ["lib", "staticlib"]
                             "lib",
                             "staticlib"
                         ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -225,6 +227,7 @@ optional_feat = []
                         "crate_types": [
                             "lib"
                         ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -340,6 +343,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -378,6 +382,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -441,6 +446,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "bin"
                         ],
+                        "doc": true,
                         "doctest": false,
                         "test": true,
                         "edition": "2015",
@@ -479,6 +485,7 @@ fn cargo_metadata_with_deps_and_version() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -615,6 +622,7 @@ name = "ex"
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -624,6 +632,7 @@ name = "ex"
                     {
                         "kind": [ "example" ],
                         "crate_types": [ "bin" ],
+                        "doc": false,
                         "doctest": false,
                         "test": false,
                         "edition": "2015",
@@ -706,6 +715,7 @@ crate-type = ["rlib", "dylib"]
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -715,6 +725,7 @@ crate-type = ["rlib", "dylib"]
                     {
                         "kind": [ "example" ],
                         "crate_types": [ "rlib", "dylib" ],
+                        "doc": false,
                         "doctest": false,
                         "test": false,
                         "edition": "2015",
@@ -804,6 +815,7 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -840,6 +852,7 @@ fn workspace_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -931,6 +944,7 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -967,6 +981,7 @@ fn workspace_metadata_no_deps() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": ["lib"],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -1028,6 +1043,7 @@ const MANIFEST_OUTPUT: &str = r#"
         "targets":[{
             "kind":["bin"],
             "crate_types":["bin"],
+            "doc": true,
             "doctest": false,
             "test": true,
             "edition": "2015",
@@ -1217,6 +1233,7 @@ fn package_metadata() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -1293,6 +1310,7 @@ fn package_publish() {
                     {
                         "kind": [ "lib" ],
                         "crate_types": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -1370,6 +1388,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                         "crate_types": [
                             "lib"
                         ],
+                        "doc": true,
                         "doctest": true,
                         "test": true,
                         "edition": "2015",
@@ -1455,6 +1474,7 @@ fn package_edition_2018() {
                                 "crate_types": [
                                     "lib"
                                 ],
+                                "doc": true,
                                 "doctest": true,
                                 "test": true,
                                 "edition": "2018",
@@ -1544,6 +1564,7 @@ fn target_edition_2018() {
                                 "crate_types": [
                                     "lib"
                                 ],
+                                "doc": true,
                                 "doctest": true,
                                 "test": true,
                                 "edition": "2018",
@@ -1557,6 +1578,7 @@ fn target_edition_2018() {
                                 "crate_types": [
                                     "bin"
                                 ],
+                                "doc": true,
                                 "doctest": false,
                                 "test": true,
                                 "edition": "2015",
@@ -1647,6 +1669,7 @@ fn rename_dependency() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doc": true,
                     "doctest": true,
                     "test": true,
                     "edition": "2015",
@@ -1685,6 +1708,7 @@ fn rename_dependency() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doc": true,
                     "doctest": true,
                     "test": true,
                     "edition": "2015",
@@ -1748,6 +1772,7 @@ fn rename_dependency() {
                     "crate_types": [
                         "lib"
                     ],
+                    "doc": true,
                     "doctest": true,
                     "test": true,
                     "edition": "2015",
@@ -1867,6 +1892,7 @@ fn metadata_links() {
                       "crate_types": [
                         "lib"
                       ],
+                      "doc": true,
                       "doctest": true,
                       "test": true,
                       "edition": "2015",
@@ -1880,6 +1906,7 @@ fn metadata_links() {
                       "crate_types": [
                         "bin"
                       ],
+                      "doc": false,
                       "doctest": false,
                       "test": false,
                       "edition": "2015",
@@ -1973,6 +2000,7 @@ fn deps_with_bin_only() {
                       "name": "foo",
                       "src_path": "[..]/foo/src/lib.rs",
                       "edition": "2015",
+                      "doc": true,
                       "doctest": true,
                       "test": true
                     }
@@ -2076,6 +2104,7 @@ fn filter_platform() {
           "src_path": "[..]/alt-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
+          "doc": true,
           "doctest": true
         }
       ],
@@ -2117,6 +2146,7 @@ fn filter_platform() {
           "src_path": "[..]/cfg-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
+          "doc": true,
           "doctest": true
         }
       ],
@@ -2158,6 +2188,7 @@ fn filter_platform() {
           "src_path": "[..]/host-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
+          "doc": true,
           "doctest": true
         }
       ],
@@ -2199,6 +2230,7 @@ fn filter_platform() {
           "src_path": "[..]/normal-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
+          "doc": true,
           "doctest": true
         }
       ],
@@ -2289,6 +2321,7 @@ fn filter_platform() {
           "src_path": "[..]/foo/src/lib.rs",
           "edition": "2015",
           "test": true,
+          "doc": true,
           "doctest": true
         }
       ],

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -28,6 +28,7 @@ fn manifest_output(readme_value: &str) -> String {
     "targets":[{{
         "kind":["bin"],
         "crate_types":["bin"],
+        "doc": true,
         "doctest": false,
         "test": true,
         "edition": "2015",

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3539,6 +3539,7 @@ fn json_artifact_includes_test_flag() {
                     "target":{
                         "kind":["lib"],
                         "crate_types":["lib"],
+                        "doc": true,
                         "doctest": true,
                         "edition": "2015",
                         "name":"foo",
@@ -3576,6 +3577,7 @@ fn json_artifact_includes_executable_for_library_tests() {
                     "target": {
                         "crate_types": [ "lib" ],
                         "kind": [ "lib" ],
+                        "doc": true,
                         "doctest": true,
                         "edition": "2015",
                         "name": "foo",
@@ -3613,6 +3615,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
                     "target": {
                         "crate_types": [ "bin" ],
                         "kind": [ "test" ],
+                        "doc": false,
                         "doctest": false,
                         "edition": "2015",
                         "name": "integration_test",

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -63,6 +63,7 @@ fn simple() {
                     "name": "a",
                     "src_path": "[..]/a-1.0.0/src/lib.rs",
                     "edition": "2015",
+                    "doc": true,
                     "doctest": true,
                     "test": true
                   },
@@ -105,6 +106,7 @@ fn simple() {
                     "name": "b",
                     "src_path": "[..]/b-1.0.0/src/lib.rs",
                     "edition": "2015",
+                    "doc": true,
                     "doctest": true,
                     "test": true
                   },
@@ -148,6 +150,7 @@ fn simple() {
                     "src_path": "[..]/c-1.0.0/src/lib.rs",
                     "edition": "2015",
                     "test": true,
+                    "doc": true,
                     "doctest": true
                   },
                   "profile": {
@@ -183,6 +186,7 @@ fn simple() {
                     "src_path": "[..]/foo/src/lib.rs",
                     "edition": "2015",
                     "test": true,
+                    "doc": true,
                     "doctest": true
                   },
                   "profile": {

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -469,6 +469,7 @@ fn update_precise_first_run() {
           "crate_types": [
             "lib"
           ],
+          "doc": true,
           "doctest": true,
           "test": true,
           "edition": "2015",
@@ -507,6 +508,7 @@ fn update_precise_first_run() {
           "crate_types": [
             "lib"
           ],
+          "doc": true,
           "doctest": true,
           "edition": "2015",
           "kind": [


### PR DESCRIPTION
Prior to this commit `cargo metadata` would not emit the value of a
target's "doc" setting, used by `cargo doc` to determine whether
documentation should be generated. However, this information is useful
for machine programs interested in such targets, and the information is
already made available on the internal representation of a target, so
this commit just exposes that during target serialization for emit.

cf https://github.com/deadlinks/cargo-deadlinks/issues/99