### PR TITLE
Use platform-defined directories for cargo state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ crypto-hash = "0.3.1"
 curl = { version = "0.4.23", features = ["http2"] }
 curl-sys = "0.4.22"
 env_logger = "0.8.1"
+directories = "1.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"
 filetime = "0.2.9"

--- a/src/cargo/util/config/dirs.rs
+++ b/src/cargo/util/config/dirs.rs
@@ -1,0 +1,137 @@
+//! An abstraction over what directories cargo should use for state
+
+use crate::util::{
+    config::Filesystem,
+    errors::{CargoResult, CargoResultExt},
+};
+use directories::ProjectDirs;
+use log::debug;
+use std::env;
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub struct CargoDirs {
+    /// The dir cargo was run in
+    pub current_dir: PathBuf,
+    /// Main directory for cargo data
+    pub data_dir: Filesystem,
+    /// Immutable global cargo configuration
+    pub config_dir: Filesystem,
+    /// Caching registry artefacts (previously .cargo/registry/cache)
+    pub cache_dir: Filesystem,
+    /// Directory where binaries are kept
+    pub bin_dir: Filesystem,
+    /// Kept to walk upwards the directory tree to find a Cargo.toml
+    pub home_dir: Filesystem,
+}
+
+impl CargoDirs {
+    /// Constructs the hierarchy of directories that cargo will use
+    pub fn new(home_dir: PathBuf) -> CargoResult<CargoDirs> {
+        let current_dir =
+            env::current_dir().chain_err(|| "couldn't get the current directory of the process")?;
+
+        let mut cache_dir = PathBuf::default();
+        let mut config_dir = PathBuf::default();
+        let mut data_dir = PathBuf::default();
+        let mut bin_dir = PathBuf::default();
+
+        // 1. CARGO_HOME set
+        let cargo_home_env = env::var_os("CARGO_HOME").map(|home| current_dir.join(home));
+        if let Some(cargo_home) = cargo_home_env.clone() {
+            cache_dir = cargo_home.clone();
+            config_dir = cargo_home.clone();
+            data_dir = cargo_home.clone();
+            bin_dir = cargo_home.join("bin");
+        }
+
+        // 2. CARGO_CACHE_DIR, CARGO_CONFIG_DIR, CARGO_BIN_DIR, ... set
+        let cargo_cache_env = env::var_os("CARGO_CACHE_DIR").map(|home| current_dir.join(home));
+        let cargo_config_env = env::var_os("CARGO_CONFIG_DIR").map(|home| current_dir.join(home));
+        let cargo_data_env = env::var_os("CARGO_DATA_DIR").map(|home| current_dir.join(home));
+        let cargo_bin_env = env::var_os("CARGO_BIN_DIR").map(|home| current_dir.join(home));
+        if let Some(cargo_cache) = cargo_cache_env.clone() {
+            cache_dir = cargo_cache.clone();
+        }
+        if let Some(cargo_config) = cargo_config_env.clone() {
+            config_dir = cargo_config.clone();
+        }
+        if let Some(cargo_data) = cargo_data_env.clone() {
+            data_dir = cargo_data.clone();
+        }
+        if let Some(cargo_bin) = cargo_bin_env.clone() {
+            bin_dir = cargo_bin.clone();
+        }
+
+        // no env vars are set ...
+        if cargo_home_env.is_none()
+            && cargo_cache_env.is_none()
+            && cargo_config_env.is_none()
+            && cargo_data_env.is_none()
+            && cargo_bin_env.is_none()
+        {
+            let legacy_cargo_dir = home_dir.join(".cargo");
+
+            // 3. ... and .cargo exist
+            if legacy_cargo_dir.exists() {
+                debug!("Using legacy paths at $HOME, consider moving to $XDG_DATA_HOME");
+                cache_dir = legacy_cargo_dir.clone();
+                config_dir = legacy_cargo_dir.clone();
+                data_dir = legacy_cargo_dir.clone();
+                bin_dir = legacy_cargo_dir.join("bin");
+
+            // 4. ... otherwise follow platform conventions
+            } else {
+                let xdg_dirs = match ProjectDirs::from("org", "rust-lang", "cargo") {
+                    Some(d) => Ok(d),
+                    None => Err(anyhow::format_err!(
+                        "failed to get directories according to XDG settings"
+                    )),
+                }?;
+
+                cache_dir = xdg_dirs.cache_dir().to_path_buf();
+                config_dir = xdg_dirs.config_dir().to_path_buf();
+                data_dir = xdg_dirs.data_dir().to_path_buf();
+                bin_dir = CargoDirs::find_bin_dir(&xdg_dirs)
+                    .ok_or_else(|| {
+                        anyhow::format_err!(
+                            "couldn't find the directory in which executables are placed"
+                        )
+                    })?
+                    .to_path_buf();
+            }
+        }
+
+        Ok(CargoDirs {
+            current_dir,
+            cache_dir: Filesystem::new(cache_dir),
+            config_dir: Filesystem::new(config_dir),
+            data_dir: Filesystem::new(data_dir),
+            bin_dir: Filesystem::new(bin_dir),
+            home_dir: Filesystem::new(home_dir),
+        })
+    }
+
+    #[cfg(target_os = "linux")]
+    fn find_bin_dir(_dirs: &ProjectDirs) -> Option<PathBuf> {
+        use directories::BaseDirs;
+        let base_dir = BaseDirs::new()?;
+        base_dir.executable_dir().map(|p| p.to_path_buf())
+    }
+
+    #[cfg(target_os = "macos")]
+    fn find_bin_dir(dirs: &ProjectDirs) -> Option<PathBuf> {
+        dirs.data_dir()
+            .parent()
+            .map(|p| p.join("bin"))
+            .map(|p| p.to_path_buf())
+    }
+
+    #[cfg(target_os = "windows")]
+    fn find_bin_dir(dirs: &ProjectDirs) -> Option<PathBuf> {
+        dirs.data_dir()
+            .parent()
+            .map(|p| p.join("bin"))
+            .map(|p| p.to_path_buf())
+    }
+}

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -431,7 +431,7 @@ fn cargo_compile_api_exposes_artifact_paths() {
         .build();
 
     let shell = Shell::from_write(Box::new(Vec::new()));
-    let config = Config::new(shell, env::current_dir().unwrap(), paths::home());
+    let config = Config::new(shell, env::current_dir().unwrap(), paths::home()).unwrap();
     let ws = Workspace::new(&p.root().join("Cargo.toml"), &config).unwrap();
     let compile_options = CompileOptions::new(ws.config(), CompileMode::Build).unwrap();
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -75,7 +75,7 @@ impl ConfigBuilder {
         let shell = Shell::from_write(output);
         let cwd = self.cwd.clone().unwrap_or_else(|| paths::root());
         let homedir = paths::home();
-        let mut config = Config::new(shell, cwd, homedir);
+        let mut config = Config::new(shell, cwd, homedir)?;
         config.set_env(self.env.clone());
         config.set_search_stop_path(paths::root());
         config.configure(

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -135,7 +135,7 @@ fn new_credentials_is_used_instead_old() {
         .arg(TOKEN)
         .run();
 
-    let mut config = Config::new(Shell::new(), cargo_home(), cargo_home());
+    let mut config = Config::new(Shell::new(), cargo_home(), cargo_home()).unwrap();
     let _ = config.values();
     let _ = config.load_credentials();
 

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -37,7 +37,8 @@ fn bad_file_member_exclusion() {
         Shell::from_write(Box::new(Vec::new())),
         cargo_home(),
         cargo_home(),
-    );
+    )
+    .unwrap();
     let ws = Workspace::new(&p.root().join("Cargo.toml"), &config).unwrap();
     assert_eq!(ws.members().count(), 1);
     assert_eq!(ws.members().next().unwrap().name(), "bar");

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -149,7 +149,8 @@ fn member_manifest_version_error() {
         Shell::from_write(Box::new(Vec::new())),
         cargo_home(),
         cargo_home(),
-    );
+    )
+    .unwrap();
     let ws = Workspace::new(&p.root().join("Cargo.toml"), &config).unwrap();
     let compile_options = CompileOptions::new(&config, CompileMode::Build).unwrap();
     let member_bar = ws.members().find(|m| &*m.name() == "bar").unwrap();

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -148,7 +148,8 @@ fn not_update() {
         Shell::from_write(Box::new(Vec::new())),
         paths::root(),
         paths::home().join(".cargo"),
-    );
+    )
+    .unwrap();
     let lock = cfg.acquire_package_cache_lock().unwrap();
     let mut regsrc = RegistrySource::remote(sid, &HashSet::new(), &cfg);
     regsrc.update().unwrap();


### PR DESCRIPTION
Continuation of PR #8063.

---

This PR changes the cargo config system to use the XDG spec directories, instead of using `$HOME/.cargo`.

Currently it only uses `XDG_DATA_HOME` and `XDG_CACHE_HOME`. There was some discussion in #1734 about also using the new `XDG_BIN_HOME` directory, but this is not yet implemented.

The priority of paths cargo will check is as follows:

1. Use `$CARGO_HOME`, if it is set
2. Use `$CARGO_CACHE_DIR`, `$CARGO_CONFIG_DIR`, etc, if they are set
3. If no environment variables are set, and `$HOME/.cargo` is present,
   use that
4. Finally, use the platform-default directory paths