### PR TITLE
Expose build.target .cargo/config setting as packages.target in Cargo.toml

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
-build = "build.rs"
-
 [lib]
 doctest = false
 

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
 
+build = "build.rs"
+
 [lib]
 doctest = false
 

--- a/crates/cargo-test-support/build.rs
+++ b/crates/cargo-test-support/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!(
+        "cargo:rustc-env=NATIVE_ARCH={}",
+        std::env::var("TARGET").unwrap()
+    );
+}

--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -179,6 +179,23 @@ rustup does not appear to be installed. Make sure that the appropriate
     panic!("{}", message);
 }
 
+/// The arch triple of the test-running host.
+pub fn native() -> &'static str {
+    env!("NATIVE_ARCH")
+}
+
+pub fn native_arch() -> &'static str {
+    match native()
+        .split("-")
+        .next()
+        .expect("Target triple has unexpected format")
+    {
+        "x86_64" => "x86_64",
+        "i686" => "x86",
+        _ => panic!("This test should be gated on cross_compile::disabled."),
+    }
+}
+
 /// The alternate target-triple to build with.
 ///
 /// Only use this function on tests that check `cross_compile::disabled`.
@@ -202,6 +219,15 @@ pub fn alternate_arch() -> &'static str {
     } else {
         "x86"
     }
+}
+
+/// A target-triple that is neither the host nor the target.
+///
+/// Rustc may not work with it and it's alright, apart from being a
+/// valid target triple it is supposed to be used only as a
+/// placeholder for targets that should not be considered.
+pub fn unused() -> &'static str {
+    "wasm32-unknown-unknown"
 }
 
 /// Whether or not the host can run cross-compiled executables.

