### PR TITLE
Sort available binaries when multiple

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -55,10 +55,11 @@ pub fn run(
 
     if bins.len() > 1 {
         if !options.filter.is_specific() {
-            let names: Vec<&str> = bins
+            let mut names: Vec<&str> = bins
                 .into_iter()
                 .map(|(_pkg, target)| target.name())
                 .collect();
+            names.sort();
             anyhow::bail!(
                 "`cargo run` could not determine which binary to run. \
                  Use the `--bin` option to specify a binary, \

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1170,6 +1170,11 @@ fn run_default_multiple_required_features() {
                 required-features = ["a"]
 
                 [[bin]]
+                name = "foo3"
+                path = "src/foo3.rs"
+                required-features = ["b"]
+
+                [[bin]]
                 name = "foo2"
                 path = "src/foo2.rs"
                 required-features = ["b"]
@@ -1177,6 +1182,7 @@ fn run_default_multiple_required_features() {
         )
         .file("src/lib.rs", "")
         .file("src/foo1.rs", "extern crate foo; fn main() {}")
+        .file("src/foo3.rs", "extern crate foo; fn main() {}")
         .file("src/foo2.rs", "extern crate foo; fn main() {}")
         .build();
 
@@ -1185,7 +1191,7 @@ fn run_default_multiple_required_features() {
         .with_stderr(
             "\
 error: `cargo run` could not determine which binary to run[..]
-available binaries: foo1, foo2",
+available binaries: foo1, foo2, foo3",
         )
         .run();
 }


### PR DESCRIPTION
From:
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: basic-tutorial-13, basic-tutorial-6, basic-tutorial-1, basic-tutorial-4, basic-tutorial-9, basic-tutorial-2, basic-tutorial-3, basic-tutorial-5, basic-tutorial-12, playback-tutorial-4, basic-tutorial-8, basic-tutorial-7
```

To:
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: basic-tutorial-1, basic-tutorial-12, basic-tutorial-13, basic-tutorial-2, basic-tutorial-3, basic-tutorial-4, basic-tutorial-5, basic-tutorial-6, basic-tutorial-7, basic-tutorial-8, basic-tutorial-9, playback-tutorial-4
```