### PR TITLE
Throw error if CARGO_TARGET_DIR is an empty string

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -450,16 +450,20 @@ impl Config {
         if let Some(dir) = &self.target_dir {
             Ok(Some(dir.clone()))
         } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
+            // Check if the CARGO_TARGET_DIR environment variable is set to an empty string.
             if dir.to_string_lossy() == "" {
-                anyhow::bail!("the target directory is set to an empty string")
+                anyhow::bail!("the target directory is set to an empty string in the CARGO_TARGET_DIR environment variable.")
             }
 
             Ok(Some(Filesystem::new(self.cwd.join(dir))))
         } else if let Some(val) = &self.build_config()?.target_dir {
             let path = val.resolve_path(self);
 
+            // Check if the target directory is set to an empty string in the config.toml file.
             if val.raw_value() == "" {
-                anyhow::bail!("the target directory is set to an empty string")
+                anyhow::bail!(
+                    "the target directory is set to an empty string in the config.toml file.",
+                )
             }
 
             Ok(Some(Filesystem::new(path)))

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -450,6 +450,10 @@ impl Config {
         if let Some(dir) = &self.target_dir {
             Ok(Some(dir.clone()))
         } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
+            if dir.to_str().unwrap().trim() == "" {
+                return Ok(Some(Filesystem::new(self.cwd.join("target"))));
+            }
+
             Ok(Some(Filesystem::new(self.cwd.join(dir))))
         } else if let Some(val) = &self.build_config()?.target_dir {
             let val = val.resolve_path(self);

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -451,7 +451,7 @@ impl Config {
             Ok(Some(dir.clone()))
         } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
             if dir.to_str().unwrap().trim() == "" {
-                return Ok(Some(Filesystem::new(self.cwd.join("target"))));
+                anyhow::bail!("The CARGO_TARGET_DIR environment variable is an empty string. Try adding the target directory name to it or deleting the variable.")
             }
 
             Ok(Some(Filesystem::new(self.cwd.join(dir))))

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -450,14 +450,19 @@ impl Config {
         if let Some(dir) = &self.target_dir {
             Ok(Some(dir.clone()))
         } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
-            if dir.to_str().unwrap().trim() == "" {
-                anyhow::bail!("The CARGO_TARGET_DIR environment variable is an empty string. Try adding the target directory name to it or deleting the variable.")
+            if dir.to_string_lossy() == "" {
+                anyhow::bail!("the target directory is set to an empty string")
             }
 
             Ok(Some(Filesystem::new(self.cwd.join(dir))))
         } else if let Some(val) = &self.build_config()?.target_dir {
-            let val = val.resolve_path(self);
-            Ok(Some(Filesystem::new(val)))
+            let path = val.resolve_path(self);
+
+            if val.raw_value() == "" {
+                anyhow::bail!("the target directory is set to an empty string")
+            }
+
+            Ok(Some(Filesystem::new(path)))
         } else {
             Ok(None)
         }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -452,7 +452,7 @@ impl Config {
         } else if let Some(dir) = env::var_os("CARGO_TARGET_DIR") {
             // Check if the CARGO_TARGET_DIR environment variable is set to an empty string.
             if dir.to_string_lossy() == "" {
-                anyhow::bail!("the target directory is set to an empty string in the CARGO_TARGET_DIR environment variable.")
+                anyhow::bail!("the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable")
             }
 
             Ok(Some(Filesystem::new(self.cwd.join(dir))))
@@ -461,9 +461,10 @@ impl Config {
 
             // Check if the target directory is set to an empty string in the config.toml file.
             if val.raw_value() == "" {
-                anyhow::bail!(
-                    "the target directory is set to an empty string in the config.toml file.",
-                )
+                anyhow::bail!(format!(
+                    "the target directory is set to an empty string in {}",
+                    val.value().definition
+                ),)
             }
 
             Ok(Some(Filesystem::new(path)))

--- a/src/cargo/util/config/path.rs
+++ b/src/cargo/util/config/path.rs
@@ -10,6 +10,11 @@ use std::path::PathBuf;
 pub struct ConfigRelativePath(Value<String>);
 
 impl ConfigRelativePath {
+    /// Returns the underlying value.
+    pub fn value(&self) -> &Value<String> {
+        &self.0
+    }
+
     /// Returns the raw underlying configuration value for this key.
     pub fn raw_value(&self) -> &str {
         &self.0.val

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1507,7 +1507,7 @@ fn cargo_target_empty_env() {
 
     project.cargo("build")
         .env("CARGO_TARGET_DIR", "")
-        .with_stderr("error: the target directory is set to an empty string in the CARGO_TARGET_DIR environment variable.")
+        .with_stderr("error: the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable")
         .with_status(101)
         .run()
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1483,3 +1483,20 @@ Caused by:
   unknown variant `invalid`, expected one of `debuginfo`, `none`, `symbols`",
     );
 }
+
+#[cargo_test]
+fn cargo_target_empty_cfg() {
+    write_config(
+        "\
+[build]
+target-dir = ''
+",
+    );
+
+    let config = new_config();
+
+    assert_error(
+        config.target_dir().unwrap_err(),
+        "the target directory is set to an empty string",
+    );
+}

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1497,7 +1497,7 @@ target-dir = ''
 
     assert_error(
         config.target_dir().unwrap_err(),
-        "the target directory is set to an empty string in the config.toml file.",
+        "the target directory is set to an empty string in [..]/.cargo/config",
     );
 }
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1497,6 +1497,17 @@ target-dir = ''
 
     assert_error(
         config.target_dir().unwrap_err(),
-        "the target directory is set to an empty string",
+        "the target directory is set to an empty string in the config.toml file.",
     );
+}
+
+#[cargo_test]
+fn cargo_target_empty_env() {
+    let project = project().build();
+
+    project.cargo("build")
+        .env("CARGO_TARGET_DIR", "")
+        .with_stderr("error: the target directory is set to an empty string in the CARGO_TARGET_DIR environment variable.")
+        .with_status(101)
+        .run()
 }


### PR DESCRIPTION
This pull request makes the target dir to be target/ if `CARGO_TARGET_DIR` is `` with spaces trimmed and not delete the current project.

Fixes: #8866