### PR TITLE
Append workspace paths using components

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1198,7 +1198,11 @@ impl WorkspaceRootConfig {
         let mut expanded_list = Vec::new();
 
         for glob in globs {
-            let pathbuf = self.root_dir.join(glob);
+            let pathbuf = self
+                .root_dir
+                .components()
+                .chain((&Path::new(&glob)).components())
+                .collect::<PathBuf>();
             let expanded_paths = Self::expand_member_path(&pathbuf)?;
 
             // If glob does not find any valid paths, then put the original


### PR DESCRIPTION
This improves the handling when cargo is run on windows using
a UNC path as its working directory.

This error was met working on https://github.com/EmbarkStudios/rust-gpu/pull/239.

An alternative implementation which would also be sufficient for rust-gpu would be to only append the new path's components, and keep the same format for `root_dir`.

This could also be limited to the `expanded_list.push(pathbuf);` branch, if preferred, although this would prevent rust-gpu from using glob paths at all, which would be unfortunate.

See also:
 - https://github.com/rust-lang/cargo/issues/7986
 - https://github.com/rust-lang/rust/issues/42869