### PR TITLE
Make cargo metadata and tree respect target

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -3,7 +3,7 @@
 use crate::core::compiler::UnitInterner;
 use crate::core::compiler::{CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::profiles::{Profiles, UnitFor};
-use crate::core::resolver::features::{FeaturesFor, ResolvedFeatures};
+use crate::core::resolver::features::{FeaturesFor, RequestedFeatures, ResolvedFeatures};
 use crate::core::resolver::{HasDevUnits, ResolveOpts};
 use crate::core::{Dependency, PackageId, PackageSet, Resolve, SourceId, Workspace};
 use crate::ops::{self, Packages};
@@ -109,8 +109,10 @@ pub fn resolve_std<'cfg>(
     };
     // dev_deps setting shouldn't really matter here.
     let opts = ResolveOpts::new(
-        /*dev_deps*/ false, &features, /*all_features*/ false,
-        /*uses_default_features*/ false,
+        /*dev_deps*/ false,
+        RequestedFeatures::from_command_line(
+            &features, /*all_features*/ false, /*uses_default_features*/ false,
+        ),
     );
     let resolve = ops::resolve_ws_with_opts(
         &std_ws,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -434,6 +434,10 @@ impl<'cfg> PackageSet<'cfg> {
         self.packages.keys().cloned()
     }
 
+    pub fn packages<'a>(&'a self) -> impl Iterator<Item = &'a Package> + 'a {
+        self.packages.values().filter_map(|p| p.borrow())
+    }
+
     pub fn enable_download<'a>(&'a self) -> CargoResult<Downloads<'a, 'cfg>> {
         assert!(!self.downloading.replace(true));
         let timeout = ops::HttpTimeout::new(self.config)?;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -494,7 +494,7 @@ impl<'cfg> PackageSet<'cfg> {
         requested_kinds: &[CompileKind],
         target_data: &RustcTargetData,
         force_all_targets: ForceAllTargets,
-    ) -> CargoResult<Vec<&Package>> {
+    ) -> CargoResult<()> {
         fn collect_used_deps(
             used: &mut BTreeSet<PackageId>,
             resolve: &Resolve,
@@ -558,7 +558,8 @@ impl<'cfg> PackageSet<'cfg> {
                 force_all_targets,
             )?;
         }
-        self.get_many(to_download.into_iter())
+        self.get_many(to_download.into_iter())?;
+        Ok(())
     }
 
     pub fn sources(&self) -> Ref<'_, SourceMap<'cfg>> {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -490,7 +490,7 @@ impl<'cfg> PackageSet<'cfg> {
         requested_kinds: &[CompileKind],
         target_data: &RustcTargetData,
         force_all_targets: ForceAllTargets,
-    ) -> CargoResult<()> {
+    ) -> CargoResult<Vec<&Package>> {
         fn collect_used_deps(
             used: &mut BTreeSet<PackageId>,
             resolve: &Resolve,
@@ -554,8 +554,7 @@ impl<'cfg> PackageSet<'cfg> {
                 force_all_targets,
             )?;
         }
-        self.get_many(to_download.into_iter())?;
-        Ok(())
+        self.get_many(to_download.into_iter())
     }
 
     pub fn sources(&self) -> Ref<'_, SourceMap<'cfg>> {

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -147,20 +147,8 @@ impl ResolveOpts {
         }
     }
 
-    pub fn new(
-        dev_deps: bool,
-        features: &[String],
-        all_features: bool,
-        uses_default_features: bool,
-    ) -> ResolveOpts {
-        ResolveOpts {
-            dev_deps,
-            features: RequestedFeatures::from_command_line(
-                features,
-                all_features,
-                uses_default_features,
-            ),
-        }
+    pub fn new(dev_deps: bool, features: RequestedFeatures) -> ResolveOpts {
+        ResolveOpts { dev_deps, features }
     }
 }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -33,7 +33,7 @@ use crate::core::compiler::{BuildConfig, BuildContext, Compilation, Context};
 use crate::core::compiler::{CompileKind, CompileMode, CompileTarget, RustcTargetData, Unit};
 use crate::core::compiler::{DefaultExecutor, Executor, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
-use crate::core::resolver::features::{self, FeaturesFor};
+use crate::core::resolver::features::{self, FeaturesFor, RequestedFeatures};
 use crate::core::resolver::{HasDevUnits, Resolve, ResolveOpts};
 use crate::core::{FeatureValue, Package, PackageSet, Shell, Summary, Target};
 use crate::core::{PackageId, PackageIdSpec, TargetKind, Workspace};
@@ -336,7 +336,10 @@ pub fn create_bcx<'a, 'cfg>(
 
     let specs = spec.to_package_id_specs(ws)?;
     let dev_deps = ws.require_optional_deps() || filter.need_dev_deps(build_config.mode);
-    let opts = ResolveOpts::new(dev_deps, features, all_features, !no_default_features);
+    let opts = ResolveOpts::new(
+        dev_deps,
+        RequestedFeatures::from_command_line(features, all_features, !no_default_features),
+    );
     let has_dev_units = if filter.need_dev_deps(build_config.mode) {
         HasDevUnits::Yes
     } else {

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,5 +1,5 @@
 use crate::core::compiler::RustcTargetData;
-use crate::core::resolver::{HasDevUnits, ResolveOpts};
+use crate::core::resolver::{features::RequestedFeatures, HasDevUnits, ResolveOpts};
 use crate::core::{Shell, Workspace};
 use crate::ops;
 use crate::util::CargoResult;
@@ -21,9 +21,11 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
     let specs = options.compile_opts.spec.to_package_id_specs(ws)?;
     let opts = ResolveOpts::new(
         /*dev_deps*/ true,
-        &options.compile_opts.features,
-        options.compile_opts.all_features,
-        !options.compile_opts.no_default_features,
+        RequestedFeatures::from_command_line(
+            &options.compile_opts.features,
+            options.compile_opts.all_features,
+            !options.compile_opts.no_default_features,
+        ),
     );
     let target_data = RustcTargetData::new(ws, &options.compile_opts.build_config.requested_kinds)?;
     let ws_resolve = ops::resolve_ws_with_opts(

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -120,12 +120,7 @@ fn build_resolve_graph(
         metadata_opts.all_features,
         !metadata_opts.no_default_features,
     );
-    let resolve_opts = ResolveOpts::new(
-        /*dev_deps*/ true,
-        &metadata_opts.features,
-        metadata_opts.all_features,
-        !metadata_opts.no_default_features,
-    );
+    let resolve_opts = ResolveOpts::new(/*dev_deps*/ true, requested_features.clone());
     let force_all = if metadata_opts.filter_platforms.is_empty() {
         crate::core::resolver::features::ForceAllTargets::Yes
     } else {

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -142,6 +142,8 @@ fn build_resolve_graph(
     )?;
 
     // Download all Packages. This is needed to serialize the information for every package.
+    // Note that even with --filter-platform we end up downloading host dependencies as well,
+    // as that is the behavior of download_accessible.
     let package_map: BTreeMap<PackageId, Package> = ws_resolve
         .pkg_set
         .download_accessible(

--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -351,6 +351,13 @@ fn add_pkg(
                 true
             })
             .collect();
+
+        // This dependency is eliminated from the dependency tree under
+        // the current target and feature set.
+        if deps.is_empty() {
+            continue;
+        }
+
         deps.sort_unstable_by_key(|dep| dep.name_in_toml());
         let dep_pkg = graph.package_map[&dep_id];
 

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -143,12 +143,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         opts.all_features,
         !opts.no_default_features,
     );
-    let resolve_opts = ResolveOpts::new(
-        /*dev_deps*/ true,
-        &opts.features,
-        opts.all_features,
-        !opts.no_default_features,
-    );
+    let resolve_opts = ResolveOpts::new(/*dev_deps*/ true, requested_features.clone());
     let has_dev = if opts
         .edge_kinds
         .contains(&EdgeKind::Dep(DepKind::Development))

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -167,23 +167,9 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         force_all,
     )?;
 
-    // Download all Packages. Some display formats need to display package metadata.
-    // This may trigger some unnecessary downloads, but trying to figure out a
-    // minimal set would be difficult.
     let package_map: HashMap<PackageId, &Package> = ws_resolve
         .pkg_set
-        .download_accessible(
-            &ws_resolve.targeted_resolve,
-            &ws.members_with_features(&specs, &requested_features)?
-                .into_iter()
-                .map(|(p, _)| p.package_id())
-                .collect::<Vec<_>>(),
-            has_dev,
-            &requested_kinds,
-            &target_data,
-            force_all,
-        )?
-        .into_iter()
+        .packages()
         .map(|pkg| (pkg.package_id(), pkg))
         .collect();
 

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2214,29 +2214,19 @@ fn minimal_download() {
         .run();
     clear();
 
-    // This disables itarget, but leaves decouple_dev_deps enabled. However,
-    // `cargo tree` downloads everything anyways. Ideally `cargo tree` should
-    // be a little smarter, but that would make it a bit more complicated. The
-    // two "Downloading" lines are because `download_accessible` doesn't
-    // download enough (`cargo tree` really wants everything). Again, that
-    // could be cleaner, but is difficult.
+    // This disables itarget, but leaves decouple_dev_deps enabled.
     p.cargo("tree -e normal --target=all -Zfeatures=all")
         .masquerade_as_nightly_cargo()
         .with_stderr_unordered(
             "\
 [DOWNLOADING] crates ...
-[DOWNLOADING] crates ...
 [DOWNLOADED] normal v1.0.0 [..]
-[DOWNLOADED] dev_dep v1.0.0 [..]
 [DOWNLOADED] normal_pm v1.0.0 [..]
 [DOWNLOADED] build_dep v1.0.0 [..]
-[DOWNLOADED] dev_dep_pm v1.0.0 [..]
 [DOWNLOADED] build_dep_pm v1.0.0 [..]
 [DOWNLOADED] itarget_normal v1.0.0 [..]
-[DOWNLOADED] itarget_dev_dep v1.0.0 [..]
 [DOWNLOADED] itarget_normal_pm v1.0.0 [..]
 [DOWNLOADED] itarget_build_dep v1.0.0 [..]
-[DOWNLOADED] itarget_dev_dep_pm v1.0.0 [..]
 [DOWNLOADED] itarget_build_dep_pm v1.0.0 [..]
 ",
         )


### PR DESCRIPTION
Previously, the `metadata` and `tree` subcommands would download
dependencies for all targets, regardless of whether those targets were
actually enabled. This PR updates them so that they only download the
same dependencies that building would do with the requested target(s).

`cargo metadata` still includes all targets by default; you can only opt
_out_ using `--filter-platform`. Ideally it should use `--target` the
same way `tree` does, but it's too late to change that now.

Fixes #8981.