### PR TITLE
Run rustdoc doctests relative to the workspace

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -334,7 +334,7 @@ use crate::util;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::interning::InternedString;
 use crate::util::paths;
-use crate::util::{internal, profile, ProcessBuilder};
+use crate::util::{internal, path_args, profile, ProcessBuilder};
 
 use super::custom_build::BuildDeps;
 use super::job::{Job, Work};
@@ -1324,7 +1324,7 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
         profile: profile_hash,
         // Note that .0 is hashed here, not .1 which is the cwd. That doesn't
         // actually affect the output artifact so there's no need to hash it.
-        path: util::hash_u64(super::path_args(cx.bcx, unit).0),
+        path: util::hash_u64(path_args(cx.bcx.ws, unit).0),
         features: format!("{:?}", unit.features),
         deps,
         local: Mutex::new(local),

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -57,7 +57,7 @@ use crate::util::errors::{self, CargoResult, CargoResultExt, ProcessError, Verbo
 use crate::util::interning::InternedString;
 use crate::util::machine_message::Message;
 use crate::util::{self, machine_message, ProcessBuilder};
-use crate::util::{internal, join_paths, paths, profile};
+use crate::util::{add_path_args, internal, join_paths, paths, profile};
 
 const RUSTDOC_CRATE_VERSION_FLAG: &str = "--crate-version";
 
@@ -582,7 +582,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
     let mut rustdoc = cx.compilation.rustdoc_process(unit, None)?;
     rustdoc.inherit_jobserver(&cx.jobserver);
     rustdoc.arg("--crate-name").arg(&unit.target.crate_name());
-    add_path_args(bcx, unit, &mut rustdoc);
+    add_path_args(bcx.ws, unit, &mut rustdoc);
     add_cap_lints(bcx, unit, &mut rustdoc);
 
     if let CompileKind::Target(target) = unit.kind {
@@ -660,41 +660,6 @@ fn append_crate_version_flag(unit: &Unit, rustdoc: &mut ProcessBuilder) {
     rustdoc
         .arg(RUSTDOC_CRATE_VERSION_FLAG)
         .arg(unit.pkg.version().to_string());
-}
-
-// The path that we pass to rustc is actually fairly important because it will
-// show up in error messages (important for readability), debug information
-// (important for caching), etc. As a result we need to be pretty careful how we
-// actually invoke rustc.
-//
-// In general users don't expect `cargo build` to cause rebuilds if you change
-// directories. That could be if you just change directories in the package or
-// if you literally move the whole package wholesale to a new directory. As a
-// result we mostly don't factor in `cwd` to this calculation. Instead we try to
-// track the workspace as much as possible and we update the current directory
-// of rustc/rustdoc where appropriate.
-//
-// The first returned value here is the argument to pass to rustc, and the
-// second is the cwd that rustc should operate in.
-fn path_args(bcx: &BuildContext<'_, '_>, unit: &Unit) -> (PathBuf, PathBuf) {
-    let ws_root = bcx.ws.root();
-    let src = match unit.target.src_path() {
-        TargetSourcePath::Path(path) => path.to_path_buf(),
-        TargetSourcePath::Metabuild => unit.pkg.manifest().metabuild_path(bcx.ws.target_dir()),
-    };
-    assert!(src.is_absolute());
-    if unit.pkg.package_id().source_id().is_path() {
-        if let Ok(path) = src.strip_prefix(ws_root) {
-            return (path.to_path_buf(), ws_root.to_path_buf());
-        }
-    }
-    (src, unit.pkg.root().to_path_buf())
-}
-
-fn add_path_args(bcx: &BuildContext<'_, '_>, unit: &Unit, cmd: &mut ProcessBuilder) {
-    let (arg, cwd) = path_args(bcx, unit);
-    cmd.arg(arg);
-    cmd.cwd(cwd);
 }
 
 fn add_cap_lints(bcx: &BuildContext<'_, '_>, unit: &Unit, cmd: &mut ProcessBuilder) {
@@ -786,7 +751,7 @@ fn build_base_args(
         cmd.arg(format!("--edition={}", edition));
     }
 
-    add_path_args(bcx, unit, cmd);
+    add_path_args(bcx.ws, unit, cmd);
     add_error_format_and_color(cx, cmd, cx.rmeta_required(unit));
 
     if !test {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -433,6 +433,7 @@ pub struct CliUnstable {
     pub build_std_features: Option<Vec<String>>,
     pub timings: Option<Vec<String>>,
     pub doctest_xcompile: bool,
+    pub doctest_in_workspace: bool,
     pub panic_abort_tests: bool,
     pub jobserver_per_rustc: bool,
     pub features: Option<Vec<String>>,
@@ -596,6 +597,7 @@ impl CliUnstable {
             "build-std-features" => self.build_std_features = Some(parse_features(v)),
             "timings" => self.timings = Some(parse_timings(v)),
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
+            "doctest-in-workspace" => self.doctest_in_workspace = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
             "features" => {

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -27,8 +27,8 @@ pub use self::sha256::Sha256;
 pub use self::to_semver::ToSemver;
 pub use self::vcs::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 pub use self::workspace::{
-    print_available_benches, print_available_binaries, print_available_examples,
-    print_available_packages, print_available_tests,
+    add_path_args, path_args, print_available_benches, print_available_binaries,
+    print_available_examples, print_available_packages, print_available_tests,
 };
 
 mod canonical_url;

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -1,8 +1,12 @@
+use super::ProcessBuilder;
+use crate::core::compiler::Unit;
+use crate::core::manifest::TargetSourcePath;
 use crate::core::{Target, Workspace};
 use crate::ops::CompileOptions;
 use crate::util::CargoResult;
 use anyhow::bail;
 use std::fmt::Write;
+use std::path::PathBuf;
 
 fn get_available_targets<'a>(
     filter_fn: fn(&Target) -> bool,
@@ -88,4 +92,39 @@ pub fn print_available_benches(ws: &Workspace<'_>, options: &CompileOptions) -> 
 
 pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
     print_available_targets(Target::is_test, ws, options, "--test", "tests")
+}
+
+/// The path that we pass to rustc is actually fairly important because it will
+/// show up in error messages (important for readability), debug information
+/// (important for caching), etc. As a result we need to be pretty careful how we
+/// actually invoke rustc.
+///
+/// In general users don't expect `cargo build` to cause rebuilds if you change
+/// directories. That could be if you just change directories in the package or
+/// if you literally move the whole package wholesale to a new directory. As a
+/// result we mostly don't factor in `cwd` to this calculation. Instead we try to
+/// track the workspace as much as possible and we update the current directory
+/// of rustc/rustdoc where appropriate.
+///
+/// The first returned value here is the argument to pass to rustc, and the
+/// second is the cwd that rustc should operate in.
+pub fn path_args(ws: &Workspace<'_>, unit: &Unit) -> (PathBuf, PathBuf) {
+    let ws_root = ws.root();
+    let src = match unit.target.src_path() {
+        TargetSourcePath::Path(path) => path.to_path_buf(),
+        TargetSourcePath::Metabuild => unit.pkg.manifest().metabuild_path(ws.target_dir()),
+    };
+    assert!(src.is_absolute());
+    if unit.pkg.package_id().source_id().is_path() {
+        if let Ok(path) = src.strip_prefix(ws_root) {
+            return (path.to_path_buf(), ws_root.to_path_buf());
+        }
+    }
+    (src, unit.pkg.root().to_path_buf())
+}
+
+pub fn add_path_args(ws: &Workspace<'_>, unit: &Unit, cmd: &mut ProcessBuilder) {
+    let (arg, cwd) = path_args(ws, unit);
+    cmd.arg(arg);
+    cmd.cwd(cwd);
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2753,7 +2753,7 @@ fn doctest_receives_build_link_args() {
 
     p.cargo("test -v")
         .with_stderr_contains(
-            "[RUNNING] `rustdoc [..]--test [..] --crate-name foo [..]-L native=bar[..]`",
+            "[RUNNING] `rustdoc [..]--crate-name foo --test [..]-L native=bar[..]`",
         )
         .run();
 }

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1109,7 +1109,7 @@ fn doctest_xcompile_linker() {
         .masquerade_as_nightly_cargo()
         .with_stderr_contains(&format!(
             "\
-[RUNNING] `rustdoc --crate-type lib --test [..]\
+[RUNNING] `rustdoc --crate-type lib --crate-name foo --test [..]\
     --target {target} [..] -C linker=my-linker-tool[..]
 ",
             target = target,

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -526,7 +526,7 @@ fn cdylib_and_rlib() {
 [RUNNING] [..]target/release/deps/bar-[..]
 [RUNNING] [..]target/release/deps/b-[..]
 [DOCTEST] bar
-[RUNNING] `rustdoc --crate-type cdylib --crate-type rlib --test [..]-C embed-bitcode=no[..]
+[RUNNING] `rustdoc --crate-type cdylib --crate-type rlib --crate-name bar --test [..]-C embed-bitcode=no[..]
 ",
         )
         .run();

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -266,7 +266,7 @@ fn can_run_doc_tests() {
         .with_stderr_contains(
             "\
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test [CWD]/src/lib.rs \
+[RUNNING] `rustdoc [..]--test [..]src/lib.rs \
         [..] \
         --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib \
         --extern baz=[CWD]/target/debug/deps/libbar-[..].rlib \

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4256,6 +4256,7 @@ fn test_workspaces_cwd() {
             r#"
                 //! ```
                 //! assert_eq!("{expected}", std::fs::read_to_string("file.txt").unwrap());
+                //! assert_eq!("{expected}", include_str!("../file.txt"));
                 //! assert_eq!(
                 //!     std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR")),
                 //!     std::env::current_dir().unwrap(),
@@ -4265,6 +4266,7 @@ fn test_workspaces_cwd() {
                 #[test]
                 fn test_unit_{expected}_cwd() {{
                     assert_eq!("{expected}", std::fs::read_to_string("file.txt").unwrap());
+                    assert_eq!("{expected}", include_str!("../file.txt"));
                     assert_eq!(
                         std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR")),
                         std::env::current_dir().unwrap(),
@@ -4280,6 +4282,7 @@ fn test_workspaces_cwd() {
                 #[test]
                 fn test_integration_{expected}_cwd() {{
                     assert_eq!("{expected}", std::fs::read_to_string("file.txt").unwrap());
+                    assert_eq!("{expected}", include_str!("../file.txt"));
                     assert_eq!(
                         std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR")),
                         std::env::current_dir().unwrap(),


### PR DESCRIPTION
By doing so, rustdoc will also emit workspace-relative filenames for the doctests.

This was first landed in #8954 but later backed out in #8996 because it changed the CWD of rustdoc test invocations.

The second try relies on the new `--test-run-directory` rustdoc option which was added in https://github.com/rust-lang/rust/pull/81264 to explicitly control the rustdoc test cwd.

fixes #8993