### PR TITLE
Run rustdoc doctests relative to the workspace

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -334,7 +334,7 @@ use crate::util;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::interning::InternedString;
 use crate::util::paths;
-use crate::util::{internal, profile, ProcessBuilder};
+use crate::util::{internal, path_args, profile, ProcessBuilder};
 
 use super::custom_build::BuildDeps;
 use super::job::{Job, Work};
@@ -1313,7 +1313,7 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
         profile: profile_hash,
         // Note that .0 is hashed here, not .1 which is the cwd. That doesn't
         // actually affect the output artifact so there's no need to hash it.
-        path: util::hash_u64(super::path_args(cx.bcx, unit).0),
+        path: util::hash_u64(path_args(cx.bcx.ws, unit).0),
         features: format!("{:?}", unit.features),
         deps,
         local: Mutex::new(local),

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -27,8 +27,8 @@ pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
 pub use self::vcs::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 pub use self::workspace::{
-    print_available_benches, print_available_binaries, print_available_examples,
-    print_available_packages, print_available_tests,
+    add_path_args, path_args, print_available_benches, print_available_binaries,
+    print_available_examples, print_available_packages, print_available_tests,
 };
 
 mod canonical_url;

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -1,8 +1,12 @@
+use super::ProcessBuilder;
+use crate::core::compiler::Unit;
+use crate::core::manifest::TargetSourcePath;
 use crate::core::{Target, Workspace};
 use crate::ops::CompileOptions;
 use crate::util::CargoResult;
 use anyhow::bail;
 use std::fmt::Write;
+use std::path::PathBuf;
 
 fn get_available_targets<'a>(
     filter_fn: fn(&Target) -> bool,
@@ -88,4 +92,39 @@ pub fn print_available_benches(ws: &Workspace<'_>, options: &CompileOptions) -> 
 
 pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
     print_available_targets(Target::is_test, ws, options, "--test", "tests")
+}
+
+/// The path that we pass to rustc is actually fairly important because it will
+/// show up in error messages (important for readability), debug information
+/// (important for caching), etc. As a result we need to be pretty careful how we
+/// actually invoke rustc.
+///
+/// In general users don't expect `cargo build` to cause rebuilds if you change
+/// directories. That could be if you just change directories in the package or
+/// if you literally move the whole package wholesale to a new directory. As a
+/// result we mostly don't factor in `cwd` to this calculation. Instead we try to
+/// track the workspace as much as possible and we update the current directory
+/// of rustc/rustdoc where appropriate.
+///
+/// The first returned value here is the argument to pass to rustc, and the
+/// second is the cwd that rustc should operate in.
+pub fn path_args(ws: &Workspace<'_>, unit: &Unit) -> (PathBuf, PathBuf) {
+    let ws_root = ws.root();
+    let src = match unit.target.src_path() {
+        TargetSourcePath::Path(path) => path.to_path_buf(),
+        TargetSourcePath::Metabuild => unit.pkg.manifest().metabuild_path(ws.target_dir()),
+    };
+    assert!(src.is_absolute());
+    if unit.pkg.package_id().source_id().is_path() {
+        if let Ok(path) = src.strip_prefix(ws_root) {
+            return (path.to_path_buf(), ws_root.to_path_buf());
+        }
+    }
+    (src, unit.pkg.root().to_path_buf())
+}
+
+pub fn add_path_args(ws: &Workspace<'_>, unit: &Unit, cmd: &mut ProcessBuilder) {
+    let (arg, cwd) = path_args(ws, unit);
+    cmd.arg(arg);
+    cmd.cwd(cwd);
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2753,7 +2753,7 @@ fn doctest_receives_build_link_args() {
 
     p.cargo("test -v")
         .with_stderr_contains(
-            "[RUNNING] `rustdoc [..]--test [..] --crate-name foo [..]-L native=bar[..]`",
+            "[RUNNING] `rustdoc [..]--crate-name foo --test [..]-L native=bar[..]`",
         )
         .run();
 }

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1109,7 +1109,7 @@ fn doctest_xcompile_linker() {
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(&format!(
             "\
-[RUNNING] `rustdoc --crate-type lib --test [..]\
+[RUNNING] `rustdoc --crate-type lib --crate-name foo --test [..]\
     --target {target} [..] -C linker=my-linker-tool[..]
 ",
             target = target,

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1638,3 +1638,73 @@ fn crate_versions_flag_is_overridden() {
     p.cargo("rustdoc -- --crate-version 2.0.3").run();
     asserts(output_documentation());
 }
+
+#[cargo_test]
+fn doc_test_in_workspace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = [
+                    "crate-a",
+                    "crate-b",
+                ]
+            "#,
+        )
+        .file(
+            "crate-a/Cargo.toml",
+            r#"
+                [project]
+                name = "crate-a"
+                version = "0.1.0"
+            "#,
+        )
+        .file(
+            "crate-a/src/lib.rs",
+            "\
+                //! ```
+                //! assert_eq!(1, 1);
+                //! ```
+            ",
+        )
+        .file(
+            "crate-b/Cargo.toml",
+            r#"
+                [project]
+                name = "crate-b"
+                version = "0.1.0"
+            "#,
+        )
+        .file(
+            "crate-b/src/lib.rs",
+            "\
+                //! ```
+                //! assert_eq!(1, 1);
+                //! ```
+            ",
+        )
+        .build();
+    p.cargo("test --doc -vv")
+        .with_stderr_contains("[DOCTEST] crate-a")
+        .with_stdout_contains(
+            "
+running 1 test
+test crate-a/src/lib.rs - (line 1) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+
+",
+        )
+        .with_stderr_contains("[DOCTEST] crate-b")
+        .with_stdout_contains(
+            "
+running 1 test
+test crate-b/src/lib.rs - (line 1) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+
+",
+        )
+        .run();
+}

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1692,7 +1692,7 @@ fn doc_test_in_workspace() {
 running 1 test
 test crate-a/src/lib.rs - (line 1) ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]
 
 ",
         )
@@ -1702,7 +1702,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
 running 1 test
 test crate-b/src/lib.rs - (line 1) ... ok
 
-test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]
 
 ",
         )

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -526,7 +526,7 @@ fn cdylib_and_rlib() {
 [RUNNING] [..]target/release/deps/bar-[..]
 [RUNNING] [..]target/release/deps/b-[..]
 [DOCTEST] bar
-[RUNNING] `rustdoc --crate-type cdylib --crate-type rlib --test [..]-C embed-bitcode=no[..]
+[RUNNING] `rustdoc --crate-type cdylib --crate-type rlib --crate-name bar --test [..]-C embed-bitcode=no[..]
 ",
         )
         .run();

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -265,7 +265,7 @@ fn can_run_doc_tests() {
         .with_stderr_contains(
             "\
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test [CWD]/src/lib.rs \
+[RUNNING] `rustdoc [..]--test src/lib.rs \
         [..] \
         --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib \
         --extern baz=[CWD]/target/debug/deps/libbar-[..].rlib \


### PR DESCRIPTION
By doing so, rustdoc will also emit workspace-relative filenames for
the doctests.

fixes #8097