### PR TITLE
Emit warning on env variable case mismatch

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -213,12 +213,14 @@ impl Config {
             })
             .collect();
 
-        let mut upper_case_env : HashMap<String, String> = HashMap::new();
+        let mut upper_case_env: HashMap<String, String> = HashMap::new();
 
         if !cfg!(windows) {
-            upper_case_env = env.clone().into_iter().map(|(k, _)| {
-                (k.to_uppercase().replace("-", "_"), k)
-            }).collect();
+            upper_case_env = env
+                .clone()
+                .into_iter()
+                .map(|(k, _)| (k.to_uppercase().replace("-", "_"), k))
+                .collect();
         }
 
         let cache_rustc_info = match env.get("CARGO_CACHE_RUSTC_INFO") {
@@ -539,7 +541,7 @@ impl Config {
             None => {
                 self.check_environment_key_case_mismatch(key);
                 Ok(None)
-            },
+            }
         }
     }
 
@@ -568,14 +570,15 @@ impl Config {
         if cfg!(windows) {
             return;
         }
-        match self.upper_case_env.get(key.as_env_key()){
+        match self.upper_case_env.get(key.as_env_key()) {
             Some(env_key) => {
-                let _ = self.shell().warn(
-                format!("Variables in environment require uppercase,
-                        but given variable: {}, contains lowercase or dash.", env_key)
-                );
-            },
-            None => {},
+                let _ = self.shell().warn(format!(
+                    "Variables in environment require uppercase,
+                        but given variable: {}, contains lowercase or dash.",
+                    env_key
+                ));
+            }
+            None => {}
         }
     }
 
@@ -673,8 +676,8 @@ impl Config {
             Some(v) => v,
             None => {
                 self.check_environment_key_case_mismatch(key);
-                return Ok(())
-            },
+                return Ok(());
+            }
         };
 
         let def = Definition::Environment(key.as_env_key().to_string());

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -575,7 +575,7 @@ impl Config {
         if let Some(env_key) = self.upper_case_env.get(key.as_env_key()) {
             let _ = self.shell().warn(format!(
                 "Environment variables are expected to use uppercase letters and underscores, \
-                the variable {} will be ignored and have no effect",
+                the variable `{}` will be ignored and have no effect",
                 env_key
             ));
         }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -572,15 +572,12 @@ impl Config {
             return;
         }
 
-        match self.upper_case_env.get(key.as_env_key()) {
-            Some(env_key) => {
-                let _ = self.shell().warn(format!(
-                    "Environment variables require uppercase letters, \
-                            but the variable: `{}` contains lowercase letters or dashes.",
-                    env_key
-                ));
-            }
-            None => {}
+        if let Some(env_key) = self.upper_case_env.get(key.as_env_key()) {
+            let _ = self.shell().warn(format!(
+                "Environment variables are expected to use uppercase letters and underscores, \
+                the variable {} will be ignored and have no effect",
+                env_key
+            ));
         }
     }
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -364,7 +364,7 @@ fn target_in_environment_contains_lower_case() {
     ];
 
     for target_key in &target_keys {
-        p.cargo("build -v --target X86_64_unknown_linux_musl")
+        p.cargo("build -v --target x86_64-unknown-linux-musl")
             .env(target_key, "nonexistent-linker")
             .with_status(101)
             .with_stderr_contains(format!(

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -368,10 +368,28 @@ fn target_in_environment_contains_lower_case() {
             .env(target_key, "nonexistent-linker")
             .with_status(101)
             .with_stderr_contains(format!(
-                "warning: Variables in environment require uppercase,
-                        but given variable: {}, contains lowercase or dash.",
+                "warning: Environment variables require uppercase letters, \
+                        but the variable: `{}` contains lowercase letters or dashes.",
                 target_key
             ))
+            .run();
+    }
+}
+
+#[cargo_test]
+#[cfg(windows)]
+fn target_in_environment_contains_lower_case_on_windows() {
+    let p = project().file("src/main.rs", "fn main() {}").build();
+
+    let target_keys = [
+        "CARGO_TARGET_X86_64_UNKNOWN_LINUX_musl_LINKER",
+        "CARGO_TARGET_x86_64_unknown_linux_musl_LINKER",
+    ];
+
+    for target_key in &target_keys {
+        p.cargo("build -v --target x86_64-unknown-linux-musl")
+            .env(target_key, "nonexistent-linker")
+            .without_status()
             .run();
     }
 }

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -368,8 +368,8 @@ fn target_in_environment_contains_lower_case() {
             .env(target_key, "nonexistent-linker")
             .with_status(101)
             .with_stderr_contains(format!(
-                "warning: Environment variables require uppercase letters, \
-                        but the variable: `{}` contains lowercase letters or dashes.",
+                "warning: Environment variables are expected to use uppercase letters and underscores, \
+                the variable {} will be ignored and have no effect",
                 target_key
             ))
             .run();
@@ -391,8 +391,8 @@ fn target_in_environment_contains_lower_case_on_windows() {
             .env(target_key, "nonexistent-linker")
             .with_status(101)
             .with_stderr_does_not_contain(format!(
-                "warning: Environment variables require uppercase letters, \
-                        but the variable: `{}` contains lowercase letters or dashes.",
+                "warning: Environment variables are expected to use uppercase letters and underscores, \
+                the variable {} will be ignored and have no effect",
                 target_key
             ))
             .run();

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -369,7 +369,7 @@ fn target_in_environment_contains_lower_case() {
             .with_status(101)
             .with_stderr_contains(format!(
                 "warning: Environment variables are expected to use uppercase letters and underscores, \
-                the variable {} will be ignored and have no effect",
+                the variable `{}` will be ignored and have no effect",
                 target_key
             ))
             .run();
@@ -392,7 +392,7 @@ fn target_in_environment_contains_lower_case_on_windows() {
             .with_status(101)
             .with_stderr_does_not_contain(format!(
                 "warning: Environment variables are expected to use uppercase letters and underscores, \
-                the variable {} will be ignored and have no effect",
+                the variable `{}` will be ignored and have no effect",
                 target_key
             ))
             .run();

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -355,6 +355,7 @@ fn custom_linker_env() {
 
 
 #[cargo_test]
+#[cfg(not(windows))]
 fn target_in_environment_contains_lower_case() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -389,7 +389,12 @@ fn target_in_environment_contains_lower_case_on_windows() {
     for target_key in &target_keys {
         p.cargo("build -v --target x86_64-unknown-linux-musl")
             .env(target_key, "nonexistent-linker")
-            .with_status(0)
+            .with_status(101)
+            .with_stderr_does_not_contain(format!(
+                "warning: Environment variables require uppercase letters, \
+                        but the variable: `{}` contains lowercase letters or dashes.",
+                target_key
+            ))
             .run();
     }
 }

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -353,23 +353,25 @@ fn custom_linker_env() {
         .run();
 }
 
-
 #[cargo_test]
 #[cfg(not(windows))]
 fn target_in_environment_contains_lower_case() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    let target_keys = ["CARGO_TARGET_X86_64_UNKNOWN_LINUX_musl_LINKER",
-    "CARGO_TARGET_x86_64_unknown_linux_musl_LINKER"];
+    let target_keys = [
+        "CARGO_TARGET_X86_64_UNKNOWN_LINUX_musl_LINKER",
+        "CARGO_TARGET_x86_64_unknown_linux_musl_LINKER",
+    ];
 
     for target_key in &target_keys {
         p.cargo("build -v --target X86_64_unknown_linux_musl")
             .env(target_key, "nonexistent-linker")
             .with_status(101)
-            .with_stderr_contains(
-                format!("warning: Variables in environment require uppercase,
-                        but given variable: {}, contains lowercase or dash.", target_key)
-            )
+            .with_stderr_contains(format!(
+                "warning: Variables in environment require uppercase,
+                        but given variable: {}, contains lowercase or dash.",
+                target_key
+            ))
             .run();
     }
 }

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -389,7 +389,7 @@ fn target_in_environment_contains_lower_case_on_windows() {
     for target_key in &target_keys {
         p.cargo("build -v --target x86_64-unknown-linux-musl")
             .env(target_key, "nonexistent-linker")
-            .without_status()
+            .with_status(0)
             .run();
     }
 }

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -353,6 +353,26 @@ fn custom_linker_env() {
         .run();
 }
 
+
+#[cargo_test]
+fn target_in_environment_contains_lower_case() {
+    let p = project().file("src/main.rs", "fn main() {}").build();
+
+    let target_keys = ["CARGO_TARGET_X86_64_UNKNOWN_LINUX_musl_LINKER",
+    "CARGO_TARGET_x86_64_unknown_linux_musl_LINKER"];
+
+    for target_key in &target_keys {
+        p.cargo("build -v --target X86_64_unknown_linux_musl")
+            .env(target_key, "nonexistent-linker")
+            .with_status(101)
+            .with_stderr_contains(
+                format!("warning: Variables in environment require uppercase,
+                        but given variable: {}, contains lowercase or dash.", target_key)
+            )
+            .run();
+    }
+}
+
 #[cargo_test]
 fn cfg_ignored_fields() {
     // Test for some ignored fields in [target.'cfg()'] tables.


### PR DESCRIPTION
When running a command like `cargo --target TRIPPLE` cargo expects to find the environment variable CARGO_TARGET_[TRIPPLE]_* with uppercase and underscores. This check emits a warning if the checked environment variable has a mismatching case and/or contains dashes rather than underscores. The warning contains the given env variable as well as an explanation for the cause of the warning.

The check is skipped on windows as environment variables are treated as case insensitive on the platform.



Fixes #8285