### PR TITLE
NatVis support in Cargo

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -943,6 +943,15 @@ fn build_base_args(
             .env("RUSTC_BOOTSTRAP", "1");
     }
 
+    // If the target is using the MSVC toolchain, then pass any NatVis files to it.
+    let target_config = bcx.target_data.target_config(unit.kind);
+    let is_msvc = target_config.triple.ends_with("-msvc");
+    if is_msvc {
+        for natvis_file in unit.pkg.manifest().natvis_files().iter() {
+            cmd.arg(format!("-Clink-arg=/natvis:{}", natvis_file));
+        }
+    }
+
     // Add `CARGO_BIN_` environment variables for building tests.
     if unit.target.is_test() || unit.target.is_bench() {
         for bin_target in unit

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -50,6 +50,7 @@ pub struct Manifest {
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
     resolve_behavior: Option<ResolveBehavior>,
+    natvis_files: Vec<String>,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -384,6 +385,7 @@ impl Manifest {
         original: Rc<TomlManifest>,
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
+        natvis_files: Vec<String>,
     ) -> Manifest {
         Manifest {
             summary,
@@ -407,6 +409,7 @@ impl Manifest {
             publish_lockfile,
             metabuild,
             resolve_behavior,
+            natvis_files,
         }
     }
 
@@ -538,6 +541,10 @@ impl Manifest {
             .into_path_unlocked()
             .join(".metabuild")
             .join(format!("metabuild-{}-{}.rs", self.name(), hash))
+    }
+
+    pub fn natvis_files(&self) -> &[String] {
+        &self.natvis_files
     }
 }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -102,6 +102,8 @@ pub struct SerializedPackage {
     links: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     metabuild: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    natvis_files: Vec<String>,
 }
 
 impl Package {
@@ -259,7 +261,12 @@ impl Package {
             links: self.manifest().links().map(|s| s.to_owned()),
             metabuild: self.manifest().metabuild().cloned(),
             publish: self.publish().as_ref().cloned(),
+            natvis_files: self.natvis_files().to_vec(),
         }
+    }
+
+    pub fn natvis_files(&self) -> &[String] {
+        self.inner.manifest.natvis_files()
     }
 }
 

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -34,6 +34,7 @@ pub struct TargetConfig {
     /// running its build script and instead use the given output from the
     /// config file.
     pub links_overrides: BTreeMap<String, BuildOutput>,
+    pub triple: String,
 }
 
 /// Loads all of the `target.'cfg()'` tables.
@@ -85,6 +86,7 @@ pub(super) fn load_target_triple(config: &Config, triple: &str) -> CargoResult<T
         rustflags,
         linker,
         links_overrides,
+        triple: triple.to_string(),
     })
 }
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -75,6 +75,7 @@ mod metabuild;
 mod metadata;
 mod minimal_versions;
 mod multitarget;
+mod natvis;
 mod net_config;
 mod new;
 mod offline;

