### PR TITLE
Improve error messages for wrong target paths 

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -826,10 +826,18 @@ fn target_path(
                     return Ok(path);
                 }
             }
+            let target_folder_name = match target_kind {
+                "test" => "tests",
+                "bench" => "benches",
+                "example" => "examples",
+                "bins" => "bin",
+                _ => target_kind,
+            };
             Err(format!(
-                "can't find `{name}` {target_kind}, specify {target_kind}.path",
+                "can't find `{name}` {target_kind} at `{target_folder_name}/{name}`, specify {target_kind}.path if you want to use a non-default path",
                 name = name,
-                target_kind = target_kind
+                target_kind = target_kind,
+                target_folder_name = target_folder_name,
             ))
         }
         (None, Some(_)) => unreachable!(),

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1849,7 +1849,7 @@ fn non_existing_example() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  can't find `hello` example, specify example.path",
+  can't find `[..]` example at `[..]`, specify [..] if you want to use a non-default path",
         )
         .run();
 }
@@ -1869,7 +1869,7 @@ fn non_existing_binary() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  can't find `foo` bin, specify bin.path",
+  can't find `[..]` bin at `[..]`, specify [..] if you want to use a non-default path",
         )
         .run();
 }
@@ -4220,7 +4220,7 @@ fn no_bin_in_src_with_lib() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  can't find `foo` bin, specify bin.path",
+  can't find `[..]` bin at `[..]`, specify [..] if you want to use a non-default path",
         )
         .run();
 }
@@ -4397,7 +4397,7 @@ fn same_metadata_different_directory() {
 }
 
 #[cargo_test]
-fn building_a_dependent_crate_witout_bin_should_fail() {
+fn building_a_dependent_crate_without_bin_should_fail() {
     Package::new("testless", "0.1.0")
         .file(
             "Cargo.toml",
@@ -4430,7 +4430,7 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
 
     p.cargo("build")
         .with_status(101)
-        .with_stderr_contains("[..]can't find `a_bin` bin, specify bin.path")
+        .with_stderr_contains("[..]can't find `[..]` bin at `[..]`, specify [..] if you want to use a non-default path")
         .run();
 }
 
@@ -5437,4 +5437,28 @@ fn primary_package_env_var() {
         .build();
 
     foo.cargo("test").run();
+}
+
+#[cargo_test]
+fn using_bins_instead_of_bin_is_warned_in_err() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+
+                [[bin]]
+                name = "a_bin"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bins/a_bin.rs", "fn main { () }")
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains("[..]can't find `[..]` bin at `[..]`, specify [..] if you want to use a non-default path")
+        .run();
 }


### PR DESCRIPTION
As it was stated in #9014 it's not really useful the message
that you get when using `bench/your_bench.rs` instead of the
correct path `benches/your_bench.rs`.

Therefore, as it was suggested, the error message has been improved
not only suggesting the correct path but also suggesting to
specify `bench.path` in `Cargo.toml` for non-default path usage.
And this has been exented to `test`, `example` and `bin`.

Closes #9014