### PR TITLE
Fix panic with -Zbuild-std and no roots.

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -62,6 +62,12 @@ pub fn build_unit_dependencies<'a, 'cfg>(
     profiles: &'a Profiles,
     interner: &'a UnitInterner,
 ) -> CargoResult<UnitGraph> {
+    if roots.is_empty() {
+        // If -Zbuild-std, don't attach units if there is nothing to build.
+        // Otherwise, other parts of the code may be confused by seeing units
+        // in the dep graph without a root.
+        return Ok(HashMap::new());
+    }
     let (std_resolve, std_features) = match std_resolve {
         Some((r, f)) => (Some(r), Some(f)),
         None => (None, None),

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -677,3 +677,23 @@ fn different_features() {
         .target_host()
         .run();
 }
+
+#[cargo_test]
+fn no_roots() {
+    // Checks for a bug where it would panic if there are no roots.
+    let setup = match setup() {
+        Some(s) => s,
+        None => return,
+    };
+    let p = project().file("tests/t1.rs", "").build();
+    p.cargo("build")
+        .build_std(&setup)
+        .target_host()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[FINISHED] [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
If a build command is run without any roots (like `cargo build` in a project with only tests), then cargo would panic with `-Z build-std`. This is because some parts of the code assumes that all units in the unit graph are reachable from the roots. However, the code was "attaching" the std units to the graph without a root.

The particular line that was panicking was [this one](https://github.com/rust-lang/cargo/blob/5c40b7f6dc94cffae0107d034ac1d1c6d3da18bf/src/cargo/core/compiler/context/mod.rs#L475) where it iterates over the units to check for collisions.  The outputs are calculated based on the roots (since they metadata computation has to walk the dep graph), so without any roots there was no metadata, and thus no outputs.
