### PR TITLE
Flip 'foo' and 'bar' to be consistent

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -429,11 +429,11 @@ Note that if you have an optional dependency like:
 
 ```toml
 [dependencies]
-foo = { version = "0.1", package = 'bar', optional = true }
+bar = { version = "0.1", package = 'foo', optional = true }
 ```
 
-you're depending on the crate `bar` from crates.io, but your crate has a `foo`
-feature instead of a `bar` feature. That is, names of features take after the
+you're depending on the crate `foo` from crates.io, but your crate has a `bar`
+feature instead of a `foo` feature. That is, names of features take after the
 name of the dependency, not the package name, when renamed.
 
 Enabling transitive dependencies works similarly, for example we could add the
@@ -441,7 +441,7 @@ following to the above manifest:
 
 ```toml
 [features]
-log-debug = ['foo/log-debug'] # using 'bar/log-debug' would be an error!
+log-debug = ['bar/log-debug'] # using 'foo/log-debug' would be an error!
 ```
 
 [crates.io]: https://crates.io/


### PR DESCRIPTION
The "Renaming dependencies" section initially uses 'foo' as the crate name and 'bar' as a rename, but then swaps them and uses 'bar' as the example crate name in the context of optional dependencies. Now both examples in this section treat 'foo' as the original crate name.