### PR TITLE
Set docs.rs as the default extern-map for crates.io

### DIFF
--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -52,11 +52,34 @@ impl<'de> serde::de::Deserialize<'de> for RustdocExternMode {
     }
 }
 
-#[derive(serde::Deserialize, Debug, Default)]
+#[derive(serde::Deserialize, Debug)]
 #[serde(default)]
 pub struct RustdocExternMap {
+    #[serde(deserialize_with = "default_crates_io_to_docs_rs")]
     pub(crate) registries: HashMap<String, String>,
     std: Option<RustdocExternMode>,
+}
+
+impl Default for RustdocExternMap {
+    fn default() -> Self {
+        let mut registries = HashMap::new();
+        registries.insert("crates-io".into(), "https://docs.rs/".into());
+        Self {
+            registries,
+            std: None,
+        }
+    }
+}
+
+fn default_crates_io_to_docs_rs<'de, D: serde::Deserializer<'de>>(
+    de: D,
+) -> Result<HashMap<String, String>, D::Error> {
+    use serde::Deserialize;
+    let mut registries = HashMap::deserialize(de)?;
+    if !registries.contains_key("crates-io") {
+        registries.insert("crates-io".into(), "https://docs.rs/".into());
+    }
+    Ok(registries)
 }
 
 impl hash::Hash for RustdocExternMap {

--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -55,7 +55,7 @@ impl<'de> serde::de::Deserialize<'de> for RustdocExternMode {
 #[derive(serde::Deserialize, Debug, Default)]
 #[serde(default)]
 pub struct RustdocExternMap {
-    registries: HashMap<String, String>,
+    pub(crate) registries: HashMap<String, String>,
     std: Option<RustdocExternMode>,
 }
 
@@ -80,10 +80,6 @@ pub fn add_root_urls(
         return Ok(());
     }
     let map = config.doc_extern_map()?;
-    if map.registries.is_empty() && map.std.is_none() {
-        // Skip doing unnecessary work.
-        return Ok(());
-    }
     let mut unstable_opts = false;
     // Collect mapping of registry name -> index url.
     let name2url: HashMap<&String, Url> = map

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1217,8 +1217,15 @@ impl Config {
         // Note: This does not support environment variables. The `Unit`
         // fundamentally does not have access to the registry name, so there is
         // nothing to query. Plumbing the name into SourceId is quite challenging.
-        self.doc_extern_map
-            .try_borrow_with(|| self.get::<RustdocExternMap>("doc.extern-map"))
+        self.doc_extern_map.try_borrow_with(|| {
+            let mut extern_map = self.get::<RustdocExternMap>("doc.extern-map");
+            if let Ok(map) = &mut extern_map {
+                map.registries
+                    .entry("crates-io".into())
+                    .or_insert("https://docs.rs/".into());
+            }
+            extern_map
+        })
     }
 
     /// Returns the `[target]` table definition for the given target triple.

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1217,15 +1217,8 @@ impl Config {
         // Note: This does not support environment variables. The `Unit`
         // fundamentally does not have access to the registry name, so there is
         // nothing to query. Plumbing the name into SourceId is quite challenging.
-        self.doc_extern_map.try_borrow_with(|| {
-            let mut extern_map = self.get::<RustdocExternMap>("doc.extern-map");
-            if let Ok(map) = &mut extern_map {
-                map.registries
-                    .entry("crates-io".into())
-                    .or_insert("https://docs.rs/".into());
-            }
-            extern_map
-        })
+        self.doc_extern_map
+            .try_borrow_with(|| self.get::<RustdocExternMap>("doc.extern-map"))
     }
 
     /// Returns the `[target]` table definition for the given target triple.

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -363,7 +363,7 @@ fn rebuilds_when_changing() {
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(
-            "[RUNNING] `rustdoc [..]--extern-html-root-url 'bar=https://example.com/bar/1.0.0/[..]' [..]",
+            "[RUNNING] `rustdoc [..]--extern-html-root-url [..]bar=https://example.com/bar/1.0.0/[..]",
         )
         .run();
 }

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -32,21 +32,10 @@ fn basic_project() -> Project {
         .build()
 }
 
-fn docs_rs(p: &Project) {
-    p.change_file(
-        ".cargo/config",
-        r#"
-            [doc.extern-map.registries]
-            crates-io = "https://docs.rs/"
-        "#,
-    );
-}
-
 #[cargo_test]
 fn ignores_on_stable() {
     // Requires -Zrustdoc-map to use.
     let p = basic_project();
-    docs_rs(&p);
     p.cargo("doc -v --no-deps")
         .with_stderr_does_not_contain("[..]--extern-html-root-url[..]")
         .run();
@@ -60,7 +49,6 @@ fn simple() {
         return;
     }
     let p = basic_project();
-    docs_rs(&p);
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(
@@ -157,7 +145,6 @@ fn renamed_dep() {
             "#,
         )
         .build();
-    docs_rs(&p);
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(
@@ -211,7 +198,6 @@ fn lib_name() {
             "#,
         )
         .build();
-    docs_rs(&p);
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(
@@ -338,7 +324,6 @@ fn multiple_versions() {
             ",
         )
         .build();
-    docs_rs(&p);
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(
@@ -364,12 +349,21 @@ fn rebuilds_when_changing() {
     let p = basic_project();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
-        .with_stderr_does_not_contain("[..]--extern-html-root-url[..]")
+        .with_stderr_contains("[..]--extern-html-root-url[..]")
         .run();
 
-    docs_rs(&p);
+    // This also tests that the map for docs.rs can be overridden.
+    p.change_file(
+        ".cargo/config",
+        r#"
+            [doc.extern-map.registries]
+            crates-io = "https://example.com/"
+        "#,
+    );
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[..]--extern-html-root-url[..]")
+        .with_stderr_contains(
+            "[RUNNING] `rustdoc [..]--extern-html-root-url 'bar=https://example.com/bar/1.0.0/[..]' [..]",
+        )
         .run();
 }


### PR DESCRIPTION
Helps address https://github.com/rust-lang/cargo/issues/8296, specifically the bit needed for https://github.com/rust-lang/docs.rs/issues/1177.
r? @ehuss 