### PR TITLE
Allow `true` and `false` as options for `strip` option

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -552,9 +552,7 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     }
     match toml.lto {
         Some(StringOrBool::Bool(b)) => profile.lto = Lto::Bool(b),
-        Some(StringOrBool::String(ref n)) if matches!(n.as_str(), "off" | "n" | "no") => {
-            profile.lto = Lto::Off
-        }
+        Some(StringOrBool::String(ref n)) if is_off(n.as_str()) => profile.lto = Lto::Off,
         Some(StringOrBool::String(ref n)) => profile.lto = Lto::Named(InternedString::new(n)),
         None => {}
     }
@@ -591,19 +589,10 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
         profile.incremental = incremental;
     }
     profile.strip = match toml.strip {
-        Some(StringOrBool::Bool(enabled)) if enabled => Strip::Symbols,
-        Some(StringOrBool::Bool(enabled)) if !enabled => Strip::None,
-        Some(StringOrBool::String(ref n)) if matches!(n.as_str(), "off" | "n" | "no" | "none") => {
-            Strip::None
-        }
-        Some(StringOrBool::String(ref n)) if matches!(n.as_str(), "debuginfo") => Strip::DebugInfo,
-        Some(StringOrBool::String(ref n)) if matches!(n.as_str(), "symbols") => Strip::Symbols,
-        None => Strip::None,
-        Some(ref strip) => panic!(
-            "unknown variant `{}`, expected one of `debuginfo`, `none`, `symbols` for key `strip`
-            ",
-            strip
-        ),
+        Some(StringOrBool::Bool(true)) => Strip::Named(InternedString::new("symbols")),
+        None | Some(StringOrBool::Bool(false)) => Strip::None,
+        Some(StringOrBool::String(ref n)) if is_off(n.as_str()) => Strip::None,
+        Some(StringOrBool::String(ref n)) => Strip::Named(InternedString::new(n)),
     };
 }
 
@@ -821,24 +810,22 @@ impl fmt::Display for PanicStrategy {
 )]
 #[serde(rename_all = "lowercase")]
 pub enum Strip {
-    /// Only strip debugging symbols
-    DebugInfo,
     /// Don't remove any symbols
     None,
-    /// Strip all non-exported symbols from the final binary
-    Symbols,
+    /// Named Strip settings
+    Named(InternedString),
 }
 
 impl fmt::Display for Strip {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            Strip::DebugInfo => "debuginfo",
             Strip::None => "none",
-            Strip::Symbols => "symbols",
+            Strip::Named(s) => s.as_str(),
         }
         .fmt(f)
     }
 }
+
 /// Flags used in creating `Unit`s to indicate the purpose for the target, and
 /// to ensure the target's dependencies have the correct settings.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
@@ -1260,4 +1247,9 @@ fn validate_packages_unmatched(
         }
     }
     Ok(())
