### PR TITLE
Show the description of extensions via --cargo-short-description

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -88,10 +88,18 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
                     drop_println!(config, "    {:<20} {}", name, summary);
                 }
                 CommandInfo::External { name, path } => {
+                    let about = std::process::Command::new(&path)
+                        .arg("--cargo-short-description")
+                        .output()
+                        .map(|output| String::from_utf8(output.stdout).ok())
+                        .ok()
+                        .flatten();
+                    let summary = about.unwrap_or_default();
+                    let summary = summary.lines().next().unwrap_or(&summary); // display only the first line
                     if is_verbose {
-                        drop_println!(config, "    {:<20} {}", name, path.display());
+                        drop_println!(config, "    {:<20} {} [{}]", name, summary, path.display());
                     } else {
-                        drop_println!(config, "    {}", name);
+                        drop_println!(config, "    {:<20} {}", name, summary);
                     }
                 }
             }


### PR DESCRIPTION
I played with cargo flags and discovered there is a `--list` of installed extensions. However there is no description of these extensions, only names and paths (with --verbose). I added a possibility for extensions to tell cargo their description calling them with `--cargo-short-description` flag. The flag is questionable, but the --help command is not unified and the first line from --help almost never prints the description.

Before:

```
$ cargo list
    cache                
    clippy               
    deb                  
    expand               
    fmt                  
    generate-rpm         
    miri                 
    nono                 
```

After:

```
    cache                
    clippy               
    deb                  Make Debian packages (.deb) easily with a Cargo subcommand
    expand               
    fmt                  
    generate-rpm         
    miri                 
    nono                 
```

I patched cargo-deb locally to make it work:

```diff
diff --git a/src/main.rs b/src/main.rs
index 4296600..83aeb59 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ fn main() {
     cli_opts.optflag("v", "verbose", "Print progress");
     cli_opts.optflag("h", "help", "Print this help menu");
     cli_opts.optflag("", "version", "Show the version of cargo-deb");
+    cli_opts.optflag("", "cargo-short-description", "Show the short description as a cargo extension");
     cli_opts.optopt("", "deb-version", "Alternate version string for package", "version");
 
     let matches = match cli_opts.parse(&args[1..]) {
@@ -52,6 +53,11 @@ fn main() {
         return;
     }
 
+    if matches.opt_present("cargo-short-description") {
+        println!("Make Debian packages (.deb) easily with a Cargo subcommand");
+        return;
+    }
+
     if matches.opt_present("version") {
         println!("{}", env!("CARGO_PKG_VERSION"));
         return;

```

Drawbacks:

If the flag is not supported - extensions print error to stderr except for `cargo-rpm`:

```
rpm                  error: unrecognized option `--cargo-short-description`
```