### PR TITLE
Remove version from dev-dependencies to make it easier to publish.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,8 +103,8 @@ features = [
 ]
 
 [dev-dependencies]
-cargo-test-macro = { path = "crates/cargo-test-macro", version = "0.1.0" }
-cargo-test-support = { path = "crates/cargo-test-support", version = "0.1.0" }
+cargo-test-macro = { path = "crates/cargo-test-macro" }
+cargo-test-support = { path = "crates/cargo-test-support" }
 
 [build-dependencies]
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }


### PR DESCRIPTION
Since #7333, released in 1.40, Cargo will strip dev-dependencies that don't have a version.  These two crates aren't published to crates.io, and thus they have to be commented out each time a release is made. This change avoids that step.
