### PR TITLE
Mark $CARGO_HOME/{registry,git} as cache directories

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -220,6 +220,9 @@ impl GitRemote {
         if into.exists() {
             paths::remove_dir_all(into)?;
         }
+        paths::create_dir_all_excluded_from_backups_atomic(
+            cargo_config.home().join("git").as_path_unlocked(),
+        )?;
         paths::create_dir_all(into)?;
         let mut repo = init(into, true)?;
         fetch(&mut repo, self.url.as_str(), reference, cargo_config)

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -73,6 +73,9 @@ impl<'cfg> RemoteRegistry<'cfg> {
                 Ok(repo) => Ok(repo),
                 Err(_) => {
                     drop(paths::remove_dir_all(&path));
+                    paths::create_dir_all_excluded_from_backups_atomic(
+                        self.config.home().join("registry").as_path_unlocked(),
+                    )?;
                     paths::create_dir_all(&path)?;
 
                     // Note that we'd actually prefer to use a bare repository


### PR DESCRIPTION
This follows GH-8378 which applies this technique to target directories
inside projects. With the patch two large-ish throwaway directories are
also excluded from backups.

I decided against excluding $CARGO_HOME/bin or $CARGO_HOME as a whole,
because there may be important binaries needed by a user to run their
system and there are credentials in the credentials file – I'm happy to
simplify this and exclude whole $CARGO_HOME though.

I'm less happy with this than I was with GH-8378 – I don't see a particularly nice way to provide an automated test this addition, I welcome guidance on this matter.