--- a/tests/testsuite/natvis.rs
+++ b/tests/testsuite/natvis.rs
@@ -1,0 +1,243 @@
+//! Tests for NatVis support.
+//!
+//! Currently, there is no way to test for the presence (or absence)
+//! of a specific item in a JSON array, so these tests verify all of
+//! the arguments in the corresponding `rustc` calls. That's fragile.
+//! Ideally, we would be able to test for the `-Clink-args=...` args
+//! without caring about any other args.
+
+use cargo_test_support::{project, rustc_host};
+
+const NATVIS_CONTENT: &str = r#"
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+</<AutoVisualizer>
+"#;
+
+fn is_natvis_supported() -> bool {
+    rustc_host().ends_with("-msvc")
+}
+
+/// Tests a project that contains a single NatVis file.
+/// The file is discovered by Cargo, since it is in the `/natvis` directory,
+/// and does not need to be explicitly specified in the manifest.
+#[cargo_test]
+fn natvis_autodiscovery() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        [package]
+        name = "natvis_autodiscovery"
+        version = "0.0.1"
+        edition = "2018"
+    "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("natvis/types.natvis", NATVIS_CONTENT)
+        .build();
+
+    let mut execs = p.cargo("build --build-plan -Zunstable-options");
+    execs.masquerade_as_nightly_cargo();
+
+    if is_natvis_supported() {
+        execs.with_json(
+            r#"
+            {
+                "inputs": [
+                    "[..]/foo/Cargo.toml"
+                ],
+                "invocations": [
+                    {
+                        "args": [
+                            "--crate-name",
+                            "natvis_autodiscovery",
+                            "--edition=2018",
+                            "src/main.rs",
+                            "--error-format=json",
+                            "--json=[..]",
+                            "--crate-type",
+                            "bin",
+                            "--emit=[..]",
+                            "-C",
+                            "embed-bitcode=[..]",
+                            "-C",
+                            "debuginfo=[..]",
+                            "-C",
+                            "metadata=[..]",
+                            "--out-dir",
+                            "[..]",
+                            "-Clink-arg=/natvis:[..]/foo/natvis/types.natvis",
+                            "-L",
+                            "dependency=[..]"
+                        ],
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": "{...}",
+                        "package_name": "natvis_autodiscovery",
+                        "package_version": "0.0.1",
+                        "program": "rustc",
+                        "target_kind": ["bin"],
+                        "compile_mode": "build"
+                    }
+                ]
+            }
+            "#,
+        );
+    }
+
+    execs.run();
+}
+
+/// Tests a project that contains a single NatVis file, which is explicitly
+/// specified in the manifest file. Because it is explicitly specified, it
+/// does not have to be in the `/natvis` subdirectory.
+#[cargo_test]
+fn natvis_explicit() {
+    if !is_natvis_supported() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        [package]
+        name = "natvis_explicit"
+        version = "0.0.1"
+        edition = "2018"
+        natvis-files = ["types.natvis"]
+    "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("types.natvis", NATVIS_CONTENT)
+        .build();
+
+    let mut execs = p.cargo("build --build-plan -Zunstable-options");
+    execs.masquerade_as_nightly_cargo();
+
+    if is_natvis_supported() {
+        execs.with_json(
+            r#"
+            {
+                "inputs": [
+                    "[..]/foo/Cargo.toml"
+                ],
+                "invocations": [
+                    {
+                        "args": [
+                            "--crate-name",
+                            "natvis_explicit",
+                            "--edition=2018",
+                            "src/main.rs",
+                            "--error-format=json",
+                            "--json=[..]",
+                            "--crate-type",
+                            "bin",
+                            "--emit=[..]",
+                            "-C",
+                            "embed-bitcode=[..]",
+                            "-C",
+                            "debuginfo=[..]",
+                            "-C",
+                            "metadata=[..]",
+                            "--out-dir",
+                            "[..]",
+                            "-Clink-arg=/natvis:[..]/foo/types.natvis",
+                            "-L",
+                            "dependency=[..]"
+                        ],
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": "{...}",
+                        "package_name": "natvis_explicit",
+                        "package_version": "0.0.1",
+                        "program": "rustc",
+                        "target_kind": ["bin"],
+                        "compile_mode": "build"
+                    }
+                ]
+            }
+            "#,
+        );
+    }
+
+    execs.run();
+}
+
+/// Tests a project that has a file in the `/natvis` directory, but which has
+/// been disabled in the manifest. This is analogous to specifying `autobenches = false`.
+#[cargo_test]
+fn natvis_disabled() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        [package]
+        name = "natvis_disabled"
+        version = "0.0.1"
+        edition = "2018"
+        natvis-files = []
+    "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("natvis/types.natvis", NATVIS_CONTENT)
+        .build();
+
+    let mut execs = p.cargo("build --build-plan -Zunstable-options");
+    execs.masquerade_as_nightly_cargo();
+    if is_natvis_supported() {
+        execs.with_json(
+            r#"
+            {
+                "inputs": [
+                    "[..]/foo/Cargo.toml"
+                ],
+                "invocations": [
+                    {
+                        "args": [
+                            "--crate-name",
+                            "natvis_disabled",
+                            "--edition=2018",
+                            "src/main.rs",
+                            "--error-format=json",
+                            "--json=[..]",
+                            "--crate-type",
+                            "bin",
+                            "--emit=[..]",
+                            "-C",
+                            "embed-bitcode=[..]",
+                            "-C",
+                            "debuginfo=[..]",
+                            "-C",
+                            "metadata=[..]",
+                            "--out-dir",
+                            "[..]",
+                            "-L",
+                            "dependency=[..]"
+                        ],
+                        "cwd": "[..]/cit/[..]/foo",
+                        "deps": [],
+                        "env": "{...}",
+                        "kind": null,
+                        "links": "{...}",
+                        "outputs": "{...}",
+                        "package_name": "natvis_disabled",
+                        "package_version": "0.0.1",
+                        "program": "rustc",
+                        "target_kind": ["bin"],
+                        "compile_mode": "build"
+                    }
+                ]
+            }
+            "#,
+        );
+    }
+    execs.run();
+}


### PR DESCRIPTION
This allows developers to write NatVis descriptions for their crates.
If a Cargo package contains NatVis files, then they will be written
into the PDB file. Debuggers that support NatVis will automatically
locate these files and use them. Currently, Visual Studio 2019,
VS Code, and WinDbg support NatVis. (NatVis is a Windows-only feature.)

The easiest way to add a NatVis file to a Cargo package is to create a
`natvis` subdirectory and place the file in that directory. The file
must have a `.natvis` extension. Any (reasonable) number of NatVis
files can be provided.

Optionally, you can give explicit paths by setting the `natvis-files`
key in `Cargo.toml`. For example:

```
[package]
name = ...
natvis-files = ["my_types.natvis", "more_types.natvis"]
```

This key can also be set to `[]` in order to prevent Cargo from
searching the `natvis` directory.

The Rust standard library already contains NatVis files, as a
special case. After this change is committed to Cargo, the
special-case logic in Rust can be removed; then the
standard library crates can just use this facility.