### PR TITLE
Fix git http.proxy config setting.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -682,8 +682,8 @@ fn http_proxy(config: &Config) -> CargoResult<Option<String>> {
         return Ok(Some(s.clone()));
     }
     if let Ok(cfg) = git2::Config::open_default() {
-        if let Ok(s) = cfg.get_str("http.proxy") {
-            return Ok(Some(s.to_string()));
+        if let Ok(s) = cfg.get_string("http.proxy") {
+            return Ok(Some(s));
         }
     }
     Ok(None)


### PR DESCRIPTION
The `http.proxy` setting in `~/.gitconfig` was never being used. This is because the `get_str` method of `git2::Config` requires a "snapshot" config. Otherwise, it aways returns an error of "get_string called on a live config object".

I'm not 100% positive it makes sense to fix this, since I'm uncertain this might introduce problems for people, but it seems to be the intent here.