### PR TITLE
Check if rerun-if-changed points to a directory.

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1700,7 +1700,7 @@ where
         let path_mtime = match mtime_cache.entry(path.to_path_buf()) {
             Entry::Occupied(o) => *o.get(),
             Entry::Vacant(v) => {
-                let mtime = match paths::mtime(path) {
+                let mtime = match paths::mtime_recursive(path) {
                     Ok(mtime) => mtime,
                     Err(..) => return Some(StaleItem::MissingFile(path.to_path_buf())),
                 };

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -258,19 +258,16 @@ filesystem last-modified "mtime" timestamp to determine if the file has
 changed. It compares against an internal cached timestamp of when the build
 script last ran.
 
-If the path points to a directory, it does *not* automatically traverse the
-directory for changes. Only the mtime change of the directory itself is
-considered (which corresponds to some types of changes within the directory,
-depending on platform). To request a re-run on any changes within an entire
-directory, print a line for the directory and separate lines for everything
-inside it, recursively.
+If the path points to a directory, it will scan the entire directory for
+any modifications.
 
 If the build script inherently does not need to re-run under any circumstance,
 then emitting `cargo:rerun-if-changed=build.rs` is a simple way to prevent it
-from being re-run. Cargo automatically handles whether or not the script
-itself needs to be recompiled, and of course the script will be re-run after
-it has been recompiled. Otherwise, specifying `build.rs` is redundant and
-unnecessary.
+from being re-run (otherwise, the default if no `rerun-if` instructions are
+emitted is to scan the entire package directory for changes). Cargo
+automatically handles whether or not the script itself needs to be recompiled,
+and of course the script will be re-run after it has been recompiled.
+Otherwise, specifying `build.rs` is redundant and unnecessary.
 
 <a id="rerun-if-env-changed"></a>
 #### `cargo:rerun-if-env-changed=NAME`


### PR DESCRIPTION
This changes it so that if a build script emits `cargo:rerun-if-changed` pointing to a directory, then Cargo will scan the entire directory for changes (instead of just looking at the mtime of the directory itself).  I think this is more useful, as otherwise build scripts have to recreate this logic.

I've tried to make it semi-intelligent in the face of symbolic links.  It checks the mtime of the link and its target, and follows the link if it points to a directory.

There are a few other edge cases. For example, if it doesn't have permission for a directory, it will skip it.  I think this is relatively reasonable, though it's hard to say for sure.
