### PR TITLE
Draft: allow patching Git source dependencies with patch files

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -34,6 +34,7 @@ struct Inner {
     specified_req: bool,
     kind: DepKind,
     only_match_name: bool,
+    patch_files: Vec<String>,
     explicit_name_in_toml: Option<InternedString>,
 
     optional: bool,
@@ -217,6 +218,7 @@ impl Dependency {
                 specified_req: false,
                 platform: None,
                 explicit_name_in_toml: None,
+                patch_files: vec![],
             }),
         }
     }
@@ -247,6 +249,10 @@ impl Dependency {
     /// ```
     pub fn name_in_toml(&self) -> InternedString {
         self.explicit_name_in_toml().unwrap_or(self.inner.name)
+    }
+
+    pub fn patch_files(&self) -> &Vec<String> {
+        &self.inner.patch_files
     }
 
     /// The name of the package that this `Dependency` depends on.
@@ -326,6 +332,15 @@ impl Dependency {
             assert_eq!(kind, DepKind::Normal);
         }
         Rc::make_mut(&mut self.inner).kind = kind;
+        self
+    }
+
+    /// Sets the list of patch files
+    pub fn set_patch_files(
+        &mut self,
+        patch_files: impl IntoIterator<Item = impl Into<String>>,
+    ) -> &mut Dependency {
+        Rc::make_mut(&mut self.inner).patch_files = patch_files.into_iter().map(|s| s.into()).collect();
         self
     }
 

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -169,9 +169,9 @@ impl ConflictCache {
     /// which are activated in `cx` and contain `PackageId` specified.
     /// If more than one are activated, then it will return
     /// one that will allow for the most jump-back.
-    pub fn find_conflicting(
+    pub fn find_conflicting<'a, 'cfg>(
         &self,
-        cx: &Context,
+        cx: &Context<'a, 'cfg>,
         dep: &Dependency,
         must_contain: Option<PackageId>,
     ) -> Option<&ConflictMap> {
@@ -186,7 +186,7 @@ impl ConflictCache {
         }
         out
     }
-    pub fn conflicting(&self, cx: &Context, dep: &Dependency) -> Option<&ConflictMap> {
+    pub fn conflicting<'a, 'cfg>(&self, cx: &Context<'a, 'cfg>, dep: &Dependency) -> Option<&ConflictMap> {
         self.find_conflicting(cx, dep, None)
     }
 

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -67,9 +67,9 @@ impl From<(PackageId, ConflictReason)> for ActivateError {
     }
 }
 
-pub(super) fn activation_error(
-    cx: &Context,
-    registry: &mut dyn Registry,
+pub(super) fn activation_error<'a, 'cfg>(
+    cx: &Context<'a, 'cfg>,
+    registry: &mut dyn Registry<'cfg>,
     parent: &Summary,
     dep: &Dependency,
     conflicting_activations: &ConflictMap,
@@ -214,7 +214,7 @@ pub(super) fn activation_error(
     let all_req = semver::VersionReq::parse("*").unwrap();
     let mut new_dep = dep.clone();
     new_dep.set_version_req(all_req);
-    let mut candidates = match registry.query_vec(&new_dep, false) {
+    let mut candidates = match registry.query_vec(cx.ws, &new_dep, false) {
         Ok(candidates) => candidates,
         Err(e) => return to_resolve_err(e),
     };
@@ -269,7 +269,7 @@ pub(super) fn activation_error(
             // Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
             // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
             let mut candidates = Vec::new();
-            if let Err(e) = registry.query(&new_dep, &mut |s| candidates.push(s), true) {
+            if let Err(e) = registry.query(cx.ws, &new_dep, &mut |s| candidates.push(s), true) {
                 return to_resolve_err(e);
             };
             candidates.sort_unstable_by_key(|a| a.name());

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -264,8 +264,8 @@ pub fn compile<'a>(ws: &Workspace<'a>, options: &CompileOptions) -> CargoResult<
 
 /// Like `compile` but allows specifying a custom `Executor` that will be able to intercept build
 /// calls and add custom logic. `compile` uses `DefaultExecutor` which just passes calls through.
-pub fn compile_with_exec<'a>(
-    ws: &Workspace<'a>,
+pub fn compile_with_exec<'a, 'cfg: 'a>(
+    ws: &Workspace<'cfg>,
     options: &CompileOptions,
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
@@ -273,8 +273,8 @@ pub fn compile_with_exec<'a>(
     compile_ws(ws, options, exec)
 }
 
-pub fn compile_ws<'a>(
-    ws: &Workspace<'a>,
+pub fn compile_ws<'a, 'cfg: 'a>(
+    ws: &Workspace<'cfg>,
     options: &CompileOptions,
     exec: &Arc<dyn Executor>,
 ) -> CargoResult<Compilation<'a>> {
@@ -290,7 +290,7 @@ pub fn compile_ws<'a>(
     cx.compile(exec)
 }
 
-pub fn create_bcx<'a, 'cfg>(
+pub fn create_bcx<'a, 'cfg: 'a>(
     ws: &'a Workspace<'cfg>,
     options: &'a CompileOptions,
     interner: &'a UnitInterner,

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -5,17 +5,17 @@ use crate::util::CargoResult;
 use crate::util::Config;
 use std::collections::HashSet;
 
-pub struct FetchOptions<'a> {
-    pub config: &'a Config,
+pub struct FetchOptions<'cfg> {
+    pub config: &'cfg Config,
     /// The target arch triple to fetch dependencies for
     pub targets: Vec<String>,
 }
 
 /// Executes `cargo fetch`.
-pub fn fetch<'a>(
-    ws: &Workspace<'a>,
-    options: &FetchOptions<'a>,
-) -> CargoResult<(Resolve, PackageSet<'a>)> {
+pub fn fetch<'a, 'cfg: 'a>(
+    ws: &'a Workspace<'cfg>,
+    options: &'a FetchOptions<'cfg>,
+) -> CargoResult<(Resolve, PackageSet<'cfg>)> {
     ws.emit_warnings()?;
     let (packages, resolve) = ops::resolve_ws(ws)?;
 

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -113,7 +113,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             }
         }
 
-        registry.add_sources(sources)?;
+        registry.add_sources(&ws, sources)?;
     }
 
     let mut resolve = ops::resolve_with_previous(

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde::Deserialize;
 
 use crate::core::source::MaybePackage;
-use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};
+use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary, Workspace};
 use crate::sources::PathSource;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::paths;
