### PR TITLE
Remove mention of --message-format taking multiple values

### DIFF
--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -241,24 +241,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -190,24 +190,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
        --build-plan
            Outputs a series of JSON messages to stdout that indicate the

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -194,24 +194,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -156,24 +156,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -243,24 +243,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -111,24 +111,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -173,24 +173,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -180,24 +180,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -263,24 +263,28 @@ OPTIONS
            times and consists of comma-separated values. Valid values:
 
            o  human (default): Display in a human-readable text format.
+              Conflicts with short and json.
 
-           o  short: Emit shorter, human-readable text messages.
+           o  short: Emit shorter, human-readable text messages. Conflicts with
+              human and json.
 
            o  json: Emit JSON messages to stdout. See the reference
               <https://doc.rust-lang.org/cargo/reference/external-tools.html#json-messages>
-              for more details.
+              for more details. Conflicts with human and short.
 
            o  json-diagnostic-short: Ensure the rendered field of JSON messages
-              contains the "short" rendering from rustc.
+              contains the "short" rendering from rustc. Cannot be used with
+              human or short.
 
            o  json-diagnostic-rendered-ansi: Ensure the rendered field of JSON
               messages contains embedded ANSI color codes for respecting
-              rustc's default color scheme.
+              rustc's default color scheme. Cannot be used with human or short.
 
            o  json-render-diagnostics: Instruct Cargo to not include rustc
               diagnostics in in JSON messages printed, but instead Cargo itself
               should render the JSON diagnostics coming from rustc. Cargo's own
               JSON diagnostics and others coming from rustc are still emitted.
+              Cannot be used with human or short.
 
    Manifest Options
        --manifest-path path

--- a/src/doc/man/includes/options-message-format.md
+++ b/src/doc/man/includes/options-message-format.md
@@ -2,18 +2,20 @@
 The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:
 
-- `human` (default): Display in a human-readable text format.
-- `short`: Emit shorter, human-readable text messages.
+- `human` (default): Display in a human-readable text format. Conflicts with
+  `short` and `json`.
+- `short`: Emit shorter, human-readable text messages. Conflicts with `human`
+  and `json`.
 - `json`: Emit JSON messages to stdout. See
   [the reference](../reference/external-tools.html#json-messages)
-  for more details.
+  for more details. Conflicts with `human` and `short`.
 - `json-diagnostic-short`: Ensure the `rendered` field of JSON messages contains
-  the "short" rendering from rustc.
+  the "short" rendering from rustc. Cannot be used with `human` or `short`.
 - `json-diagnostic-rendered-ansi`: Ensure the `rendered` field of JSON messages
   contains embedded ANSI color codes for respecting rustc's default color
-  scheme.
+  scheme. Cannot be used with `human` or `short`.
 - `json-render-diagnostics`: Instruct Cargo to not include rustc diagnostics in
   in JSON messages printed, but instead Cargo itself should render the
   JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-  coming from rustc are still emitted.
+  coming from rustc are still emitted. Cannot be used with `human` or `short`.
 {{/option}}

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -296,20 +296,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -244,20 +244,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -249,20 +249,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -206,20 +206,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -309,20 +309,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -154,20 +154,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -223,20 +223,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -235,20 +235,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -322,20 +322,22 @@ terminal.</li>
 <dd class="option-desc">The output format for diagnostic messages. Can be specified multiple times
 and consists of comma-separated values. Valid values:</p>
 <ul>
-<li><code>human</code> (default): Display in a human-readable text format.</li>
-<li><code>short</code>: Emit shorter, human-readable text messages.</li>
+<li><code>human</code> (default): Display in a human-readable text format. Conflicts with
+<code>short</code> and <code>json</code>.</li>
+<li><code>short</code>: Emit shorter, human-readable text messages. Conflicts with <code>human</code>
+and <code>json</code>.</li>
 <li><code>json</code>: Emit JSON messages to stdout. See
 <a href="../reference/external-tools.html#json-messages">the reference</a>
-for more details.</li>
+for more details. Conflicts with <code>human</code> and <code>short</code>.</li>
 <li><code>json-diagnostic-short</code>: Ensure the <code>rendered</code> field of JSON messages contains
-the &quot;short&quot; rendering from rustc.</li>
+the &quot;short&quot; rendering from rustc. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-diagnostic-rendered-ansi</code>: Ensure the <code>rendered</code> field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.</li>
+scheme. Cannot be used with <code>human</code> or <code>short</code>.</li>
 <li><code>json-render-diagnostics</code>: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.</li>
+coming from rustc are still emitted. Cannot be used with <code>human</code> or <code>short</code>.</li>
 </ul></dd>
 
 

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -309,35 +309,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -238,35 +238,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -242,35 +242,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -193,35 +193,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -315,35 +315,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -139,35 +139,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -214,35 +214,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -223,35 +223,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -333,35 +333,37 @@ The output format for diagnostic messages. Can be specified multiple times
 and consists of comma\-separated values. Valid values:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format.
+\h'-04'\(bu\h'+02'\fBhuman\fR (default): Display in a human\-readable text format. Conflicts with
+\fBshort\fR and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages.
+\h'-04'\(bu\h'+02'\fBshort\fR: Emit shorter, human\-readable text messages. Conflicts with \fBhuman\fR
+and \fBjson\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\fR: Emit JSON messages to stdout. See
 \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/external\-tools.html#json\-messages>
-for more details.
+for more details. Conflicts with \fBhuman\fR and \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-short\fR: Ensure the \fBrendered\fR field of JSON messages contains
-the "short" rendering from rustc.
+the "short" rendering from rustc. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-diagnostic\-rendered\-ansi\fR: Ensure the \fBrendered\fR field of JSON messages
 contains embedded ANSI color codes for respecting rustc's default color
-scheme.
+scheme. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBjson\-render\-diagnostics\fR: Instruct Cargo to not include rustc diagnostics in
 in JSON messages printed, but instead Cargo itself should render the
 JSON diagnostics coming from rustc. Cargo's own JSON diagnostics and others
-coming from rustc are still emitted.
+coming from rustc are still emitted. Cannot be used with \fBhuman\fR or \fBshort\fR\&.
 .RE
 .RE
 .SS "Manifest Options"


### PR DESCRIPTION
I tried passing multiple values to `--message-format`, as is mentioned in the docs, and it didn't work:

```
$ cargo test --message-format human,json
error: cannot specify two kinds of `message-format` arguments
$ cargo test --message-format human --message-format json
error: cannot specify two kinds of `message-format` arguments
````

It's entirely possible I misunderstood the docs, but just in case I didn't, I thought I'd open this PR to remove the bit that mentions that the flag accepts multiple values.