### PR TITLE
Stabilize RUSTC_WORKSPACE_WRAPPER

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -327,10 +327,6 @@ impl Config {
             &self.build_config()?.rustc_workspace_wrapper,
         );
 
-        if !self.cli_unstable().unstable_options && rustc_workspace_wrapper.is_some() {
-            bail!("Usage of `RUSTC_WORKSPACE_WRAPPER` requires `-Z unstable-options`")
-        }
-
         Rustc::new(
             self.get_tool("rustc", &self.build_config()?.rustc),
             wrapper,

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -54,17 +54,18 @@ rr = "run --release"
 space_example = ["run", "--release", "--", "\"command list\""]
 
 [build]
-jobs = 1                  # number of parallel jobs, defaults to # of CPUs
-rustc = "rustc"           # the rust compiler tool
-rustc-wrapper = "…"       # run this wrapper instead of `rustc`
-rustdoc = "rustdoc"       # the doc generator tool
-target = "triple"         # build for the target triple (ignored by `cargo install`)
-target-dir = "target"     # path of where to place all generated artifacts
-rustflags = ["…", "…"]    # custom flags to pass to all compiler invocations
-rustdocflags = ["…", "…"] # custom flags to pass to rustdoc
-incremental = true        # whether or not to enable incremental compilation
-dep-info-basedir = "…"    # path for the base directory for targets in depfiles
-pipelining = true         # rustc pipelining
+jobs = 1                      # number of parallel jobs, defaults to # of CPUs
+rustc = "rustc"               # the rust compiler tool
+rustc-wrapper = "…"           # run this wrapper instead of `rustc`
+rustc-workspace-wrapper = "…" # run this wrapper instead of `rustc` for workspace members
+rustdoc = "rustdoc"           # the doc generator tool
+target = "triple"             # build for the target triple (ignored by `cargo install`)
+target-dir = "target"         # path of where to place all generated artifacts
+rustflags = ["…", "…"]        # custom flags to pass to all compiler invocations
+rustdocflags = ["…", "…"]     # custom flags to pass to rustdoc
+incremental = true            # whether or not to enable incremental compilation
+dep-info-basedir = "…"        # path for the base directory for targets in depfiles
+pipelining = true             # rustc pipelining
 
 [cargo-new]
 name = "Your Name"        # name to use in `authors` field
@@ -281,6 +282,15 @@ Sets the executable to use for `rustc`.
 
 Sets a wrapper to execute instead of `rustc`. The first argument passed to the
 wrapper is the path to the actual `rustc`.
+
+##### `build.rustc-workspace-wrapper`
+* Type: string (program path)
+* Default: none
+* Environment: `CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER` or `RUSTC_WORKSPACE_WRAPPER`
+
+Sets a wrapper to execute instead of `rustc`, for workspace members only.
+The first argument passed to the wrapper is the path to the actual `rustc`.
+It affects the filename hash so that artifacts produced by the wrapper are cached separately.
 
 ##### `build.rustdoc`
 * Type: string (program path)

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -24,6 +24,12 @@ system:
   specified wrapper instead, passing as its commandline arguments the rustc
   invocation, with the first argument being `rustc`. Useful to set up a build
   cache tool such as `sccache`. See [`build.rustc-wrapper`] to set via config.
+* `RUSTC_WORKSPACE_WRAPPER` — Instead of simply running `rustc`, Cargo will 
+  execute this specified wrapper instead for workspace members only, passing
+  as its commandline arguments the rustc invocation, with the first argument 
+  being `rustc`. It affects the filename hash so that artifacts produced by 
+  the wrapper are cached separately. See [`build.rustc-workspace-wrapper`] 
+  to set via config.
 * `RUSTDOC` — Instead of running `rustdoc`, Cargo will execute this specified
   `rustdoc` instance instead. See [`build.rustdoc`] to set via config.
 * `RUSTDOCFLAGS` — A space-separated list of custom flags to pass to all `rustdoc`
@@ -63,6 +69,7 @@ supported environment variables are:
 * `CARGO_BUILD_JOBS` — Number of parallel jobs, see [`build.jobs`].
 * `CARGO_BUILD_RUSTC` — The `rustc` executable, see [`build.rustc`].
 * `CARGO_BUILD_RUSTC_WRAPPER` — The `rustc` wrapper, see [`build.rustc-wrapper`].
+* `CARGO_BUILD_RUSTC_WORKSPACE_WRAPPER` — The `rustc` wrapper for workspace members only, see [`build.rustc-workspace-wrapper`].
 * `CARGO_BUILD_RUSTDOC` — The `rustdoc` executable, see [`build.rustdoc`].
 * `CARGO_BUILD_TARGET` — The default target platform, see [`build.target`].
 * `CARGO_BUILD_TARGET_DIR` — The default output directory, see [`build.target-dir`].
@@ -121,6 +128,7 @@ supported environment variables are:
 [`build.jobs`]: config.md#buildjobs
 [`build.rustc`]: config.md#buildrustc
 [`build.rustc-wrapper`]: config.md#buildrustc-wrapper
+[`build.rustc-workspace-wrapper`]: config.md#buildrustc-workspace-wrapper
 [`build.rustdoc`]: config.md#buildrustdoc
 [`build.target`]: config.md#buildtarget
 [`build.target-dir`]: config.md#buildtarget-dir

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4023,9 +4023,8 @@ fn rustc_wrapper_from_path() {
 #[cfg(not(windows))]
 fn rustc_workspace_wrapper() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("build -v -Zunstable-options")
+    p.cargo("build -v")
         .env("RUSTC_WORKSPACE_WRAPPER", "/usr/bin/env")
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("[RUNNING] `/usr/bin/env rustc --crate-name foo [..]")
         .run();
 }
@@ -4034,9 +4033,8 @@ fn rustc_workspace_wrapper() {
 #[cfg(not(windows))]
 fn rustc_workspace_wrapper_relative() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("build -v -Zunstable-options")
+    p.cargo("build -v")
         .env("RUSTC_WORKSPACE_WRAPPER", "./sccache")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr_contains("[..]/foo/./sccache rustc[..]")
         .run();
@@ -4046,9 +4044,8 @@ fn rustc_workspace_wrapper_relative() {
 #[cfg(not(windows))]
 fn rustc_workspace_wrapper_from_path() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("build -v -Zunstable-options")
+    p.cargo("build -v")
         .env("RUSTC_WORKSPACE_WRAPPER", "wannabe_sccache")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr_contains("[..]`wannabe_sccache rustc [..]")
         .run();

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -469,9 +469,8 @@ fn rustc_workspace_wrapper() {
         )
         .build();
 
-    p.cargo("check -Zunstable-options -v")
+    p.cargo("check -v")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name foo src/lib.rs [..]")
         .run();
 
@@ -488,9 +487,8 @@ fn rustc_workspace_wrapper() {
         .run();
 
     // Again, reading from the cache.
-    p.cargo("check -Zunstable-options -v")
+    p.cargo("check -v")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("[FRESH] foo [..]")
         .with_stdout_does_not_contain("WRAPPER CALLED: rustc --crate-name foo src/lib.rs [..]")
         .run();

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -861,10 +861,7 @@ fn does_not_use_empty_rustc_wrapper() {
 #[cargo_test]
 fn does_not_use_empty_rustc_workspace_wrapper() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("check -Zunstable-options")
-        .masquerade_as_nightly_cargo()
-        .env("RUSTC_WORKSPACE_WRAPPER", "")
-        .run();
+    p.cargo("check").env("RUSTC_WORKSPACE_WRAPPER", "").run();
 }
 
 #[cargo_test]
@@ -905,9 +902,8 @@ fn rustc_workspace_wrapper_affects_all_workspace_members() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("check -Zunstable-options")
+    p.cargo("check")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name bar [..]")
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name baz [..]")
         .run();
@@ -939,9 +935,8 @@ fn rustc_workspace_wrapper_includes_path_deps() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("check --workspace -Zunstable-options")
+    p.cargo("check --workspace")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name foo [..]")
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name bar [..]")
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name baz [..]")
@@ -965,9 +960,8 @@ fn rustc_workspace_wrapper_respects_primary_units() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("check -p bar -Zunstable-options")
+    p.cargo("check -p bar")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name bar [..]")
         .with_stdout_does_not_contain("WRAPPER CALLED: rustc --crate-name baz [..]")
         .run();
@@ -999,9 +993,8 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
 
     Package::new("baz", "1.0.0").publish();
 
-    p.cargo("check --workspace -v -Zunstable-options")
+    p.cargo("check --workspace -v")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name foo [..]")
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name bar [..]")
         .with_stderr_contains("[CHECKING] baz [..]")

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1096,9 +1096,8 @@ fn does_not_crash_with_rustc_workspace_wrapper() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fix --allow-no-vcs --verbose -Zunstable-options")
+    p.cargo("fix --allow-no-vcs --verbose")
         .env("RUSTC_WORKSPACE_WRAPPER", "/usr/bin/env")
-        .masquerade_as_nightly_cargo()
         .run();
 }
 
@@ -1117,9 +1116,8 @@ fn uses_workspace_wrapper_and_primary_wrapper_override() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("fix --allow-no-vcs --verbose -Zunstable-options")
+    p.cargo("fix --allow-no-vcs --verbose")
         .env("RUSTC_WORKSPACE_WRAPPER", paths::echo_wrapper())
-        .masquerade_as_nightly_cargo()
         .with_stderr_contains("WRAPPER CALLED: rustc src/lib.rs --crate-name foo [..]")
         .run();
 }


### PR DESCRIPTION
Stabilizing this environment variable would allow Clippy to fix a long-standing usability problem, [clippy#4612](https://github.com/rust-lang/rust-clippy/issues/4612). 

It's also the last step towards stabilizing the `--fix` command-line argument in Clippy, that allows applying suggestions automatically when the lint supports it.

Closes #8143 

r? @ehuss 