### PR TITLE
Backport #9102 to the 1.49 release branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo"
-version = "0.50.0"
+version = "0.50.1"
 edition = "2018"
 authors = ["Yehuda Katz <wycats@gmail.com>",
            "Carl Lerche <me@carllerche.com>",

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -527,7 +527,7 @@ impl<'de, 'config> de::MapAccess<'de> for ValueDeserializer<'config> {
                 seed.deserialize(Tuple2Deserializer(0i32, path.to_string_lossy()))
             }
             Definition::Environment(env) => {
-                seed.deserialize(Tuple2Deserializer(1i32, env.as_ref()))
+                seed.deserialize(Tuple2Deserializer(1i32, env.as_str()))
             }
             Definition::Cli => seed.deserialize(Tuple2Deserializer(2i32, "")),
         }


### PR DESCRIPTION
#9129 but to the branch that matters, this time with the version bump.

Does this look correct?