### PR TITLE
Add schema field and `features2` to the index.

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -56,6 +56,8 @@ pub struct NewCrate {
     pub repository: Option<String>,
     pub badges: BTreeMap<String, BTreeMap<String, String>>,
     pub links: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub v: Option<u32>,
 }
 
 #[derive(Serialize)]

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -37,6 +37,9 @@ impl Summary {
         features: &BTreeMap<InternedString, Vec<InternedString>>,
         links: Option<impl Into<InternedString>>,
     ) -> CargoResult<Summary> {
+        // ****CAUTION**** If you change anything here than may raise a new
+        // error, be sure to coordinate that change with either the index
+        // schema field or the SummariesCache version.
         let mut has_overlapping_features = None;
         for dep in dependencies.iter() {
             let dep_name = dep.name_in_toml();

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -305,6 +305,7 @@ fn transmit(
             license_file: license_file.clone(),
             badges: badges.clone(),
             links: links.clone(),
+            v: None,
         },
         tarball,
     );

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -708,9 +708,9 @@ impl<'a> SummariesCache<'a> {
             .get(..4)
             .ok_or_else(|| anyhow::anyhow!("cache expected 4 bytes for index version"))?;
         let index_v = u32::from_le_bytes(index_v_bytes.try_into().unwrap());
-        if index_v > INDEX_V_MAX {
+        if index_v != INDEX_V_MAX {
             bail!(
-                "index format version {} is greater than the newest version I know ({})",
+                "index format version {} doesn't match the version I know ({})",
                 index_v,
                 INDEX_V_MAX
             );

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -258,6 +258,13 @@ pub struct RegistryPackage<'a> {
     #[serde(borrow)]
     deps: Vec<RegistryDependency<'a>>,
     features: BTreeMap<InternedString, Vec<InternedString>>,
+    /// This field contains features with new, extended syntax. Specifically,
+    /// namespaced features (`dep:`) and weak dependencies (`pkg?/feat`).
+    ///
+    /// This is separated from `features` because versions older than 1.19
+    /// will fail to load due to not being able to parse the new syntax, even
+    /// with a `Cargo.lock` file.
+    features2: Option<BTreeMap<InternedString, Vec<InternedString>>>,
     cksum: String,
     /// If `true`, Cargo will skip this version when resolving.
     ///
@@ -274,10 +281,12 @@ pub struct RegistryPackage<'a> {
     /// If this is None, it defaults to version 1. Entries with unknown
     /// versions are ignored.
     ///
+    /// Version `2` format adds the `features2` field.
+    ///
     /// This provides a method to safely introduce changes to index entries
     /// and allow older versions of cargo to ignore newer entries it doesn't
     /// understand. This is honored as of 1.51, so unfortunately older
-    /// versions will ignore it, and potentially misinterpret version 1 and
+    /// versions will ignore it, and potentially misinterpret version 2 and
     /// newer entries.
     ///
     /// The intent is that versions older than 1.51 will work with a

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -269,6 +269,24 @@ pub struct RegistryPackage<'a> {
     /// Added early 2018 (see <https://github.com/rust-lang/cargo/pull/4978>),
     /// can be `None` if published before then.
     links: Option<InternedString>,
+    /// The schema version for this entry.
+    ///
+    /// If this is None, it defaults to version 1. Entries with unknown
+    /// versions are ignored.
+    ///
+    /// This provides a method to safely introduce changes to index entries
+    /// and allow older versions of cargo to ignore newer entries it doesn't
+    /// understand. This is honored as of 1.51, so unfortunately older
+    /// versions will ignore it, and potentially misinterpret version 1 and
+    /// newer entries.
+    ///
+    /// The intent is that versions older than 1.51 will work with a
+    /// pre-existing `Cargo.lock`, but they may not correctly process `cargo
+    /// update` or build a lock from scratch. In that case, cargo may
+    /// incorrectly select a new package that uses a new index format. A
+    /// workaround is to downgrade any packages that are incompatible with the
+    /// `--precise` flag of `cargo update`.
+    v: Option<u32>,
 }
 
 #[test]

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -250,6 +250,10 @@ pub struct RegistryConfig {
     pub api: Option<String>,
 }
 
+/// The maximum version of the `v` field in the index this version of cargo
+/// understands.
+pub(crate) const INDEX_V_MAX: u32 = 2;
+
 /// A single line in the index representing a single version of a package.
 #[derive(Deserialize)]
 pub struct RegistryPackage<'a> {

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -1106,3 +1106,105 @@ feat = ["opt-dep1"]
         )],
     );
 }