@@ -71,7 +71,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         self.source_id
     }
 
-    fn update(&mut self) -> CargoResult<()> {
+    fn update_ws<'a>(&mut self, _ws: Option<&Workspace<'a>>, _patch_files: &Vec<String>) -> CargoResult<()> {
         self.packages.clear();
         let entries = self.root.read_dir().chain_err(|| {
             format!(

--- a/src/cargo/sources/git/mod.rs
+++ b/src/cargo/sources/git/mod.rs
@@ -1,4 +1,4 @@
 pub use self::source::GitSource;
 pub use self::utils::{fetch, GitCheckout, GitDatabase, GitRemote};
 mod source;
-mod utils;
+pub mod utils;

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,6 +1,6 @@
 use crate::core::source::{MaybePackage, Source, SourceId};
 use crate::core::GitReference;
-use crate::core::{Dependency, Package, PackageId, Summary};
+use crate::core::{Dependency, Package, PackageId, Summary, Workspace};
 use crate::sources::git::utils::GitRemote;
 use crate::sources::PathSource;
 use crate::util::errors::CargoResult;
@@ -111,7 +111,7 @@ impl<'cfg> Source for GitSource<'cfg> {
         self.source_id
     }
 
-    fn update(&mut self) -> CargoResult<()> {
+    fn update_ws<'a>(&mut self, _ws: Option<&Workspace<'a>>, _patch_files: &Vec<String>) -> CargoResult<()> {
         let git_path = self.config.git_path();
         let git_path = self.config.assert_package_cache_locked(&git_path);
         let db_path = git_path.join("db").join(&self.ident);

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -8,7 +8,7 @@ use ignore::Match;
 use log::{trace, warn};
 
 use crate::core::source::MaybePackage;
-use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};
+use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary, Workspace};
 use crate::ops;
 use crate::util::{internal, paths, CargoResult, CargoResultExt, Config};
 
@@ -497,7 +497,7 @@ impl<'cfg> Source for PathSource<'cfg> {
         self.source_id
     }
 
-    fn update(&mut self) -> CargoResult<()> {
+    fn update_ws<'a>(&mut self, _ws: Option<&Workspace<'a>>, _patch_files: &Vec<String>) -> CargoResult<()> {
         if !self.updated {
             let packages = self.read_packages()?;
             self.packages.extend(packages.into_iter());

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -173,7 +173,7 @@ use tar::Archive;
 
 use crate::core::dependency::{DepKind, Dependency};
 use crate::core::source::MaybePackage;
-use crate::core::{Package, PackageId, Source, SourceId, Summary};
+use crate::core::{Package, PackageId, Source, SourceId, Summary, Workspace};
 use crate::sources::PathSource;
 use crate::util::errors::CargoResultExt;
 use crate::util::hex;
@@ -612,7 +612,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         self.source_id
     }
 
-    fn update(&mut self) -> CargoResult<()> {
+    fn update_ws<'a>(&mut self, _ws: Option<&Workspace<'a>>, _patch_files: &Vec<String>) -> CargoResult<()> {
         // If we have an imprecise version then we don't know what we're going
         // to look for, so we always attempt to perform an update here.
         //

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -1,5 +1,5 @@
 use crate::core::source::MaybePackage;
-use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};
+use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary, Workspace};
 use crate::util::errors::{CargoResult, CargoResultExt};
 
 pub struct ReplacedSource<'cfg> {
@@ -63,9 +63,9 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         Ok(())
     }
 
-    fn update(&mut self) -> CargoResult<()> {
+    fn update_ws<'a>(&mut self, ws: Option<&Workspace<'a>>, patch_files: &Vec<String>) -> CargoResult<()> {
         self.inner
-            .update()
+            .update_ws(ws, patch_files)
             .chain_err(|| format!("failed to update replaced source {}", self.to_replace))?;
         Ok(())
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -260,6 +260,7 @@ pub struct DetailedTomlDependency {
     default_features2: Option<bool>,
     package: Option<String>,
     public: Option<bool>,
+    patch_files: Option<Vec<String>>,
 }
 
 /// This type is used to deserialize `Cargo.toml` files.
@@ -1756,6 +1757,7 @@ impl DetailedTomlDependency {
             Some(id) => Dependency::parse(pkg_name, version, new_source_id, id, cx.config)?,
             None => Dependency::parse_no_deprecated(pkg_name, version, new_source_id)?,
         };
+        dep.set_patch_files(self.patch_files.iter().flatten());
         dep.set_features(self.features.iter().flatten())
             .set_default_features(
                 self.default_features


### PR DESCRIPTION
First attempt at addressing #4648. This is a functioning demo (though sure there are some bugs).

This is currently lacking testing/documentation to get early feedback. It's also narrowed to Git sources only (i.e. `git = <url>`), `patch-files` spec on other sources are currently ignored.

I'm posting this to understand whether I've came close to a good approach before investing more time to extend it, and to get some answers to questions that came up during the implementation - 

1) Should `SourceId` know about the patches? Does the lockfile need to know?
2) Patches are essentially per source and not per package, so would we have to respecify all of them for packages that share a source, or should we move this out of `TomlDependency`?
3) Should this really be only under `target/`, and what should we name this directory?
4) How to handle other kind of Sources? Should we limit this to the standard Repository and Git sources dependencies?
5) Is it okay to rely over `git` command in order to apply the patches, or should we rely over `patch` util, or on some Rust crate that knows how to apply diffs independently?