### PR TITLE
Remove Registry::new.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/cargo/lib.rs"
 atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.1" }
-crates-io = { path = "crates/crates-io", version = "0.31.1" }
+crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
 crypto-hash = "0.3.1"
 curl = { version = "0.4.23", features = ["http2"] }

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.31.1"
+version = "0.33.0"
 edition = "2018"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT OR Apache-2.0"

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -122,10 +122,19 @@ struct Crates {
     meta: TotalCrates,
 }
 impl Registry {
-    pub fn new(host: String, token: Option<String>) -> Registry {
-        Registry::new_handle(host, token, Easy::new())
-    }
-
+    /// Creates a new `Registry`.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use curl::easy::Easy;
+    /// use crates_io::Registry;
+    ///
+    /// let mut handle = Easy::new();
+    /// // If connecting to crates.io, a user-agent is required.
+    /// handle.useragent("my_crawler (example.com/info)");
+    /// let mut reg = Registry::new_handle(String::from("https://crates.io"), None, handle);
+    /// ```
     pub fn new_handle(host: String, token: Option<String>, handle: Easy) -> Registry {
         Registry {
             host,


### PR DESCRIPTION
`Registry::new` doesn't work in most circumstances because crates.io requires a user-agent, and it does not set one.  

This also bumps the version over 0.32 due to #8914.

Closes #8914.
Closes #9040.
