### PR TITLE
Reject ambiguous git dependency declaration.

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1692,13 +1692,11 @@ impl DetailedTomlDependency {
                     .count();
 
                 if n_details > 1 {
-                    let msg = format!(
+                    bail!(
                         "dependency ({}) specification is ambiguous. \
-                         Only one of `branch`, `tag` or `rev` is allowed. \
-                         This will be considered an error in future versions",
+                         Only one of `branch`, `tag` or `rev` is allowed.",
                         name_in_toml
                     );
-                    cx.warnings.push(msg)
                 }
 
                 let reference = self

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -851,11 +851,12 @@ fn ambiguous_git_reference() {
 
     p.cargo("build -v")
         .with_status(101)
-        .with_stderr_contains(
+        .with_stderr(
             "\
-[WARNING] dependency (bar) specification is ambiguous. \
-Only one of `branch`, `tag` or `rev` is allowed. \
-This will be considered an error in future versions
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  dependency (bar) specification is ambiguous. Only one of `branch`, `tag` or `rev` is allowed.
 ",
         )
         .run();


### PR DESCRIPTION
This rejects a git dependency that specifies more than one of `branch`, `tag`, or `rev`. Cargo does not handle this case very well, and this warning has been in place for 4 years (since #2940).

Fixes #7841
