### PR TITLE
Fix some rustdoc warnings.

### DIFF
--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -16,7 +16,7 @@ use url::Url;
 pub enum RustdocExternMode {
     /// Use a local `file://` URL.
     Local,
-    /// Use a remote URL to https://doc.rust-lang.org/ (default).
+    /// Use a remote URL to <https://doc.rust-lang.org/> (default).
     Remote,
     /// An arbitrary URL.
     Url(String),

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -19,8 +19,6 @@ lazy_static::lazy_static! {
 }
 
 /// Unique identifier for a source of packages.
-///
-/// See also: [`SourceKind`].
 #[derive(Clone, Copy, Eq, Debug)]
 pub struct SourceId {
     inner: &'static SourceIdInner,

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -240,7 +240,7 @@ pub struct RegistryPackage<'a> {
     yanked: Option<bool>,
     /// Native library name this package links to.
     ///
-    /// Added early 2018 (see https://github.com/rust-lang/cargo/pull/4978),
+    /// Added early 2018 (see <https://github.com/rust-lang/cargo/pull/4978>),
     /// can be `None` if published before then.
     links: Option<InternedString>,
 }


### PR DESCRIPTION
Silences some warnings from rustdoc.  `SourceKind` is private and can't be linked from a public type.
