### PR TITLE
Fix test escaping __CARGO_TEST_ROOT

### DIFF
--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -340,10 +340,7 @@ fn finds_git_author_in_included_config() {
     )
     .unwrap();
 
-    cargo_process("new foo/bar")
-        // Avoid the special treatment of tests to find git configuration
-        .env_remove("__CARGO_TEST_ROOT")
-        .run();
+    cargo_process("new foo/bar").run();
     let toml = paths::root().join("foo/bar/Cargo.toml");
     let contents = fs::read_to_string(&toml).unwrap();
     assert!(contents.contains(r#"authors = ["foo <bar>"]"#), contents,);


### PR DESCRIPTION
#8886 added a test which unsets `__CARGO_TEST_ROOT`, but that environment variable is there for a reason. This causes problems as it causes that test to load the `.cargo/config` from the real home directory, which if it contains a `[cargo-new]` section, causes the test to fail.

The fix here is to change `find_tests_git_config` so that it behaves more like the real git config loader, but avoids escaping the test sandbox.  There are some subtle issues here, like #7469, which I believe should still work correctly.
