### PR TITLE
Fix warnings of the new non_fmt_panic lint

### DIFF
--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -177,7 +177,7 @@ rustup does not appear to be installed. Make sure that the appropriate
         },
     }
 
-    panic!(message);
+    panic!("{}", message);
 }
 
 /// The alternate target-triple to build with.

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -365,5 +365,5 @@ fn closed_output_ok() {
         .unwrap();
     let status = child.wait().unwrap();
     assert!(status.success());
-    assert!(s.is_empty(), s);
+    assert!(s.is_empty(), "{}", s);
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -370,7 +370,11 @@ fn finds_git_author() {
 
     let toml = paths::root().join("foo/Cargo.toml");
     let contents = fs::read_to_string(&toml).unwrap();
-    assert!(contents.contains(r#"authors = ["foo <gitfoo>"]"#), contents);
+    assert!(
+        contents.contains(r#"authors = ["foo <gitfoo>"]"#),
+        "{}",
+        contents
+    );
 }
 
 #[cargo_test]
@@ -411,7 +415,11 @@ fn finds_git_author_in_included_config() {
     cargo_process("new foo/bar").run();
     let toml = paths::root().join("foo/bar/Cargo.toml");
     let contents = fs::read_to_string(&toml).unwrap();
-    assert!(contents.contains(r#"authors = ["foo <bar>"]"#), contents,);
+    assert!(
+        contents.contains(r#"authors = ["foo <bar>"]"#),
+        "{}",
+        contents
+    );
 }
 
 #[cargo_test]
@@ -632,7 +640,7 @@ fn new_with_blank_email() {
         .run();
 
     let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(contents.contains(r#"authors = ["Sen"]"#), contents);
+    assert!(contents.contains(r#"authors = ["Sen"]"#), "{}", contents);
 }
 
 #[cargo_test]


### PR DESCRIPTION
This fixes the CI failure since the latest nightly. See https://github.com/rust-lang/rust/pull/81645