+}
+
+/// Returns `true` if a string is a toggle that turns an option off.
+fn is_off(s: &str) -> bool {
+    matches!(s, "off" | "n" | "no" | "none")
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -560,18 +560,6 @@ impl TomlProfile {
 
         if self.strip.is_some() {
             features.require(Feature::strip())?;
-            match self.strip {
-                Some(StringOrBool::Bool(_)) => {}
-                Some(StringOrBool::String(ref n)) => match n.as_str() {
-                    "off" | "n" | "none" | "no" | "debuginfo" | "symbols" => {}
-                    _ => bail!(
-                        "`strip` setting of `{}` is not a valid setting,\
-                         must be `symbols`, `debuginfo`, `none`, `true`, or `false`",
-                        n
-                    ),
-                },
-                None => {}
-            }
         }
         Ok(())
     }
@@ -777,15 +765,6 @@ impl<'de> de::Deserialize<'de> for StringOrBool {
         }
 
         deserializer.deserialize_any(Visitor)
-    }
-}
-
-impl fmt::Display for StringOrBool {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::String(s) => write!(f, "{}", &s),
-            Self::Bool(b) => write!(f, "{}", b),
-        }
     }
 }
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -765,8 +765,11 @@ cargo-features = ["strip"]
 strip = "debuginfo"
 ```
 
-Other possible values of `strip` are `none` and `symbols`. The default is
-`none`.
+Other possible string values of `strip` are `none`, `symbols`, and `off`. The default is `none`.
+
+You can also configure this option with the two absolute boolean values
+`true` and `false`. The former enables `strip` at its higher level, `symbols`,
+whilst the later disables `strip` completely.
 
 ### rustdoc-map
 * Tracking Issue: [#8296](https://github.com/rust-lang/cargo/issues/8296)

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1459,26 +1459,3 @@ strip = 'debuginfo'
     let strip = p.strip.unwrap();
     assert_eq!(strip, toml::StringOrBool::String("debuginfo".to_string()));
 }
-
-#[cargo_test]
-fn parse_strip_with_unknown_string_fail() {
-    write_config(
-        "\
-[profile.release]
-strip = 'invalid'
-",
-    );
-
-    let config = new_config();
-
-    assert_error(
-        config
-            .get::<toml::TomlProfile>("profile.release")
-            .unwrap_err(),
-        "\
-error in [..]/.cargo/config: could not load config key `profile.release.strip`
-
-Caused by:
-  `strip` setting of `wrong` is not a valid setting,must be `symbols`, `debuginfo`, `none`, `true`, or `false`",
-    );
-}

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,6 +1,5 @@
 //! Tests for config settings.
 
-use cargo::core::profiles::Strip;
 use cargo::core::{enable_nightly_features, Shell};
 use cargo::util::config::{self, Config, SslVersionConfig, StringList};
 use cargo::util::interning::InternedString;
@@ -1446,7 +1445,7 @@ fn string_list_advanced_env() {
 }
 
 #[cargo_test]
-fn parse_enum() {
+fn parse_strip_with_string() {
     write_config(
         "\
 [profile.release]
@@ -1458,11 +1457,11 @@ strip = 'debuginfo'
 
     let p: toml::TomlProfile = config.get("profile.release").unwrap();
     let strip = p.strip.unwrap();
-    assert_eq!(strip, Strip::DebugInfo);
+    assert_eq!(strip, toml::StringOrBool::String("debuginfo".to_string()));
 }
 
 #[cargo_test]
-fn parse_enum_fail() {
+fn parse_strip_with_unknown_string_fail() {
     write_config(
         "\
 [profile.release]
@@ -1480,6 +1479,6 @@ strip = 'invalid'
 error in [..]/.cargo/config: could not load config key `profile.release.strip`
 
 Caused by:
-  unknown variant `invalid`, expected one of `debuginfo`, `none`, `symbols`",
+  `strip` setting of `wrong` is not a valid setting,must be `symbols`, `debuginfo`, `none`, `true`, or `false`",
     );
 }

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -546,7 +546,7 @@ Caused by:
 }
 
 #[cargo_test]
-fn strip_rejects_invalid_option() {
+fn strip_passes_unknown_option_to_rustc() {
     if !is_nightly() {
         // -Zstrip is unstable
         return;
@@ -563,7 +563,7 @@ fn strip_rejects_invalid_option() {
                 version = "0.1.0"
 
                 [profile.release]
-                strip = 'wrong'
+                strip = 'unknown'
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -574,10 +574,9 @@ fn strip_rejects_invalid_option() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  unknown variant `wrong`, expected one of `debuginfo`, `none`, `symbols` for key `strip`
+[COMPILING] foo [..]
+[RUNNING] `rustc [..] -Z strip=unknown [..]`
+[FINISHED] [..]
 ",
         )
         .run();
@@ -644,13 +643,6 @@ fn strip_accepts_false_to_disable_strip() {
 
     p.cargo("build --release -v")
         .masquerade_as_nightly_cargo()
-        .with_stderr(
-            "\
-[COMPILING] foo [..]
-[RUNNING] `rustc [..] -Z strip=none
- [..]`
-[FINISHED] [..]
-",
-        )
+        .with_stderr_does_not_contain("-Z strip")
         .run();
 }

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -572,11 +572,11 @@ fn strip_passes_unknown_option_to_rustc() {
     p.cargo("build --release -v")
         .masquerade_as_nightly_cargo()
         .with_status(101)
-        .with_stderr(
+        .with_stderr_contains(
             "\
 [COMPILING] foo [..]
 [RUNNING] `rustc [..] -Z strip=unknown [..]`
-[FINISHED] [..]
+error: incorrect value `unknown` for debugging option `strip` - either `none`, `debuginfo`, or `symbols` was expected
 ",
         )
         .run();


### PR DESCRIPTION
This follows the convention of `lto` and `debug` that allow `true` for
the highest level, and `false` for disabled.

Signed-off-by: David Calavera <david.calavera@gmail.com>