### PR TITLE
Source::{fuzzy_}query{_vec} can say "try again"

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::fmt::Write;
 use std::rc::Rc;
+use std::task::Poll;
 use std::time::Instant;
 
 use cargo::core::dependency::DepKind;
@@ -130,14 +131,14 @@ pub fn resolve_with_config_raw(
             dep: &Dependency,
             f: &mut dyn FnMut(Summary),
             fuzzy: bool,
-        ) -> CargoResult<()> {
+        ) -> CargoResult<Poll<()>> {
             for summary in self.list.iter() {
                 if fuzzy || dep.matches(summary) {
                     self.used.insert(summary.package_id());
                     f(summary.clone());
                 }
             }
-            Ok(())
+            Ok(Poll::Ready(()))
         }
 
         fn describe_source(&self, _src: SourceId) -> String {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -806,18 +806,12 @@ fn summary_for_patch(
     // No summaries found, try to help the user figure out what is wrong.
     if let Some((_locked_patch, locked_id)) = locked {
         // Since the locked patch did not match anything, try the unlocked one.
-        let orig_matches = loop {
-            match source.query_vec(orig_patch) {
-                Ok(Poll::Ready(deps)) => {
-                    break Ok(deps);
-                }
-                Ok(Poll::Pending) => {
-                    // TODO: dont hot loop for it to be Ready
-                }
-                Err(x) => {
-                    break Err(x);
-                }
+        let orig_matches = match source.query_vec(orig_patch) {
+            Ok(Poll::Ready(deps)) => Ok(deps),
+            Ok(Poll::Pending) => {
+                return Ok(Poll::Pending);
             }
+            Err(x) => Err(x),
         }
         .unwrap_or_else(|e| {
             log::warn!(

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -6,6 +6,7 @@ use crate::core::{Dependency, PackageId, Source, SourceId, SourceMap, Summary};
 use crate::sources::config::SourceConfigMap;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::interning::InternedString;
+use crate::util::network::PollExt;
 use crate::util::{profile, CanonicalUrl, Config};
 use anyhow::bail;
 use log::{debug, trace};
@@ -334,10 +335,7 @@ impl<'cfg> PackageRegistry<'cfg> {
             if try_summaries.iter().all(|p| p.is_ready()) {
                 break try_summaries
                     .into_iter()
-                    .map(|p| match p {
-                        Poll::Ready(s) => s,
-                        Poll::Pending => unreachable!("we just check for this!"),
-                    })
+                    .map(|p| p.expect("we just checked for this!"))
                     .collect::<Vec<_>>();
             } else {
                 // TODO: dont hot loop for it to be Ready

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -1,10 +1,8 @@
-use std::fmt;
-use std::task::Poll;
-
 use crate::core::{Dependency, PackageId, Registry, Summary};
 use crate::util::lev_distance::lev_distance;
 use crate::util::Config;
 use anyhow::Error;
+use std::fmt;
 
 use super::context::Context;
 use super::types::{ConflictMap, ConflictReason};
@@ -216,12 +214,12 @@ pub(super) fn activation_error(
     let mut new_dep = dep.clone();
     new_dep.set_version_req(all_req);
 
-    let mut candidates = loop {
-        match registry.query_vec(&new_dep, false) {
-            Ok(Poll::Ready(candidates)) => break candidates,
-            Ok(Poll::Pending) => (), // TODO: dont hot loop for it to be Ready
-            Err(e) => return to_resolve_err(e),
-        }
+    let mut candidates = Vec::new();
+    // we can ignore the `Pending` case because we are just in an error reporting path,
+    // and we have probably already triggered the query anyway. But, if we start getting reports
+    // of confusing errors that go away when called again this is a place to look.
+    if let Err(e) = registry.query(&new_dep, &mut |s| candidates.push(s), false) {
+        return to_resolve_err(e);
     };
     candidates.sort_unstable_by(|a, b| b.version().cmp(a.version()));
 
@@ -275,6 +273,9 @@ pub(super) fn activation_error(
             // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
             let mut candidates = Vec::new();
             if let Err(e) = registry.query(&new_dep, &mut |s| candidates.push(s), true) {
+                // we can ignore the `Pending` case because we are just in an error reporting path,
+                // and we have probably already triggered the query anyway. But, if we start getting reports
+                // of confusing errors that go away when called again this is a place to look.
                 return to_resolve_err(e);
             };
             candidates.sort_unstable_by_key(|a| a.name());

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -134,13 +134,13 @@ pub fn resolve(
         Some(config) => config.cli_unstable().minimal_versions,
         None => false,
     };
-    let (registry, cx) = loop {
-        let mut registry =
-            RegistryQueryer::new(registry, replacements, try_to_use, minimal_versions, config);
+    let mut registry =
+        RegistryQueryer::new(registry, replacements, try_to_use, minimal_versions, config);
+    let cx = loop {
         let cx = Context::new(check_public_visible_dependencies);
         let cx = activate_deps_loop(cx, &mut registry, summaries, config)?;
-        if registry.all_ready() {
-            break (registry, cx);
+        if registry.reset_pending() {
+            break cx;
         } else {
             // TODO: dont hot loop for it to be Ready
         }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::path::{Path, PathBuf};
+use std::task::Poll;
 
 use serde::Deserialize;
 
@@ -42,21 +43,25 @@ impl<'cfg> Debug for DirectorySource<'cfg> {
 }
 
 impl<'cfg> Source for DirectorySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<Poll<()>> {
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
         for summary in matches.map(|pkg| pkg.summary().clone()) {
             f(summary);
         }
-        Ok(())
+        Ok(Poll::Ready(()))
     }
 
-    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        _dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> CargoResult<Poll<()>> {
         let packages = self.packages.values().map(|p| &p.0);
         for summary in packages.map(|pkg| pkg.summary().clone()) {
             f(summary);
         }
-        Ok(())
+        Ok(Poll::Ready(()))
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -9,6 +9,7 @@ use crate::util::Config;
 use anyhow::Context;
 use log::trace;
 use std::fmt::{self, Debug, Formatter};
+use std::task::Poll;
 use url::Url;
 
 pub struct GitSource<'cfg> {
@@ -83,7 +84,7 @@ impl<'cfg> Debug for GitSource<'cfg> {
 }
 
 impl<'cfg> Source for GitSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<Poll<()>> {
         let src = self
             .path_source
             .as_mut()
@@ -91,7 +92,11 @@ impl<'cfg> Source for GitSource<'cfg> {
         src.query(dep, f)
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> CargoResult<Poll<()>> {
         let src = self
             .path_source
             .as_mut()

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::task::Poll;
 
 use filetime::FileTime;
 use ignore::gitignore::GitignoreBuilder;
@@ -469,20 +470,24 @@ impl<'cfg> Debug for PathSource<'cfg> {
 }
 
 impl<'cfg> Source for PathSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<Poll<()>> {
         for s in self.packages.iter().map(|p| p.summary()) {
             if dep.matches(s) {
                 f(s.clone())
             }
         }
-        Ok(())
+        Ok(Poll::Ready(()))
     }
 
-    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        _dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> CargoResult<Poll<()>> {
         for s in self.packages.iter().map(|p| p.summary()) {
             f(s.clone())
         }
-        Ok(())
+        Ok(Poll::Ready(()))
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -78,6 +78,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::Path;
 use std::str;
+use std::task::Poll;
 
 /// Crates.io treats hyphen and underscores as interchangeable, but the index and old Cargo do not.
 /// Therefore, the index must store uncanonicalized version of the name so old Cargo's can find it.
@@ -391,11 +392,11 @@ impl<'cfg> RegistryIndex<'cfg> {
         load: &mut dyn RegistryData,
         yanked_whitelist: &HashSet<PackageId>,
         f: &mut dyn FnMut(Summary),
-    ) -> CargoResult<()> {
+    ) -> CargoResult<Poll<()>> {
         if self.config.offline()
             && self.query_inner_with_online(dep, load, yanked_whitelist, f, false)? != 0
         {
-            return Ok(());
+            return Ok(Poll::Ready(()));
             // If offline, and there are no matches, try again with online.
             // This is necessary for dependencies that are not used (such as
             // target-cfg or optional), but are not downloaded. Normally the
@@ -406,7 +407,7 @@ impl<'cfg> RegistryIndex<'cfg> {
             // offline will be displayed.
         }
         self.query_inner_with_online(dep, load, yanked_whitelist, f, true)?;
-        Ok(())
+        Ok(Poll::Ready(()))
     }
 
     fn query_inner_with_online(

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -510,18 +510,14 @@ impl<'cfg> RegistryIndex<'cfg> {
         Ok(Poll::Ready(count))
     }
 
-    pub fn is_yanked(&mut self, pkg: PackageId, load: &mut dyn RegistryData) -> CargoResult<bool> {
-        let req = VersionReq::exact(pkg.version());
-        loop {
-            match self.summaries(pkg.name(), &req, load)? {
-                Poll::Ready(mut summaries) => {
-                    return Ok(summaries.any(|summary| summary.yanked));
-                }
-                Poll::Pending => {
-                    // TODO: dont hot loop for it to be Ready
-                }
-            }
-        }
+    pub fn is_yanked(
+        &mut self,
+        pkg: PackageId,
+        load: &mut dyn RegistryData,
+    ) -> CargoResult<Poll<bool>> {
+        Ok(self
+            .summaries(pkg.name(), &VersionReq::exact(pkg.version()), load)?
+            .map(|mut p| p.any(|summary| summary.yanked)))
     }
 }
 

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::Path;
+use std::task::Poll;
 
 /// A local registry is a registry that lives on the filesystem as a set of
 /// `.crate` files with an `index` directory in the same format as a remote
@@ -54,8 +55,8 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         root: &Path,
         path: &Path,
         data: &mut dyn FnMut(&[u8]) -> CargoResult<()>,
-    ) -> CargoResult<()> {
-        data(&paths::read_bytes(&root.join(path))?)
+    ) -> CargoResult<Poll<()>> {
+        Ok(Poll::Ready(data(&paths::read_bytes(&root.join(path))?)?))
     }
 
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -787,6 +787,15 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         if !self.updated {
             self.do_update()?;
         }
-        self.index.is_yanked(pkg, &mut *self.ops)
+        loop {
+            match self.index.is_yanked(pkg, &mut *self.ops)? {
+                Poll::Ready(yanked) => {
+                    return Ok(yanked);
+                }
+                Poll::Pending => {
+                    // TODO: dont hot loop for it to be Ready
+                }
+            }
+        }
     }
 }

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -2,6 +2,21 @@ use anyhow::Error;
 
 use crate::util::errors::{CargoResult, HttpNot200};
 use crate::util::Config;
+use std::task::Poll;
+
+pub trait PollExt<T> {
+    fn expect(self, msg: &str) -> T;
+}
+
+impl<T> PollExt<T> for Poll<T> {
+    #[track_caller]
+    fn expect(self, msg: &str) -> T {
+        match self {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("{}", msg),
+        }
+    }
+}
 
 pub struct Retry<'a> {
     config: &'a Config,


### PR DESCRIPTION
This adds `Poll` to the return type of `Source`. This is prep work for @jonhoo's #8890 as suggested by @alexcrichton.

There is definitely a lot of polishing work to do before merge, but it is good enough to start a conversation and see what CI has to say.

Some questions as it stands now:
- `CargoResult<Poll<_>>` vs `Poll<CargoResult<()>>` neither is clearly more ergonomic to work with?
- Is there some use case that makes `query` pull its weight, or should we only have the `query_vec` version?
- What to do when we get a `Poll::Pending`? Currently we bizzy weight, but that is not grate. What can we do short of async and await.
- There are a lot of places that want to "just weight till it is ready", should we find a way to have that code in only one or two places? Should we have a `query_weight` that is defaulted to call `query` in a loop?
- Should we move some of the loops up the stack for better parallelism?
- Should we move some of the loops down the stack to do less redundant work?
- Can we break some of the caches up, so that there is more sharing between runs? (Yes, but maybe it can be left for later.)
- There are 2 places where we want `expect` for `Poll`, should we start an extension trait to add a method?