### PR TITLE
Forbid setting `RUSTC_BOOTSTRAP` from a build script on stable

### DIFF
--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -55,9 +55,8 @@ proptest! {
     fn prop_minimum_version_errors_the_same(
             PrettyPrintRegistry(input) in registry_strategy(50, 20, 60)
     ) {
-        enable_nightly_features();
-
         let mut config = Config::default().unwrap();
+        enable_nightly_features(&mut config);
         config
             .configure(
                 1,
@@ -553,11 +552,6 @@ fn test_resolving_maximum_version_with_transitive_deps() {
 
 #[test]
 fn test_resolving_minimum_version_with_transitive_deps() {
-    enable_nightly_features(); // -Z minimal-versions
-                               // When the minimal-versions config option is specified then the lowest
-                               // possible version of a package should be selected. "util 1.0.0" can't be
-                               // selected because of the requirements of "bar", so the minimum version
-                               // must be 1.1.1.
     let reg = registry(vec![
         pkg!(("util", "1.2.2")),
         pkg!(("util", "1.0.0")),
@@ -567,6 +561,12 @@ fn test_resolving_minimum_version_with_transitive_deps() {
     ]);
 
     let mut config = Config::default().unwrap();
+    // -Z minimal-versions
+    // When the minimal-versions config option is specified then the lowest
+    // possible version of a package should be selected. "util 1.0.0" can't be
+    // selected because of the requirements of "bar", so the minimum version
+    // must be 1.1.1.
+    enable_nightly_features(&mut config);
     config
         .configure(
             1,

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -1,5 +1,5 @@
 use cargo::core::dependency::DepKind;
-use cargo::core::{enable_nightly_features, Dependency};
+use cargo::core::Dependency;
 use cargo::util::{is_ci, Config};
 
 use resolver_tests::{
@@ -56,7 +56,7 @@ proptest! {
             PrettyPrintRegistry(input) in registry_strategy(50, 20, 60)
     ) {
         let mut config = Config::default().unwrap();
-        enable_nightly_features(&mut config);
+        config.nightly_features_allowed = true;
         config
             .configure(
                 1,
@@ -566,7 +566,7 @@ fn test_resolving_minimum_version_with_transitive_deps() {
     // possible version of a package should be selected. "util 1.0.0" can't be
     // selected because of the requirements of "bar", so the minimum version
     // must be 1.1.1.
-    enable_nightly_features(&mut config);
+    config.nightly_features_allowed = true;
     config
         .configure(
             1,

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -48,7 +48,7 @@ Available unstable (nightly-only) flags:
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );
-        if !features::nightly_features_allowed(config) {
+        if !config.nightly_features_allowed {
             drop_println!(
                 config,
                 "\nUnstable flags are only available on the nightly channel \

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -48,7 +48,7 @@ Available unstable (nightly-only) flags:
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
         );
-        if !features::nightly_features_allowed() {
+        if !features::nightly_features_allowed(config) {
             drop_println!(
                 config,
                 "\nUnstable flags are only available on the nightly channel \

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -16,7 +16,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if !(unstable.credential_process || unstable.unstable_options) {
         const SEE: &str = "See https://github.com/rust-lang/cargo/issues/8933 for more \
         information about the `cargo logout` command.";
-        if features::nightly_features_allowed(config) {
+        if config.nightly_features_allowed {
             return Err(format_err!(
                 "the `cargo logout` command is unstable, pass `-Z unstable-options` to enable it\n\
                 {}",

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -16,7 +16,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if !(unstable.credential_process || unstable.unstable_options) {
         const SEE: &str = "See https://github.com/rust-lang/cargo/issues/8933 for more \
         information about the `cargo logout` command.";
-        if features::nightly_features_allowed() {
+        if features::nightly_features_allowed(config) {
             return Err(format_err!(
                 "the `cargo logout` command is unstable, pass `-Z unstable-options` to enable it\n\
                 {}",

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -30,7 +30,6 @@ fn main() {
             cargo::exit_with_error(e.into(), &mut shell)
         }
     };
-    cargo::core::maybe_allow_nightly_features(&mut config);
 
     let result = match cargo::ops::fix_maybe_exec_rustc(&config) {
         Ok(true) => Ok(()),

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -22,7 +22,6 @@ fn main() {
     pretty_env_logger::init_custom_env("CARGO_LOG");
     #[cfg(not(feature = "pretty-env-logger"))]
     env_logger::init_from_env("CARGO_LOG");
-    cargo::core::maybe_allow_nightly_features();
 
     let mut config = match Config::default() {
         Ok(cfg) => cfg,
@@ -31,8 +30,9 @@ fn main() {
             cargo::exit_with_error(e.into(), &mut shell)
         }
     };
+    cargo::core::maybe_allow_nightly_features(&mut config);
 
-    let result = match cargo::ops::fix_maybe_exec_rustc() {
+    let result = match cargo::ops::fix_maybe_exec_rustc(&config) {
         Ok(true) => Ok(()),
         Ok(false) => {
             let _token = cargo::util::job::setup();

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -589,8 +589,7 @@ impl BuildOutput {
                         // behavior, so still only give a warning.
                         if nightly_features_allowed {
                             warnings.push(format!("Cannot set `RUSTC_BOOTSTRAP={}` from {}.\n\
-                                note: Crates cannot set `RUSTC_BOOTSTRAP` themselves, as doing so would subvert the stability guarantees of Rust for your project.\n\
-                                help: See https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env for details.",
+                                note: Crates cannot set `RUSTC_BOOTSTRAP` themselves, as doing so would subvert the stability guarantees of Rust for your project.",
                                 val, whence
                             ));
                         } else {
@@ -598,8 +597,7 @@ impl BuildOutput {
                             // Abort with an error.
                             anyhow::bail!("Cannot set `RUSTC_BOOTSTRAP={}` from {}.\n\
                                 note: Crates cannot set `RUSTC_BOOTSTRAP` themselves, as doing so would subvert the stability guarantees of Rust for your project.\n\
-                                help: If you're sure you want to do this in your project, set the environment variable `RUSTC_BOOTSTRAP={}` before running cargo instead.\n\
-                                help: See https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env for details.",
+                                help: If you're sure you want to do this in your project, set the environment variable `RUSTC_BOOTSTRAP={}` before running cargo instead.",
                                 val,
                                 whence,
                                 pkg_name,

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -598,7 +598,7 @@ impl BuildOutput {
                             // Abort with an error.
                             anyhow::bail!("Cannot set `RUSTC_BOOTSTRAP={}` from {}.\n\
                                 note: Crates cannot set `RUSTC_BOOTSTRAP` themselves, as doing so would subvert the stability guarantees of Rust for your project.\n\
-                                help: If you're sure you want to do this in your project, use `RUSTC_BOOTSTRAP={} cargo build` instead.\n\
+                                help: If you're sure you want to do this in your project, set the environment variable `RUSTC_BOOTSTRAP={}` before running cargo instead.\n\
                                 help: See https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-env for details.",
                                 val,
                                 whence,

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -2,7 +2,6 @@ use super::job::{Freshness, Job, Work};
 use super::{fingerprint, Context, LinkType, Unit};
 use crate::core::compiler::context::Metadata;
 use crate::core::compiler::job_queue::JobState;
-use crate::core::nightly_features_allowed;
 use crate::core::{profiles::ProfileRoot, PackageId};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::interning::InternedString;
@@ -295,7 +294,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     paths::create_dir_all(&script_out_dir)?;
 
     let extra_link_arg = cx.bcx.config.cli_unstable().extra_link_arg;
-    let nightly_features_allowed = nightly_features_allowed(cx.bcx.config);
+    let nightly_features_allowed = cx.bcx.config.nightly_features_allowed;
 
     // Prepare the unit of "dirty work" which will actually run the custom build
     // command.
@@ -856,7 +855,6 @@ fn prev_build_output(cx: &mut Context<'_, '_>, unit: &Unit) -> (Option<BuildOutp
         .unwrap_or_else(|_| script_out_dir.clone());
 
     let extra_link_arg = cx.bcx.config.cli_unstable().extra_link_arg;
-    let nightly_features_allowed = nightly_features_allowed(cx.bcx.config);
 
     (
         BuildOutput::parse_file(
@@ -866,7 +864,7 @@ fn prev_build_output(cx: &mut Context<'_, '_>, unit: &Unit) -> (Option<BuildOutp
             &prev_script_out_dir,
             &script_out_dir,
             extra_link_arg,
-            nightly_features_allowed,
+            cx.bcx.config.nightly_features_allowed,
         )
         .ok(),
         prev_script_out_dir,

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -700,8 +700,8 @@ fn add_error_format_and_color(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder, pi
     }
     cmd.arg(json);
 
-    if nightly_features_allowed() {
-        let config = cx.bcx.config;
+    let config = cx.bcx.config;
+    if nightly_features_allowed(config) {
         match (
             config.cli_unstable().terminal_width,
             config.shell().err_width().diagnostic_terminal_width(),

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -49,7 +49,6 @@ pub use self::lto::Lto;
 use self::output_depinfo::output_depinfo;
 use self::unit_graph::UnitDep;
 pub use crate::core::compiler::unit::{Unit, UnitInterner};
-use crate::core::features::nightly_features_allowed;
 use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{PanicStrategy, Profile, Strip};
 use crate::core::{Feature, PackageId, Target};
@@ -701,7 +700,7 @@ fn add_error_format_and_color(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder, pi
     cmd.arg(json);
 
     let config = cx.bcx.config;
-    if nightly_features_allowed(config) {
+    if config.nightly_features_allowed {
         match (
             config.cli_unstable().terminal_width,
             config.shell().err_width().diagnostic_terminal_width(),

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -1,7 +1,7 @@
 use crate::core::compiler::Unit;
 use crate::core::compiler::{CompileKind, CompileMode};
 use crate::core::profiles::{Profile, UnitFor};
-use crate::core::{nightly_features_allowed, PackageId, Target};
+use crate::core::{PackageId, Target};
 use crate::util::interning::InternedString;
 use crate::util::CargoResult;
 use crate::Config;
@@ -68,7 +68,6 @@ pub fn emit_serialized_unit_graph(
     unit_graph: &UnitGraph,
     config: &Config,
 ) -> CargoResult<()> {
-    let is_nightly = nightly_features_allowed(config);
     let mut units: Vec<(&Unit, &Vec<UnitDep>)> = unit_graph.iter().collect();
     units.sort_unstable();
     // Create a map for quick lookup for dependencies.
@@ -85,7 +84,7 @@ pub fn emit_serialized_unit_graph(
                 .iter()
                 .map(|unit_dep| {
                     // https://github.com/rust-lang/rust/issues/64260 when stabilized.
-                    let (public, noprelude) = if is_nightly {
+                    let (public, noprelude) = if config.nightly_features_allowed {
                         (Some(unit_dep.public), Some(unit_dep.noprelude))
                     } else {
                         (None, None)

--- a/src/cargo/core/compiler/unit_graph.rs
+++ b/src/cargo/core/compiler/unit_graph.rs
@@ -4,6 +4,7 @@ use crate::core::profiles::{Profile, UnitFor};
 use crate::core::{nightly_features_allowed, PackageId, Target};
 use crate::util::interning::InternedString;
 use crate::util::CargoResult;
+use crate::Config;
 use std::collections::HashMap;
 use std::io::Write;
 
@@ -62,8 +63,12 @@ struct SerializedUnitDep {
     // internal detail that is mostly used for building the graph.
 }
 
-pub fn emit_serialized_unit_graph(root_units: &[Unit], unit_graph: &UnitGraph) -> CargoResult<()> {
-    let is_nightly = nightly_features_allowed();
+pub fn emit_serialized_unit_graph(
+    root_units: &[Unit],
+    unit_graph: &UnitGraph,
+    config: &Config,
+) -> CargoResult<()> {
+    let is_nightly = nightly_features_allowed(config);
     let mut units: Vec<(&Unit, &Vec<UnitDep>)> = unit_graph.iter().collect();
     units.sort_unstable();
     // Create a map for quick lookup for dependencies.

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -92,7 +92,6 @@
 //!    of that page. Update the rest of the documentation to add the new
 //!    feature.
 
-use std::cell::Cell;
 use std::env;
 use std::fmt;
 use std::str::FromStr;
@@ -816,11 +815,6 @@ pub fn channel() -> String {
         .map(|c| c.release_channel)
         .unwrap_or_else(|| String::from("dev"))
 }
-
-thread_local!(
-    static NIGHTLY_FEATURES_ALLOWED: Cell<bool> = Cell::new(false);
-    static ENABLE_NIGHTLY_FEATURES: Cell<bool> = Cell::new(false);
-);
 
 /// This is a little complicated.
 /// This should return false if:

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -276,6 +276,7 @@ macro_rules! features {
         pub struct Features {
             $($feature: bool,)*
             activated: Vec<String>,
+            nightly_features_allowed: bool,
         }
 
         impl Feature {
@@ -416,6 +417,7 @@ impl Features {
             ret.add(feature, config, warnings)?;
             ret.activated.push(feature.to_string());
         }
+        ret.nightly_features_allowed = config.nightly_features_allowed;
         Ok(ret)
     }
 
@@ -497,9 +499,7 @@ impl Features {
             let feature = feature.name.replace("_", "-");
             let mut msg = format!("feature `{}` is required", feature);
 
-            // TODO
-            let channel = channel();
-            if channel == "nightly" || channel == "dev" {
+            if self.nightly_features_allowed {
                 let s = format!(
                     "\n\nconsider adding `cargo-features = [\"{0}\"]` \
                      to the manifest",

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -830,24 +830,10 @@ pub fn channel() -> String {
 /// - this is a integration test that uses `ProcessBuilder`
 ///       that called `masquerade_as_nightly_cargo`
 pub fn nightly_features_allowed(config: &Config) -> bool {
-    if config.enable_nightly_features {
-        return true;
-    }
-    match &channel()[..] {
-        "nightly" | "dev" => config.maybe_allow_nightly_features,
-        _ => false,
-    }
+    config.enable_nightly_features
 }
 
-/// Allows nightly features to be enabled for this thread, but only if the
-/// development channel is nightly or dev.
-///
-/// Used by cargo main to ensure that a cargo build from source has nightly features
-pub fn maybe_allow_nightly_features(config: &mut Config) {
-    config.maybe_allow_nightly_features = true;
-}
-
-/// Forcibly enables nightly features for this thread.
+/// Forcibly enables nightly features for this config.
 ///
 /// Used by tests to allow the use of nightly features.
 /// NOTE: this should be called before `configure()`. Consider using `ConfigBuilder::enable_nightly_features` instead.

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -462,7 +462,7 @@ impl Features {
                 );
                 warnings.push(warning);
             }
-            Status::Unstable if !nightly_features_allowed(config) => bail!(
+            Status::Unstable if !config.nightly_features_allowed => bail!(
                 "the cargo feature `{}` requires a nightly version of \
                  Cargo, but this is the `{}` channel\n\
                  {}\n{}",
@@ -814,29 +814,4 @@ pub fn channel() -> String {
         .cfg_info
         .map(|c| c.release_channel)
         .unwrap_or_else(|| String::from("dev"))
-}
-
-/// This is a little complicated.
-/// This should return false if:
-/// - this is an artifact of the rustc distribution process for "stable" or for "beta"
-/// - this is an `#[test]` that does not opt in with `enable_nightly_features`
-/// - this is a integration test that uses `ProcessBuilder`
-///      that does not opt in with `masquerade_as_nightly_cargo`
-/// This should return true if:
-/// - this is an artifact of the rustc distribution process for "nightly"
-/// - this is being used in the rustc distribution process internally
-/// - this is a cargo executable that was built from source
-/// - this is an `#[test]` that called `enable_nightly_features`
-/// - this is a integration test that uses `ProcessBuilder`
-///       that called `masquerade_as_nightly_cargo`
-pub fn nightly_features_allowed(config: &Config) -> bool {
-    config.enable_nightly_features
-}
-
-/// Forcibly enables nightly features for this config.
-///
-/// Used by tests to allow the use of nightly features.
-/// NOTE: this should be called before `configure()`. Consider using `ConfigBuilder::enable_nightly_features` instead.
-pub fn enable_nightly_features(config: &mut Config) {
-    config.enable_nightly_features = true;
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -822,7 +822,7 @@ pub fn nightly_features_allowed() -> bool {
         return true;
     }
     match &channel()[..] {
-        "nightly" | "dev" => NIGHTLY_FEATURES_ALLOWED.with(|c| c.get()),
+        "nightly" | "dev" => true, //NIGHTLY_FEATURES_ALLOWED.with(|c| c.get()),
         _ => false,
     }
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -413,20 +413,16 @@ impl Features {
         warnings: &mut Vec<String>,
     ) -> CargoResult<Features> {
         let mut ret = Features::default();
+        ret.nightly_features_allowed = config.nightly_features_allowed;
         for feature in features {
-            ret.add(feature, config, warnings)?;
+            ret.add(feature, warnings)?;
             ret.activated.push(feature.to_string());
         }
-        ret.nightly_features_allowed = config.nightly_features_allowed;
         Ok(ret)
     }
 
-    fn add(
-        &mut self,
-        feature_name: &str,
-        config: &Config,
-        warnings: &mut Vec<String>,
-    ) -> CargoResult<()> {
+    fn add(&mut self, feature_name: &str, warnings: &mut Vec<String>) -> CargoResult<()> {
+        let nightly_features_allowed = self.nightly_features_allowed;
         let (slot, feature) = match self.status(feature_name) {
             Some(p) => p,
             None => bail!("unknown cargo feature `{}`", feature_name),
@@ -464,7 +460,7 @@ impl Features {
                 );
                 warnings.push(warning);
             }
-            Status::Unstable if !config.nightly_features_allowed => bail!(
+            Status::Unstable if !nightly_features_allowed => bail!(
                 "the cargo feature `{}` requires a nightly version of \
                  Cargo, but this is the `{}` channel\n\
                  {}\n{}",

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -1,6 +1,6 @@
 pub use self::dependency::Dependency;
 pub use self::features::{
-    enable_nightly_features, maybe_allow_nightly_features, nightly_features_allowed,
+    enable_nightly_features, nightly_features_allowed,
 };
 pub use self::features::{CliUnstable, Edition, Feature, Features};
 pub use self::manifest::{EitherManifest, VirtualManifest};

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -1,7 +1,4 @@
 pub use self::dependency::Dependency;
-pub use self::features::{
-    enable_nightly_features, nightly_features_allowed,
-};
 pub use self::features::{CliUnstable, Edition, Feature, Features};
 pub use self::manifest::{EitherManifest, VirtualManifest};
 pub use self::manifest::{Manifest, Target, TargetKind};

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -287,7 +287,7 @@ pub fn compile_ws<'a>(
     let interner = UnitInterner::new();
     let bcx = create_bcx(ws, options, &interner)?;
     if options.build_config.unit_graph {
-        unit_graph::emit_serialized_unit_graph(&bcx.roots, &bcx.unit_graph)?;
+        unit_graph::emit_serialized_unit_graph(&bcx.roots, &bcx.unit_graph, ws.config())?;
         return Compilation::new(&bcx);
     }
     let _p = profile::start("compiling");

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -50,7 +50,7 @@ use log::{debug, trace, warn};
 use rustfix::diagnostics::Diagnostic;
 use rustfix::{self, CodeFix};
 
-use crate::core::{nightly_features_allowed, Edition, Workspace};
+use crate::core::{Edition, Workspace};
 use crate::ops::{self, CompileOptions};
 use crate::util::diagnostic_server::{Message, RustfixDiagnosticServer};
 use crate::util::errors::CargoResult;
@@ -700,7 +700,7 @@ impl FixArgs {
         // Unfortunately this results in a pretty poor error message when
         // multiple jobs run in parallel (the error appears multiple
         // times). Hopefully this doesn't happen often in practice.
-        if !to_edition.is_stable() && !nightly_features_allowed(config) {
+        if !to_edition.is_stable() && !config.nightly_features_allowed {
             bail!(
                 "cannot migrate {} to edition {to_edition}\n\
                  Edition {to_edition} is unstable and not allowed in this release, \

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -74,7 +74,7 @@ use url::Url;
 use self::ConfigValue as CV;
 use crate::core::compiler::rustdoc::RustdocExternMap;
 use crate::core::shell::Verbosity;
-use crate::core::{nightly_features_allowed, CliUnstable, Shell, SourceId, Workspace};
+use crate::core::{features, nightly_features_allowed, CliUnstable, Shell, SourceId, Workspace};
 use crate::ops;
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::toml as cargo_toml;
@@ -185,7 +185,6 @@ pub struct Config {
     progress_config: ProgressConfig,
     env_config: LazyCell<EnvConfig>,
     pub(crate) enable_nightly_features: bool,
-    pub(crate) maybe_allow_nightly_features: bool,
 }
 
 impl Config {
@@ -270,8 +269,10 @@ impl Config {
             doc_extern_map: LazyCell::new(),
             progress_config: ProgressConfig::default(),
             env_config: LazyCell::new(),
-            enable_nightly_features: false,
-            maybe_allow_nightly_features: false,
+            enable_nightly_features: match &*features::channel() {
+                "nightly" | "dev" => true,
+                _ => false,
+            }
         }
     }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -15,7 +15,6 @@ use url::Url;
 
 use crate::core::dependency::DepKind;
 use crate::core::manifest::{ManifestMetadata, TargetSourcePath, Warnings};
-use crate::core::nightly_features_allowed;
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{Dependency, Manifest, PackageId, Summary, Target};
 use crate::core::{Edition, EitherManifest, Feature, Features, VirtualManifest, Workspace};
@@ -1076,7 +1075,7 @@ impl TomlManifest {
                 let mut msg =
                     "`rust-version` is not supported on this version of Cargo and will be ignored"
                         .to_string();
-                if nightly_features_allowed(config) {
+                if config.nightly_features_allowed {
                     msg.push_str(
                         "\n\n\
                         consider adding `cargo-features = [\"rust-version\"]` to the manifest",

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1037,7 +1037,7 @@ impl TomlManifest {
         // Parse features first so they will be available when parsing other parts of the TOML.
         let empty = Vec::new();
         let cargo_features = me.cargo_features.as_ref().unwrap_or(&empty);
-        let features = Features::new(cargo_features, &mut warnings)?;
+        let features = Features::new(cargo_features, config, &mut warnings)?;
 
         let project = me.project.as_ref().or_else(|| me.package.as_ref());
         let project = project.ok_or_else(|| anyhow!("no `package` section found"))?;
@@ -1076,7 +1076,7 @@ impl TomlManifest {
                 let mut msg =
                     "`rust-version` is not supported on this version of Cargo and will be ignored"
                         .to_string();
-                if nightly_features_allowed() {
+                if nightly_features_allowed(config) {
                     msg.push_str(
                         "\n\n\
                         consider adding `cargo-features = [\"rust-version\"]` to the manifest",
@@ -1432,7 +1432,7 @@ impl TomlManifest {
         let mut deps = Vec::new();
         let empty = Vec::new();
         let cargo_features = me.cargo_features.as_ref().unwrap_or(&empty);
-        let features = Features::new(cargo_features, &mut warnings)?;
+        let features = Features::new(cargo_features, config, &mut warnings)?;
 
         let (replace, patch) = {
             let mut cx = Context {

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -108,7 +108,7 @@ fn rerun_if_env_or_file_changes() {
 }
 
 #[cargo_test]
-fn rustc_bootstrap_is_disallowed() {
+fn rustc_bootstrap() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
@@ -121,7 +121,12 @@ fn rustc_bootstrap_is_disallowed() {
         )
         .build();
     p.cargo("build")
-        .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP` [..]")
+        .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
+        .with_stderr_contains("help: [..] use `RUSTC_BOOTSTRAP=1 cargo build` [..]")
         .with_status(101)
+        .run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("warning: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .run();
 }

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -122,7 +122,7 @@ fn rustc_bootstrap() {
         .build();
     p.cargo("build")
         .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
-        .with_stderr_contains("help: [..] use `RUSTC_BOOTSTRAP=foo cargo build` [..]")
+        .with_stderr_contains("help: [..] set the environment variable `RUSTC_BOOTSTRAP=foo` [..]")
         .with_status(101)
         .run();
     p.cargo("build")

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -1,4 +1,4 @@
-//! Tests for build.rs rerun-if-env-changed.
+//! Tests for build.rs rerun-if-env-changed and rustc-env
 
 use cargo_test_support::project;
 use cargo_test_support::sleep_ms;

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -106,3 +106,22 @@ fn rerun_if_env_or_file_changes() {
         )
         .run();
 }
+
+#[cargo_test]
+fn rustc_bootstrap_is_disallowed() {
+    let p = project()
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+            fn main() {
+                println!("cargo:rustc-env=RUSTC_BOOTSTRAP=1");
+            }
+        "#,
+        )
+        .build();
+    p.cargo("build")
+        .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP` [..]")
+        .with_status(101)
+        .run();
+}

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -122,7 +122,7 @@ fn rustc_bootstrap() {
         .build();
     p.cargo("build")
         .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
-        .with_stderr_contains("help: [..] use `RUSTC_BOOTSTRAP=1 cargo build` [..]")
+        .with_stderr_contains("help: [..] use `RUSTC_BOOTSTRAP=foo cargo build` [..]")
         .with_status(101)
         .run();
     p.cargo("build")

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -47,8 +47,8 @@ impl ConfigBuilder {
     }
 
     /// Unconditionaly enable nightly features, even on stable channels.
-    pub fn enable_nightly_features(&mut self) -> &mut Self {
-        self.enable_nightly_features = true;
+    pub fn nightly_features_allowed(&mut self, allowed: bool) -> &mut Self {
+        self.enable_nightly_features = allowed;
         self
     }
 
@@ -80,9 +80,7 @@ impl ConfigBuilder {
         let cwd = self.cwd.clone().unwrap_or_else(|| paths::root());
         let homedir = paths::home();
         let mut config = Config::new(shell, cwd, homedir);
-        if self.enable_nightly_features || !self.unstable.is_empty() {
-            config.nightly_features_allowed = true;
-        }
+        config.nightly_features_allowed = self.enable_nightly_features || !self.unstable.is_empty();
         config.set_env(self.env.clone());
         config.set_search_stop_path(paths::root());
         config.configure(
@@ -1108,7 +1106,7 @@ fn unstable_table_notation() {
 print-im-a-teapot = true
 ",
     );
-    let config = ConfigBuilder::new().enable_nightly_features().build();
+    let config = ConfigBuilder::new().nightly_features_allowed(true).build();
     assert_eq!(config.cli_unstable().print_im_a_teapot, true);
 }
 
@@ -1120,7 +1118,7 @@ fn unstable_dotted_notation() {
 unstable.print-im-a-teapot = true
 ",
     );
-    let config = ConfigBuilder::new().enable_nightly_features().build();
+    let config = ConfigBuilder::new().nightly_features_allowed(true).build();
     assert_eq!(config.cli_unstable().print_im_a_teapot, true);
 }
 
@@ -1132,7 +1130,7 @@ fn unstable_cli_precedence() {
 unstable.print-im-a-teapot = true
 ",
     );
-    let config = ConfigBuilder::new().enable_nightly_features().build();
+    let config = ConfigBuilder::new().nightly_features_allowed(true).build();
     assert_eq!(config.cli_unstable().print_im_a_teapot, true);
 
     let config = ConfigBuilder::new()
@@ -1163,7 +1161,8 @@ fn unstable_flags_ignored_on_stable() {
 print-im-a-teapot = true
 ",
     );
-    let config = ConfigBuilder::new().build();
+    // Enforce stable channel even when testing on nightly.
+    let config = ConfigBuilder::new().nightly_features_allowed(false).build();
     assert_eq!(config.cli_unstable().print_im_a_teapot, false);
 }
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,6 +1,6 @@
 //! Tests for config settings.
 
-use cargo::core::{enable_nightly_features, Shell};
+use cargo::core::Shell;
 use cargo::util::config::{self, Config, SslVersionConfig, StringList};
 use cargo::util::interning::InternedString;
 use cargo::util::toml::{self, VecStringOrBool as VSOB};
@@ -81,7 +81,7 @@ impl ConfigBuilder {
         let homedir = paths::home();
         let mut config = Config::new(shell, cwd, homedir);
         if self.enable_nightly_features || !self.unstable.is_empty() {
-            enable_nightly_features(&mut config);
+            config.nightly_features_allowed = true;
         }
         config.set_env(self.env.clone());
         config.set_search_stop_path(paths::root());

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -392,7 +392,7 @@ fn named_config_profile() {
         "#,
     )
     .unwrap();
-    let config = ConfigBuilder::new().enable_nightly_features().build();
+    let config = ConfigBuilder::new().nightly_features_allowed(true).build();
     let profile_name = InternedString::new("foo");
     let ws = Workspace::new(&paths::root().join("Cargo.toml"), &config).unwrap();
     let profiles = Profiles::new(&ws, profile_name).unwrap();

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -343,12 +343,10 @@ fn named_config_profile() {
     // middle exists in Cargo.toml, the others in .cargo/config
     use super::config::ConfigBuilder;
     use cargo::core::compiler::CompileMode;
-    use cargo::core::enable_nightly_features;
     use cargo::core::profiles::{Profiles, UnitFor};
     use cargo::core::{PackageId, Workspace};
     use cargo::util::interning::InternedString;
     use std::fs;
-    enable_nightly_features();
     paths::root().join(".cargo").mkdir_p();
     fs::write(
         paths::root().join(".cargo/config"),
@@ -394,7 +392,7 @@ fn named_config_profile() {
         "#,
     )
     .unwrap();
-    let config = ConfigBuilder::new().build();
+    let config = ConfigBuilder::new().enable_nightly_features().build();
     let profile_name = InternedString::new("foo");
     let ws = Workspace::new(&paths::root().join("Cargo.toml"), &config).unwrap();
     let profiles = Profiles::new(&ws, profile_name).unwrap();


### PR DESCRIPTION
Instead, recommend `RUSTC_BOOTSTRAP=crate_name`. If cargo is using a nightly toolchain, or if RUSTC_BOOTSTRAP was set in *cargo*'s build environment, the error is downgraded to a warning, since the variable won't affect the build.

This is mostly the same as suggested in https://github.com/rust-lang/cargo/issues/7088#issuecomment-713867773, except that `RUSTC_BOOTSTRAP=` values other than 1 are treated the same as `RUSTC_BOOTSTRAP=1`. My reasoning was that https://github.com/rust-lang/rust/pull/77802 is now on 1.50 stable, so some crates may have started using it, and I would still prefer not to give hard errors when there's no workaround.

Closes https://github.com/rust-lang/cargo/issues/7088.

r? @joshtriplett 