### PR TITLE
Unstable updates

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -327,9 +327,12 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(opt("locked", "Require Cargo.lock is up to date").global(true))
         .arg(opt("offline", "Run without accessing the network").global(true))
         .arg(
-            multi_opt("config", "KEY=VALUE", "Override a configuration value")
-                .global(true)
-                .hidden(true),
+            multi_opt(
+                "config",
+                "KEY=VALUE",
+                "Override a configuration value (unstable)",
+            )
+            .global(true),
         )
         .arg(
             Arg::with_name("unstable-features")

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -10,6 +10,7 @@ pub fn cli() -> App {
         )
         .arg(opt("quiet", "No output printed to stdout").short("q"))
         .arg(Arg::with_name("token"))
+        // --host is deprecated (use --registry instead)
         .arg(
             opt("host", "Host to set the token for")
                 .value_name("HOST")

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -19,7 +19,9 @@ pub fn cli() -> App {
             "Display the tree for all packages in the workspace",
             "Exclude specific workspace members",
         )
+        // Deprecated, use --no-dedupe instead.
         .arg(Arg::with_name("all").long("all").short("a").hidden(true))
+        // Deprecated, use --target=all instead.
         .arg(
             Arg::with_name("all-targets")
                 .long("all-targets")
@@ -30,6 +32,7 @@ pub fn cli() -> App {
             "Filter dependencies matching the given target-triple (default host platform). \
             Pass `all` to include all targets.",
         )
+        // Deprecated, use -e=no-dev instead.
         .arg(
             Arg::with_name("no-dev-dependencies")
                 .long("no-dev-dependencies")
@@ -52,7 +55,9 @@ pub fn cli() -> App {
             )
             .short("i"),
         )
+        // Deprecated, use --prefix=none instead.
         .arg(Arg::with_name("no-indent").long("no-indent").hidden(true))
+        // Deprecated, use --prefix=depth instead.
         .arg(
             Arg::with_name("prefix-depth")
                 .long("prefix-depth")

--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -32,21 +32,25 @@ pub fn cli() -> App {
                 .long("versioned-dirs")
                 .help("Always include version in subdir name"),
         )
+        // Not supported.
         .arg(
             Arg::with_name("no-merge-sources")
                 .long("no-merge-sources")
                 .hidden(true),
         )
+        // Not supported.
         .arg(
             Arg::with_name("relative-path")
                 .long("relative-path")
                 .hidden(true),
         )
+        // Not supported.
         .arg(
             Arg::with_name("only-git-deps")
                 .long("only-git-deps")
                 .hidden(true),
         )
+        // Not supported.
         .arg(
             Arg::with_name("disallow-duplicates")
                 .long("disallow-duplicates")

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -39,7 +39,6 @@ pub struct Manifest {
     custom_metadata: Option<toml::Value>,
     profiles: Option<TomlProfiles>,
     publish: Option<Vec<String>>,
-    publish_lockfile: bool,
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: WorkspaceConfig,
@@ -374,7 +373,6 @@ impl Manifest {
         custom_metadata: Option<toml::Value>,
         profiles: Option<TomlProfiles>,
         publish: Option<Vec<String>>,
-        publish_lockfile: bool,
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
@@ -407,7 +405,6 @@ impl Manifest {
             original,
             im_a_teapot,
             default_run,
-            publish_lockfile,
             metabuild,
             resolve_behavior,
         }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -37,7 +37,7 @@ use log::debug;
 use std::fmt;
 
 pub use crate::util::errors::{InternalError, VerboseError};
-pub use crate::util::{CargoResult, CliError, CliResult, Config};
+pub use crate::util::{indented_lines, CargoResult, CliError, CliResult, Config};
 
 pub const CARGO_ENV: &str = "CARGO";
 
@@ -163,13 +163,11 @@ fn _display_error(err: &Error, shell: &mut Shell, as_err: bool) -> bool {
             return true;
         }
         drop(writeln!(shell.err(), "\nCaused by:"));
-        for line in cause.to_string().lines() {
-            if line.is_empty() {
-                drop(writeln!(shell.err()));
-            } else {
-                drop(writeln!(shell.err(), "  {}", line));
-            }
-        }
+        drop(write!(
+            shell.err(),
+            "{}",
+            indented_lines(&cause.to_string())
+        ));
     }
     false
 }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -169,7 +169,7 @@ pub trait AppExt: Sized {
     }
 
     fn arg_unit_graph(self) -> Self {
-        self._arg(opt("unit-graph", "Output build graph in JSON (unstable)").hidden(true))
+        self._arg(opt("unit-graph", "Output build graph in JSON (unstable)"))
     }
 
     fn arg_new_opts(self) -> Self {
@@ -214,13 +214,10 @@ pub trait AppExt: Sized {
     }
 
     fn arg_ignore_rust_version(self) -> Self {
-        self._arg(
-            opt(
-                "ignore-rust-version",
-                "Ignore `rust-version` specification in packages",
-            )
-            .hidden(true), // nightly only (`rust-version` feature)
-        )
+        self._arg(opt(
+            "ignore-rust-version",
+            "Ignore `rust-version` specification in packages (unstable)",
+        ))
     }
 }
 

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -704,7 +704,9 @@ impl Config {
         unstable_flags: &[String],
         cli_config: &[String],
     ) -> CargoResult<()> {
-        self.unstable_flags.parse(unstable_flags)?;
+        for warning in self.unstable_flags.parse(unstable_flags)? {
+            self.shell().warn(warning)?;
+        }
         if !unstable_flags.is_empty() {
             // store a copy of the cli flags separately for `load_unstable_flags_from_config`
             // (we might also need it again for `reload_rooted_at`)

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -79,3 +79,15 @@ pub fn elapsed(duration: Duration) -> String {
 pub fn is_ci() -> bool {
     std::env::var("CI").is_ok() || std::env::var("TF_BUILD").is_ok()
 }
+
+pub fn indented_lines(text: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::from("\n")
+            } else {
+                format!("  {}\n", line)
+            }
+        })
+        .collect()
+}

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -825,7 +825,6 @@ pub struct TomlProject {
     exclude: Option<Vec<String>>,
     include: Option<Vec<String>>,
     publish: Option<VecStringOrBool>,
-    publish_lockfile: Option<bool>,
     workspace: Option<String>,
     im_a_teapot: Option<bool>,
     autobins: Option<bool>,
@@ -1304,19 +1303,6 @@ impl TomlManifest {
             None | Some(VecStringOrBool::Bool(true)) => None,
         };
 
-        let publish_lockfile = match project.publish_lockfile {
-            Some(b) => {
-                features.require(Feature::publish_lockfile())?;
-                warnings.push(
-                    "The `publish-lockfile` feature is deprecated and currently \
-                     has no effect. It may be removed in a future version."
-                        .to_string(),
-                );
-                b
-            }
-            None => features.is_enabled(Feature::publish_lockfile()),
-        };
-
         if summary.features().contains_key("default-features") {
             warnings.push(
                 "`default-features = [\"..\"]` was found in [features]. \
@@ -1348,7 +1334,6 @@ impl TomlManifest {
             custom_metadata,
             profiles,
             publish,
-            publish_lockfile,
             replace,
             patch,
             workspace_config,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -69,6 +69,17 @@ fn do_read_manifest(
         parse(contents, pretty_filename, config)?
     };
 
+    // Provide a helpful error message for a common user error.
+    if let Some(package) = toml.get("package").or_else(|| toml.get("project")) {
+        if let Some(feats) = package.get("cargo-features") {
+            bail!(
+                "cargo-features = {} was found in the wrong location, it \
+                 should be set at the top of Cargo.toml before any tables",
+                toml::to_string(feats).unwrap()
+            );
+        }
+    }
+
     let mut unused = BTreeSet::new();
     let manifest: TomlManifest = serde_ignored::deserialize(toml, |path| {
         let mut key = String::new();

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1060,3 +1060,35 @@ name = "mypackage"
 version = "0.0.1"
 rust-version = "1.42"
 ```
+
+<script>
+(function() {
+    var fragments = {
+        "#edition": "manifest.html#the-edition-field",
+        "#compile-progress": "config.html#termprogresswhen",
+        "#rename-dependency": "specifying-dependencies.html#renaming-dependencies-in-cargotoml",
+        "#alternate-registries": "registries.html",
+        "#offline-mode": "../commands/cargo.html",
+        "#publish-lockfile": "../commands/cargo-package.html",
+        "#default-run": "manifest.html#the-default-run-field",
+        "#cache-messages": "https://github.com/rust-lang/cargo/pull/7450",
+        "#install-upgrade": "../commands/cargo-install.html",
+        "#profile-overrides": "profiles.html#overrides",
+        "#config-profiles": "config.html#profile",
+        "#crate-versions": "https://github.com/rust-lang/cargo/pull/8509",
+        "#features": "features.html#feature-resolver-version-2",
+        "#package-features": "features.html#resolver-version-2-command-line-flags",
+        "#resolver": "resolver.html#resolver-versions",
+    };
+    var target = fragments[window.location.hash];
+    if (target) {
+        if (target.startsWith('https')) {
+          window.location.replace(target);
+        } else {
+          var url = window.location.toString();
+          var base = url.substring(0, url.lastIndexOf('/'));
+          window.location.replace(base + "/" + target);
+        }
+    }
+})();
+</script>

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1,24 +1,62 @@
 ## Unstable Features
 
-Experimental Cargo features are only available on the nightly channel. You
-typically use one of the `-Z` flags to enable them. Run `cargo -Z help` to
-see a list of flags available.
+Experimental Cargo features are only available on the [nightly channel]. You
+are encouraged to experiment with these features to see if they meet your
+needs, and if there are any issues or problems. Check the linked tracking
+issues listed below for more information on the feature, and click the GitHub
+subscribe button if you want future updates.
 
-`-Z unstable-options` is a generic flag for enabling other unstable
-command-line flags. Options requiring this will be called out below.
+After some period of time, if the feature does not have any major concerns, it
+can be [stabilized], which will make it available on stable once the current
+nightly release reaches the stable channel (anywhere from 6 to 12 weeks).
 
-Anything which can be configured with a Z flag can also be set in the cargo
-config file (`.cargo/config.toml`) in the `unstable` table. For example:
+There are three different ways that unstable features can be enabled based on
+how the feature works:
 
-```toml
-[unstable]
-mtime-on-use = true
-multitarget = true
-timings = ["html"]
-```
+* New syntax in `Cargo.toml` requires a `cargo-features` key at the top of
+  `Cargo.toml`, before any tables. For example:
 
-Some unstable features will require you to specify the `cargo-features` key in
-`Cargo.toml`.
+  ```toml
+  # This specifies which new Cargo.toml features are enabled.
+  cargo-features = ["test-dummy-unstable"]
+
+  [package]
+  name = "my-package"
+  version = "0.1.0"
+  im-a-teapot = true  # This is a new option enabled by test-dummy-unstable.
+  ```
+
+* New command-line flags, options, and subcommands require the `-Z
+  unstable-options` CLI option to also be included. For example, the new
+  `--out-dir` option is only available on nightly:
+
+  ```cargo +nightly build --out-dir=out -Z unstable-options```
+
+* `-Z` command-line flags are used to enable new functionality that may not
+  have an interface, or the interface has not yet been designed, or for more
+  complex features that affect multiple parts of Cargo. For example, the
+  [timings](#timings) feature can be enabled with:
+
+  ```cargo +nightly build -Z timings```
+
+  Run `cargo -Z help` to see a list of flags available.
+
+  Anything which can be configured with a `-Z` flag can also be set in the
+  cargo [config file] (`.cargo/config.toml`) in the `unstable` table. For
+  example:
+
+  ```toml
+  [unstable]
+  mtime-on-use = true
+  multitarget = true
+  timings = ["html"]
+  ```
+
+Each new feature described below should explain how to use it.
+
+[config file]: config.md
+[nightly channel]: ../../book/appendix-07-nightly-rust.html
+[stabilized]: https://doc.crates.io/contrib/process/unstable.html#stabilization
 
 ### extra-link-arg
 * Original Pull Request: [#7811](https://github.com/rust-lang/cargo/pull/7811)

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -356,3 +356,34 @@ Caused by:
         )
         .run();
 }
+
+#[cargo_test]
+fn z_stabilized() {
+    let p = project().file("src/lib.rs", "").build();
+
+    p.cargo("check -Z cache-messages")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+warning: flag `-Z cache-messages` has been stabilized in the 1.40 release, \
+  and is no longer necessary
+  Message caching is now always enabled.
+
+[CHECKING] foo [..]
+[FINISHED] [..]
+",
+        )
+        .run();
+
+    p.cargo("check -Z offline")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+error: flag `-Z offline` has been stabilized in the 1.36 release
+  Offline mode is now available via the --offline CLI option
+
+",
+        )
+        .run();
+}

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -103,8 +103,9 @@ fn stable_feature_warns() {
     p.cargo("build")
         .with_stderr(
             "\
-warning: the cargo feature `test-dummy-stable` is now stable and is no longer \
-necessary to be listed in the manifest
+warning: the cargo feature `test-dummy-stable` has been stabilized in the 1.0 \
+release and is no longer necessary to be listed in the manifest
+  See https://doc.rust-lang.org/[..]cargo/ for more information about using this feature.
 [COMPILING] a [..]
 [FINISHED] [..]
 ",
@@ -149,6 +150,8 @@ Caused by:
   the cargo feature `test-dummy-unstable` requires a nightly version of Cargo, \
   but this is the `stable` channel
   See [..]
+  See https://doc.rust-lang.org/[..]cargo/reference/unstable.html for more \
+  information about using this feature.
 ",
         )
         .run();
@@ -214,6 +217,8 @@ Caused by:
   the cargo feature `test-dummy-unstable` requires a nightly version of Cargo, \
   but this is the `stable` channel
   See [..]
+  See https://doc.rust-lang.org/[..]cargo/reference/unstable.html for more \
+  information about using this feature.
 ",
         )
         .run();
@@ -256,6 +261,8 @@ Caused by:
   the cargo feature `test-dummy-unstable` requires a nightly version of Cargo, \
   but this is the `stable` channel
   See [..]
+  See https://doc.rust-lang.org/[..]cargo/reference/unstable.html for more \
+  information about using this feature.
 ",
         )
         .run();

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -327,3 +327,32 @@ fn publish_allowed() {
         .masquerade_as_nightly_cargo()
         .run();
 }
+
+#[cargo_test]
+fn wrong_position() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                cargo-features = ["test-dummy-unstable"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("check")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at [..]
+
+Caused by:
+  cargo-features = [\"test-dummy-unstable\"] was found in the wrong location, it \
+  should be set at the top of Cargo.toml before any tables
+",
+        )
+        .run();
+}

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -115,6 +115,7 @@ error: failed to parse manifest at `[..]`
 Caused by:
   the cargo feature `public-dependency` requires a nightly version of Cargo, but this is the `stable` channel
   See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
+  See https://doc.rust-lang.org/[..]cargo/reference/unstable.html#public-dependency for more information about using this feature.
 "
         )
         .run()

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -48,12 +48,16 @@ fn deprecated() {
         .build();
     p.cargo("package")
         .masquerade_as_nightly_cargo()
+        .with_status(101)
         .with_stderr(
             "\
-[PACKAGING] foo v0.1.0 ([..])
-[VERIFYING] foo v0.1.0 ([..])
-[COMPILING] foo v0.1.0 ([..])
-[FINISHED] dev [..]
+[ERROR] failed to parse manifest at [..]
+
+Caused by:
+  the cargo feature `publish-lockfile` has been removed
+  Remove the feature from Cargo.toml to remove this error.
+  The publish-lockfile key [..]
+  See [..]
 ",
         )
         .run();

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -52,8 +52,6 @@ fn deprecated() {
             "\
 [PACKAGING] foo v0.1.0 ([..])
 [VERIFYING] foo v0.1.0 ([..])
-[WARNING] The `publish-lockfile` feature is deprecated and currently has no effect. \
-    It may be removed in a future version.
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] dev [..]
 ",

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -336,7 +336,7 @@ optional dependency with `?` is not allowed in required-features
 
 #[cargo_test]
 fn weak_with_host_decouple() {
-    // -Z weak-opt-features with -Z features=host
+    // -Z weak-opt-features with new resolver
     //
     // foo v0.1.0
     // └── common v1.0.0
@@ -390,6 +390,7 @@ fn weak_with_host_decouple() {
                 [package]
                 name = "foo"
                 version = "0.1.0"
+                resolver = "2"
 
                 [dependencies]
                 common = { version = "1.0", features = ["feat"] }
@@ -416,7 +417,7 @@ fn weak_with_host_decouple() {
         )
         .build();
 
-    p.cargo("run -Z weak-dep-features -Z features=host_dep")
+    p.cargo("run -Z weak-dep-features")
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\


### PR DESCRIPTION
This is a collection of updates for unstable/nightly feature support, intended to provide better messages for users and better internal and external documentation.  Separated by commit, in summary:

* Added comments and new docstrings for improved internal documentation.
* Added new documentation to the reference guide on how unstable things work.
  * Also added redirects for stabilized features so any external links won't be broken.
* Add a targeted error message if you put `cargo-features` in the wrong place in `Cargo.toml`.
* Remove `publish-lockfile`.  The feature was stabilized without the key in #7026 about 1.5 years ago.  Also added "removed" support for features, which prints out a more helpful error message.
* Add help messages about stabilized `-Z` flags (instead of spitting out an unhelpful error message).
* Add help messages about stabilized `cargo-features` features.
* Add more context to the error when using `cargo-features` on stable.
* Unhide nightly CLI flags. I changed my mind on how these should work. I think it is useful to "advertise" the existence of these options on stable. The error message if you try to use it should help guide on what to do.

Closes #9074.
