### PR TITLE
New index schema and registry API for extended feature syntax.

### DIFF
--- a/crates/cargo-test-support/src/publish.rs
+++ b/crates/cargo-test-support/src/publish.rs
@@ -30,12 +30,16 @@ pub fn validate_upload(expected_json: &str, expected_crate_name: &str, expected_
 
 /// Checks the result of a crate publish, along with the contents of the files.
 pub fn validate_upload_with_contents(
+    version: &str,
     expected_json: &str,
     expected_crate_name: &str,
     expected_files: &[&str],
     expected_contents: &[(&str, &str)],
 ) {
-    let new_path = registry::api_path().join("api/v1/crates/new");
+    let new_path = registry::api_path()
+        .join("api")
+        .join(version)
+        .join("crates/new");
     _validate_upload(
         &new_path,
         expected_json,

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -328,6 +328,7 @@ pub struct Package {
     links: Option<String>,
     rust_version: Option<String>,
     cargo_features: Vec<String>,
+    v: Option<u32>,
 }
 
 #[derive(Clone)]
@@ -389,6 +390,7 @@ impl Package {
             links: None,
             rust_version: None,
             cargo_features: Vec::new(),
+            v: None,
         }
     }
 
@@ -528,6 +530,14 @@ impl Package {
         self
     }
 
+    /// Sets the index schema version for this package.
+    ///
+    /// See [`cargo::sources::registry::RegistryPackage`] for more information.
+    pub fn schema_version(&mut self, version: u32) -> &mut Package {
+        self.v = Some(version);
+        self
+    }
+
     /// Creates the package and place it in the registry.
     ///
     /// This does not actually use Cargo's publishing system, but instead
@@ -585,6 +595,10 @@ impl Package {
         });
         if let Some(f2) = &features2 {
             json["features2"] = serde_json::json!(f2);
+            json["v"] = serde_json::json!(2);
+        }
+        if let Some(v) = self.v {
+            json["v"] = serde_json::json!(v);
         }
         let line = json.to_string();
 

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -60,6 +60,8 @@ pub struct NewCrate {
     pub repository: Option<String>,
     pub badges: BTreeMap<String, BTreeMap<String, String>>,
     pub links: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub v: Option<u32>,
 }
 
 #[derive(Serialize)]
@@ -105,7 +107,7 @@ struct OwnerResponse {
 struct ApiErrorList {
     errors: Vec<ApiError>,
 }
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct ApiError {
     detail: String,
 }
@@ -269,8 +271,7 @@ impl Registry {
         let size = tarball_len as usize + header.len();
         let mut body = Cursor::new(header).chain(tarball);
 
-        let version = if krate.features2.is_some() { 2 } else { 1 };
-        self.set_url(version, "/crates/new")?;
+        self.set_url(krate.v.unwrap_or(1), "/crates/new")?;
 
         let token = match self.token.as_ref() {
             Some(s) => s,

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -37,12 +37,16 @@ pub struct Crate {
     pub max_version: String,
 }
 
+pub type NewFeatureMap = BTreeMap<String, Vec<String>>;
+
 #[derive(Serialize)]
 pub struct NewCrate {
     pub name: String,
     pub vers: String,
     pub deps: Vec<NewCrateDependency>,
-    pub features: BTreeMap<String, Vec<String>>,
+    pub features: NewFeatureMap,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub features2: Option<NewFeatureMap>,
     pub authors: Vec<String>,
     pub description: Option<String>,
     pub documentation: Option<String>,
@@ -294,6 +298,13 @@ impl Registry {
                          10MB in size, you can email help@crates.io for assistance.\n\
                          Total size was {}.",
                         tarball_len
+                    )
+                }
+                ResponseError::Code { code, .. } if code == 404 && krate.features2.is_some() => {
+                    format_err!(
+                        "This package uses new feature syntax that is not supported by \
+                         the registry at {}.",
+                        self.host,
                     )
                 }
                 _ => e.into(),

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -19,11 +19,11 @@ pub use self::cargo_test::{run_benches, run_tests, TestOptions};
 pub use self::cargo_uninstall::uninstall;
 pub use self::fix::{fix, fix_maybe_exec_rustc, FixOptions};
 pub use self::lockfile::{load_pkg_lockfile, resolve_to_string, write_pkg_lockfile};
-pub use self::registry::HttpTimeout;
-pub use self::registry::{configure_http_handle, http_handle, http_handle_and_timeout};
-pub use self::registry::{modify_owners, yank, OwnersOptions, PublishOpts};
-pub use self::registry::{needs_custom_http_transport, registry_login, registry_logout, search};
-pub use self::registry::{publish, registry_configuration, RegistryConfig};
+pub use self::registry::{
+    configure_http_handle, features_for_publish, http_handle, http_handle_and_timeout,
+    modify_owners, needs_custom_http_transport, publish, registry_configuration, registry_login,
+    registry_logout, search, yank, HttpTimeout, OwnersOptions, PublishOpts, RegistryConfig,
+};
 pub use self::resolve::{
     add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws, resolve_ws_with_opts,
 };

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -274,6 +274,7 @@ fn transmit(
     }
 
     let (features, features2) = features_for_publish(manifest.original().features());
+    let v = if features2.is_some() { Some(2) } else { None };
 
     let publish = registry.publish(
         &NewCrate {
@@ -295,6 +296,7 @@ fn transmit(
             license_file: license_file.clone(),
             badges: badges.clone(),
             links: links.clone(),
+            v,
         },
         tarball,
     );

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -164,10 +164,28 @@ fn overflow_hyphen() {
     )
 }
 
+/// Manager for handling the on-disk index.
+///
+/// Note that local and remote registries store the index differently. Local
+/// is a simple on-disk tree of files of the raw index. Remote registries are
+/// stored as a raw git repository. The different means of access are handled
+/// via the [`RegistryData`] trait abstraction.
+///
+/// This transparently handles caching of the index in a more efficient format.
 pub struct RegistryIndex<'cfg> {
     source_id: SourceId,
+    /// Root directory of the index for the registry.
     path: Filesystem,
+    /// Cache of summary data.
+    ///
+    /// This is keyed off the package name. The [`Summaries`] value handles
+    /// loading the summary data. It keeps an optimized on-disk representation
+    /// of the JSON files, which is created in an as-needed fashion. If it
+    /// hasn't been cached already, it uses [`RegistryData::load`] to access
+    /// to JSON files from the index, and the creates the optimized on-disk
+    /// summary cache.
     summaries_cache: HashMap<InternedString, Summaries>,
+    /// [`Config`] reference for convenience.
     config: &'cfg Config,
 }
 

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -68,7 +68,7 @@
 
 use crate::core::dependency::Dependency;
 use crate::core::{PackageId, SourceId, Summary};
-use crate::sources::registry::{RegistryData, RegistryPackage};
+use crate::sources::registry::{RegistryData, RegistryPackage, INDEX_SCHEMA_VERSION};
 use crate::util::interning::InternedString;
 use crate::util::paths;
 use crate::util::{internal, CargoResult, Config, Filesystem, ToSemver};
@@ -751,7 +751,12 @@ impl IndexSummary {
             features2,
             yanked,
             links,
+            v,
         } = serde_json::from_slice(line)?;
+        let v = v.unwrap_or(1);
+        if v > INDEX_SCHEMA_VERSION {
+            bail!("unsupported schema version {} ({} {})", v, name, vers);
+        }
         log::trace!("json parsed registry {}/{}", name, vers);
         let pkgid = PackageId::new(name, &vers, source_id)?;
         let deps = deps

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -9,6 +9,9 @@ use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::Path;
 
+/// A local registry is a registry that lives on the filesystem as a set of
+/// `.crate` files with an `index` directory in the same format as a remote
+/// registry.
 pub struct LocalRegistry<'cfg> {
     index_path: Filesystem,
     root: Filesystem,

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -258,6 +258,13 @@ pub struct RegistryPackage<'a> {
     #[serde(borrow)]
     deps: Vec<RegistryDependency<'a>>,
     features: BTreeMap<InternedString, Vec<InternedString>>,
+    /// This field contains features with new, extended syntax. Specifically,
+    /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
+    ///
+    /// This is separated from `features` because versions older than 1.19
+    /// will fail to load due to not being able to parse the new syntax, even
+    /// with a `Cargo.lock` file.
+    features2: Option<BTreeMap<InternedString, Vec<InternedString>>>,
     cksum: String,
     /// If `true`, Cargo will skip this version when resolving.
     ///

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -188,6 +188,7 @@ const CRATE_TEMPLATE: &str = "{crate}";
 const VERSION_TEMPLATE: &str = "{version}";
 const PREFIX_TEMPLATE: &str = "{prefix}";
 const LOWER_PREFIX_TEMPLATE: &str = "{lowerprefix}";
+pub const INDEX_SCHEMA_VERSION: u32 = 2;
 
 /// A "source" for a [local](local::LocalRegistry) or
 /// [remote](remote::RemoteRegistry) registry.
@@ -276,6 +277,25 @@ pub struct RegistryPackage<'a> {
     /// Added early 2018 (see <https://github.com/rust-lang/cargo/pull/4978>),
     /// can be `None` if published before then.
     links: Option<InternedString>,
+    /// The schema version for this entry.
+    ///
+    /// If this is None, it defaults to version 1. Version 2 means the
+    /// `features2` field is present. Entries with unknown versions are
+    /// ignored.
+    ///
+    /// This provides a method to safely introduce changes to index entries
+    /// and allow older versions of cargo to ignore newer entries it doesn't
+    /// understand. This is honored as of 1.51, so unfortunately older
+    /// versions will ignore it, and potentially misinterpret version 2 and
+    /// newer entries.
+    ///
+    /// The intent is that versions older than 1.51 will work with a
+    /// pre-existing `Cargo.lock`, but they may not correctly process `cargo
+    /// update` or build a lock from scratch. In that case, cargo may
+    /// incorrectly select a new package that uses a new index format. A
+    /// workaround is to downgrade any packages that are incompatible with the
+    /// `--precise` flag of `cargo update`.
+    v: Option<u32>,
 }
 
 #[test]

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -29,8 +29,12 @@ fn make_dep_prefix(name: &str) -> String {
     }
 }
 
+/// A remote registry is a registry that lives at a remote URL (such as
+/// crates.io). The git index is cloned locally, and `.crate` files are
+/// downloaded as needed and cached locally.
 pub struct RemoteRegistry<'cfg> {
     index_path: Filesystem,
+    /// Path to the cache of `.crate` files (`$CARGO_HOME/registry/path/$REG-HASH`).
     cache_path: Filesystem,
     source_id: SourceId,
     index_git_ref: GitReference,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -876,7 +876,7 @@ struct Context<'a, 'b> {
 }
 
 impl TomlManifest {
-    /// Prepares the manfiest for publishing.
+    /// Prepares the manifest for publishing.
     // - Path and git components of dependency specifications are removed.
     // - License path is updated to point within the package.
     pub fn prepare_for_publish(

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -8,6 +8,7 @@ use std::fs;
 
 #[cargo_test]
 fn depend_on_alt_registry() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -57,6 +58,7 @@ fn depend_on_alt_registry() {
 
 #[cargo_test]
 fn depend_on_alt_registry_depends_on_same_registry_no_index() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -99,6 +101,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
 
 #[cargo_test]
 fn depend_on_alt_registry_depends_on_same_registry() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -141,6 +144,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
 
 #[cargo_test]
 fn depend_on_alt_registry_depends_on_crates_io() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -185,7 +189,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
 
 #[cargo_test]
 fn registry_and_path_dep_works() {
-    registry::init();
+    registry::alt_init();
 
     let p = project()
         .file(
@@ -219,7 +223,7 @@ fn registry_and_path_dep_works() {
 
 #[cargo_test]
 fn registry_incompatible_with_git() {
-    registry::init();
+    registry::alt_init();
 
     let p = project()
         .file(
@@ -249,6 +253,7 @@ fn registry_incompatible_with_git() {
 
 #[cargo_test]
 fn cannot_publish_to_crates_io_with_registry_dependency() {
+    registry::alt_init();
     let fakeio_path = paths::root().join("fake.io");
     let fakeio_url = fakeio_path.into_url().unwrap();
     let p = project()
@@ -307,6 +312,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
 
 #[cargo_test]
 fn publish_with_registry_dependency() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -370,6 +376,7 @@ fn publish_with_registry_dependency() {
 
 #[cargo_test]
 fn alt_registry_and_crates_io_deps() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -415,7 +422,7 @@ fn alt_registry_and_crates_io_deps() {
 
 #[cargo_test]
 fn block_publish_due_to_no_token() {
-    registry::init();
+    registry::alt_init();
     let p = project().file("src/lib.rs", "").build();
 
     fs::remove_file(paths::home().join(".cargo/credentials")).unwrap();
@@ -432,6 +439,7 @@ fn block_publish_due_to_no_token() {
 
 #[cargo_test]
 fn publish_to_alt_registry() {
+    registry::alt_init();
     let p = project().file("src/main.rs", "fn main() {}").build();
 
     // Setup the registry by publishing a package
@@ -472,6 +480,7 @@ fn publish_to_alt_registry() {
 
 #[cargo_test]
 fn publish_with_crates_io_dep() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -537,7 +546,7 @@ fn publish_with_crates_io_dep() {
 
 #[cargo_test]
 fn passwords_in_registries_index_url_forbidden() {
-    registry::init();
+    registry::alt_init();
 
     let config = paths::home().join(".cargo/config");
 
@@ -567,6 +576,7 @@ Caused by:
 
 #[cargo_test]
 fn patch_alt_reg() {
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     let p = project()
         .file(
@@ -656,6 +666,7 @@ Caused by:
 
 #[cargo_test]
 fn no_api() {
+    registry::alt_init();
     Package::new("bar", "0.0.1").alternative(true).publish();
     // Configure without `api`.
     let repo = git2::Repository::open(registry::alt_registry_path()).unwrap();
@@ -739,6 +750,7 @@ fn no_api() {
 #[cargo_test]
 fn alt_reg_metadata() {
     // Check for "registry" entries in `cargo metadata` with alternative registries.
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -1033,6 +1045,7 @@ fn alt_reg_metadata() {
 fn unknown_registry() {
     // A known registry refers to an unknown registry.
     // foo -> bar(crates.io) -> baz(alt)
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -1188,6 +1201,7 @@ fn unknown_registry() {
 
 #[cargo_test]
 fn registries_index_relative_url() {
+    registry::alt_init();
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(
@@ -1237,6 +1251,7 @@ fn registries_index_relative_url() {
 
 #[cargo_test]
 fn registries_index_relative_path_not_allowed() {
+    registry::alt_init();
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -1191,7 +1191,8 @@ fn publish() {
           "readme": null,
           "readme_file": null,
           "repository": null,
-          "vers": "0.1.0"
+          "vers": "0.1.0",
+          "v": 2
           }
         "#,
         "foo-0.1.0.crate",

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use cargo_test_support::install::{cargo_home, exe};
 use cargo_test_support::paths::CargoPathExt;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, cross_compile, execs, git, process, project, Execs,
 };
@@ -549,6 +549,7 @@ fn upgrade_git() {
 fn switch_sources() {
     // Installing what appears to be the same thing, but from different
     // sources should reinstall.
+    registry::alt_init();
     pkg("foo", "1.0.0");
     Package::new("foo", "1.0.0")
         .file("src/main.rs", r#"fn main() { println!("alt"); }"#)

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -145,7 +145,7 @@ fn new_credentials_is_used_instead_old() {
 
 #[cargo_test]
 fn registry_credentials() {
-    registry::init();
+    registry::alt_init();
 
     let config = paths::home().join(".cargo/config");
     let mut f = OpenOptions::new().append(true).open(config).unwrap();

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -78,5 +78,6 @@ fn default_registry() {
 
 #[cargo_test]
 fn other_registry() {
+    registry::alt_init();
     simple_logout_test(Some("alternative"), "--registry alternative");
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -818,6 +818,7 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
 
 #[cargo_test]
 fn generated_manifest() {
+    registry::alt_init();
     Package::new("abc", "1.0.0").publish();
     Package::new("def", "1.0.0").alternative(true).publish();
     Package::new("ghi", "1.0.0").publish();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2,7 +2,7 @@
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project};
 use std::fs;
 
@@ -1543,6 +1543,7 @@ fn update_unused_new_version() {
 #[cargo_test]
 fn too_many_matches() {
     // The patch locations has multiple versions that match.
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.0").alternative(true).publish();
     Package::new("bar", "0.1.1").alternative(true).publish();
@@ -1866,6 +1867,7 @@ fn patched_dep_new_version() {
 fn patch_update_doesnt_update_other_sources() {
     // Very extreme edge case, make sure a patch update doesn't update other
     // sources.
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.0").alternative(true).publish();
 
@@ -1931,6 +1933,7 @@ fn patch_update_doesnt_update_other_sources() {
 #[cargo_test]
 fn can_update_with_alt_reg() {
     // A patch to an alt reg can update.
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.0").alternative(true).publish();
     Package::new("bar", "0.1.1").alternative(true).publish();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1175,6 +1175,7 @@ fn publish_git_with_version() {
     p.cargo("publish --no-verify --token sekrit").run();
 
     publish::validate_upload_with_contents(
+        "v1",
         r#"
         {
           "authors": [],
@@ -1272,6 +1273,7 @@ fn publish_dev_dep_no_version() {
         .run();
 
     publish::validate_upload_with_contents(
+        "v1",
         r#"
         {
           "authors": [],

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1457,3 +1457,172 @@ Caused by:
         ))
         .run();
 }
+
+#[cargo_test]
+fn api_error_json() {
+    // Registry returns an API error.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| {
+        (403, &r#"{"errors": [{"detail": "you must be logged in"}]}"#)
+    });
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] api errors (status 403 Forbidden): you must be logged in
+",
+        )
+        .run();
+
+    t.join().unwrap();
+}
+
+#[cargo_test]
+fn api_error_code() {
+    // Registry returns an error code without a JSON message.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| (400, &"go away"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] failed to get a 200 OK response, got 400
+headers:
+<tab>HTTP/1.1 400
+<tab>Content-Length: 7
+<tab>
+body:
+go away
+",
+        )
+        .run();
+
+    t.join().unwrap();
+}
+
+#[cargo_test]
+fn api_curl_error() {
+    // Registry has a network error.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| panic!("broke!"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    // This doesn't check for the exact text of the error in the remote
+    // possibility that cargo is linked with a weird version of libcurl, or
+    // curl changes the text of the message. Currently the message 52
+    // (CURLE_GOT_NOTHING) is:
+    //    Server returned nothing (no headers, no data) (Empty reply from server)
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] [52] [..]
+",
+        )
+        .run();
+
+    let e = t.join().unwrap_err();
+    assert_eq!(*e.downcast::<&str>().unwrap(), "broke!");
+}
+
+#[cargo_test]
+fn api_other_error() {
+    // Registry returns an invalid response.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| (200, b"\xff"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] invalid response from server
+
+Caused by:
+  response body was not valid utf-8
+",
+        )
+        .run();
+
+    t.join().unwrap();
+}

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -677,7 +677,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
 
 #[cargo_test]
 fn publish_allowed_registry() {
-    registry::init();
+    registry::alt_init();
 
     let p = project().build();
 
@@ -717,7 +717,7 @@ fn publish_allowed_registry() {
 
 #[cargo_test]
 fn publish_implicitly_to_only_allowed_registry() {
-    registry::init();
+    registry::alt_init();
 
     let p = project().build();
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -2,7 +2,7 @@
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project};
 
 #[cargo_test]
@@ -66,6 +66,7 @@ fn rename_with_different_names() {
 
 #[cargo_test]
 fn lots_of_names() {
+    registry::alt_init();
     Package::new("foo", "0.1.0")
         .file("src/lib.rs", "pub fn foo1() {}")
         .publish();

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -1,6 +1,6 @@
 //! Tests for the -Zrustdoc-map feature.
 
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{is_nightly, paths, project, Project};
 
 fn basic_project() -> Project {
@@ -215,6 +215,7 @@ fn alt_registry() {
         // --extern-html-root-url is unstable
         return;
     }
+    registry::alt_init();
     Package::new("bar", "1.0.0")
         .alternative(true)
         .file(

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -7,7 +7,7 @@
 use std::fs;
 
 use cargo_test_support::git;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_lib_manifest, paths, project, Project};
 
 #[cargo_test]
@@ -594,6 +594,7 @@ fn ignore_hidden() {
 #[cargo_test]
 fn config_instructions_works() {
     // Check that the config instructions work for all dependency kinds.
+    registry::alt_init();
     Package::new("dep", "0.1.0").publish();
     Package::new("altdep", "0.1.0").alternative(true).publish();
     let git_project = git::new("gitdep", |project| {

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -1,7 +1,8 @@
 //! Tests for weak-dep-features.
 
-use cargo_test_support::project;
-use cargo_test_support::registry::{Dependency, Package};
+use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::registry::{self, Dependency, Package};
+use cargo_test_support::{project, publish};
 use std::fmt::Write;
 
 // Helper to create lib.rs files that check features.
@@ -564,4 +565,108 @@ bar v1.0.0
 ",
         )
         .run();
+}
+
+#[cargo_test]
+fn publish() {
+    // Publish uploads `features2` in JSON.
+    Package::new("bar", "1.0.0").feature("feat", &[]).publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                description = "foo"
+                license = "MIT"
+                homepage = "https://example.com/"
+
+                [dependencies]
+                bar = { version = "1.0", optional = true }
+
+                [features]
+                feat1 = []
+                feat2 = ["bar?/feat"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    registry::api_path().join("api/v2/crates").mkdir_p();
+
+    p.cargo("publish --token sekrit -Z weak-dep-features")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.1.0 [..]
+[VERIFYING] foo v0.1.0 [..]
+[COMPILING] foo v0.1.0 [..]
+[FINISHED] [..]
+[UPLOADING] foo v0.1.0 [..]
+",
+        )
+        .run();
+
+    publish::validate_upload_with_contents(
+        r#"
+        {
+          "authors": [],
+          "badges": {},
+          "categories": [],
+          "deps": [
+            {
+              "default_features": true,
+              "features": [],
+              "kind": "normal",
+              "name": "bar",
+              "optional": true,
+              "registry": "https://github.com/rust-lang/crates.io-index",
+              "target": null,
+              "version_req": "^1.0"
+            }
+          ],
+          "description": "foo",
+          "documentation": null,
+          "features": {
+            "feat1": [],
+            "feat2": []
+          },
+          "features2": {
+            "feat2": ["bar?/feat"]
+          },
+          "homepage": "https://example.com/",
+          "keywords": [],
+          "license": "MIT",
+          "license_file": null,
+          "links": null,
+          "name": "foo",
+          "readme": null,
+          "readme_file": null,
+          "repository": null,
+          "vers": "0.1.0"
+          }
+        "#,
+        "foo-0.1.0.crate",
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &[(
+            "Cargo.toml",
+            r#"[..]
+[package]
+name = "foo"
+version = "0.1.0"
+description = "foo"
+homepage = "https://example.com/"
+license = "MIT"
+[dependencies.bar]
+version = "1.0"
+optional = true
+
+[features]
+feat1 = []
+feat2 = ["bar?/feat"]
+"#,
+        )],
+    );
 }

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -610,6 +610,7 @@ fn publish() {
         .run();
 
     publish::validate_upload_with_contents(
+        "v2",
         r#"
         {
           "authors": [],

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -646,7 +646,8 @@ fn publish() {
           "readme": null,
           "readme_file": null,
           "repository": null,
-          "vers": "0.1.0"
+          "vers": "0.1.0",
+          "v": 2
           }
         "#,
         "foo-0.1.0.crate",


### PR DESCRIPTION
This introduces a new `features2` field in the index to segregate the new feature syntax for namespaced features and weak dependency features. The intent here is to prevent versions of Cargo older than 1.19 from breaking, since they will fail to run even with a `Cargo.lock` file.

To prevent publishing from breaking when talking to a registry that does not understand this new field, this switches the publish API to a new URL (`api/v2/crates/new`).

This also introduces a new schema field to the index and publish API, so that in the future changes can be made, and versions of cargo after this is introduced will silently ignore entries it doesn't understand.

This is split into a number of different commits, with more information in each commit.
