### PR TITLE
Improve Crates.io rate limiting response display

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -342,6 +342,14 @@ impl Registry {
 
         match (self.handle.response_code()?, errors) {
             (0, None) | (200, None) => {}
+            // We need to report this until https://github.com/rust-lang/crates.io/issues/1643 is
+            // handled better or cargo publishes considering the MAX rate..
+            (429, None) => bail!(
+                "The maximum publish rate for crates.io is 30 crates/min.
+                If the number of components of your workspace is bigger, please \
+                fill an issue in https://github.com/rust-lang/crates.io
+                For more info see: https://github.com/rust-lang/crates.io/pull/1596"
+            ),
             (503, None) if started.elapsed().as_secs() >= 29 && self.host_is_crates_io() => bail!(
                 "Request timed out after 30 seconds. If you're trying to \
                  upload a crate it may be too large. If the crate is under \

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -344,7 +344,7 @@ impl Registry {
             (0, None) | (200, None) => {}
             // We need to report this until https://github.com/rust-lang/crates.io/issues/1643 is
             // handled better or cargo publishes considering the MAX rate..
-            (429, None) => bail!(
+            (429, None) if self.host_is_crates_io() => bail!(
                 "The maximum publish rate for crates.io is 30 crates/min.
                 If the number of components of your workspace is bigger, please \
                 fill an issue in https://github.com/rust-lang/crates.io


### PR DESCRIPTION
In https://github.com/rust-lang/crates.io/pull/1596 it was added
a rate limit for crate publishing endpoint connections (10 components/min).
As is said in the PR. The strategy used allows to upload 10 components
first and then the ratio starts to be applied.
Now, if the rate is surpassed, crates.io returns a 429 HTTP response.

Cargo, tries to publish all of the workspace/crate components as fast
as possible (as we should expect) but when we have more than 10
components and we try to publish the 11th, usually a minute hasn't
passed yet and therefore we get a HTTP-429.

This made some users to experience confusing/not well explained error
messages as seen in https://github.com/rust-lang/crates.io/issues/1643.

The limit got increased to 30 components/min. But who knows..

So this closes https://github.com/rust-lang/cargo/issues/6714 while
a better solution is not found.