### PR TITLE
Document -Z extra-link-arg.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -36,6 +36,7 @@ pub fn main(config: &mut Config) -> CliResult {
 Available unstable (nightly-only) flags:
 
     -Z avoid-dev-deps      -- Avoid installing dev-dependencies if possible
+    -Z extra-link-arg      -- Allow `cargo:rustc-link-arg` in build scripts
     -Z minimal-versions    -- Install minimal dependency versions instead of maximum
     -Z no-index-update     -- Do not update the registry, avoids a network request for benchmarking
     -Z unstable-options    -- Allow the usage of unstable options


### PR DESCRIPTION
Whilst reading the cargo source code, I encountered `-Z extra-link-arg`. I'd missed this flag before because it is not documented in `-Z help`.

This commit adds the one-liner documentation.

([This argument **is** mentioned in the unstable cargo book](https://doc.rust-lang.org/beta/cargo/reference/unstable.html#extra-link-arg))