### PR TITLE
Add RegistryBuilder for tests, and update crates-io error handling.

### DIFF
--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -8,6 +8,7 @@ use std::fs;
 
 #[cargo_test]
 fn depend_on_alt_registry() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -57,6 +58,7 @@ fn depend_on_alt_registry() {
 
 #[cargo_test]
 fn depend_on_alt_registry_depends_on_same_registry_no_index() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -99,6 +101,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
 
 #[cargo_test]
 fn depend_on_alt_registry_depends_on_same_registry() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -141,6 +144,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
 
 #[cargo_test]
 fn depend_on_alt_registry_depends_on_crates_io() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -185,7 +189,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
 
 #[cargo_test]
 fn registry_and_path_dep_works() {
-    registry::init();
+    registry::alt_init();
 
     let p = project()
         .file(
@@ -219,7 +223,7 @@ fn registry_and_path_dep_works() {
 
 #[cargo_test]
 fn registry_incompatible_with_git() {
-    registry::init();
+    registry::alt_init();
 
     let p = project()
         .file(
@@ -249,6 +253,7 @@ fn registry_incompatible_with_git() {
 
 #[cargo_test]
 fn cannot_publish_to_crates_io_with_registry_dependency() {
+    registry::alt_init();
     let fakeio_path = paths::root().join("fake.io");
     let fakeio_url = fakeio_path.into_url().unwrap();
     let p = project()
@@ -307,6 +312,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
 
 #[cargo_test]
 fn publish_with_registry_dependency() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -370,6 +376,7 @@ fn publish_with_registry_dependency() {
 
 #[cargo_test]
 fn alt_registry_and_crates_io_deps() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -415,7 +422,7 @@ fn alt_registry_and_crates_io_deps() {
 
 #[cargo_test]
 fn block_publish_due_to_no_token() {
-    registry::init();
+    registry::alt_init();
     let p = project().file("src/lib.rs", "").build();
 
     fs::remove_file(paths::home().join(".cargo/credentials")).unwrap();
@@ -432,6 +439,7 @@ fn block_publish_due_to_no_token() {
 
 #[cargo_test]
 fn publish_to_alt_registry() {
+    registry::alt_init();
     let p = project().file("src/main.rs", "fn main() {}").build();
 
     // Setup the registry by publishing a package
@@ -472,6 +480,7 @@ fn publish_to_alt_registry() {
 
 #[cargo_test]
 fn publish_with_crates_io_dep() {
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -537,7 +546,7 @@ fn publish_with_crates_io_dep() {
 
 #[cargo_test]
 fn passwords_in_registries_index_url_forbidden() {
-    registry::init();
+    registry::alt_init();
 
     let config = paths::home().join(".cargo/config");
 
@@ -567,6 +576,7 @@ Caused by:
 
 #[cargo_test]
 fn patch_alt_reg() {
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     let p = project()
         .file(
@@ -656,6 +666,7 @@ Caused by:
 
 #[cargo_test]
 fn no_api() {
+    registry::alt_init();
     Package::new("bar", "0.0.1").alternative(true).publish();
     // Configure without `api`.
     let repo = git2::Repository::open(registry::alt_registry_path()).unwrap();
@@ -739,6 +750,7 @@ fn no_api() {
 #[cargo_test]
 fn alt_reg_metadata() {
     // Check for "registry" entries in `cargo metadata` with alternative registries.
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -1033,6 +1045,7 @@ fn alt_reg_metadata() {
 fn unknown_registry() {
     // A known registry refers to an unknown registry.
     // foo -> bar(crates.io) -> baz(alt)
+    registry::alt_init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -1188,6 +1201,7 @@ fn unknown_registry() {
 
 #[cargo_test]
 fn registries_index_relative_url() {
+    registry::alt_init();
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(
@@ -1237,6 +1251,7 @@ fn registries_index_relative_url() {
 
 #[cargo_test]
 fn registries_index_relative_path_not_allowed() {
+    registry::alt_init();
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use cargo_test_support::install::{cargo_home, exe};
 use cargo_test_support::paths::CargoPathExt;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, cross_compile, execs, git, process, project, Execs,
 };
@@ -549,6 +549,7 @@ fn upgrade_git() {
 fn switch_sources() {
     // Installing what appears to be the same thing, but from different
     // sources should reinstall.
+    registry::alt_init();
     pkg("foo", "1.0.0");
     Package::new("foo", "1.0.0")
         .file("src/main.rs", r#"fn main() { println!("alt"); }"#)

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -145,7 +145,7 @@ fn new_credentials_is_used_instead_old() {
 
 #[cargo_test]
 fn registry_credentials() {
-    registry::init();
+    registry::alt_init();
 
     let config = paths::home().join(".cargo/config");
     let mut f = OpenOptions::new().append(true).open(config).unwrap();

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -78,5 +78,6 @@ fn default_registry() {
 
 #[cargo_test]
 fn other_registry() {
+    registry::alt_init();
     simple_logout_test(Some("alternative"), "--registry alternative");
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -818,6 +818,7 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
 
 #[cargo_test]
 fn generated_manifest() {
+    registry::alt_init();
     Package::new("abc", "1.0.0").publish();
     Package::new("def", "1.0.0").alternative(true).publish();
     Package::new("ghi", "1.0.0").publish();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2,7 +2,7 @@
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project};
 use std::fs;
 
@@ -1543,6 +1543,7 @@ fn update_unused_new_version() {
 #[cargo_test]
 fn too_many_matches() {
     // The patch locations has multiple versions that match.
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.0").alternative(true).publish();
     Package::new("bar", "0.1.1").alternative(true).publish();
@@ -1866,6 +1867,7 @@ fn patched_dep_new_version() {
 fn patch_update_doesnt_update_other_sources() {
     // Very extreme edge case, make sure a patch update doesn't update other
     // sources.
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.0").alternative(true).publish();
 
@@ -1931,6 +1933,7 @@ fn patch_update_doesnt_update_other_sources() {
 #[cargo_test]
 fn can_update_with_alt_reg() {
     // A patch to an alt reg can update.
+    registry::alt_init();
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.1.0").alternative(true).publish();
     Package::new("bar", "0.1.1").alternative(true).publish();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1457,3 +1457,172 @@ Caused by:
         ))
         .run();
 }
+
+#[cargo_test]
+fn api_error_json() {
+    // Registry returns an API error.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| {
+        (403, &r#"{"errors": [{"detail": "you must be logged in"}]}"#)
+    });
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] api errors (status 403 Forbidden): you must be logged in
+",
+        )
+        .run();
+
+    t.join().unwrap();
+}
+
+#[cargo_test]
+fn api_error_code() {
+    // Registry returns an error code without a JSON message.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| (400, &"go away"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] failed to get a 200 OK response, got 400
+headers:
+<tab>HTTP/1.1 400
+<tab>Content-Length: 7
+<tab>
+body:
+go away
+",
+        )
+        .run();
+
+    t.join().unwrap();
+}
+
+#[cargo_test]
+fn api_curl_error() {
+    // Registry has a network error.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| panic!("broke!"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    // This doesn't check for the exact text of the error in the remote
+    // possibility that cargo is linked with a weird version of libcurl, or
+    // curl changes the text of the message. Currently the message 52
+    // (CURLE_GOT_NOTHING) is:
+    //    Server returned nothing (no headers, no data) (Empty reply from server)
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] [52] [..]
+",
+        )
+        .run();
+
+    let e = t.join().unwrap_err();
+    assert_eq!(*e.downcast::<&str>().unwrap(), "broke!");
+}
+
+#[cargo_test]
+fn api_other_error() {
+    // Registry returns an invalid response.
+    let t = registry::RegistryBuilder::new().build_api_server(&|_headers| (200, b"\xff"));
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.0.1 [..]
+[UPLOADING] foo v0.0.1 [..]
+[ERROR] invalid response from server
+
+Caused by:
+  response body was not valid utf-8
+",
+        )
+        .run();
+
+    t.join().unwrap();
+}

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -677,7 +677,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
 
 #[cargo_test]
 fn publish_allowed_registry() {
-    registry::init();
+    registry::alt_init();
 
     let p = project().build();
 
@@ -717,7 +717,7 @@ fn publish_allowed_registry() {
 
 #[cargo_test]
 fn publish_implicitly_to_only_allowed_registry() {
-    registry::init();
+    registry::alt_init();
 
     let p = project().build();
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -2,7 +2,7 @@
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project};
 
 #[cargo_test]
@@ -66,6 +66,7 @@ fn rename_with_different_names() {
 
 #[cargo_test]
 fn lots_of_names() {
+    registry::alt_init();
     Package::new("foo", "0.1.0")
         .file("src/lib.rs", "pub fn foo1() {}")
         .publish();

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -1,6 +1,6 @@
 //! Tests for the -Zrustdoc-map feature.
 
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{is_nightly, paths, project, Project};
 
 fn basic_project() -> Project {
@@ -215,6 +215,7 @@ fn alt_registry() {
         // --extern-html-root-url is unstable
         return;
     }
+    registry::alt_init();
     Package::new("bar", "1.0.0")
         .alternative(true)
         .file(

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -7,7 +7,7 @@
 use std::fs;
 
 use cargo_test_support::git;
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_lib_manifest, paths, project, Project};
 
 #[cargo_test]
@@ -594,6 +594,7 @@ fn ignore_hidden() {
 #[cargo_test]
 fn config_instructions_works() {
     // Check that the config instructions work for all dependency kinds.
+    registry::alt_init();
     Package::new("dep", "0.1.0").publish();
     Package::new("altdep", "0.1.0").alternative(true).publish();
     let git_project = git::new("gitdep", |project| {


### PR DESCRIPTION
This adds `RegistryBuilder` to the test suite to make it more flexible to create different registry setups, and to reuse code a little more easily.

This also makes a small adjustment to the registry API to add a `ResponseError` type to make it easier to work with API errors.  As part of this, some tests were added to validate the API behavior for response errors.  There are only a few very small changes here:
* Extra newlines are removed from the headers printed in the error message.
* The UTF-8 error now also includes the text "invalid response from server".
* The "file too large" crates.io publish error now displays the tarball size.  (There is no test for this because it is only issued for talking to `crates.io`.)

Split from #9111.
