### PR TITLE
Shrink the progress bar, to give more space after it.

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -71,7 +71,9 @@ impl<'cfg> Progress<'cfg> {
                 format: Format {
                     style,
                     max_width: n,
-                    max_print: 80,
+                    // 50 gives some space for text after the progress bar,
+                    // even on narrow (e.g. 80 char) terminals.
+                    max_print: 50,
                 },
                 name: name.to_string(),
                 done: false,


### PR DESCRIPTION
Because:
- A big progress bar isn't necessary. Making it smaller loses some
  precision, but a big bar isn't that precise in the first place. If you
  precision you can look at the percentage or ratio figure after the
  progress bar anyway.
- A big bar sometimes obscures important info. For the "Building"
  step the crate names after the progress bar are important -- they make
  it clear how much parallelism is in the build. If you don't see that
  you're getting a much worse understanding of the build process.

On an 80-char wide terminal, the change looks like this. Before:
```
    Building [========>                                               ] 18/105
```
After:
```
    Building [=======================>  ] 97/105: goblin, pdb, symbolic-dem...
```

On a 100-char wide terminal, it looks like this. Before:
```
    Building [============================>                           ] 56/105: cpp_demangle(bu...
```
After:
```
    Building [============>             ] 56/105: byteorder, proc-macro2, pest, gimli, cpp_dema...
```