### PR TITLE
Add support for [env] section in .cargo/config.toml

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -339,7 +339,6 @@ impl<'cfg> Compilation<'cfg> {
             )
             .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
             .cwd(pkg.root());
-        
 
         // Apply any environment variables from the config
         for (key, value) in self.config.env_config()?.iter() {

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -340,10 +340,12 @@ impl<'cfg> Compilation<'cfg> {
             .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
             .cwd(pkg.root());
 
-        // Apply any environment variables from the config
-        for (key, value) in self.config.env_config()?.iter() {
-            if value.is_force() || cmd.get_env(&key).is_none() {
-                cmd.env(&key, value.resolve(&self.config));
+        if self.config.cli_unstable().configurable_env {
+            // Apply any environment variables from the config
+            for (key, value) in self.config.env_config()?.iter() {
+                if value.is_force() || cmd.get_env(&key).is_none() {
+                    cmd.env(&key, value.resolve(&self.config));
+                }
             }
         }
 

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -339,6 +339,15 @@ impl<'cfg> Compilation<'cfg> {
             )
             .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
             .cwd(pkg.root());
+        
+
+        // Apply any environment variables from the config
+        for (key, value) in self.config.env_config()?.iter() {
+            if value.is_force() || cmd.get_env(&key).is_none() {
+                cmd.env(&key, value.resolve(&self.config));
+            }
+        }
+
         Ok(cmd)
     }
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -444,6 +444,7 @@ pub struct CliUnstable {
     pub weak_dep_features: bool,
     pub extra_link_arg: bool,
     pub credential_process: bool,
+    pub configurable_env: bool,
 }
 
 const STABILIZED_COMPILE_PROGRESS: &str = "The progress bar is now always \
@@ -598,6 +599,7 @@ impl CliUnstable {
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
+            "configurable-env" => self.configurable_env = parse_empty(k, v)?,
             "features" => {
                 // For now this is still allowed (there are still some
                 // unstable options like "compare"). This should be removed at

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -49,10 +49,12 @@
 //! translate from `ConfigValue` and environment variables to the caller's
 //! desired type.
 
+use std::borrow::Cow;
 use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{HashMap, HashSet};
 use std::env;
+use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, File};
 use std::io::prelude::*;
@@ -62,8 +64,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Once;
 use std::time::Instant;
-use std::borrow::Cow;
-use std::ffi::OsStr;
 
 use anyhow::{anyhow, bail, format_err};
 use curl::easy::Easy;
@@ -1278,9 +1278,7 @@ impl Config {
     }
 
     pub fn env_config(&self) -> CargoResult<&EnvConfig> {
-        self.env_config.try_borrow_with(|| {
-            self.get_env_config()
-        })
+        self.env_config.try_borrow_with(|| self.get_env_config())
     }
 
     /// This is used to validate the `term` table has valid syntax.
@@ -2006,7 +2004,7 @@ impl EnvConfigValue {
         EnvConfigValue {
             value,
             force: false,
-            relative: false
+            relative: false,
         }
     }
 

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -25,7 +25,8 @@ fn env_basic() {
         )
         .build();
 
-    p.cargo("run")
+    p.cargo("run -Zconfigurable-env")
+        .masquerade_as_nightly_cargo()
         .with_stdout_contains("compile-time:Hello")
         .with_stdout_contains("run-time:Hello")
         .run();
@@ -51,7 +52,8 @@ fn env_invalid() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("build -Zconfigurable-env")
+        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr_contains("[..]`env.ENV_TEST_BOOL` expected a string, but found a boolean")
         .run();
@@ -81,7 +83,8 @@ fn env_force() {
         )
         .build();
 
-    p.cargo("run")
+    p.cargo("run -Zconfigurable-env")
+        .masquerade_as_nightly_cargo()
         .env("ENV_TEST_FORCED", "from-env")
         .env("ENV_TEST_UNFORCED", "from-env")
         .with_stdout_contains("ENV_TEST_FORCED:from-config")
@@ -117,5 +120,7 @@ fn env_relative() {
         )
         .build();
 
-    p.cargo("run").run();
+    p.cargo("run -Zconfigurable-env")
+        .masquerade_as_nightly_cargo()
+        .run();
 }

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -1,0 +1,110 @@
+//! Tests for `[env]` config.
+
+use cargo_test_support::{basic_bin_manifest, project};
+
+#[cargo_test]
+fn env_basic() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+        use std::env;
+        fn main() {
+            println!( "compile-time:{}", env!("ENV_TEST_1233") );
+            println!( "run-time:{}", env::var("ENV_TEST_1233").unwrap());
+        }
+        "#)
+        .file(
+        ".cargo/config",
+        r#"
+                [env]
+                ENV_TEST_1233 = "Hello"
+            "#,
+        )
+        .build();
+
+    p.cargo("run")
+        .with_stdout_contains("compile-time:Hello")
+        .with_stdout_contains("run-time:Hello")
+        .run();
+}
+
+#[cargo_test]
+fn env_invalid() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+        fn main() {
+        }
+        "#)
+        .file(
+        ".cargo/config",
+        r#"
+                [env]
+                ENV_TEST_BOOL = false
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains("[..]`env.ENV_TEST_BOOL` expected a string, but found a boolean")
+        .run();
+}
+
+#[cargo_test]
+fn env_force() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", r#"
+        use std::env;
+        fn main() {
+            println!( "ENV_TEST_FORCED:{}", env!("ENV_TEST_FORCED") );
+            println!( "ENV_TEST_UNFORCED:{}", env!("ENV_TEST_UNFORCED") );
+        }
+        "#)
+        .file(
+        ".cargo/config",
+        r#"
+                [env]
+                ENV_TEST_UNFORCED = "from-config"
+                ENV_TEST_FORCED = { value = "from-config", force = true }
+            "#,
+        )
+        .build();
+
+    p.cargo("run")
+        .env("ENV_TEST_FORCED", "from-env")
+        .env("ENV_TEST_UNFORCED", "from-env")
+        .with_stdout_contains("ENV_TEST_FORCED:from-config")
+        .with_stdout_contains("ENV_TEST_UNFORCED:from-env")
+        .run();
+}
+
+#[cargo_test]
+fn env_relative() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo2"))
+        .file("src/main.rs", r#"
+        use std::env;
+        use std::path::Path;
+        fn main() {
+            println!( "ENV_TEST_RELATIVE:{}", env!("ENV_TEST_RELATIVE") );
+            println!( "ENV_TEST_ABSOLUTE:{}", env!("ENV_TEST_ABSOLUTE") );
+
+            assert!( Path::new(env!("ENV_TEST_ABSOLUTE")).is_absolute() );
+            assert!( !Path::new(env!("ENV_TEST_RELATIVE")).is_absolute() );
+        }
+        "#)
+        .file(
+        ".cargo/config",
+        r#"
+                [env]
+                ENV_TEST_RELATIVE = "Cargo.toml"
+                ENV_TEST_ABSOLUTE = { value = "Cargo.toml", relative = true }
+            "#,
+        )
+        .build();
+
+    p.cargo("run")
+        .run();
+}

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -6,16 +6,19 @@ use cargo_test_support::{basic_bin_manifest, project};
 fn env_basic() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", r#"
