### PR TITLE
Unstable section of cargo/config.toml takes bools

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -12,9 +12,9 @@ config file (`.cargo/config.toml`) in the `unstable` table. For example:
 
 ```toml
 [unstable]
-mtime-on-use = 'yes'
-multitarget = 'yes'
-timings = 'yes'
+mtime-on-use = true
+multitarget = true
+timings = true
 ```
 
 Some unstable features will require you to specify the `cargo-features` key in

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -14,7 +14,7 @@ config file (`.cargo/config.toml`) in the `unstable` table. For example:
 [unstable]
 mtime-on-use = true
 multitarget = true
-timings = true
+timings = ["html"]
 ```
 
 Some unstable features will require you to specify the `cargo-features` key in


### PR DESCRIPTION
At least according to a quick local test, those should not be strings, but booleans! With the following cargo config:

```toml
[unstable]
mtime-on-use = 'yes'
```

I get the following cargo output:

```
error: error in /root/builds/hlab/isengard/agent-rust/.cargo_cache/config: `unstable.mtime-on-use` expected true/false, but found a string
```