### PR TITLE
Fix documentation for CARGO_PRIMARY_PACKAGE.

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -49,7 +49,7 @@ system:
 * `TERM` — If this is set to `dumb`, it disables the progress bar.
 * `BROWSER` — The web browser to execute to open documentation with [`cargo
   doc`]'s' `--open` flag.
-* `RUSTFMT` — Instead of running `rustfmt`, 
+* `RUSTFMT` — Instead of running `rustfmt`,
   [`cargo fmt`](https://github.com/rust-lang/rustfmt) will execute this specified
   `rustfmt` instance instead.
 
@@ -206,6 +206,12 @@ let version = env!("CARGO_PKG_VERSION");
   example, `CARGO_BIN_EXE_my-program` for a binary named `my-program`.
   Binaries are automatically built when the test is built, unless the binary
   has required features that are not enabled.
+* `CARGO_PRIMARY_PACKAGE` — This environment variable will be set if the
+  package being built is primary. Primary packages are the ones the user
+  selected on the command-line, either with `-p` flags or the defaults based
+  on the current directory and the default workspace members. This environment
+  variable will not be set when building dependencies. This is only set when
+  compiling the package (not when running binaries or tests).
 
 [integration test]: cargo-targets.md#integration-tests
 [`env` macro]: ../../std/macro.env.html
@@ -266,12 +272,6 @@ let out_dir = env::var("OUT_DIR").unwrap();
                       Currently Cargo doesn't set the `MAKEFLAGS` variable,
                       but it's free for build scripts invoking GNU Make
                       to set it to the contents of `CARGO_MAKEFLAGS`.
-* `CARGO_PRIMARY_PACKAGE` — This environment variable will be set if the package being
-                            built is primary. Primary packages are the ones the user 
-                            selected on the command-line, either with `-p` flags or 
-                            the defaults based on the current directory and the default 
-                            workspace members.
-                            This environment variable will not be set when building dependencies.
 * `CARGO_FEATURE_<name>` — For each activated feature of the package being
                            built, this environment variable will be present
                            where `<name>` is the name of the feature uppercased


### PR DESCRIPTION
The environment variable `CARGO_PRIMARY_PACKAGE` is set when running `rustc`, not when running a build script.
