### PR TITLE
With debug HTTP mode log curl's version

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -603,6 +603,7 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
 
     if let Some(true) = http.debug {
         handle.verbose(true)?;
+        log::debug!("{:#?}", curl::Version::get());
         handle.debug_function(|kind, data| {
             let (prefix, level) = match kind {
                 InfoType::Text => ("*", Level::Debug),


### PR DESCRIPTION
This will hopefully help any future reports where we're trying to
figure out what's going on with possible different versions of the
`curl` library.