### PR TITLE
Add support for Rust edition 2021.

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -66,6 +66,8 @@ pub enum Edition {
     Edition2015,
     /// The 2018 edition
     Edition2018,
+    /// The 2021 edition
+    Edition2021,
 }
 
 impl fmt::Display for Edition {
@@ -73,6 +75,7 @@ impl fmt::Display for Edition {
         match *self {
             Edition::Edition2015 => f.write_str("2015"),
             Edition::Edition2018 => f.write_str("2018"),
+            Edition::Edition2021 => f.write_str("2021"),
         }
     }
 }
@@ -82,14 +85,15 @@ impl FromStr for Edition {
         match s {
             "2015" => Ok(Edition::Edition2015),
             "2018" => Ok(Edition::Edition2018),
-            s if s.parse().map_or(false, |y: u16| y > 2020 && y < 2050) => bail!(
+            "2021" => Ok(Edition::Edition2021),
+            s if s.parse().map_or(false, |y: u16| y > 2021 && y < 2050) => bail!(
                 "this version of Cargo is older than the `{}` edition, \
-                 and only supports `2015` and `2018` editions.",
+                 and only supports `2015`, `2018`, and `2021` editions.",
                 s
             ),
             s => bail!(
-                "supported edition values are `2015` or `2018`, but `{}` \
-                 is unknown",
+                "supported edition values are `2015`, `2018`, or `2021`, \
+                 but `{}` is unknown",
                 s
             ),
         }

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -50,7 +50,7 @@ use log::{debug, trace, warn};
 use rustfix::diagnostics::Diagnostic;
 use rustfix::{self, CodeFix};
 
-use crate::core::Workspace;
+use crate::core::{Edition, Workspace};
 use crate::ops::{self, CompileOptions};
 use crate::util::diagnostic_server::{Message, RustfixDiagnosticServer};
 use crate::util::errors::CargoResult;
@@ -203,7 +203,7 @@ pub fn fix_maybe_exec_rustc() -> CargoResult<bool> {
         Err(_) => return Ok(false),
     };
 
-    let args = FixArgs::get();
+    let args = FixArgs::get()?;
     trace!("cargo-fix as rustc got file {:?}", args.file);
 
     let rustc = args.rustc.as_ref().expect("fix wrapper rustc was not set");
@@ -583,7 +583,7 @@ struct FixArgs {
     file: Option<PathBuf>,
     prepare_for_edition: PrepareFor,
     idioms: bool,
-    enabled_edition: Option<String>,
+    enabled_edition: Option<Edition>,
     other: Vec<OsString>,
     rustc: Option<PathBuf>,
     format_args: Vec<String>,
@@ -591,7 +591,7 @@ struct FixArgs {
 
 enum PrepareFor {
     Next,
-    Edition(String),
+    Edition(Edition),
     None,
 }
 
@@ -602,7 +602,7 @@ impl Default for PrepareFor {
 }
 
 impl FixArgs {
-    fn get() -> FixArgs {
+    fn get() -> Result<FixArgs, Error> {
         let mut ret = FixArgs::default();
 
         ret.rustc = env::args_os().nth(1).map(PathBuf::from);
@@ -615,7 +615,7 @@ impl FixArgs {
             }
             if let Some(s) = path.to_str() {
                 if let Some(edition) = s.strip_prefix("--edition=") {
-                    ret.enabled_edition = Some(edition.to_string());
+                    ret.enabled_edition = Some(edition.parse()?);
                     continue;
                 }
                 if s.starts_with("--error-format=") || s.starts_with("--json=") {
@@ -628,13 +628,13 @@ impl FixArgs {
             ret.other.push(path.into());
         }
         if let Ok(s) = env::var(PREPARE_FOR_ENV) {
-            ret.prepare_for_edition = PrepareFor::Edition(s);
+            ret.prepare_for_edition = PrepareFor::Edition(s.parse()?);
         } else if env::var(EDITION_ENV).is_ok() {
             ret.prepare_for_edition = PrepareFor::Next;
         }
 
         ret.idioms = env::var(IDIOMS_ENV).is_ok();
-        ret
+        Ok(ret)
     }
 
     fn apply(&self, cmd: &mut Command) {
@@ -643,9 +643,9 @@ impl FixArgs {
         }
 
         cmd.args(&self.other).arg("--cap-lints=warn");
-        if let Some(edition) = &self.enabled_edition {
-            cmd.arg("--edition").arg(edition);
-            if self.idioms && edition == "2018" {
+        if let Some(edition) = self.enabled_edition {
+            cmd.arg("--edition").arg(edition.to_string());
+            if self.idioms && edition >= Edition::Edition2018 {
                 cmd.arg("-Wrust-2018-idioms");
             }
         }
@@ -667,7 +667,7 @@ impl FixArgs {
             Some(s) => s,
             None => return Ok(()),
         };
-        let enabled = match &self.enabled_edition {
+        let enabled = match self.enabled_edition {
             Some(s) => s,
             None => return Ok(()),
         };
@@ -688,23 +688,19 @@ impl FixArgs {
         process::exit(1);
     }
 
-    fn prepare_for_edition_resolve(&self) -> Option<&str> {
-        match &self.prepare_for_edition {
+    fn prepare_for_edition_resolve(&self) -> Option<Edition> {
+        match self.prepare_for_edition {
             PrepareFor::Edition(s) => Some(s),
             PrepareFor::Next => Some(self.next_edition()),
             PrepareFor::None => None,
         }
     }
 
-    fn next_edition(&self) -> &str {
-        match self.enabled_edition.as_deref() {
-            // 2015 -> 2018,
-            None | Some("2015") => "2018",
-
-            // This'll probably be wrong in 2020, but that's future Cargo's
-            // problem. Eventually though we'll just add more editions here as
-            // necessary.
-            _ => "2018",
+    fn next_edition(&self) -> Edition {
+        match self.enabled_edition {
+            None | Some(Edition::Edition2015) => Edition::Edition2018,
+            Some(Edition::Edition2018) => Edition::Edition2021,
+            Some(Edition::Edition2021) => Edition::Edition2021,
         }
     }
 }

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -699,7 +699,7 @@ impl FixArgs {
     fn next_edition(&self) -> Edition {
         match self.enabled_edition {
             None | Some(Edition::Edition2015) => Edition::Edition2018,
-            Some(Edition::Edition2018) => Edition::Edition2021,
+            Some(Edition::Edition2018) => Edition::Edition2018, // TODO: Change to 2021 when rustc is ready for it.
             Some(Edition::Edition2021) => Edition::Edition2021,
         }
     }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -188,7 +188,7 @@ pub trait AppExt: Sized {
         ._arg(opt("lib", "Use a library template"))
         ._arg(
             opt("edition", "Edition to set for the crate generated")
-                .possible_values(&["2015", "2018"])
+                .possible_values(&["2015", "2018", "2021"])
                 .value_name("YEAR"),
         )
         ._arg(

--- a/src/doc/man/generated_txt/cargo-init.txt
+++ b/src/doc/man/generated_txt/cargo-init.txt
@@ -69,7 +69,7 @@ OPTIONS
 
        --edition edition
            Specify the Rust edition to use. Default is 2018. Possible values:
-           2015, 2018
+           2015, 2018, 2021
 
        --name name
            Set the package name. Defaults to the directory name.

--- a/src/doc/man/generated_txt/cargo-new.txt
+++ b/src/doc/man/generated_txt/cargo-new.txt
@@ -64,7 +64,7 @@ OPTIONS
 
        --edition edition
            Specify the Rust edition to use. Default is 2018. Possible values:
-           2015, 2018
+           2015, 2018, 2021
 
        --name name
            Set the package name. Defaults to the directory name.

--- a/src/doc/man/includes/options-new.md
+++ b/src/doc/man/includes/options-new.md
@@ -11,7 +11,7 @@ Create a package with a library target (`src/lib.rs`).
 
 {{#option "`--edition` _edition_" }}
 Specify the Rust edition to use. Default is 2018.
-Possible values: 2015, 2018
+Possible values: 2015, 2018, 2021
 {{/option}}
 
 {{#option "`--name` _name_" }}

--- a/src/doc/src/commands/cargo-init.md
+++ b/src/doc/src/commands/cargo-init.md
@@ -66,7 +66,7 @@ This is the default behavior.</dd>
 
 <dt class="option-term" id="option-cargo-init---edition"><a class="option-anchor" href="#option-cargo-init---edition"></a><code>--edition</code> <em>edition</em></dt>
 <dd class="option-desc">Specify the Rust edition to use. Default is 2018.
-Possible values: 2015, 2018</dd>
+Possible values: 2015, 2018, 2021</dd>
 
 
 <dt class="option-term" id="option-cargo-init---name"><a class="option-anchor" href="#option-cargo-init---name"></a><code>--name</code> <em>name</em></dt>

--- a/src/doc/src/commands/cargo-new.md
+++ b/src/doc/src/commands/cargo-new.md
@@ -61,7 +61,7 @@ This is the default behavior.</dd>
 
 <dt class="option-term" id="option-cargo-new---edition"><a class="option-anchor" href="#option-cargo-new---edition"></a><code>--edition</code> <em>edition</em></dt>
 <dd class="option-desc">Specify the Rust edition to use. Default is 2018.
-Possible values: 2015, 2018</dd>
+Possible values: 2015, 2018, 2021</dd>
 
 
 <dt class="option-term" id="option-cargo-new---name"><a class="option-anchor" href="#option-cargo-new---name"></a><code>--name</code> <em>name</em></dt>

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -136,7 +136,7 @@ _cargo() {
                 init)
                     _arguments -s -S $common $registry \
                         '--lib[use library template]' \
-                        '--edition=[specify edition to set for the crate generated]:edition:(2015 2018)' \
+                        '--edition=[specify edition to set for the crate generated]:edition:(2015 2018 2021)' \
                         '--vcs=[initialize a new repo with a given VCS]:vcs:(git hg pijul fossil none)' \
                         '--name=[set the resulting package name]:name' \
                         '1:path:_directories'

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -102,7 +102,7 @@ Create a package with a library target (\fBsrc/lib.rs\fR).
 \fB\-\-edition\fR \fIedition\fR
 .RS 4
 Specify the Rust edition to use. Default is 2018.
-Possible values: 2015, 2018
+Possible values: 2015, 2018, 2021
 .RE
 .sp
 \fB\-\-name\fR \fIname\fR

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -97,7 +97,7 @@ Create a package with a library target (\fBsrc/lib.rs\fR).
 \fB\-\-edition\fR \fIedition\fR
 .RS 4
 Specify the Rust edition to use. Default is 2018.
-Possible values: 2015, 2018
+Possible values: 2015, 2018, 2021
 .RE
 .sp
 \fB\-\-name\fR \fIname\fR

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1043,7 +1043,7 @@ Caused by:
   failed to parse the `edition` key
 
 Caused by:
-  supported edition values are `2015` or `2018`, but `chicken` is unknown
+  supported edition values are `2015`, `2018`, or `2021`, but `chicken` is unknown
 "
             .to_string(),
         )
@@ -1075,7 +1075,7 @@ Caused by:
   failed to parse the `edition` key
 
 Caused by:
-  this version of Cargo is older than the `2038` edition, and only supports `2015` and `2018` editions.
+  this version of Cargo is older than the `2038` edition, and only supports `2015`, `2018`, and `2021` editions.
 "
             .to_string(),
         )


### PR DESCRIPTION
This adds support for `ediiton = "2021"`.

Related `rustc` PR: https://github.com/rust-lang/rust/pull/79576