### PR TITLE
Updates to edition handling.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1535,6 +1535,7 @@ fn substitute_macros(input: &str) -> String {
         ("[LOGOUT]", "      Logout"),
         ("[YANK]", "        Yank"),
         ("[OWNER]", "       Owner"),
+        ("[MIGRATING]", "   Migrating"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1524,6 +1524,7 @@ fn substitute_macros(input: &str) -> String {
         ("[REPLACING]", "   Replacing"),
         ("[UNPACKING]", "   Unpacking"),
         ("[SUMMARY]", "     Summary"),
+        ("[FIXED]", "       Fixed"),
         ("[FIXING]", "      Fixing"),
         ("[EXE]", env::consts::EXE_SUFFIX),
         ("[IGNORED]", "     Ignored"),

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -42,17 +42,6 @@ pub fn cli() -> App {
                 .help("Fix in preparation for the next edition"),
         )
         .arg(
-            // This is a deprecated argument, we'll want to phase it out
-            // eventually.
-            Arg::with_name("prepare-for")
-                .long("prepare-for")
-                .help("Fix warnings in preparation of an edition upgrade")
-                .takes_value(true)
-                .possible_values(&["2018"])
-                .conflicts_with("edition")
-                .hidden(true),
-        )
-        .arg(
             Arg::with_name("idioms")
                 .long("edition-idioms")
                 .help("Fix warnings to migrate to the idioms of an edition"),
@@ -111,7 +100,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         &ws,
         &mut ops::FixOptions {
             edition: args.is_present("edition"),
-            prepare_for: args.value_of("prepare-for"),
             idioms: args.is_present("idioms"),
             compile_opts: opts,
             allow_dirty: args.is_present("allow-dirty"),

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -8,7 +8,7 @@ use semver::Version;
 
 use super::BuildContext;
 use crate::core::compiler::{CompileKind, Metadata, Unit};
-use crate::core::{Edition, Package};
+use crate::core::Package;
 use crate::util::{self, config, join_paths, process, CargoResult, Config, ProcessBuilder};
 
 /// Structure with enough information to run `rustdoc --test`.
@@ -187,9 +187,7 @@ impl<'cfg> Compilation<'cfg> {
         let rustdoc = process(&*self.config.rustdoc()?);
         let cmd = fill_rustc_tool_env(rustdoc, unit);
         let mut p = self.fill_env(cmd, &unit.pkg, script_meta, unit.kind, true)?;
-        if unit.target.edition() != Edition::Edition2015 {
-            p.arg(format!("--edition={}", unit.target.edition()));
-        }
+        unit.target.edition().cmd_edition_arg(&mut p);
 
         for crate_type in unit.target.rustc_crate_types() {
             p.arg("--crate-type").arg(crate_type.as_str());

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -52,7 +52,7 @@ pub use crate::core::compiler::unit::{Unit, UnitInterner};
 use crate::core::features::nightly_features_allowed;
 use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{PanicStrategy, Profile, Strip};
-use crate::core::{Edition, Feature, PackageId, Target};
+use crate::core::{Feature, PackageId, Target};
 use crate::util::errors::{self, CargoResult, CargoResultExt, ProcessError, VerboseError};
 use crate::util::interning::InternedString;
 use crate::util::machine_message::Message;
@@ -782,9 +782,7 @@ fn build_base_args(
     cmd.arg("--crate-name").arg(&unit.target.crate_name());
 
     let edition = unit.target.edition();
-    if edition != Edition::Edition2015 {
-        cmd.arg(format!("--edition={}", edition));
-    }
+    edition.cmd_edition_arg(cmd);
 
     add_path_args(bcx, unit, cmd);
     add_error_format_and_color(cx, cmd, cx.rmeta_required(unit));

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -144,6 +144,18 @@ impl Edition {
         }
     }
 
+    /// Returns the previous edition from this edition.
+    ///
+    /// Returns `None` for 2015.
+    pub fn previous(&self) -> Option<Edition> {
+        use Edition::*;
+        match self {
+            Edition2015 => None,
+            Edition2018 => Some(Edition2015),
+            Edition2021 => Some(Edition2018),
+        }
+    }
+
     /// Updates the given [`ProcessBuilder`] to include the appropriate flags
     /// for setting the edition.
     pub(crate) fn cmd_edition_arg(&self, cmd: &mut ProcessBuilder) {
@@ -152,6 +164,20 @@ impl Edition {
         }
         if !self.is_stable() {
             cmd.arg("-Z").arg("unstable-options");
+        }
+    }
+
+    /// Whether or not this edition supports the `rust_*_compatibility` lint.
+    ///
+    /// Ideally this would not be necessary, but currently 2021 does not have
+    /// any lints, and thus `rustc` doesn't recognize it. Perhaps `rustc`
+    /// could create an empty group instead?
+    pub(crate) fn supports_compat_lint(&self) -> bool {
+        use Edition::*;
+        match self {
+            Edition2015 => false,
+            Edition2018 => true,
+            Edition2021 => false,
         }
     }
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -182,6 +182,17 @@ impl Edition {
         }
     }
 
+    /// Returns the next edition from this edition, returning the last edition
+    /// if this is already the last one.
+    pub fn saturating_next(&self) -> Edition {
+        use Edition::*;
+        match self {
+            Edition2015 => Edition2018,
+            Edition2018 => Edition2021,
+            Edition2021 => Edition2021,
+        }
+    }
+
     /// Updates the given [`ProcessBuilder`] to include the appropriate flags
     /// for setting the edition.
     pub(crate) fn cmd_edition_arg(&self, cmd: &mut ProcessBuilder) {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,4 +1,4 @@
-use crate::core::{Shell, Workspace};
+use crate::core::{Edition, Shell, Workspace};
 use crate::util::errors::{CargoResult, CargoResultExt};
 use crate::util::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 use crate::util::{paths, restricted_names, Config};
@@ -743,7 +743,7 @@ edition = {}
             },
             match opts.edition {
                 Some(edition) => toml::Value::String(edition.to_string()),
-                None => toml::Value::String("2018".to_string()),
+                None => toml::Value::String(Edition::LATEST_STABLE.to_string()),
             },
             match opts.registry {
                 Some(registry) => format!(

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -675,8 +675,8 @@ impl FixArgs {
         cmd.args(&self.other).arg("--cap-lints=warn");
         if let Some(edition) = self.enabled_edition {
             cmd.arg("--edition").arg(edition.to_string());
-            if self.idioms && edition >= Edition::Edition2018 {
-                cmd.arg("-Wrust-2018-idioms");
+            if self.idioms && edition.supports_idiom_lint() {
+                cmd.arg(format!("-Wrust-{}-idioms", edition));
             }
         }
 

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -238,7 +238,7 @@ pub fn fix_maybe_exec_rustc() -> CargoResult<bool> {
 
         if output.status.success() {
             for (path, file) in fixes.files.iter() {
-                Message::Fixing {
+                Message::Fixed {
                     file: path.clone(),
                     fixes: file.fixes_applied,
                 }
@@ -695,7 +695,12 @@ impl FixArgs {
     fn verify_not_preparing_for_enabled_edition(&self) -> CargoResult<()> {
         let edition = match self.prepare_for_edition {
             Some(s) => s,
-            None => return Ok(()),
+            None => {
+                return Message::Fixing {
+                    file: self.file.display().to_string(),
+                }
+                .post();
+            }
         };
         let enabled = match self.enabled_edition {
             Some(s) => s,

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1,5 +1,5 @@
 use crate::core::compiler::{BuildConfig, MessageFormat};
-use crate::core::Workspace;
+use crate::core::{Edition, Workspace};
 use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::important_paths::find_root_manifest_for_wd;
@@ -188,7 +188,7 @@ pub trait AppExt: Sized {
         ._arg(opt("lib", "Use a library template"))
         ._arg(
             opt("edition", "Edition to set for the crate generated")
-                .possible_values(&["2015", "2018", "2021"])
+                .possible_values(Edition::CLI_VALUES)
                 .value_name("YEAR"),
         )
         ._arg(

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -33,6 +33,9 @@ const PLEASE_REPORT_THIS_BUG: &str =
 pub enum Message {
     Fixing {
         file: String,
+    },
+    Fixed {
+        file: String,
         fixes: u32,
     },
     FixFailed {
@@ -89,10 +92,14 @@ impl<'a> DiagnosticPrinter<'a> {
 
     pub fn print(&mut self, msg: &Message) -> CargoResult<()> {
         match msg {
-            Message::Fixing { file, fixes } => {
+            Message::Fixing { file } => self
+                .config
+                .shell()
+                .verbose(|shell| shell.status("Fixing", file)),
+            Message::Fixed { file, fixes } => {
                 let msg = if *fixes == 1 { "fix" } else { "fixes" };
                 let msg = format!("{} ({} {})", file, fixes, msg);
-                self.config.shell().status("Fixing", msg)
+                self.config.shell().status("Fixed", msg)
             }
             Message::ReplaceFailed { file, message } => {
                 let msg = format!("error applying suggestions to `{}`\n", file);

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -180,24 +180,10 @@ impl<'a> DiagnosticPrinter<'a> {
                 if !self.dedupe.insert(msg.clone()) {
                     return Ok(());
                 }
-
-                let msg = format!(
-                    "\
-cannot prepare for the {} edition when it is enabled, so cargo cannot
-automatically fix errors in `{}`
-
-To prepare for the {0} edition you should first remove `edition = '{0}'` from
-your `Cargo.toml` and then rerun this command. Once all warnings have been fixed
-then you can re-enable the `edition` key in `Cargo.toml`. For some more
-information about transitioning to the {0} edition see:
-
-  https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
-",
-                    edition,
-                    file,
-                );
-                self.config.shell().error(&msg)?;
-                Ok(())
+                self.config.shell().warn(&format!(
+                    "`{}` is already on the latest edition ({}), unable to migrate further",
+                    file, edition
+                ))
             }
         }
     }

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -31,6 +31,11 @@ const PLEASE_REPORT_THIS_BUG: &str =
 
 #[derive(Deserialize, Serialize, Hash, Eq, PartialEq, Clone)]
 pub enum Message {
+    Migrating {
+        file: String,
+        from_edition: Edition,
+        to_edition: Edition,
+    },
     Fixing {
         file: String,
     },
@@ -92,6 +97,19 @@ impl<'a> DiagnosticPrinter<'a> {
 
     pub fn print(&mut self, msg: &Message) -> CargoResult<()> {
         match msg {
+            Message::Migrating {
+                file,
+                from_edition,
+                to_edition,
+            } => {
+                if !self.dedupe.insert(msg.clone()) {
+                    return Ok(());
+                }
+                self.config.shell().status(
+                    "Migrating",
+                    &format!("{} from {} edition to {}", file, from_edition, to_edition),
+                )
+            }
             Message::Fixing { file } => self
                 .config
                 .shell()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1132,13 +1132,7 @@ impl TomlManifest {
             project.resolver.as_ref(),
             me.workspace.as_ref().and_then(|ws| ws.resolver.as_ref()),
         ) {
-            (None, None) => {
-                if edition == Edition::Edition2021 {
-                    Some(ResolveBehavior::V2)
-                } else {
-                    None
-                }
-            }
+            (None, None) => None,
             (Some(s), None) | (None, Some(s)) => Some(ResolveBehavior::from_manifest(s)?),
             (Some(_), Some(_)) => {
                 bail!("cannot specify `resolver` field in both `[workspace]` and `[package]`")

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1132,7 +1132,13 @@ impl TomlManifest {
             project.resolver.as_ref(),
             me.workspace.as_ref().and_then(|ws| ws.resolver.as_ref()),
         ) {
-            (None, None) => None,
+            (None, None) => {
+                if edition == Edition::Edition2021 {
+                    Some(ResolveBehavior::V2)
+                } else {
+                    None
+                }
+            }
             (Some(s), None) | (None, Some(s)) => Some(ResolveBehavior::from_manifest(s)?),
             (Some(_), Some(_)) => {
                 bail!("cannot specify `resolver` field in both `[workspace]` and `[package]`")

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1061,6 +1061,15 @@ impl TomlManifest {
         } else {
             Edition::Edition2015
         };
+        if edition == Edition::Edition2021 {
+            features.require(Feature::edition2021())?;
+        } else if !edition.is_stable() {
+            // Guard in case someone forgets to add .require()
+            return Err(util::errors::internal(format!(
+                "edition {} should be gated",
+                edition
+            )));
+        }
 
         let rust_version = if let Some(rust_version) = &project.rust_version {
             if features.require(Feature::rust_version()).is_err() {

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -44,9 +44,15 @@ or feature requests please don't hesitate to file an issue at
 The `cargo fix` subcommand can also be used to migrate a package from one
 [edition] to the next. The general procedure is:
 
-1. Run `cargo fix --edition`
+1. Run `cargo fix --edition`. Consider also using the `--all-features` flag if
+   your project has multiple features. You may also want to run `cargo fix
+   --edition` multiple times with different `--target` flags if your project
+   has platform-specific code gated by `cfg` attributes.
 2. Modify `Cargo.toml` to set the [edition field] to the new edition.
-3. Run your project tests to verify that everything still works.
+3. Run your project tests to verify that everything still works. If new
+   warnings are issued, you may want to consider running `cargo fix` again
+   (without the `--edition` flag) to apply any suggestions given by the
+   compiler.
 
 And hopefully that's it! Just keep in mind of the caveats mentioned above that
 `cargo fix` cannot update code for inactive features or `cfg` expressions.

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -14,17 +14,13 @@ cargo-fix - Automatically fix lint warnings reported by rustc
 This Cargo subcommand will automatically take rustc's suggestions from
 diagnostics like warnings and apply them to your source code. This is intended
 to help automate tasks that rustc itself already knows how to tell you to fix!
-The `cargo fix` subcommand is also being developed for the Rust 2018 edition
-to provide code the ability to easily opt-in to the new edition without having
-to worry about any breakage.
 
 Executing `cargo fix` will under the hood execute {{man "cargo-check" 1}}. Any warnings
 applicable to your crate will be automatically fixed (if possible) and all
 remaining warnings will be displayed when the check process is finished. For
-example if you'd like to prepare for the 2018 edition, you can do so by
-executing:
+example if you'd like to apply all fixes to the current package, you can run:
 
-    cargo fix --edition
+    cargo fix
 
 which behaves the same as `cargo check --all-targets`.
 
@@ -32,16 +28,34 @@ which behaves the same as `cargo check --all-targets`.
 `cargo check`. If code is conditionally enabled with optional features, you
 will need to enable those features for that code to be analyzed:
 
-    cargo fix --edition --features foo
+    cargo fix --features foo
 
 Similarly, other `cfg` expressions like platform-specific code will need to
 pass `--target` to fix code for the given target.
 
-    cargo fix --edition --target x86_64-pc-windows-gnu
+    cargo fix --target x86_64-pc-windows-gnu
 
 If you encounter any problems with `cargo fix` or otherwise have any questions
 or feature requests please don't hesitate to file an issue at
-<https://github.com/rust-lang/cargo>
+<https://github.com/rust-lang/cargo>.
+
+### Edition migration
+
+The `cargo fix` subcommand can also be used to migrate a package from one
+[edition] to the next. The general procedure is:
+
+1. Run `cargo fix --edition`
+2. Modify `Cargo.toml` to set the [edition field] to the new edition.
+3. Run your project tests to verify that everything still works.
+
+And hopefully that's it! Just keep in mind of the caveats mentioned above that
+`cargo fix` cannot update code for inactive features or `cfg` expressions.
+Also, in some rare cases the compiler is unable to automatically migrate all
+code to the new edition, and this may require manual changes after building
+with the new edition.
+
+[edition]: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
+[edition field]: ../reference/manifest.html#the-edition-field
 
 ## OPTIONS
 
@@ -56,9 +70,9 @@ code in the working directory for you to inspect and manually fix.
 {{/option}}
 
 {{#option "`--edition`" }}
-Apply changes that will update the code to the latest edition. This will not
+Apply changes that will update the code to the next edition. This will not
 update the edition in the `Cargo.toml` manifest, which must be updated
-manually.
+manually after `cargo fix --edition` has finished.
 {{/option}}
 
 {{#option "`--edition-idioms`" }}
@@ -146,7 +160,7 @@ When no target selection options are given, `cargo fix` will fix all targets
 
        cargo fix
 
-2. Convert a 2015 edition to 2018:
+2. Update a package to prepare it for the next edition:
 
        cargo fix --edition
 

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -10,17 +10,15 @@ DESCRIPTION
        This Cargo subcommand will automatically take rustc's suggestions from
        diagnostics like warnings and apply them to your source code. This is
        intended to help automate tasks that rustc itself already knows how to
-       tell you to fix! The cargo fix subcommand is also being developed for
-       the Rust 2018 edition to provide code the ability to easily opt-in to
-       the new edition without having to worry about any breakage.
+       tell you to fix!
 
        Executing cargo fix will under the hood execute cargo-check(1). Any
        warnings applicable to your crate will be automatically fixed (if
        possible) and all remaining warnings will be displayed when the check
-       process is finished. For example if you'd like to prepare for the 2018
-       edition, you can do so by executing:
+       process is finished. For example if you'd like to apply all fixes to the
+       current package, you can run:
 
-           cargo fix --edition
+           cargo fix
 
        which behaves the same as cargo check --all-targets.
 
@@ -28,16 +26,36 @@ DESCRIPTION
        cargo check. If code is conditionally enabled with optional features,
        you will need to enable those features for that code to be analyzed:
 
-           cargo fix --edition --features foo
+           cargo fix --features foo
 
        Similarly, other cfg expressions like platform-specific code will need
        to pass --target to fix code for the given target.
 
-           cargo fix --edition --target x86_64-pc-windows-gnu
+           cargo fix --target x86_64-pc-windows-gnu
 
        If you encounter any problems with cargo fix or otherwise have any
        questions or feature requests please don't hesitate to file an issue at
-       <https://github.com/rust-lang/cargo>
+       <https://github.com/rust-lang/cargo>.
+
+   Edition migration
+       The cargo fix subcommand can also be used to migrate a package from one
+       edition
+       <https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html>
+       to the next. The general procedure is:
+
+       1. Run cargo fix --edition
+
+       2. Modify Cargo.toml to set the edition field
+          <https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field>
+          to the new edition.
+
+       3. Run your project tests to verify that everything still works.
+
+       And hopefully that's it! Just keep in mind of the caveats mentioned
+       above that cargo fix cannot update code for inactive features or cfg
+       expressions. Also, in some rare cases the compiler is unable to
+       automatically migrate all code to the new edition, and this may require
+       manual changes after building with the new edition.
 
 OPTIONS
    Fix options
@@ -48,9 +66,9 @@ OPTIONS
            and manually fix.
 
        --edition
-           Apply changes that will update the code to the latest edition. This
+           Apply changes that will update the code to the next edition. This
            will not update the edition in the Cargo.toml manifest, which must
-           be updated manually.
+           be updated manually after cargo fix --edition has finished.
 
        --edition-idioms
            Apply suggestions that will update code to the preferred style for
@@ -356,7 +374,7 @@ EXAMPLES
 
               cargo fix
 
-       2. Convert a 2015 edition to 2018:
+       2. Update a package to prepare it for the next edition:
 
               cargo fix --edition
 

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -43,13 +43,19 @@ DESCRIPTION
        <https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html>
        to the next. The general procedure is:
 
-       1. Run cargo fix --edition
+       1. Run cargo fix --edition. Consider also using the --all-features flag
+          if your project has multiple features. You may also want to run cargo
+          fix --edition multiple times with different --target flags if your
+          project has platform-specific code gated by cfg attributes.
 
        2. Modify Cargo.toml to set the edition field
           <https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field>
           to the new edition.
 
-       3. Run your project tests to verify that everything still works.
+       3. Run your project tests to verify that everything still works. If new
+          warnings are issued, you may want to consider running cargo fix again
+          (without the --edition flag) to apply any suggestions given by the
+          compiler.
 
        And hopefully that's it! Just keep in mind of the caveats mentioned
        above that cargo fix cannot update code for inactive features or cfg

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -14,17 +14,13 @@ cargo-fix - Automatically fix lint warnings reported by rustc
 This Cargo subcommand will automatically take rustc's suggestions from
 diagnostics like warnings and apply them to your source code. This is intended
 to help automate tasks that rustc itself already knows how to tell you to fix!
-The `cargo fix` subcommand is also being developed for the Rust 2018 edition
-to provide code the ability to easily opt-in to the new edition without having
-to worry about any breakage.
 
 Executing `cargo fix` will under the hood execute [cargo-check(1)](cargo-check.html). Any warnings
 applicable to your crate will be automatically fixed (if possible) and all
 remaining warnings will be displayed when the check process is finished. For
-example if you'd like to prepare for the 2018 edition, you can do so by
-executing:
+example if you'd like to apply all fixes to the current package, you can run:
 
-    cargo fix --edition
+    cargo fix
 
 which behaves the same as `cargo check --all-targets`.
 
@@ -32,16 +28,34 @@ which behaves the same as `cargo check --all-targets`.
 `cargo check`. If code is conditionally enabled with optional features, you
 will need to enable those features for that code to be analyzed:
 
-    cargo fix --edition --features foo
+    cargo fix --features foo
 
 Similarly, other `cfg` expressions like platform-specific code will need to
 pass `--target` to fix code for the given target.
 
-    cargo fix --edition --target x86_64-pc-windows-gnu
+    cargo fix --target x86_64-pc-windows-gnu
 
 If you encounter any problems with `cargo fix` or otherwise have any questions
 or feature requests please don't hesitate to file an issue at
-<https://github.com/rust-lang/cargo>
+<https://github.com/rust-lang/cargo>.
+
+### Edition migration
+
+The `cargo fix` subcommand can also be used to migrate a package from one
+[edition] to the next. The general procedure is:
+
+1. Run `cargo fix --edition`
+2. Modify `Cargo.toml` to set the [edition field] to the new edition.
+3. Run your project tests to verify that everything still works.
+
+And hopefully that's it! Just keep in mind of the caveats mentioned above that
+`cargo fix` cannot update code for inactive features or `cfg` expressions.
+Also, in some rare cases the compiler is unable to automatically migrate all
+code to the new edition, and this may require manual changes after building
+with the new edition.
+
+[edition]: https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
+[edition field]: ../reference/manifest.html#the-edition-field
 
 ## OPTIONS
 
@@ -56,9 +70,9 @@ code in the working directory for you to inspect and manually fix.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---edition"><a class="option-anchor" href="#option-cargo-fix---edition"></a><code>--edition</code></dt>
-<dd class="option-desc">Apply changes that will update the code to the latest edition. This will not
+<dd class="option-desc">Apply changes that will update the code to the next edition. This will not
 update the edition in the <code>Cargo.toml</code> manifest, which must be updated
-manually.</dd>
+manually after <code>cargo fix --edition</code> has finished.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---edition-idioms"><a class="option-anchor" href="#option-cargo-fix---edition-idioms"></a><code>--edition-idioms</code></dt>
@@ -437,7 +451,7 @@ details on environment variables that Cargo reads.
 
        cargo fix
 
-2. Convert a 2015 edition to 2018:
+2. Update a package to prepare it for the next edition:
 
        cargo fix --edition
 

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -44,9 +44,15 @@ or feature requests please don't hesitate to file an issue at
 The `cargo fix` subcommand can also be used to migrate a package from one
 [edition] to the next. The general procedure is:
 
-1. Run `cargo fix --edition`
+1. Run `cargo fix --edition`. Consider also using the `--all-features` flag if
+   your project has multiple features. You may also want to run `cargo fix
+   --edition` multiple times with different `--target` flags if your project
+   has platform-specific code gated by `cfg` attributes.
 2. Modify `Cargo.toml` to set the [edition field] to the new edition.
-3. Run your project tests to verify that everything still works.
+3. Run your project tests to verify that everything still works. If new
+   warnings are issued, you may want to consider running `cargo fix` again
+   (without the `--edition` flag) to apply any suggestions given by the
+   compiler.
 
 And hopefully that's it! Just keep in mind of the caveats mentioned above that
 `cargo fix` cannot update code for inactive features or `cfg` expressions.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1078,6 +1078,10 @@ version = "0.1.0"
 edition = "2021"
 ```
 
+If you want to transition an existing project from a previous edition, then
+`cargo fix --edition` can be used on the nightly channel. After running `cargo
+fix`, you can switch the edition to 2021 as illustrated above.
+
 This feature is very unstable, and is only intended for early testing and
 experimentation. Future nightly releases may introduce changes for the 2021
 edition that may break your build.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1082,7 +1082,10 @@ This feature is very unstable, and is only intended for early testing and
 experimentation. Future nightly releases may introduce changes for the 2021
 edition that may break your build.
 
+The 2021 edition will set the default [resolver version] to "2".
+
 [edition]: ../../edition-guide/index.html
+[resolver version]: resolver.md#resolver-versions
 
 <script>
 (function() {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1064,6 +1064,26 @@ version = "0.0.1"
 rust-version = "1.42"
 ```
 
+### edition 2021
+
+Support for the 2021 [edition] can be enabled by adding the `edition2021`
+unstable feature to the top of `Cargo.toml`:
+
+```toml
+cargo-features = ["edition2021"]
+
+[package]
+name = "my-package"
+version = "0.1.0"
+edition = "2021"
+```
+
+This feature is very unstable, and is only intended for early testing and
+experimentation. Future nightly releases may introduce changes for the 2021
+edition that may break your build.
+
+[edition]: ../../edition-guide/index.html
+
 <script>
 (function() {
     var fragments = {

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -11,19 +11,15 @@ cargo\-fix \- Automatically fix lint warnings reported by rustc
 This Cargo subcommand will automatically take rustc's suggestions from
 diagnostics like warnings and apply them to your source code. This is intended
 to help automate tasks that rustc itself already knows how to tell you to fix!
-The \fBcargo fix\fR subcommand is also being developed for the Rust 2018 edition
-to provide code the ability to easily opt\-in to the new edition without having
-to worry about any breakage.
 .sp
 Executing \fBcargo fix\fR will under the hood execute \fBcargo\-check\fR(1). Any warnings
 applicable to your crate will be automatically fixed (if possible) and all
 remaining warnings will be displayed when the check process is finished. For
-example if you'd like to prepare for the 2018 edition, you can do so by
-executing:
+example if you'd like to apply all fixes to the current package, you can run:
 .sp
 .RS 4
 .nf
-cargo fix \-\-edition
+cargo fix
 .fi
 .RE
 .sp
@@ -35,7 +31,7 @@ will need to enable those features for that code to be analyzed:
 .sp
 .RS 4
 .nf
-cargo fix \-\-edition \-\-features foo
+cargo fix \-\-features foo
 .fi
 .RE
 .sp
@@ -44,13 +40,34 @@ pass \fB\-\-target\fR to fix code for the given target.
 .sp
 .RS 4
 .nf
-cargo fix \-\-edition \-\-target x86_64\-pc\-windows\-gnu
+cargo fix \-\-target x86_64\-pc\-windows\-gnu
 .fi
 .RE
 .sp
 If you encounter any problems with \fBcargo fix\fR or otherwise have any questions
 or feature requests please don't hesitate to file an issue at
-<https://github.com/rust\-lang/cargo>
+<https://github.com/rust\-lang/cargo>\&.
+.SS "Edition migration"
+The \fBcargo fix\fR subcommand can also be used to migrate a package from one
+\fIedition\fR <https://doc.rust\-lang.org/edition\-guide/editions/transitioning\-an\-existing\-project\-to\-a\-new\-edition.html> to the next. The general procedure is:
+.sp
+.RS 4
+\h'-04' 1.\h'+01'Run \fBcargo fix \-\-edition\fR
+.RE
+.sp
+.RS 4
+\h'-04' 2.\h'+01'Modify \fBCargo.toml\fR to set the \fIedition field\fR <https://doc.rust\-lang.org/cargo/reference/manifest.html#the\-edition\-field> to the new edition.
+.RE
+.sp
+.RS 4
+\h'-04' 3.\h'+01'Run your project tests to verify that everything still works.
+.RE
+.sp
+And hopefully that's it! Just keep in mind of the caveats mentioned above that
+\fBcargo fix\fR cannot update code for inactive features or \fBcfg\fR expressions.
+Also, in some rare cases the compiler is unable to automatically migrate all
+code to the new edition, and this may require manual changes after building
+with the new edition.
 .SH "OPTIONS"
 .SS "Fix options"
 .sp
@@ -63,9 +80,9 @@ code in the working directory for you to inspect and manually fix.
 .sp
 \fB\-\-edition\fR
 .RS 4
-Apply changes that will update the code to the latest edition. This will not
+Apply changes that will update the code to the next edition. This will not
 update the edition in the \fBCargo.toml\fR manifest, which must be updated
-manually.
+manually after \fBcargo fix \-\-edition\fR has finished.
 .RE
 .sp
 \fB\-\-edition\-idioms\fR
@@ -476,7 +493,7 @@ cargo fix
 .RE
 .sp
 .RS 4
-\h'-04' 2.\h'+01'Convert a 2015 edition to 2018:
+\h'-04' 2.\h'+01'Update a package to prepare it for the next edition:
 .sp
 .RS 4
 .nf

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -52,7 +52,9 @@ The \fBcargo fix\fR subcommand can also be used to migrate a package from one
 \fIedition\fR <https://doc.rust\-lang.org/edition\-guide/editions/transitioning\-an\-existing\-project\-to\-a\-new\-edition.html> to the next. The general procedure is:
 .sp
 .RS 4
-\h'-04' 1.\h'+01'Run \fBcargo fix \-\-edition\fR
+\h'-04' 1.\h'+01'Run \fBcargo fix \-\-edition\fR\&. Consider also using the \fB\-\-all\-features\fR flag if
+your project has multiple features. You may also want to run \fBcargo fix \-\-edition\fR multiple times with different \fB\-\-target\fR flags if your project
+has platform\-specific code gated by \fBcfg\fR attributes.
 .RE
 .sp
 .RS 4
@@ -60,7 +62,10 @@ The \fBcargo fix\fR subcommand can also be used to migrate a package from one
 .RE
 .sp
 .RS 4
-\h'-04' 3.\h'+01'Run your project tests to verify that everything still works.
+\h'-04' 3.\h'+01'Run your project tests to verify that everything still works. If new
+warnings are issued, you may want to consider running \fBcargo fix\fR again
+(without the \fB\-\-edition\fR flag) to apply any suggestions given by the
+compiler.
 .RE
 .sp
 And hopefully that's it! Just keep in mind of the caveats mentioned above that

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -39,11 +39,13 @@ fn edition_unstable_gated() {
     // During the period where a new edition is coming up, but not yet stable,
     // this test will verify that it cannot be used on stable. If there is no
     // next edition, it does nothing.
-    let next = Edition::LATEST;
-    if next.is_stable() {
-        eprintln!("Next edition is currently not available, skipping test.");
-        return;
-    }
+    let next = match Edition::LATEST_UNSTABLE {
+        Some(next) => next,
+        None => {
+            eprintln!("Next edition is currently not available, skipping test.");
+            return;
+        }
+    };
     let p = project()
         .file(
             "Cargo.toml",
@@ -87,11 +89,13 @@ fn edition_unstable() {
         // This test is fundamentally always nightly.
         return;
     }
-    let next = Edition::LATEST;
-    if next.is_stable() {
-        eprintln!("Next edition is currently not available, skipping test.");
-        return;
-    }
+    let next = match Edition::LATEST_UNSTABLE {
+        Some(next) => next,
+        None => {
+            eprintln!("Next edition is currently not available, skipping test.");
+            return;
+        }
+    };
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -1,6 +1,7 @@
 //! Tests for edition setting.
 
-use cargo_test_support::{basic_lib_manifest, project};
+use cargo::core::Edition;
+use cargo_test_support::{basic_lib_manifest, is_nightly, project};
 
 #[cargo_test]
 fn edition_works_for_build_script() {
@@ -31,4 +32,91 @@ fn edition_works_for_build_script() {
         .build();
 
     p.cargo("build -v").run();
+}
+
+#[cargo_test]
+fn edition_unstable_gated() {
+    // During the period where a new edition is coming up, but not yet stable,
+    // this test will verify that it cannot be used on stable. If there is no
+    // next edition, it does nothing.
+    let next = Edition::LATEST;
+    if next.is_stable() {
+        eprintln!("Next edition is currently not available, skipping test.");
+        return;
+    }
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "{}"
+            "#,
+                next
+            ),
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(&format!(
+            "\
+[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
+
+Caused by:
+  feature `edition{next}` is required
+
+  this Cargo does not support nightly features, but if you
+  switch to nightly channel you can add
+  `cargo-features = [\"edition{next}\"]` to enable this feature
+",
+            next = next
+        ))
+        .run();
+}
+
+#[cargo_test]
+fn edition_unstable() {
+    // During the period where a new edition is coming up, but not yet stable,
+    // this test will verify that it can be used with `cargo-features`. If
+    // there is no next edition, it does nothing.
+    if !is_nightly() {
+        // This test is fundamentally always nightly.
+        return;
+    }
+    let next = Edition::LATEST;
+    if next.is_stable() {
+        eprintln!("Next edition is currently not available, skipping test.");
+        return;
+    }
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                cargo-features = ["edition{next}"]
+
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "{next}"
+            "#,
+                next = next
+            ),
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[CHECKING] foo [..]
+[FINISHED] [..]
+",
+        )
+        .run();
 }

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -795,12 +795,14 @@ fn prepare_for_unstable() {
     // During the period where a new edition is coming up, but not yet stable,
     // this test will verify that it cannot be migrated to on stable. If there
     // is no next edition, it does nothing.
-    let next = Edition::LATEST;
-    if next.is_stable() {
-        eprintln!("Next edition is currently not available, skipping test.");
-        return;
-    }
-    let latest_stable = next.previous().unwrap();
+    let next = match Edition::LATEST_UNSTABLE {
+        Some(next) => next,
+        None => {
+            eprintln!("Next edition is currently not available, skipping test.");
+            return;
+        }
+    };
+    let latest_stable = Edition::LATEST_STABLE;
     let p = project()
         .file(
             "Cargo.toml",
@@ -853,12 +855,7 @@ To learn more, run the command again with --verbose.
 #[cargo_test]
 fn prepare_for_latest_stable() {
     // This is the stable counterpart of prepare_for_unstable.
-    let latest = Edition::LATEST;
-    let latest_stable = if latest.is_stable() {
-        latest
-    } else {
-        latest.previous().unwrap()
-    };
+    let latest_stable = Edition::LATEST_STABLE;
     let previous = latest_stable.previous().unwrap();
     let p = project()
         .file(
@@ -897,11 +894,13 @@ fn prepare_for_already_on_latest_unstable() {
         // This test is fundamentally always nightly.
         return;
     }
-    let next_edition = Edition::LATEST;
-    if next_edition.is_stable() {
-        eprintln!("Next edition is currently not available, skipping test.");
-        return;
-    }
+    let next_edition = match Edition::LATEST_UNSTABLE {
+        Some(next) => next,
+        None => {
+            eprintln!("Next edition is currently not available, skipping test.");
+            return;
+        }
+    };
     let p = project()
         .file(
             "Cargo.toml",
@@ -936,11 +935,11 @@ fn prepare_for_already_on_latest_unstable() {
 #[cargo_test]
 fn prepare_for_already_on_latest_stable() {
     // Stable counterpart of prepare_for_already_on_latest_unstable.
-    if !Edition::LATEST.is_stable() {
+    if Edition::LATEST_UNSTABLE.is_some() {
         eprintln!("This test cannot run while the latest edition is unstable, skipping.");
         return;
     }
-    let latest_stable = Edition::LATEST;
+    let latest_stable = Edition::LATEST_STABLE;
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -286,6 +286,7 @@ fn prepare_for_2018() {
 
     let stderr = "\
 [CHECKING] foo v0.0.1 ([..])
+[MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (2 fixes)
 [FINISHED] [..]
 ";
@@ -324,6 +325,7 @@ fn local_paths() {
         .with_stderr(
             "\
 [CHECKING] foo v0.0.1 ([..])
+[MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (1 fix)
 [FINISHED] [..]
 ",
@@ -409,6 +411,7 @@ fn specify_rustflags() {
         .with_stderr(
             "\
 [CHECKING] foo v0.0.1 ([..])
+[MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (1 fix)
 [FINISHED] [..]
 ",
@@ -842,6 +845,7 @@ fn fix_overlapping() {
         .with_stderr(
             "\
 [CHECKING] foo [..]
+[MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (2 fixes)
 [FINISHED] dev [..]
 ",
@@ -1164,6 +1168,7 @@ fn only_warn_for_relevant_crates() {
             "\
 [CHECKING] a v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
+[MIGRATING] src/lib.rs from 2015 edition to 2018
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -986,7 +986,7 @@ fn fix_overlapping() {
         )
         .build();
 
-    p.cargo("fix --allow-no-vcs --prepare-for 2018 --lib")
+    p.cargo("fix --allow-no-vcs --edition --lib")
         .with_stderr(
             "\
 [CHECKING] foo [..]
@@ -1042,25 +1042,6 @@ fn idioms_2015_ok() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("fix --edition-idioms --allow-no-vcs").run();
-}
-
-#[cargo_test]
-fn both_edition_migrate_flags() {
-    let p = project().file("src/lib.rs", "").build();
-
-    let stderr = "\
-error: The argument '--edition' cannot be used with '--prepare-for <prepare-for>'
-
-USAGE:
-    cargo[..] fix --edition
-
-For more information try --help
-";
-
-    p.cargo("fix --prepare-for 2018 --edition")
-        .with_status(1)
-        .with_stderr(stderr)
-        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -150,6 +150,7 @@ fn fix_example() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name example1 [..]`
+[FIXING] examples/example1.rs
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -164,6 +165,7 @@ fn fix_bin() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name bin1 [..]`
+[FIXING] src/bin/bin1.rs
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -178,6 +180,7 @@ fn fix_bench() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name bench1 [..]`
+[FIXING] benches/bench1.rs
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -192,6 +195,7 @@ fn fix_test() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name test1 [..]`
+[FIXING] tests/test1.rs
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )


### PR DESCRIPTION
This introduces some updates for edition handling (split into commits for review).  In short:

* `cargo-features = ["edition2021"]` can be used to opt-in to 2021 support without needing to pass around `-Z unstable-options`. I tried to emphasize in the docs that this is only for testing and experimentation.  
* Make `"2"` the default resolver for 2021 edition.
* Make `cargo fix --edition` mean the "next" edition from the present one, and support 2021. Also, if already at the latest edition, generate a warning instead an error.
* I decided to allow `cargo fix --edition` from 2018 to 2021 on the nightly channel without an explicit opt-in. It's tricky to implement with an opt-in (see comment in diff).

Partial for #9048.
Fixes #9047.
