### PR TITLE
Fixes #8783 , cargo new fails without a author name or email

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -645,7 +645,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     init_vcs(path, vcs, config)?;
     write_ignore_file(path, &ignore, vcs)?;
 
-    let (discovered_name, discovered_email) = discover_author(path)?;
+    let (discovered_name, discovered_email) = discover_author(path);
 
     // "Name <email>" or "Name" or "<email>" or None if neither name nor email is obtained
     // cfg takes priority over the discovered ones
@@ -802,7 +802,7 @@ fn get_environment_variable(variables: &[&str]) -> Option<String> {
     variables.iter().filter_map(|var| env::var(var).ok()).next()
 }
 
-fn discover_author(path: &Path) -> CargoResult<(Option<String>, Option<String>)> {
+fn discover_author(path: &Path) -> (Option<String>, Option<String>) {
     let git_config = find_git_config(path);
     let git_config = git_config.as_ref();
 
@@ -845,7 +845,7 @@ fn discover_author(path: &Path) -> CargoResult<(Option<String>, Option<String>)>
         s.to_string()
     });
 
-    Ok((name, email))
+    (name, email)
 }
 
 fn find_git_config(path: &Path) -> Option<GitConfig> {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -649,15 +649,8 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
 
     // "Name <email>" or "Name" or "<email>" or None if neither name nor email is obtained
     // cfg takes priority over the discovered ones
-    let author_name = match (cfg.name, discovered_name) {
-        (Some(name), _) | (_, Some(name)) => Some(name),
-        (None, None) => None,
-    };
-
-    let author_email = match (cfg.email, discovered_email) {
-        (Some(email), _) | (_, Some(email)) => Some(email),
-        (None, None) => None,
-    };
+    let author_name = cfg.name.or(discovered_name);
+    let author_email = cfg.email.or(discovered_email);
 
     let author = match (author_name, author_email) {
         (Some(name), Some(email)) => {

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -195,8 +195,37 @@ fn finds_author_user() {
     cargo_process("new foo").env("USER", "foo").run();
 
     let toml = paths::root().join("foo/Cargo.toml");
+    println!("{:?}", toml);
     let contents = fs::read_to_string(&toml).unwrap();
     assert!(contents.contains(r#"authors = ["foo"]"#));
+}
+
+#[cargo_test]
+fn author_without_user_or_email() {
+    create_empty_gitconfig();
+    cargo_process("new foo")
+        .env_remove("USER")
+        .env_remove("USERNAME")
+        .env_remove("NAME")
+        .env_remove("EMAIL")
+        .run();
+
+    let toml = paths::root().join("foo/Cargo.toml");
+    let contents = fs::read_to_string(&toml).unwrap();
+    assert!(contents.contains(r#"authors = []"#));
+}
+
+#[cargo_test]
+fn finds_author_email_only() {
+    create_empty_gitconfig();
+    cargo_process("new foo")        
+        .env("EMAIL", "baz")
+        .run();
+
+    let toml = paths::root().join("foo/Cargo.toml");
+    println!("{:?}", toml);
+    let contents = fs::read_to_string(&toml).unwrap();
+    assert!(contents.contains(r#"authors = ["<baz>"]"#));
 }
 
 #[cargo_test]

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -221,7 +221,9 @@ fn finds_author_email_only() {
         .env_remove("USER")
         .env_remove("USERNAME")
         .env_remove("NAME")
-        .env_remove("EMAIL").env("EMAIL", "baz").run();
+        .env_remove("EMAIL")
+        .env("EMAIL", "baz")
+        .run();
 
     let toml = paths::root().join("foo/Cargo.toml");
     println!("{:?}", toml);

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -226,7 +226,6 @@ fn finds_author_email_only() {
         .run();
 
     let toml = paths::root().join("foo/Cargo.toml");
-    println!("{:?}", toml);
     let contents = fs::read_to_string(&toml).unwrap();
     assert!(contents.contains(r#"authors = ["<baz>"]"#));
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -195,7 +195,6 @@ fn finds_author_user() {
     cargo_process("new foo").env("USER", "foo").run();
 
     let toml = paths::root().join("foo/Cargo.toml");
-    println!("{:?}", toml);
     let contents = fs::read_to_string(&toml).unwrap();
     assert!(contents.contains(r#"authors = ["foo"]"#));
 }
@@ -218,9 +217,7 @@ fn author_without_user_or_email() {
 #[cargo_test]
 fn finds_author_email_only() {
     create_empty_gitconfig();
-    cargo_process("new foo")        
-        .env("EMAIL", "baz")
-        .run();
+    cargo_process("new foo").env("EMAIL", "baz").run();
 
     let toml = paths::root().join("foo/Cargo.toml");
     println!("{:?}", toml);

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -217,7 +217,11 @@ fn author_without_user_or_email() {
 #[cargo_test]
 fn finds_author_email_only() {
     create_empty_gitconfig();
-    cargo_process("new foo").env("EMAIL", "baz").run();
+    cargo_process("new foo")
+        .env_remove("USER")
+        .env_remove("USERNAME")
+        .env_remove("NAME")
+        .env_remove("EMAIL").env("EMAIL", "baz").run();
 
     let toml = paths::root().join("foo/Cargo.toml");
     println!("{:?}", toml);


### PR DESCRIPTION
If user can not be obtained from git or env variables $USER, new command defaults to empty author in generated Cargo.toml

Could not edit old PR(#8910 8783) as the original clone was deleted. 