### PR TITLE
Update link for no_std attribute.

### DIFF
--- a/src/doc/src/reference/features-examples.md
+++ b/src/doc/src/reference/features-examples.md
@@ -62,7 +62,7 @@ Then, in various places in the code ([example1][wasm-bindgen-cfg1],
 [example2][wasm-bindgen-cfg2]), it uses `#[cfg(feature = "std")]` attributes
 to conditionally enable extra functionality that requires `std`.
 
-[`no_std`]: ../../reference/crates-and-source-files.html#preludes-and-no_std
+[`no_std`]: ../../reference/names/preludes.html#the-no_std-attribute
 [`wasm-bindgen`]: https://crates.io/crates/wasm-bindgen
 [`std` prelude]: ../../std/prelude/index.html
 [wasm-bindgen-std]: https://github.com/rustwasm/wasm-bindgen/blob/0.2.69/Cargo.toml#L25

--- a/src/doc/src/reference/features.md
+++ b/src/doc/src/reference/features.md
@@ -252,7 +252,7 @@ pub fn function_that_requires_std() {
 }
 ```
 
-[`no_std`]: ../../reference/crates-and-source-files.html#preludes-and-no_std
+[`no_std`]: ../../reference/names/preludes.html#the-no_std-attribute
 [features section]: resolver.md#features
 
 #### Mutually exclusive features

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1328,7 +1328,7 @@ your decisions on how to apply versioning to your application, or at least
 document what your commitments are.
 
 [`cfg` attribute]: ../../reference/conditional-compilation.md#the-cfg-attribute
-[`no_std`]: ../../reference/crates-and-source-files.html#preludes-and-no_std
+[`no_std`]: ../../reference/names/preludes.html#the-no_std-attribute
 [`pub use`]: ../../reference/items/use-declarations.html
 [Cargo feature]: features.md
 [Cargo features]: features.md


### PR DESCRIPTION
There was some reorganization in the reference as part of https://github.com/rust-lang/reference/pull/937.