### PR TITLE
Refactor RustcTargetData to do lazy loading of targets information

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -109,19 +109,19 @@ impl<'cfg> Compilation<'cfg> {
             deps_output: HashMap::new(),
             sysroot_host_libdir: bcx
                 .target_data
-                .info(CompileKind::Host)
+                .info(CompileKind::Host)?
                 .sysroot_host_libdir
                 .clone(),
             sysroot_target_libdir: bcx
                 .all_kinds
                 .iter()
                 .map(|kind| {
-                    (
+                    Ok((
                         *kind,
-                        bcx.target_data.info(*kind).sysroot_target_libdir.clone(),
-                    )
+                        bcx.target_data.info(*kind)?.sysroot_target_libdir.clone(),
+                    ))
                 })
-                .collect(),
+                .collect::<CargoResult<_>>()?,
             tests: Vec::new(),
             binaries: Vec::new(),
             cdylibs: Vec::new(),
@@ -351,7 +351,7 @@ fn target_runner(
     }
 
     // try target.'cfg(...)'.runner
-    let target_cfg = bcx.target_data.info(kind).cfg();
+    let target_cfg = bcx.target_data.info(kind)?.cfg();
     let mut cfgs = bcx
         .config
         .target_cfgs()?

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -296,7 +296,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     ) -> CargoResult<PathBuf> {
         assert!(target.is_bin());
         let dest = self.layout(kind).dest();
-        let info = bcx.target_data.info(kind);
+        let info = bcx.target_data.info(kind)?;
         let (file_types, _) = info
             .rustc_outputs(
                 CompileMode::Build,
@@ -422,7 +422,7 @@ impl<'a, 'cfg: 'a> CompilationFiles<'a, 'cfg> {
     ) -> CargoResult<Vec<OutputFile>> {
         let out_dir = self.out_dir(unit);
 
-        let info = bcx.target_data.info(unit.kind);
+        let info = bcx.target_data.info(unit.kind)?;
         let triple = bcx.target_data.short_name(&unit.kind);
         let (file_types, unsupported) =
             info.rustc_outputs(unit.mode, unit.target.kind(), triple)?;

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -216,7 +216,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                     unit: unit.clone(),
                     args,
                     unstable_opts,
-                    linker: self.bcx.linker(unit.kind),
+                    linker: self.bcx.linker(unit.kind)?,
                 });
             }
 
@@ -235,7 +235,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             }
 
             // Collect rustdocflags.