--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -39,7 +39,7 @@ pub struct BuildContext<'a, 'cfg> {
     pub packages: PackageSet<'cfg>,
 
     /// Information about rustc and the target platform.
-    pub target_data: RustcTargetData,
+    pub target_data: RustcTargetData<'cfg>,
 
     /// The root units of `unit_graph` (units requested on the command-line).
     pub roots: Vec<Unit>,
@@ -58,7 +58,7 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         build_config: &'a BuildConfig,
         profiles: Profiles,
         extra_compiler_args: HashMap<Unit, Vec<String>>,
-        target_data: RustcTargetData,
+        target_data: RustcTargetData<'cfg>,
         roots: Vec<Unit>,
         unit_graph: UnitGraph,
     ) -> CargoResult<BuildContext<'a, 'cfg>> {

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -727,22 +727,15 @@ impl<'cfg> RustcTargetData<'cfg> {
             }));
         for kind in all_kinds {
             if let CompileKind::Target(target) = kind {
-                match res.target_config.entry(target) {
-                    std::collections::hash_map::Entry::Occupied(_) => (),
-                    std::collections::hash_map::Entry::Vacant(place) => {
-                        place.insert(res.config.target_cfg_triple(target.short_name())?);
-                    }
+                if !res.target_config.contains_key(&target) {
+                    res.target_config
+                        .insert(target, res.config.target_cfg_triple(target.short_name())?);
                 }
-                match res.target_info.entry(target) {
-                    std::collections::hash_map::Entry::Occupied(_) => (),
-                    std::collections::hash_map::Entry::Vacant(place) => {
-                        place.insert(TargetInfo::new(
-                            res.config,
-                            &res.requested_kinds,
-                            &res.rustc,
-                            kind,
-                        )?);
-                    }
+                if !res.target_info.contains_key(&target) {
+                    res.target_info.insert(
+                        target,
+                        TargetInfo::new(res.config, &res.requested_kinds, &res.rustc, kind)?,
+                    );
                 }
             }
         }

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -127,10 +127,10 @@ impl<'cfg> Compilation<'cfg> {
             sysroot_target_libdir: bcx
                 .all_kinds
                 .iter()
-                .map(|kind| {
+                .map(|&kind| {
                     (
-                        *kind,
-                        bcx.target_data.info(*kind).sysroot_target_libdir.clone(),
+                        kind,
+                        bcx.target_data.info(kind).sysroot_target_libdir.clone(),
                     )
                 })
                 .collect(),

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -33,7 +33,7 @@ pub fn parse_unstable_flag(value: Option<&str>) -> Vec<String> {
 /// Resolve the standard library dependencies.
 pub fn resolve_std<'cfg>(
     ws: &Workspace<'cfg>,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'cfg>,
     requested_targets: &[CompileKind],
     crates: &[String],
 ) -> CargoResult<(PackageSet<'cfg>, Resolve, ResolvedFeatures)> {
@@ -185,7 +185,7 @@ pub fn generate_std_roots(
     Ok(ret)
 }
 
-fn detect_sysroot_src_path(target_data: &RustcTargetData) -> CargoResult<PathBuf> {
+fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<PathBuf> {
     if let Some(s) = env::var_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
         return Ok(s.into());
     }

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -44,7 +44,7 @@ struct State<'a, 'cfg> {
     /// library.
     is_std: bool,
     global_mode: CompileMode,
-    target_data: &'a RustcTargetData,
+    target_data: &'a RustcTargetData<'cfg>,
     profiles: &'a Profiles,
     interner: &'a UnitInterner,
 
@@ -63,7 +63,7 @@ pub fn build_unit_dependencies<'a, 'cfg>(
     roots: &[Unit],
     std_roots: &HashMap<CompileKind, Vec<Unit>>,
     global_mode: CompileMode,
-    target_data: &'a RustcTargetData,
+    target_data: &'a RustcTargetData<'cfg>,
     profiles: &'a Profiles,
     interner: &'a UnitInterner,
 ) -> CargoResult<UnitGraph> {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -390,6 +390,9 @@ features! {
 
     // Support for 2021 edition.
     (unstable, edition2021, "", "reference/unstable.html#edition-2021"),
+
+    // Allow to specify per-package targets (compile kinds)
+    (unstable, per_package_target, "", "reference/unstable.html#per-package-target"),
 }
 
 const PUBLISH_LOCKFILE_REMOVED: &str = "The publish-lockfile key in Cargo.toml \

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -518,11 +518,9 @@ impl Manifest {
         if self.default_kind.is_some() || self.forced_kind.is_some() {
             self.unstable_features
                 .require(Feature::per_package_target())
-                .chain_err(|| {
-                    anyhow::format_err!(
-                        "the `package.default-target` and `package.forced-target` \
-                         manifest keys are unstable and may not work properly"
-                    )
+                .with_context(|| {
+                    "the `package.default-target` and `package.forced-target` \
+                     manifest keys are unstable and may not work properly"
                 })?;
         }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -520,7 +520,7 @@ impl Manifest {
                 .require(Feature::per_package_target())
                 .chain_err(|| {
                     anyhow::format_err!(
-                        "the `package.default-kind` and `package.forced-kind` \
+                        "the `package.default-target` and `package.forced-target` \
                          manifest keys are unstable and may not work properly"
                     )
                 })?;

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -11,7 +11,7 @@ use serde::ser;
 use serde::Serialize;
 use url::Url;
 
-use crate::core::compiler::CrateType;
+use crate::core::compiler::{CompileKind, CrateType};
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{Dependency, PackageId, PackageIdSpec, SourceId, Summary};
 use crate::core::{Edition, Feature, Features, WorkspaceConfig};
@@ -32,6 +32,8 @@ pub enum EitherManifest {
 pub struct Manifest {
     summary: Summary,
     targets: Vec<Target>,
+    default_kind: Option<CompileKind>,
+    forced_kind: Option<CompileKind>,
     links: Option<String>,
     warnings: Warnings,
     exclude: Vec<String>,
@@ -366,6 +368,8 @@ compact_debug! {
 impl Manifest {
     pub fn new(
         summary: Summary,
+        default_kind: Option<CompileKind>,
+        forced_kind: Option<CompileKind>,
         targets: Vec<Target>,
         exclude: Vec<String>,
         include: Vec<String>,
@@ -388,6 +392,8 @@ impl Manifest {
     ) -> Manifest {
         Manifest {
             summary,
+            default_kind,
+            forced_kind,
             targets,
             warnings: Warnings::new(),
             exclude,
@@ -413,6 +419,12 @@ impl Manifest {
 
     pub fn dependencies(&self) -> &[Dependency] {
         self.summary.dependencies()
+    }
+    pub fn default_kind(&self) -> Option<CompileKind> {
+        self.default_kind
+    }
+    pub fn forced_kind(&self) -> Option<CompileKind> {
+        self.forced_kind
     }
     pub fn exclude(&self) -> &[String] {
         &self.exclude
@@ -500,6 +512,17 @@ impl Manifest {
                 .with_context(|| {
                     "the `im-a-teapot` manifest key is unstable and may \
                      not work properly in England"
+                })?;
+        }
+
+        if self.default_kind.is_some() || self.forced_kind.is_some() {
+            self.unstable_features
+                .require(Feature::per_package_target())
+                .chain_err(|| {
+                    anyhow::format_err!(
+                        "the `package.default-kind` and `package.forced-kind` \
+                         manifest keys are unstable and may not work properly"
+                    )
                 })?;
         }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -500,7 +500,7 @@ impl<'cfg> PackageSet<'cfg> {
         root_ids: &[PackageId],
         has_dev_units: HasDevUnits,
         requested_kinds: &[CompileKind],
-        target_data: &RustcTargetData,
+        target_data: &RustcTargetData<'cfg>,
         force_all_targets: ForceAllTargets,
     ) -> CargoResult<()> {
         fn collect_used_deps(
@@ -509,7 +509,7 @@ impl<'cfg> PackageSet<'cfg> {
             pkg_id: PackageId,
             has_dev_units: HasDevUnits,
             requested_kinds: &[CompileKind],
-            target_data: &RustcTargetData,
+            target_data: &RustcTargetData<'_>,
             force_all_targets: ForceAllTargets,
         ) -> CargoResult<()> {
             if !used.insert(pkg_id) {

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -414,7 +414,7 @@ pub struct FeatureDifferences {
 
 pub struct FeatureResolver<'a, 'cfg> {
     ws: &'a Workspace<'cfg>,
-    target_data: &'a RustcTargetData,
+    target_data: &'a RustcTargetData<'cfg>,
     /// The platforms to build for, requested by the user.
     requested_targets: &'a [CompileKind],
     resolve: &'a Resolve,
@@ -452,7 +452,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
     /// with the result.
     pub fn resolve(
         ws: &Workspace<'cfg>,
-        target_data: &RustcTargetData,
+        target_data: &RustcTargetData<'cfg>,
         resolve: &Resolve,
         package_set: &'a PackageSet<'cfg>,
         cli_features: &CliFeatures,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -467,11 +467,17 @@ pub fn create_bcx<'a, 'cfg>(
         })
         .collect();
 
+    // Passing `build_config.requested_kinds` instead of
+    // `explicit_host_kinds` here so that `generate_targets` can do
+    // its own special handling of `CompileKind::Host`. It will
+    // internally replace the host kind by the `explicit_host_kind`
+    // before setting as a unit.
     let mut units = generate_targets(
         ws,
         &to_builds,
         filter,
-        &explicit_host_kinds,
+        &build_config.requested_kinds,
+        explicit_host_kind,
         build_config.mode,
         &resolve,
         &workspace_resolve,
@@ -842,6 +848,7 @@ fn generate_targets(
     packages: &[&Package],
     filter: &CompileFilter,
     requested_kinds: &[CompileKind],
+    explicit_host_kind: CompileKind,
     mode: CompileMode,
     resolve: &Resolve,
     workspace_resolve: &Option<Resolve>,
@@ -915,7 +922,27 @@ fn generate_targets(
             let features_for = FeaturesFor::from_for_host(target.proc_macro());
             let features = resolved_features.activated_features(pkg.package_id(), features_for);
 
-            for kind in requested_kinds {
+            // If `--target` has not been specified, then the unit
+            // graph is built almost like if `--target $HOST` was
+            // specified. See `rebuild_unit_graph_shared` for more on
+            // why this is done. However, if the package has its own
+            // `package.target` key, then this gets used instead of
+            // `$HOST`
+            let explicit_kinds = if let Some(k) = pkg.manifest().forced_kind() {
+                vec![k]
+            } else {
+                requested_kinds
+                    .iter()
+                    .map(|kind| match kind {
+                        CompileKind::Host => {
+                            pkg.manifest().default_kind().unwrap_or(explicit_host_kind)
+                        }
+                        CompileKind::Target(t) => CompileKind::Target(*t),
+                    })
+                    .collect()
+            };
+
+            for kind in explicit_kinds.iter() {
                 let profile = profiles.get_profile(
                     pkg.package_id(),
                     ws.is_member(pkg),

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -171,7 +171,7 @@ fn build_resolve_graph_r(
     pkg_id: PackageId,
     resolve: &Resolve,
     package_map: &BTreeMap<PackageId, Package>,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'_>,
     requested_kinds: &[CompileKind],
 ) {
     if node_map.contains_key(&pkg_id) {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -79,7 +79,7 @@ pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolv
 /// members. In this case, `opts.all_features` must be `true`.
 pub fn resolve_ws_with_opts<'cfg>(
     ws: &Workspace<'cfg>,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'cfg>,
     requested_targets: &[CompileKind],
     cli_features: &CliFeatures,
     specs: &[PackageIdSpec],

--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -249,7 +249,7 @@ pub fn build<'a>(
     resolved_features: &ResolvedFeatures,
     specs: &[PackageIdSpec],
     cli_features: &CliFeatures,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'_>,
     requested_kinds: &[CompileKind],
     package_map: HashMap<PackageId, &'a Package>,
     opts: &TreeOptions,
@@ -294,7 +294,7 @@ fn add_pkg(
     resolved_features: &ResolvedFeatures,
     package_id: PackageId,
     features_for: FeaturesFor,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'_>,
     requested_kind: CompileKind,
     opts: &TreeOptions,
 ) -> usize {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -15,6 +15,7 @@ use serde::ser;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::core::compiler::{CompileKind, CompileTarget};
 use crate::core::dependency::DepKind;
 use crate::core::manifest::{ManifestMetadata, TargetSourcePath, Warnings};
 use crate::core::resolver::ResolveBehavior;
@@ -793,6 +794,10 @@ pub struct TomlProject {
     authors: Option<Vec<String>>,
     build: Option<StringOrBool>,
     metabuild: Option<StringOrVec>,
+    #[serde(rename = "default-target")]
+    default_target: Option<String>,
+    #[serde(rename = "forced-target")]
+    forced_target: Option<String>,
     links: Option<String>,
     exclude: Option<Vec<String>>,
     include: Option<Vec<String>>,
@@ -1313,9 +1318,24 @@ impl TomlManifest {
             }
         }
 
+        let default_kind = project
+            .default_target
+            .as_ref()
+            .map(|t| CompileTarget::new(&*t))
+            .transpose()? // TODO: anyhow::Context isn't imported yet so I guess .context() isn't the right way to do it?
+            .map(CompileKind::Target);
+        let forced_kind = project
+            .forced_target
+            .as_ref()
+            .map(|t| CompileTarget::new(&*t))
+            .transpose()?
+            .map(CompileKind::Target);
+
         let custom_metadata = project.metadata.clone();
         let mut manifest = Manifest::new(
             summary,
+            default_kind,
+            forced_kind,
             targets,
             exclude,
             include,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1322,7 +1322,7 @@ impl TomlManifest {
             .default_target
             .as_ref()
             .map(|t| CompileTarget::new(&*t))
-            .transpose()? // TODO: anyhow::Context isn't imported yet so I guess .context() isn't the right way to do it?
+            .transpose()?
             .map(CompileKind::Target);
         let forced_kind = project
             .forced_target

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -895,6 +895,26 @@ In this example, the `std` feature enables the `std` feature on the `serde`
 dependency. However, unlike the normal `serde/std` syntax, it will not enable
 the optional dependency `serde` unless something else has included it.
 
+### per-package-target
+
+The `per-package-target` feature adds two keys to the manifest:
+`package.default-target` and `package.forced-target`. The first makes
+the package be compiled by default (ie. when no `--target` argument is
+passed) for some target. The second one makes the package always be
+compiled for the target.
+
+Example:
+
+```toml
+[package]
+forced-target = "wasm32-unknown-unknown"
+```
+
+In this example, the crate is always built for
+`wasm32-unknown-unknown`, for instance because it is going to be used
+as a plugin for a main program that runs on the host (or provided on
+the command line) target.
+
 ### credential-process
 * Tracking Issue: [#8933](https://github.com/rust-lang/cargo/issues/8933)
 * RFC: [#2730](https://github.com/rust-lang/rfcs/pull/2730)

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -153,6 +153,209 @@ fn simple_deps() {
     }
 }
 
+/// Always take care of setting these so that
+/// `cross_compile::alternate()` is the actually-picked target
+fn per_crate_target_test(
+    default_target: Option<&'static str>,
+    forced_target: Option<&'static str>,
+    arg_target: Option<&'static str>,
+) {
+    if cross_compile::disabled() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    cargo-features = ["per-package-target"]
+
+                    [package]
+                    name = "foo"
+                    version = "0.0.0"
+                    authors = []
+                    build = "build.rs"
+                    {}
+                    {}
+                "#,
+                default_target
+                    .map(|t| format!(r#"default-target = "{}""#, t))
+                    .unwrap_or(String::new()),
+                forced_target
+                    .map(|t| format!(r#"forced-target = "{}""#, t))
+                    .unwrap_or(String::new()),
+            ),
+        )
+        .file(
+            "build.rs",
+            &format!(
+                r#"
+                    fn main() {{
+                        assert_eq!(std::env::var("TARGET").unwrap(), "{}");
+                    }}
+                "#,
+                cross_compile::alternate()
+            ),
+        )
+        .file(
+            "src/main.rs",
+            &format!(
+                r#"
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
+                cross_compile::alternate_arch()
+            ),
+        )
+        .build();
+
+    let mut cmd = p.cargo("build -v");
+    if let Some(t) = arg_target {
+        cmd.arg("--target").arg(&t);
+    }
+    cmd.masquerade_as_nightly_cargo().run();
+    assert!(p.target_bin(cross_compile::alternate(), "foo").is_file());
+
+    if cross_compile::can_run_on_host() {
+        p.process(&p.target_bin(cross_compile::alternate(), "foo"))
+            .run();
+    }
+}
+
+#[cargo_test]
+fn per_crate_default_target_is_default() {
+    per_crate_target_test(Some(cross_compile::alternate()), None, None);
+}
+
+#[cargo_test]
+fn per_crate_default_target_gets_overridden() {
+    per_crate_target_test(
+        Some(cross_compile::unused()),
+        None,
+        Some(cross_compile::alternate()),
+    );
+}
+
+#[cargo_test]
+fn per_crate_forced_target_is_default() {
+    per_crate_target_test(None, Some(cross_compile::alternate()), None);
+}
+
+#[cargo_test]
+fn per_crate_forced_target_does_not_get_overridden() {
+    per_crate_target_test(
+        None,
+        Some(cross_compile::alternate()),
+        Some(cross_compile::unused()),
+    );
+}
+
+#[cargo_test]
+fn workspace_with_multiple_targets() {
+    if cross_compile::disabled() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [workspace]
+                members = ["native", "cross"]
+            "#,
+        )
+        .file(
+            "native/Cargo.toml",
+            r#"
+                cargo-features = ["per-package-target"]
+
+                [package]
+                name = "native"
+                version = "0.0.0"
+                authors = []
+                build = "build.rs"
+            "#,
+        )
+        .file(
+            "native/build.rs",
+            &format!(
+                r#"
+                    fn main() {{
+                        assert_eq!(std::env::var("TARGET").unwrap(), "{}");
+                    }}
+                "#,
+                cross_compile::native()
+            ),
+        )
+        .file(
+            "native/src/main.rs",
+            &format!(
+                r#"
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
+                cross_compile::native_arch()
+            ),
+        )
+        .file(
+            "cross/Cargo.toml",
+            &format!(
+                r#"
+                    cargo-features = ["per-package-target"]
+
+                    [package]
+                    name = "cross"
+                    version = "0.0.0"
+                    authors = []
+                    build = "build.rs"
+                    default-target = "{}"
+                "#,
+                cross_compile::alternate(),
+            ),
+        )
+        .file(
+            "cross/build.rs",
+            &format!(
+                r#"
+                    fn main() {{
+                        assert_eq!(std::env::var("TARGET").unwrap(), "{}");
+                    }}
+                "#,
+                cross_compile::alternate()
+            ),
+        )
+        .file(
+            "cross/src/main.rs",
+            &format!(
+                r#"
+                    use std::env;
+                    fn main() {{
+                        assert_eq!(env::consts::ARCH, "{}");
+                    }}
+                "#,
+                cross_compile::alternate_arch()
+            ),
+        )
+        .build();
+
+    let mut cmd = p.cargo("build -v");
+    cmd.masquerade_as_nightly_cargo().run();
+
+    assert!(p.bin("native").is_file());
+    assert!(p.target_bin(cross_compile::alternate(), "cross").is_file());
+
+    p.process(&p.bin("native")).run();
+    if cross_compile::can_run_on_host() {
+        p.process(&p.target_bin(cross_compile::alternate(), "cross"))
+            .run();
+    }
+}
+
 #[cargo_test]
 fn linker() {
     if cross_compile::disabled() {


### PR DESCRIPTION
Hey!

I'm trying to do my first cargo contribution by implementing per-crate target settings as per [the irlo thread](https://internals.rust-lang.org/t/proposal-move-some-cargo-config-settings-to-cargo-toml/13336) ; and I think I have a draft that looks good-ish (the root units returned by `generate_targets` have the right kinds set).

Closes #7004

**_Edit: the below problem description is now solved in the latest version of this PR, please ignore_**

But for some reason running on a test project now blocks on `Blocking waiting for file lock on build directory` and I have literally no idea how my changes could trigger this… would anyone have an idea of how the changes could lead to infinitely blocking there? (I already tried cargo clean just in case and it didn't appear to help)

FWIW, the output that looks hopeful to me is, on my testbed workspace:
```
Root units [out of generate_targets] are [...]:
 - package ‘smtp-client’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-server’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘yuubind-config’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-message-fuzz’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘yuubind-rpc’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘yuubind-config-example’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-message-fuzz’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘yuubind-config-example’ with kind ‘Target(CompileTarget { name: "wasm32-unknown-unknown" })’
 - package ‘smtp-queue’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-message-fuzz’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-message’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-server-fuzz’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘yuubind-config’ with kind ‘Target(CompileTarget { name: "wasm32-unknown-unknown" })’
 - package ‘yuubind’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
 - package ‘smtp-queue-fs’ with kind ‘Target(CompileTarget { name: "x86_64-unknown-linux-gnu" })’
```
(where both `yuubind-config` and `yuubind-config-example` are being configured to be `wasm32-unknown-unknown` and the other ones stay as host).

Interestingly enough, if I remove the `target` setting from `yuubind-config` (and leave it on `yuubind-config-example`) then it does no longer block on waiting for file lock on build directory, even though it does not actually compile with `wasm32-unknown-unknown`. And it does appear to correctly build yuubind-config-example as wasm32.

My investigation shows that it appears to happen iff there is a package with `package.target` being set that has dependencies.

This most likely is a bug in my code (eg. I build only the root units and not the whole unit graph maybe?), and am going to keep investigating it as such, but maybe someone would already know how dependency resolution could interact with build lock acquisition and give me hints?

Anyway, thank you all for all you do cargo!