### PR TITLE
Add the path to the manifest in json output

### DIFF
--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -20,6 +20,7 @@ pub trait Message: ser::Serialize {
 #[derive(Serialize)]
 pub struct FromCompiler<'a> {
     pub package_id: PackageId,
+    pub manifest_path: &'a Path,
     pub target: &'a Target,
     pub message: Box<RawValue>,
 }
@@ -33,6 +34,7 @@ impl<'a> Message for FromCompiler<'a> {
 #[derive(Serialize)]
 pub struct Artifact<'a> {
     pub package_id: PackageId,
+    pub manifest_path: PathBuf,
     pub target: &'a Target,
     pub profile: ArtifactProfile,
     pub features: Vec<String>,

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1736,6 +1736,7 @@ fn json_artifact_includes_executable_for_benchmark() {
                     "filenames": "{...}",
                     "fresh": false,
                     "package_id": "foo 0.0.1 ([..])",
+                    "manifest_path": "[..]",
                     "profile": "{...}",
                     "reason": "compiler-artifact",
                     "target": {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3140,6 +3140,7 @@ fn compiler_json_error_format() {
             {
                 "reason":"compiler-artifact",
                 "package_id":"foo 0.5.0 ([..])",
+                "manifest_path": "[..]",
                 "target":{
                     "kind":["custom-build"],
                     "crate_types":["bin"],
@@ -3166,6 +3167,7 @@ fn compiler_json_error_format() {
             {
                 "reason":"compiler-message",
                 "package_id":"bar 0.5.0 ([..])",
+                "manifest_path": "[..]",
                 "target":{
                     "kind":["lib"],
                     "crate_types":["lib"],
@@ -3191,6 +3193,7 @@ fn compiler_json_error_format() {
                 "executable": null,
                 "features": [],
                 "package_id":"bar 0.5.0 ([..])",
+                "manifest_path": "[..]",
                 "target":{
                     "kind":["lib"],
                     "crate_types":["lib"],
@@ -3221,6 +3224,7 @@ fn compiler_json_error_format() {
             {
                 "reason":"compiler-message",
                 "package_id":"foo 0.5.0 ([..])",
+                "manifest_path": "[..]",
                 "target":{
                     "kind":["bin"],
                     "crate_types":["bin"],
@@ -3237,6 +3241,7 @@ fn compiler_json_error_format() {
             {
                 "reason":"compiler-artifact",
                 "package_id":"foo 0.5.0 ([..])",
+                "manifest_path": "[..]",
                 "target":{
                     "kind":["bin"],
                     "crate_types":["bin"],
@@ -3307,6 +3312,7 @@ fn message_format_json_forward_stderr() {
                 {
                     "reason":"compiler-message",
                     "package_id":"foo 0.5.0 ([..])",
+                    "manifest_path": "[..]",
                     "target":{
                         "kind":["bin"],
                         "crate_types":["bin"],
@@ -3323,6 +3329,7 @@ fn message_format_json_forward_stderr() {
                 {
                     "reason":"compiler-artifact",
                     "package_id":"foo 0.5.0 ([..])",
+                    "manifest_path": "[..]",
                     "target":{
                         "kind":["bin"],
                         "crate_types":["bin"],

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1414,6 +1414,7 @@ fn doc_message_format() {
                     "spans": "{...}"
                 },
                 "package_id": "foo [..]",
+                "manifest_path": "[..]",
                 "reason": "compiler-message",
                 "target": "{...}"
             }

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -691,6 +691,7 @@ fn metabuild_json_artifact() {
               "filenames": "{...}",
               "fresh": false,
               "package_id": "foo [..]",
+              "manifest_path": "[..]",
               "profile": "{...}",
               "reason": "compiler-artifact",
               "target": {
@@ -743,6 +744,7 @@ fn metabuild_failed_build_json() {
                 "spans": "{...}"
               },
               "package_id": "foo [..]",
+              "manifest_path": "[..]",
               "reason": "compiler-message",
               "target": {
                 "crate_types": [

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3536,6 +3536,7 @@ fn json_artifact_includes_test_flag() {
                     "executable": "[..]/foo-[..]",
                     "features": [],
                     "package_id":"foo 0.0.1 ([..])",
+                    "manifest_path": "[..]",
                     "target":{
                         "kind":["lib"],
                         "crate_types":["lib"],
@@ -3572,6 +3573,7 @@ fn json_artifact_includes_executable_for_library_tests() {
                     "filenames": "{...}",
                     "fresh": false,
                     "package_id": "foo 0.0.1 ([..])",
+                    "manifest_path": "[..]",
                     "profile": "{...}",
                     "reason": "compiler-artifact",
                     "target": {
@@ -3610,6 +3612,7 @@ fn json_artifact_includes_executable_for_integration_tests() {
                     "filenames": "{...}",
                     "fresh": false,
                     "package_id": "foo 0.0.1 ([..])",
+                    "manifest_path": "[..]",
                     "profile": "{...}",
                     "reason": "compiler-artifact",
                     "target": {


### PR DESCRIPTION
This allows consumers of the json messages to avoid guessing where
exactly the package root is. Having access to the package root is
difficult by virtue of requiring logic to guess its location by e.g.
walking filesystem from the source file.

This guessing logic becomes further complicated in presence of
workspaces and nigh impossible to implement correctly in instances where
artifacts end up produced from paths above the package root (e.g.
`../foo.rs`).

Since Cargo has access to this data in the first place, there doesn't
seem to be much reason to force consumers to invent their own, possibly
flawed, logic.