+        .file(
+            "src/main.rs",
+            r#"
         use std::env;
         fn main() {
             println!( "compile-time:{}", env!("ENV_TEST_1233") );
             println!( "run-time:{}", env::var("ENV_TEST_1233").unwrap());
         }
-        "#)
+        "#,
+        )
         .file(
-        ".cargo/config",
-        r#"
+            ".cargo/config",
+            r#"
                 [env]
                 ENV_TEST_1233 = "Hello"
             "#,
@@ -32,13 +35,16 @@ fn env_basic() {
 fn env_invalid() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", r#"
+        .file(
+            "src/main.rs",
+            r#"
         fn main() {
         }
-        "#)
+        "#,
+        )
         .file(
-        ".cargo/config",
-        r#"
+            ".cargo/config",
+            r#"
                 [env]
                 ENV_TEST_BOOL = false
             "#,
@@ -55,16 +61,19 @@ fn env_invalid() {
 fn env_force() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", r#"
+        .file(
+            "src/main.rs",
+            r#"
         use std::env;
         fn main() {
             println!( "ENV_TEST_FORCED:{}", env!("ENV_TEST_FORCED") );
             println!( "ENV_TEST_UNFORCED:{}", env!("ENV_TEST_UNFORCED") );
         }
-        "#)
+        "#,
+        )
         .file(
-        ".cargo/config",
-        r#"
+            ".cargo/config",
+            r#"
                 [env]
                 ENV_TEST_UNFORCED = "from-config"
                 ENV_TEST_FORCED = { value = "from-config", force = true }
@@ -84,7 +93,9 @@ fn env_force() {
 fn env_relative() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo2"))
-        .file("src/main.rs", r#"
+        .file(
+            "src/main.rs",
+            r#"
         use std::env;
         use std::path::Path;
         fn main() {
@@ -94,10 +105,11 @@ fn env_relative() {
             assert!( Path::new(env!("ENV_TEST_ABSOLUTE")).is_absolute() );
             assert!( !Path::new(env!("ENV_TEST_RELATIVE")).is_absolute() );
         }
-        "#)
+        "#,
+        )
         .file(
-        ".cargo/config",
-        r#"
+            ".cargo/config",
+            r#"
                 [env]
                 ENV_TEST_RELATIVE = "Cargo.toml"
                 ENV_TEST_ABSOLUTE = { value = "Cargo.toml", relative = true }
@@ -105,6 +117,5 @@ fn env_relative() {
         )
         .build();
 
-    p.cargo("run")
-        .run();
+    p.cargo("run").run();
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -24,6 +24,7 @@ mod build_script_extra_link_arg;
 mod cache_messages;
 mod cargo_alias_config;
 mod cargo_command;
+mod cargo_env_config;
 mod cargo_features;
 mod cargo_targets;
 mod cfg;


### PR DESCRIPTION
This adds support for an `[env]` section in the config.toml files. Environment variables set in this section will be applied to the environment of any processes executed by cargo.

This is implemented to follow the recommendations in https://github.com/rust-lang/cargo/pull/8839#issuecomment-725678657

Variables have optional `force` and `relative` flags. `force` means the variable can override an existing environment variable. `relative` means the variable represents a path relative to the location of the directory that contains the `.cargo/` directory that contains the `config.toml` file. A relative variable will have an absolute path prepended to it before setting it in the environment.

```
[env]
FOOBAR = "Apple"
PATH_TO_SOME_TOOL = { value = "bin/tool", relative = true }
USERNAME = { value = "test_user", force = true }
```

Fixes #4121