### PR TITLE
[doc] add note about empty environment variables for missing manifest keys

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -188,6 +188,9 @@ let version = env!("CARGO_PKG_VERSION");
 
 `version` will now contain the value of `CARGO_PKG_VERSION`.
 
+Note that if one of these values is not provided in the manifest, the
+corresponding environment variable is set to the empty string, `""`.
+
 * `CARGO` — Path to the `cargo` binary performing the build.
 * `CARGO_MANIFEST_DIR` — The directory containing the manifest of your package.
 * `CARGO_PKG_VERSION` — The full version of your package.


### PR DESCRIPTION
This is a small addition to the cargo book.

In [the section](https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates) about the environment variables cargo sets to provide information about a crate, there's no mention about the value of those environment variables is if the key isn't present in the manifest.

As can be seen [here](https://github.com/rust-lang/cargo/blob/94e21ada550f91f5d32f2f51635792a79aeb8d63/src/cargo/core/compiler/compilation.rs#L287)¹, the values default to the empty string (instead of, say, not being present), so this change just adds a sentence in the book to clarify that.

If the terminology could be improved or there's a better place for this to be included, I'm happy to change it :)

---

¹ To be clear, I did also play around with this and found that the environment variables were empty. The code reference was more to double-check that the behavior I saw was a consistent pattern.