### PR TITLE
Clarify the help text of `--aggressive` and `--precise` of `update`

### DIFF
--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -11,10 +11,16 @@ pub fn cli() -> App {
         .arg_package_spec_simple("Package to update")
         .arg(opt(
             "aggressive",
-            "Force updating all dependencies of <name> as well",
+            "Force updating all dependencies of SPEC as well when used with -p",
         ))
         .arg_dry_run("Don't actually write the lockfile")
-        .arg(opt("precise", "Update a single dependency to exactly PRECISE").value_name("PRECISE"))
+        .arg(
+            opt(
+                "precise",
+                "Update a single dependency to exactly PRECISE when used with -p",
+            )
+            .value_name("PRECISE"),
+        )
         .arg_manifest_path()
         .after_help("Run `cargo help update` for more detailed information.\n")
 }


### PR DESCRIPTION
In the help text, `--aggressive` is described as follows:

```
        --aggressive              Force updating all dependencies of <name> as well
```

But `<name>` is not documented anywhere and it seems to be an older parameter name of `SPEC` before 0d2a2434f6f49cd671bd06e8cfc9f88bbbc67ff8.

This PR updates that parameter name and also clarifies in the help text that `--aggressive` and `--precise` make sense when used with `-p`, which specifies `SPEC`.