### PR TITLE
Count RUSTC_BOOTSTRAP as nightly for tests

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1571,8 +1571,11 @@ pub fn rustc_host() -> String {
 
 pub fn is_nightly() -> bool {
     env::var("CARGO_TEST_DISABLE_NIGHTLY").is_err()
-        && RUSTC
-            .with(|r| r.verbose_version.contains("-nightly") || r.verbose_version.contains("-dev"))
+        && (RUSTC.with(|r| {
+            r.verbose_version.contains("-nightly")
+                || r.verbose_version.contains("-dev")
+                || env::var("RUSTC_BOOTSTRAP").as_deref() == Ok("1")
+        }))
 }
 
 pub fn process<T: AsRef<OsStr>>(t: T) -> cargo::util::ProcessBuilder {


### PR DESCRIPTION
Rustdoc will count this as nightly, so cargo should too. This allows
running nightly-only tests without having to rebuild all 175
dependencies.