### PR TITLE
Prevent testsuite from loading config out of sandbox.

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -78,6 +78,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if let Some(path) = args.value_of_path("path", config) {
         config.reload_rooted_at(path)?;
     } else {
+        // TODO: Consider calling set_search_stop_path(home).
         config.reload_rooted_at(config.home().clone().into_path_unlocked())?;
     }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -461,7 +461,7 @@ impl<'cfg> Workspace<'cfg> {
             }
         }
 
-        for path in paths::ancestors(manifest_path).skip(2) {
+        for path in paths::ancestors(manifest_path, None).skip(2) {
             if path.ends_with("target/package") {
                 break;
             }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -872,7 +872,7 @@ fn find_tests_git_config(path: &Path) -> Option<GitConfig> {
     // Don't escape the test sandbox when looking for a git repository.
     // NOTE: libgit2 has support to define the path ceiling in
     // git_repository_discover, but the git2 bindings do not expose that.
-    for path in paths::ancestors(path) {
+    for path in paths::ancestors(path, None) {
         if let Ok(repo) = GitRepository::open(path) {
             return Some(repo.config().expect("test repo should have valid config"));
         }

--- a/src/cargo/util/important_paths.rs
+++ b/src/cargo/util/important_paths.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 /// Finds the root `Cargo.toml`.
 pub fn find_root_manifest_for_wd(cwd: &Path) -> CargoResult<PathBuf> {
     let file = "Cargo.toml";
-    for current in paths::ancestors(cwd) {
+    for current in paths::ancestors(cwd, None) {
         let manifest = current.join(file);
         if manifest.exists() {
             return Ok(manifest);

--- a/src/cargo/util/paths.rs
+++ b/src/cargo/util/paths.rs
@@ -306,8 +306,8 @@ pub fn bytes2path(bytes: &[u8]) -> CargoResult<PathBuf> {
     }
 }
 
-pub fn ancestors(path: &Path) -> PathAncestors<'_> {
-    PathAncestors::new(path)
+pub fn ancestors<'a>(path: &'a Path, stop_root_at: Option<&Path>) -> PathAncestors<'a> {
+    PathAncestors::new(path, stop_root_at)
 }
 
 pub struct PathAncestors<'a> {
@@ -316,11 +316,15 @@ pub struct PathAncestors<'a> {
 }
 
 impl<'a> PathAncestors<'a> {
-    fn new(path: &Path) -> PathAncestors<'_> {
+    fn new(path: &'a Path, stop_root_at: Option<&Path>) -> PathAncestors<'a> {
+        let stop_at = env::var("__CARGO_TEST_ROOT")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| stop_root_at.map(|p| p.to_path_buf()));
         PathAncestors {
             current: Some(path),
             //HACK: avoid reading `~/.cargo/config` when testing Cargo itself.
-            stop_at: env::var("__CARGO_TEST_ROOT").ok().map(PathBuf::from),
+            stop_at,
         }
     }
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -77,6 +77,7 @@ impl ConfigBuilder {
         let homedir = paths::home();
         let mut config = Config::new(shell, cwd, homedir);
         config.set_env(self.env.clone());
+        config.set_search_stop_path(paths::root());
         config.configure(
             0,
             false,


### PR DESCRIPTION
This adds a limit to prevent config loading from walking outside of the test sandbox root. There was an environment variable for this, but that doesn't work too well for tests that were loading the config directly.

Fixes #9107