### PR TITLE
fix: we don't ignore `version` for `git`/`path` deps now

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -205,9 +205,9 @@ hello_utils = { path = "hello_utils", version = "0.1.0" }
 
 It is possible to specify both a registry version and a `git` or `path`
 location. The `git` or `path` dependency will be used locally (in which case
-the `version` is ignored), and when published to a registry like [crates.io],
-it will use the registry version. Other combinations are not allowed.
-Examples:
+the `version` is checked against the local copy), and when published to a
+registry like [crates.io], it will use the registry version. Other
+combinations are not allowed. Examples:
 
 ```toml
 [dependencies]
@@ -218,6 +218,8 @@ bitflags = { path = "my-bitflags", version = "1.0" }
 # Uses the given git repo when used locally, and uses
 # version 1.0 from crates.io when published.
 smallvec = { git = "https://github.com/servo/rust-smallvec", version = "1.0" }
+
+# N.B. that if a version doesn't match, Cargo will fail to compile!
 ```
 
 One example where this can be useful is when you have split up a library into


### PR DESCRIPTION
Here's a sample invocation using Cargo 1.48 to prove this:

```
$ cargo new test-cargo-version-path-constraints && cd test-cargo-version-path-constraints
     Created binary (application) `test-cargo-version-path-constraints` package

$ echo 'windows-service = { version = "999", git = "https://github.com/NZXTCorp/windows-service-rs" }' >> Cargo.toml

$ cargo build
    Updating git repository `https://github.com/NZXTCorp/windows-service-rs`
error: failed to select a version for the requirement `windows-service = "^999"`
candidate versions found which didn't match: 0.3.2
location searched: Git repository https://github.com/NZXTCorp/windows-service-rs
required by package `test-cargo-version-path-constraints v0.1.0 (C:\tools\msys64\home\erich\workspace\tmp\test-cargo-version-path-constraints)`
```