### PR TITLE
Add a profile option to select the codegen backend

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -796,6 +796,7 @@ fn build_base_args(
     let bcx = cx.bcx;
     let Profile {
         ref opt_level,
+        codegen_backend,
         codegen_units,
         debuginfo,
         debug_assertions,
@@ -858,6 +859,10 @@ fn build_base_args(
         if let Some(split) = split_debuginfo {
             cmd.arg("-C").arg(format!("split-debuginfo={}", split));
         }
+    }
+
+    if let Some(backend) = codegen_backend {
+        cmd.arg("-Z").arg(&format!("codegen-backend={}", backend));
     }
 
     if let Some(n) = codegen_units {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -402,6 +402,9 @@ features! {
 
     // Allow to specify per-package targets (compile kinds)
     (unstable, per_package_target, "", "reference/unstable.html#per-package-target"),
+
+    // Allow to specify which codegen backend should be used.
+    (unstable, codegen_backend, "", "reference/unstable.html#codegen-backend"),
 }
 
 pub struct Feature {

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -565,6 +565,9 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
         Some(StringOrBool::String(ref n)) => profile.lto = Lto::Named(InternedString::new(n)),
         None => {}
     }
+    if toml.codegen_backend.is_some() {
+        profile.codegen_backend = toml.codegen_backend;
+    }
     if toml.codegen_units.is_some() {
         profile.codegen_units = toml.codegen_units;
     }
@@ -626,6 +629,8 @@ pub struct Profile {
     pub root: ProfileRoot,
     pub lto: Lto,
     // `None` means use rustc default.
+    pub codegen_backend: Option<InternedString>,
+    // `None` means use rustc default.
     pub codegen_units: Option<u32>,
     pub debuginfo: Option<u32>,
     pub split_debuginfo: Option<InternedString>,
@@ -644,6 +649,7 @@ impl Default for Profile {
             opt_level: InternedString::new("0"),
             root: ProfileRoot::Debug,
             lto: Lto::Bool(false),
+            codegen_backend: None,
             codegen_units: None,
             debuginfo: None,
             debug_assertions: false,
@@ -670,6 +676,7 @@ compact_debug! {
                 opt_level
                 lto
                 root
+                codegen_backend
                 codegen_units
                 debuginfo
                 split_debuginfo
@@ -757,6 +764,7 @@ impl Profile {
         (
             self.opt_level,
             self.lto,
+            self.codegen_backend,
             self.codegen_units,
             self.debuginfo,
             self.split_debuginfo,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -566,10 +566,11 @@ impl TomlProfile {
 
         if let Some(codegen_backend) = &self.codegen_backend {
             features.require(Feature::codegen_backend())?;
-            if codegen_backend.contains('.') {
+            if codegen_backend.contains(|c| !c.is_ascii_alphanumeric() && c != '_') {
                 bail!(
-                    "`profile.{}.codegen-backend` is an external backend, but only builtin codegen \
-                    backends are allowed."
+                    "`profile.{}.codegen-backend` setting of `{}` is not a valid backend name.",
+                    name,
+                    codegen_backend,
                 );
             }
         }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -564,8 +564,14 @@ impl TomlProfile {
             features.require(Feature::strip())?;
         }
 
-        if self.codegen_backend.is_some() {
+        if let Some(codegen_backend) = &self.codegen_backend {
             features.require(Feature::codegen_backend())?;
+            if codegen_backend.contains('.') {
+                bail!(
+                    "`profile.{}.codegen-backend` is an external backend, but only builtin codegen \
+                    backends are allowed."
+                );
+            }
         }
 
         Ok(())

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -566,7 +566,7 @@ impl TomlProfile {
 
         if let Some(codegen_backend) = &self.codegen_backend {
             features.require(Feature::codegen_backend())?;
-            if codegen_backend.contains(|c| !c.is_ascii_alphanumeric() && c != '_') {
+            if codegen_backend.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_') {
                 bail!(
                     "`profile.{}.codegen-backend` setting of `{}` is not a valid backend name.",
                     name,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1406,3 +1406,21 @@ environment variables.
 The `rust-version` field in `Cargo.toml` has been stabilized in the 1.56 release.
 See the [rust-version field](manifest.html#the-rust-version-field) for more
 information on using the `rust-version` field and the `--ignore-rust-version` option.
+
+### codegen-backend
+
+The `codegen-backend` feature makes it possible to select the codegen backend used by rustc using a
+profile.
+
+Example:
+
+```toml
+[package]
+name = "foo"
+
+[dependencies]
+serde = "1.0.117"
+
+[profile.dev.package.foo]
+codegen-backend = "cranelift"
+```

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -49,177 +49,183 @@ fn simple() {
         .masquerade_as_nightly_cargo()
         .with_json(
             r#"{
-              "version": 1,
+              "roots": [
+                3
+              ],
               "units": [
                 {
+                  "dependencies": [
+                    {
+                      "extern_crate_name": "b",
+                      "index": 1,
+                      "noprelude": false,
+                      "public": false
+                    }
+                  ],
+                  "features": [
+                    "feata"
+                  ],
+                  "mode": "build",
                   "pkg_id": "a 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "platform": null,
+                  "profile": {
+                    "codegen_backend": null,
+                    "codegen_units": null,
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "incremental": false,
+                    "lto": "false",
+                    "name": "dev",
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "panic": "unwind",
+                    "rpath": false,
+                    "split_debuginfo": null,
+                    "strip": "none"
+                  },
                   "target": {
-                    "kind": [
+                    "crate_types": [
                       "lib"
                     ],
-                    "crate_types": [
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2015",
+                    "kind": [
                       "lib"
                     ],
                     "name": "a",
                     "src_path": "[..]/a-1.0.0/src/lib.rs",
-                    "edition": "2015",
-                    "doc": true,
-                    "doctest": true,
                     "test": true
-                  },
-                  "profile": {
-                    "name": "dev",
-                    "opt_level": "0",
-                    "lto": "false",
-                    "codegen_units": null,
-                    "debuginfo": 2,
-                    "debug_assertions": true,
-                    "overflow_checks": true,
-                    "rpath": false,
-                    "incremental": false,
-                    "panic": "unwind",
-                    "strip": "none",
-                    "split_debuginfo": "{...}"
-                  },
-                  "platform": null,
-                  "mode": "build",
-                  "features": [
-                    "feata"
-                  ],
-                  "dependencies": [
-                    {
-                      "index": 1,
-                      "extern_crate_name": "b",
-                      "public": false,
-                      "noprelude": false
-                    }
-                  ]
+                  }
                 },
                 {
+                  "dependencies": [
+                    {
+                      "extern_crate_name": "c",
+                      "index": 2,
+                      "noprelude": false,
+                      "public": false
+                    }
+                  ],
+                  "features": [
+                    "featb"
+                  ],
+                  "mode": "build",
                   "pkg_id": "b 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "platform": null,
+                  "profile": {
+                    "codegen_backend": null,
+                    "codegen_units": null,
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "incremental": false,
+                    "lto": "false",
+                    "name": "dev",
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "panic": "unwind",
+                    "rpath": false,
+                    "split_debuginfo": null,
+                    "strip": "none"
+                  },
                   "target": {
-                    "kind": [
+                    "crate_types": [
                       "lib"
                     ],
-                    "crate_types": [
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2015",
+                    "kind": [
                       "lib"
                     ],
                     "name": "b",
                     "src_path": "[..]/b-1.0.0/src/lib.rs",
-                    "edition": "2015",
-                    "doc": true,
-                    "doctest": true,
                     "test": true
-                  },
-                  "profile": {
-                    "name": "dev",
-                    "opt_level": "0",
-                    "lto": "false",
-                    "codegen_units": null,
-                    "debuginfo": 2,
-                    "debug_assertions": true,
-                    "overflow_checks": true,
-                    "rpath": false,
-                    "incremental": false,
-                    "panic": "unwind",
-                    "strip": "none",
-                    "split_debuginfo": "{...}"
-                  },
-                  "platform": null,
-                  "mode": "build",
-                  "features": [
-                    "featb"
-                  ],
-                  "dependencies": [
-                    {
-                      "index": 2,
-                      "extern_crate_name": "c",
-                      "public": false,
-                      "noprelude": false
-                    }
-                  ]
+                  }
                 },
                 {
+                  "dependencies": [],
+                  "features": [
+                    "featc"
+                  ],
+                  "mode": "build",
                   "pkg_id": "c 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "platform": null,
+                  "profile": {
+                    "codegen_backend": null,
+                    "codegen_units": null,
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "incremental": false,
+                    "lto": "false",
+                    "name": "dev",
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "panic": "unwind",
+                    "rpath": false,
+                    "split_debuginfo": null,
+                    "strip": "none"
+                  },
                   "target": {
-                    "kind": [
+                    "crate_types": [
                       "lib"
                     ],
-                    "crate_types": [
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2015",
+                    "kind": [
                       "lib"
                     ],
                     "name": "c",
                     "src_path": "[..]/c-1.0.0/src/lib.rs",
-                    "edition": "2015",
-                    "test": true,
-                    "doc": true,
-                    "doctest": true
-                  },
-                  "profile": {
-                    "name": "dev",
-                    "opt_level": "0",
-                    "lto": "false",
-                    "codegen_units": null,
-                    "debuginfo": 2,
-                    "debug_assertions": true,
-                    "overflow_checks": true,
-                    "rpath": false,
-                    "incremental": false,
-                    "panic": "unwind",
-                    "strip": "none",
-                    "split_debuginfo": "{...}"
-                  },
-                  "platform": null,
-                  "mode": "build",
-                  "features": [
-                    "featc"
-                  ],
-                  "dependencies": []
+                    "test": true
+                  }
                 },
                 {
+                  "dependencies": [
+                    {
+                      "extern_crate_name": "a",
+                      "index": 0,
+                      "noprelude": false,
+                      "public": false
+                    }
+                  ],
+                  "features": [],
+                  "mode": "build",
                   "pkg_id": "foo 0.1.0 (path+file://[..]/foo)",
+                  "platform": null,
+                  "profile": {
+                    "codegen_backend": null,
+                    "codegen_units": null,
+                    "debug_assertions": true,
+                    "debuginfo": 2,
+                    "incremental": false,
+                    "lto": "false",
+                    "name": "dev",
+                    "opt_level": "0",
+                    "overflow_checks": true,
+                    "panic": "unwind",
+                    "rpath": false,
+                    "split_debuginfo": null,
+                    "strip": "none"
+                  },
                   "target": {
-                    "kind": [
+                    "crate_types": [
                       "lib"
                     ],
-                    "crate_types": [
+                    "doc": true,
+                    "doctest": true,
+                    "edition": "2015",
+                    "kind": [
                       "lib"
                     ],
                     "name": "foo",
                     "src_path": "[..]/foo/src/lib.rs",
-                    "edition": "2015",
-                    "test": true,
-                    "doc": true,
-                    "doctest": true
-                  },
-                  "profile": {
-                    "name": "dev",
-                    "opt_level": "0",
-                    "lto": "false",
-                    "codegen_units": null,
-                    "debuginfo": 2,
-                    "debug_assertions": true,
-                    "overflow_checks": true,
-                    "rpath": false,
-                    "incremental": false,
-                    "panic": "unwind",
-                    "strip": "none",
-                    "split_debuginfo": "{...}"
-                  },
-                  "platform": null,
-                  "mode": "build",
-                  "features": [],
-                  "dependencies": [
-                    {
-                      "index": 0,
-                      "extern_crate_name": "a",
-                      "public": false,
-                      "noprelude": false
-                    }
-                  ]
+                    "test": true
+                  }
                 }
               ],
-              "roots": [3]
+              "version": 1
             }
             "#,
         )

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -80,7 +80,7 @@ fn simple() {
                     "overflow_checks": true,
                     "panic": "unwind",
                     "rpath": false,
-                    "split_debuginfo": null,
+                    "split_debuginfo": "{...}",
                     "strip": "none"
                   },
                   "target": {
@@ -125,7 +125,7 @@ fn simple() {
                     "overflow_checks": true,
                     "panic": "unwind",
                     "rpath": false,
-                    "split_debuginfo": null,
+                    "split_debuginfo": "{...}",
                     "strip": "none"
                   },
                   "target": {
@@ -163,7 +163,7 @@ fn simple() {
                     "overflow_checks": true,
                     "panic": "unwind",
                     "rpath": false,
-                    "split_debuginfo": null,
+                    "split_debuginfo": "{...}",
                     "strip": "none"
                   },
                   "target": {
@@ -206,7 +206,7 @@ fn simple() {
                     "overflow_checks": true,
                     "panic": "unwind",
                     "rpath": false,
-                    "split_debuginfo": null,
+                    "split_debuginfo": "{...}",
                     "strip": "none"
                   },
                   "target": {


### PR DESCRIPTION
This makes it possible to compile only specific crates with a certain codegen backend.

I have tested this by compiling Bevy with cg_llvm, but one of the examples using cg_clif.

By the way I noticed that many unstable profile options are not checked when using profile overrides.