### PR TITLE
Bump miow dependency to not invalidly assume memory layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ rustc-workspace-hack = "1.0.0"
 core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
-miow = "0.3.1"
+miow = "0.3.6"
 fwdansi = "1.1.0"
 
 [target.'cfg(windows)'.dependencies.winapi]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/78802 and https://github.com/yoshuawuyts/miow/pull/39