-            let rustdocflags = self.bcx.rustdocflags_args(unit);
+            let rustdocflags = self.bcx.rustdocflags_args(unit)?;
             if !rustdocflags.is_empty() {
                 self.compilation
                     .rustdocflags

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -198,7 +198,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
         .env("RUSTDOC", &*bcx.config.rustdoc()?)
         .inherit_jobserver(&cx.jobserver);
 
-    if let Some(linker) = &bcx.target_data.target_config(unit.kind).linker {
+    if let Some(linker) = &bcx.target_data.target_config(unit.kind)?.linker {
         cmd.env(
             "RUSTC_LINKER",
             linker.val.clone().resolve_program(bcx.config),
@@ -216,7 +216,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     }
 
     let mut cfg_map = HashMap::new();
-    for cfg in bcx.target_data.cfg(unit.kind) {
+    for cfg in bcx.target_data.cfg(unit.kind)? {
         match *cfg {
             Cfg::Name(ref n) => {
                 cfg_map.insert(n.clone(), None);
@@ -727,7 +727,7 @@ pub fn build_map(cx: &mut Context<'_, '_>) -> CargoResult<()> {
         // If there is a build script override, pre-fill the build output.
         if unit.mode.is_run_custom_build() {
             if let Some(links) = unit.pkg.manifest().links() {
-                if let Some(output) = cx.bcx.target_data.script_override(links, unit.kind) {
+                if let Some(output) = cx.bcx.target_data.script_override(links, unit.kind)? {
                     let metadata = cx.get_run_build_script_metadata(unit);
                     cx.build_script_outputs.lock().unwrap().insert(
                         unit.pkg.package_id(),

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1296,9 +1296,9 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
     // hashed to take up less space on disk as we just need to know when things
     // change.
     let extra_flags = if unit.mode.is_doc() {
-        cx.bcx.rustdocflags_args(unit)
+        cx.bcx.rustdocflags_args(unit)?
     } else {
-        cx.bcx.rustflags_args(unit)
+        cx.bcx.rustflags_args(unit)?
     }
     .to_vec();
 
@@ -1432,9 +1432,9 @@ fn build_script_local_fingerprints(
 ) -> (
     Box<
         dyn FnOnce(
-                &BuildDeps,
-                Option<&dyn Fn() -> CargoResult<String>>,
-            ) -> CargoResult<Option<Vec<LocalFingerprint>>>
+            &BuildDeps,
+            Option<&dyn Fn() -> CargoResult<String>>,
+        ) -> CargoResult<Option<Vec<LocalFingerprint>>>
             + Send,
     >,
     bool,

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -232,7 +232,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
     let rustc_dep_info_loc = root.join(dep_info_name);
     let dep_info_loc = fingerprint::dep_info_loc(cx, unit);
 
-    rustc.args(cx.bcx.rustflags_args(unit));
+    rustc.args(cx.bcx.rustflags_args(unit)?);
     if cx.bcx.config.cli_unstable().binary_dep_depinfo {
         rustc.arg("-Z").arg("binary-dep-depinfo");
     }
@@ -612,7 +612,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
     build_deps_args(&mut rustdoc, cx, unit)?;
     rustdoc::add_root_urls(cx, unit, &mut rustdoc)?;
 
-    rustdoc.args(bcx.rustdocflags_args(unit));
+    rustdoc.args(bcx.rustdocflags_args(unit)?);
 
     if !crate_version_flag_already_present(&rustdoc) {
         append_crate_version_flag(unit, &mut rustdoc);
@@ -921,7 +921,7 @@ fn build_base_args(
         cmd,
         "-C",
         "linker=",
-        bcx.linker(unit.kind).as_ref().map(|s| s.as_ref()),
+        bcx.linker(unit.kind)?.as_ref().map(|s| s.as_ref()),
     );
     if incremental {
         let dir = cx.files().layout(unit.kind).incremental().as_os_str();

--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -157,7 +157,7 @@ pub fn add_root_urls(
     let std_url = match &map.std {
         None | Some(RustdocExternMode::Remote) => None,
         Some(RustdocExternMode::Local) => {
-            let sysroot = &cx.bcx.target_data.info(CompileKind::Host).sysroot;
+            let sysroot = &cx.bcx.target_data.info(CompileKind::Host)?.sysroot;
             let html_root = sysroot.join("share").join("doc").join("rust").join("html");
             if html_root.exists() {
                 let url = Url::from_file_path(&html_root).map_err(|()| {

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -33,7 +33,7 @@ pub fn parse_unstable_flag(value: Option<&str>) -> Vec<String> {
 /// Resolve the standard library dependencies.
 pub fn resolve_std<'cfg>(
     ws: &Workspace<'cfg>,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'cfg>,
     requested_targets: &[CompileKind],
     crates: &[String],
 ) -> CargoResult<(PackageSet<'cfg>, Resolve, ResolvedFeatures)> {
@@ -188,14 +188,14 @@ pub fn generate_std_roots(
     Ok(ret)
 }
 
-fn detect_sysroot_src_path(target_data: &RustcTargetData) -> CargoResult<PathBuf> {
+fn detect_sysroot_src_path<'cfg>(target_data: &RustcTargetData<'cfg>) -> CargoResult<PathBuf> {
     if let Some(s) = env::var_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
         return Ok(s.into());
     }
 
     // NOTE: This is temporary until we figure out how to acquire the source.
     let src_path = target_data
-        .info(CompileKind::Host)
+        .info(CompileKind::Host)?
         .sysroot
         .join("lib")
         .join("rustlib")

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -151,7 +151,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                     let triple = target_data.short_name(compile_kind);
 
                     let (file_types, _unsupported) = target_data
-                        .info(*compile_kind)
+                        .info(*compile_kind)?
                         .rustc_outputs(mode, target.kind(), triple)?;
                     let (dir, uplift_dir) = match target.kind() {
                         TargetKind::ExampleBin | TargetKind::ExampleLib(..) => {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -74,7 +74,7 @@ pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolv
 /// members. In this case, `opts.all_features` must be `true`.
 pub fn resolve_ws_with_opts<'cfg>(
     ws: &Workspace<'cfg>,
-    target_data: &RustcTargetData,
+    target_data: &RustcTargetData<'cfg>,
     requested_targets: &[CompileKind],
     opts: &ResolveOpts,
     specs: &[PackageIdSpec],


### PR DESCRIPTION
I gave up midway through this refactoring, it looks way too big for what it's supposed to do.

More discussion on what to actually do will probably be available at https://github.com/rust-lang/cargo/pull/9030#discussion_r552265630