+
+#[cargo_test]
+fn publish() {
+    // Publish behavior with explicit dep: syntax.
+    Package::new("bar", "1.0.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                description = "foo"
+                license = "MIT"
+                homepage = "https://example.com/"
+
+                [dependencies]
+                bar = { version = "1.0", optional = true }
+
+                [features]
+                feat1 = []
+                feat2 = ["dep:bar"]
+                feat3 = ["feat2"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --token sekrit -Z namespaced-features")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[PACKAGING] foo v0.1.0 [..]
+[VERIFYING] foo v0.1.0 [..]
+[COMPILING] foo v0.1.0 [..]
+[FINISHED] [..]
+[UPLOADING] foo v0.1.0 [..]
+",
+        )
+        .run();
+
+    publish::validate_upload_with_contents(
+        r#"
+        {
+          "authors": [],
+          "badges": {},
+          "categories": [],
+          "deps": [
+            {
+              "default_features": true,
+              "features": [],
+              "kind": "normal",
+              "name": "bar",
+              "optional": true,
+              "registry": "https://github.com/rust-lang/crates.io-index",
+              "target": null,
+              "version_req": "^1.0"
+            }
+          ],
+          "description": "foo",
+          "documentation": null,
+          "features": {
+            "feat1": [],
+            "feat2": ["dep:bar"],
+            "feat3": ["feat2"]
+          },
+          "homepage": "https://example.com/",
+          "keywords": [],
+          "license": "MIT",
+          "license_file": null,
+          "links": null,
+          "name": "foo",
+          "readme": null,
+          "readme_file": null,
+          "repository": null,
+          "vers": "0.1.0"
+          }
+        "#,
+        "foo-0.1.0.crate",
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &[(
+            "Cargo.toml",
+            r#"[..]
+[package]
+name = "foo"
+version = "0.1.0"
+description = "foo"
+homepage = "https://example.com/"
+license = "MIT"
+[dependencies.bar]
+version = "1.0"
+optional = true
+
+[features]
+feat1 = []
+feat2 = ["dep:bar"]
+feat3 = ["feat2"]
+"#,
+        )],
+    );
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -78,6 +78,7 @@ mod multitarget;
 mod net_config;
 mod new;
 mod offline;
+mod old_cargos;
 mod out_dir;
 mod owner;
 mod package;

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -1,0 +1,501 @@
+//! Tests for checking behavior of old cargos.
+//!
+//! These tests are ignored because it is intended to be run on a developer
+//! system with a bunch of toolchains installed. This requires `rustup` to be
+//! installed. It will iterate over installed toolchains, and run some tests
+//! over each one, producing a report at the end. As of this writing, I have
+//! tested 1.0 to 1.51. Run this with:
+//!
+//! ```console
+//! cargo test --test testsuite -- old_cargos --nocapture --ignored
+//! ```
+
+use cargo::util::{ProcessBuilder, ProcessError};
+use cargo::CargoResult;
+use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::registry::{self, Dependency, Package};
+use cargo_test_support::{cargo_exe, paths, process, project, rustc_host};
+use semver::Version;
+use std::fs;
+
+fn tc_process(cmd: &str, toolchain: &str) -> ProcessBuilder {
+    if toolchain == "this" {
+        if cmd == "cargo" {
+            process(&cargo_exe())
+        } else {
+            process(cmd)
+        }
+    } else {
+        let mut cmd = process(cmd);
+        cmd.arg(format!("+{}", toolchain));
+        cmd
+    }
+}
+
+/// Returns a sorted list of all toolchains.
+///
+/// The returned value includes the parsed version, and the rustup toolchain
+/// name as a string.
+fn collect_all_toolchains() -> Vec<(Version, String)> {
+    let rustc_version = |tc| {
+        let mut cmd = tc_process("rustc", tc);
+        cmd.arg("-V");
+        let output = cmd.exec_with_output().expect("rustc installed");
+        let version = std::str::from_utf8(&output.stdout).unwrap();
+        let parts: Vec<_> = version.split_whitespace().collect();
+        assert_eq!(parts[0], "rustc");
+        assert!(parts[1].starts_with("1."));
+        Version::parse(parts[1]).expect("valid version")
+    };
+
+    // Provide a way to override the list.
+    if let Ok(tcs) = std::env::var("OLD_CARGO") {
+        return tcs
+            .split(',')
+            .map(|tc| (rustc_version(tc), tc.to_string()))
+            .collect();
+    }
+
+    let host = rustc_host();
+    // I tend to have lots of toolchains installed, but I don't want to test
+    // all of them (like dated nightlies, or toolchains for non-host targets).
+    let valid_names = &[
+        format!("stable-{}", host),
+        format!("beta-{}", host),
+        format!("nightly-{}", host),
+    ];
+
+    let output = cargo::util::process("rustup")
+        .args(&["toolchain", "list"])
+        .exec_with_output()
+        .expect("rustup should be installed");
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let mut toolchains: Vec<_> = stdout
+        .lines()
+        .map(|line| {
+            // Some lines say things like (default), just get the version.
+            line.split_whitespace().next().expect("non-empty line")
+        })
+        .filter(|line| {
+            line.ends_with(&host)
+                && (line.starts_with("1.") || valid_names.iter().any(|name| name == line))
+        })
+        .map(|line| (rustc_version(line), line.to_string()))
+        .collect();
+
+    // Also include *this* cargo.
+    toolchains.push((rustc_version("this"), "this".to_string()));
+    toolchains.sort_by(|a, b| a.0.cmp(&b.0));
+    toolchains
+}
+
+// This is a test for exercising the behavior of older versions of cargo with
+// the new feature syntax.
+//
+// The test involves a few dependencies with different feature requirements:
+//
+// * `bar` 1.0.0 is the base version that does not use the new syntax.
+// * `bar` 1.0.1 has a feature with the new syntax, but the feature is unused.
+//   The optional dependency `new-baz-dep` should not be activated.
+// * `bar` 1.0.2 has a dependency on `baz` that *requires* the new feature
+//   syntax.
+#[ignore]
+#[cargo_test]
+fn new_features() {
+    if std::process::Command::new("rustup").output().is_err() {
+        panic!("old_cargos requires rustup to be installed");
+    }
+    Package::new("new-baz-dep", "1.0.0").publish();
+
+    Package::new("baz", "1.0.0").publish();
+    let baz101_cksum = Package::new("baz", "1.0.1")
+        .add_dep(Dependency::new("new-baz-dep", "1.0").optional(true))
+        .feature("new-feat", &["dep:new-baz-dep"])
+        .publish();
+
+    let bar100_cksum = Package::new("bar", "1.0.0")
+        .add_dep(Dependency::new("baz", "1.0").optional(true))
+        .feature("feat", &["baz"])
+        .publish();
+    let bar101_cksum = Package::new("bar", "1.0.1")
+        .add_dep(Dependency::new("baz", "1.0").optional(true))
+        .feature("feat", &["dep:baz"])
+        .publish();
+    let bar102_cksum = Package::new("bar", "1.0.2")
+        .add_dep(Dependency::new("baz", "1.0").enable_features(&["new-feat"]))
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    let lock_bar_to = |toolchain_version: &Version, bar_version| {
+        let lock = if toolchain_version < &Version::new(1, 12, 0) {
+            let url = registry::registry_url();
+            match bar_version {
+                100 => format!(
+                    r#"
+                        [root]
+                        name = "foo"
+                        version = "0.1.0"
+                        dependencies = [
+                         "bar 1.0.0 (registry+{url})",
+                        ]
+
+                        [[package]]
+                        name = "bar"
+                        version = "1.0.0"
+                        source = "registry+{url}"
+                    "#,
+                    url = url
+                ),
+                101 => format!(
+                    r#"
+                        [root]
+                        name = "foo"
+                        version = "0.1.0"
+                        dependencies = [
+                         "bar 1.0.1 (registry+{url})",
+                        ]
+
+                        [[package]]
+                        name = "bar"
+                        version = "1.0.1"
+                        source = "registry+{url}"
+                    "#,
+                    url = url
+                ),
+                102 => format!(
+                    r#"
+                        [root]
+                        name = "foo"
+                        version = "0.1.0"
+                        dependencies = [
+                         "bar 1.0.2 (registry+{url})",
+                        ]
+
+                        [[package]]
+                        name = "bar"
+                        version = "1.0.2"
+                        source = "registry+{url}"
+                        dependencies = [
+                         "baz 1.0.1 (registry+{url})",
+                        ]
+
+                        [[package]]
+                        name = "baz"
+                        version = "1.0.1"
+                        source = "registry+{url}"
+                    "#,
+                    url = url
+                ),
+                _ => panic!("unexpected version"),
+            }
+        } else {
+            match bar_version {
+                100 => format!(
+                    r#"
+                        [root]
+                        name = "foo"
+                        version = "0.1.0"
+                        dependencies = [
+                         "bar 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+                        ]
+
+                        [[package]]
+                        name = "bar"
+                        version = "1.0.0"
+                        source = "registry+https://github.com/rust-lang/crates.io-index"
+
+                        [metadata]
+                        "checksum bar 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "{}"
+                    "#,
+                    bar100_cksum
+                ),
+                101 => format!(
+                    r#"
+                        [root]
+                        name = "foo"
+                        version = "0.1.0"
+                        dependencies = [
+                         "bar 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        ]
+
+                        [[package]]
+                        name = "bar"
+                        version = "1.0.1"
+                        source = "registry+https://github.com/rust-lang/crates.io-index"
+
+                        [metadata]
+                        "checksum bar 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "{}"
+                    "#,
+                    bar101_cksum
+                ),
+                102 => format!(
+                    r#"
+                        [root]
+                        name = "foo"
+                        version = "0.1.0"
+                        dependencies = [
+                         "bar 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+                        ]
+
+                        [[package]]
+                        name = "bar"
+                        version = "1.0.2"
+                        source = "registry+https://github.com/rust-lang/crates.io-index"
+                        dependencies = [
+                         "baz 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        ]
+
+                        [[package]]
+                        name = "baz"
+                        version = "1.0.1"
+                        source = "registry+https://github.com/rust-lang/crates.io-index"
+
+                        [metadata]
+                        "checksum bar 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "{bar102_cksum}"
+                        "checksum baz 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "{baz101_cksum}"
+                    "#,
+                    bar102_cksum = bar102_cksum,
+                    baz101_cksum = baz101_cksum
+                ),
+                _ => panic!("unexpected version"),
+            }
+        };
+        p.change_file("Cargo.lock", &lock);
+    };
+
+    let toolchains = collect_all_toolchains();
+
+    let config_path = paths::home().join(".cargo/config");
+    let lock_path = p.root().join("Cargo.lock");
+
+    struct ToolchainBehavior {
+        bar: Option<Version>,
+        baz: Option<Version>,
+        new_baz_dep: Option<Version>,
+    }
+
+    // Collect errors to print at the end. One entry per toolchain, a list of
+    // strings to print.
+    let mut unexpected_results: Vec<Vec<String>> = Vec::new();
+
+    for (version, toolchain) in &toolchains {
+        let mut tc_result = Vec::new();
+        // Write a config appropriate for this version.
+        if version < &Version::new(1, 12, 0) {
+            fs::write(
+                &config_path,
+                format!(
+                    r#"
+                        [registry]
+                        index = "{}"
+                    "#,
+                    registry::registry_url()
+                ),
+            )
+            .unwrap();
+        } else {
+            fs::write(
+                &config_path,
+                format!(
+                    "
+                        [source.crates-io]
+                        registry = 'https://wut'  # only needed by 1.12
+                        replace-with = 'dummy-registry'
+
+                        [source.dummy-registry]
+                        registry = '{}'
+                    ",
+                    registry::registry_url()
+                ),
+            )
+            .unwrap();
+        }
+
+        // Fetches the version of a package in the lock file.
+        let pkg_version = |pkg| -> Option<Version> {
+            let output = tc_process("cargo", toolchain)
+                .args(&["pkgid", pkg])
+                .cwd(p.root())
+                .exec_with_output()
+                .ok()?;
+            let stdout = std::str::from_utf8(&output.stdout).unwrap();
+            let version = stdout
+                .trim()
+                .rsplitn(2, ':')
+                .next()
+                .expect("version after colon");
+            Some(Version::parse(version).expect("parseable version"))
+        };
+
+        // Runs `cargo build` and returns the versions selected in the lock.
+        let run_cargo = || -> CargoResult<ToolchainBehavior> {
+            match tc_process("cargo", toolchain)
+                .args(&["build", "--verbose"])
+                .cwd(p.root())
+                .exec_with_output()
+            {
+                Ok(_output) => {
+                    eprintln!("{} ok", toolchain);
+                    let bar = pkg_version("bar");
+                    let baz = pkg_version("baz");
+                    let new_baz_dep = pkg_version("new-baz-dep");
+                    Ok(ToolchainBehavior {
+                        bar,
+                        baz,
+                        new_baz_dep,
+                    })
+                }
+                Err(e) => {
+                    eprintln!("{} err {}", toolchain, e);
+                    Err(e)
+                }
+            }
+        };
+
+        macro_rules! check_lock {
+            ($tc_result:ident, $pkg:expr, $which:expr, $actual:expr, None) => {
+                check_lock!(= $tc_result, $pkg, $which, $actual, None);
+            };
+            ($tc_result:ident, $pkg:expr, $which:expr, $actual:expr, $expected:expr) => {
+                check_lock!(= $tc_result, $pkg, $which, $actual, Some(Version::parse($expected).unwrap()));
+            };
+            (= $tc_result:ident, $pkg:expr, $which:expr, $actual:expr, $expected:expr) => {
+                let exp: Option<Version> = $expected;
+                if $actual != $expected {
+                    $tc_result.push(format!(
+                        "{} for {} saw {:?} but expected {:?}",
+                        $which, $pkg, $actual, exp
+                    ));
+                }
+            };
+        }
+
+        let check_err_contains = |tc_result: &mut Vec<_>, err: anyhow::Error, contents| {
+            if let Some(ProcessError {
+                stderr: Some(stderr),
+                ..
+            }) = err.downcast_ref::<ProcessError>()
+            {
+                let stderr = std::str::from_utf8(&stderr).unwrap();
+                if !stderr.contains(contents) {
+                    tc_result.push(format!(
+                        "{} expected to see error contents:\n{}\nbut saw:\n{}",
+                        toolchain, contents, stderr
+                    ));
+                }
+            } else {
+                panic!("{} unexpected error {}", toolchain, err);
+            }
+        };
+
+        // Unlocked behavior.
+        let which = "unlocked";
+        lock_path.rm_rf();
+        p.build_dir().rm_rf();
+        match run_cargo() {
+            Ok(behavior) => {
+                // TODO: Switch to 51 after backport.
+                if version < &Version::new(1, 52, 0) && toolchain != "this" {
+                    check_lock!(tc_result, "bar", which, behavior.bar, "1.0.2");
+                    check_lock!(tc_result, "baz", which, behavior.baz, "1.0.1");
+                    check_lock!(tc_result, "new-baz-dep", which, behavior.new_baz_dep, None);
+                } else {
+                    check_lock!(tc_result, "bar", which, behavior.bar, "1.0.0");
+                    check_lock!(tc_result, "baz", which, behavior.baz, None);
+                    check_lock!(tc_result, "new-baz-dep", which, behavior.new_baz_dep, None);
+                }
+            }
+            Err(e) => {
+                tc_result.push(format!("unlocked build failed: {}", e));
+            }
+        }
+
+        let which = "locked bar 1.0.0";
+        lock_bar_to(&version, 100);
+        match run_cargo() {
+            Ok(behavior) => {
+                check_lock!(tc_result, "bar", which, behavior.bar, "1.0.0");
+                check_lock!(tc_result, "baz", which, behavior.baz, None);
+                check_lock!(tc_result, "new-baz-dep", which, behavior.new_baz_dep, None);
+            }
+            Err(e) => {
+                tc_result.push(format!("bar 1.0.0 locked build failed: {}", e));
+            }
+        }
+
+        let which = "locked bar 1.0.1";
+        lock_bar_to(&version, 101);
+        match run_cargo() {
+            Ok(behavior) => {
+                check_lock!(tc_result, "bar", which, behavior.bar, "1.0.1");
+                check_lock!(tc_result, "baz", which, behavior.baz, None);
+                check_lock!(tc_result, "new-baz-dep", which, behavior.new_baz_dep, None);
+            }
+            Err(e) => {
+                if toolchain == "this" {
+                    // 1.0.1 can't be used without -Znamespaced-features
+                    // It gets filtered out of the index.
+                    check_err_contains(&mut tc_result, e,
+                        "error: failed to select a version for the requirement `bar = \"=1.0.1\"`\n\
+                        candidate versions found which didn't match: 1.0.2, 1.0.0"
+                    );
+                } else {
+                    tc_result.push(format!("bar 1.0.1 locked build failed: {}", e));
+                }
+            }
+        }
+
+        let which = "locked bar 1.0.2";
+        lock_bar_to(&version, 102);
+        match run_cargo() {
+            Ok(behavior) => {
+                check_lock!(tc_result, "bar", which, behavior.bar, "1.0.2");
+                check_lock!(tc_result, "baz", which, behavior.baz, "1.0.1");
+                check_lock!(tc_result, "new-baz-dep", which, behavior.new_baz_dep, None);
+            }
+            Err(e) => {
+                if toolchain == "this" {
+                    // baz can't lock to 1.0.1, it requires -Znamespaced-features
+                    check_err_contains(&mut tc_result, e,
+                        "error: failed to select a version for the requirement `baz = \"=1.0.1\"`\n\
+                        candidate versions found which didn't match: 1.0.0"
+                    );
+                } else {
+                    tc_result.push(format!("bar 1.0.2 locked build failed: {}", e));
+                }
+            }
+        }
+
+        unexpected_results.push(tc_result);
+    }
+
+    // Generate a report.
+    let mut has_err = false;
+    for ((tc_vers, tc_name), errs) in toolchains.iter().zip(unexpected_results) {
+        if errs.is_empty() {
+            continue;
+        }
+        eprintln!("error: toolchain {} (version {}):", tc_name, tc_vers);
+        for err in errs {
+            eprintln!("  {}", err);
+        }
+        has_err = true;
+    }
+    if has_err {
+        panic!("at least one toolchain did not run as expected");
+    }
+}


### PR DESCRIPTION
This adds a `v` field to the index which indicates a format version for an index entry. If Cargo encounters a version newer than it understands, it will ignore those entries. This makes it safer to make changes to the index entries (such as adding new things), and not need to worry about how older cargos will react to it. In particular, this will make it safer to run `cargo update` on older versions if we ever decide to add new things to the index.

Currently this is not written anywhere, and is intended as a safety guard for the future. For now I will leave it undocumented until we actually decide to start using it.

This also moves the new syntax for namespaced features and weak dependency features into a new field ("features2") in the index. This is necessary to avoid breaking Cargo versions older than 1.19, which fail to parse the index even if there is a Cargo.lock file.

It is intended that only crates.io will bother with creating this field. Other registries don't need to bother, since they generally don't support Cargo older than 1.19.

I'm uncertain exactly when we should try to update crates.io to start accepting this, as that is a somewhat permanent decision.
