### PR TITLE
Remove unnecessary trailing semicolons

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -426,7 +426,7 @@ impl CliUnstable {
                 bail!("flag -Z{} does not take a value, found: `{}`", key, v);
             }
             Ok(true)
-        };
+        }
 
         fn parse_usize_opt(value: Option<&str>) -> CargoResult<Option<usize>> {
             Ok(match value {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -445,7 +445,7 @@ impl<'cfg> Workspace<'cfg> {
                 .join("Cargo.toml");
             debug!("find_root - pointer {}", path.display());
             Ok(paths::normalize_path(&path))
-        };
+        }
 
         {
             let current = self.packages.load(manifest_path)?;


### PR DESCRIPTION
PR https://github.com/rust-lang/rust/pull/78296 will cause rustc to
start warning on semicolons following item statements.