### PR TITLE
Fix semver documentation tests.

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -224,7 +224,7 @@ pub struct Foo {
 ///////////////////////////////////////////////////////////
 // Example usage that will break.
 fn main() {
-    let x = updated_crate::Foo { f1: 123 }; // Error: missing field `f2`
+    let x = updated_crate::Foo { f1: 123 }; // Error: cannot construct `Foo`
 }
 ```
 
@@ -738,7 +738,7 @@ pub struct Foo<A: Eq> {
 use updated_crate::Foo;
 
 fn main() {
-    let s = Foo { f1: 1.23 }; // Error: the trait bound `{float}: std::cmp::Eq` is not satisfied
+    let s = Foo { f1: 1.23 }; // Error: the trait bound `{float}: Eq` is not satisfied
 }
 ```
 
@@ -1070,7 +1070,7 @@ pub fn foo<T: Copy + IntoIterator<Item = u8>>(x: T) {}
 use updated_crate::foo;
 
 fn main() {
-    foo(vec![1, 2, 3]); // Error: `std::marker::Copy` is not implemented for `std::vec::Vec<u8>`
+    foo(vec![1, 2, 3]); // Error: `Copy` is not implemented for `Vec<u8>`
 }
 ```
 


### PR DESCRIPTION
GitHub just updated the VM image to include the latest stable rust (1.48), which included some minor changes to diagnostic outputs.  This updates the semver chapter tests which validates that the correct error is displayed for the 1.48 release.  These diagnostics were changed via https://github.com/rust-lang/rust/pull/76524 and https://github.com/rust-lang/rust/pull/73996.
