### PR TITLE
Impl warn for locked install without Cargo.lock

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -254,6 +254,14 @@ fn install_one(
     };
 
     let (mut ws, rustc, target) = make_ws_rustc_target(config, opts, &source_id, pkg.clone())?;
+    // If we're installing in --locked mode and there's no `Cargo.lock` published
+    // ie. the bin was published before https://github.com/rust-lang/cargo/pull/7026
+    if config.locked() && !ws.root().join("Cargo.lock").exists() {
+        config.shell().warn(format!(
+            "no Cargo.lock file published in {}",
+            pkg.to_string()
+        ))?;
+    }
     let pkg = if source_id.is_git() {
         // Don't use ws.current() in order to keep the package source as a git source so that
         // install tracking uses the correct source.

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -806,6 +806,10 @@ impl Config {
         self.frozen
     }
 
+    pub fn locked(&self) -> bool {
+        self.locked
+    }
+
     pub fn lock_update_allowed(&self) -> bool {
         !self.frozen && !self.locked
     }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -682,6 +682,7 @@ fn git_repo() {
         .with_stderr(
             "\
 [UPDATING] git repository `[..]`
+[WARNING] no Cargo.lock file published in foo v0.1.0 ([..])
 [INSTALLING] foo v0.1.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] release [optimized] target(s) in [..]
@@ -1664,4 +1665,15 @@ workspace: [..]/foo/Cargo.toml
         )
         .run();
     assert_has_installed_exe(cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn locked_install_without_published_lockfile() {
+    Package::new("foo", "0.1.0")
+        .file("src/main.rs", "//! Some docs\nfn main() {}")
+        .publish();
+
+    cargo_process("install foo --locked")
+        .with_stderr_contains("[WARNING] no Cargo.lock file published in foo v0.1.0")
+        .run();
 }


### PR DESCRIPTION
If we're installing in --locked mode and there's no `Cargo.lock` published
ie. the bin was published before https://github.com/rust-lang/cargo/pull/7026
the cargo install errors were not stating that it was due to the lack of
the `Cargo.lock` file. Instead, the error seemed completely unrelated.

Therefore, this tries to address this by adding a warn in the stderr
output.

Closes #9106

I will need some help on the testing side (assuming the code I added for the warning is correct).
It looks to me that the publish function implemented for testing purposes does not publish `Cargo.lock` which is the actual convention. Should this be updated too? See  #7026