### PR TITLE
Package ID specification urls must contain a host

### DIFF
--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -38,12 +38,9 @@ impl PackageIdSpec {
     /// use cargo::core::PackageIdSpec;
     ///
     /// let specs = vec![
+    ///     "https://crates.io/foo",
     ///     "https://crates.io/foo#1.2.3",
     ///     "https://crates.io/foo#bar:1.2.3",
-    ///     "crates.io/foo",
-    ///     "crates.io/foo#1.2.3",
-    ///     "crates.io/foo#bar",
-    ///     "crates.io/foo#bar:1.2.3",
     ///     "foo",
     ///     "foo:1.2.3",
     /// ];

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -97,6 +97,9 @@ impl PackageIdSpec {
 
     /// Tries to convert a valid `Url` to a `PackageIdSpec`.
     fn from_url(mut url: Url) -> CargoResult<PackageIdSpec> {
+        if url.host().is_none() {
+            bail!("pkgid urls must have a host: {}", url)
+        }
         if url.query().is_some() {
             bail!("cannot have a query string in a pkgid: {}", url)
         }
@@ -405,6 +408,8 @@ mod tests {
         assert!(PackageIdSpec::parse("baz:1.0").is_err());
         assert!(PackageIdSpec::parse("https://baz:1.0").is_err());
         assert!(PackageIdSpec::parse("https://#baz:1.0").is_err());
+        assert!(PackageIdSpec::parse("file:///baz").is_err());
+        assert!(PackageIdSpec::parse("/baz").is_err());
     }
 
     #[test]

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -279,7 +279,8 @@ impl fmt::Display for PackageIdSpec {
         match self.url {
             Some(ref url) => {
                 if url.scheme() == "cargo" {
-                    write!(f, "{}{}", url.host().unwrap(), url.path())?;
+                    let host = url.host().unwrap_or(url::Host::Domain(""));
+                    write!(f, "{}{}", host, url.path())?;
                 } else {
                     write!(f, "{}", url)?;
                 }

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -87,8 +87,11 @@ impl PackageIdSpec {
     where
         I: IntoIterator<Item = PackageId>,
     {
-        let spec = PackageIdSpec::parse(spec)
-            .chain_err(|| anyhow::format_err!("invalid package ID specification: `{}`", spec))?;
+        let i: Vec<_> = i.into_iter().collect();
+        let spec = PackageIdSpec::parse(spec).chain_err(|| {
+            let suggestion = lev_distance::closest_msg(spec, i.iter(), |id| id.name().as_str());
+            anyhow::format_err!("invalid package ID specification: `{}`{}", spec, suggestion)
+        })?;
         spec.query(i)
     }
 

--- a/src/doc/man/cargo-pkgid.md
+++ b/src/doc/man/cargo-pkgid.md
@@ -81,5 +81,9 @@ Get the package ID for the given package instead of the current package.
 
        cargo pkgid https://github.com/rust-lang/crates.io-index#foo
 
+4. Retrieve package specification for `foo` from a local package:
+
+       cargo pkgid file:///path/to/local/package#foo
+
 ## SEE ALSO
 {{man "cargo" 1}}, {{man "cargo-generate-lockfile" 1}}, {{man "cargo-metadata" 1}}

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -137,6 +137,10 @@ EXAMPLES
 
               cargo pkgid https://github.com/rust-lang/crates.io-index#foo
 
+       4. Retrieve package specification for foo from a local package:
+
+              cargo pkgid file:///path/to/local/package#foo
+
 SEE ALSO
        cargo(1), cargo-generate-lockfile(1), cargo-metadata(1)
 

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -163,5 +163,9 @@ details on environment variables that Cargo reads.
 
        cargo pkgid https://github.com/rust-lang/crates.io-index#foo
 
+4. Retrieve package specification for `foo` from a local package:
+
+       cargo pkgid file:///path/to/local/package#foo
+
 ## SEE ALSO
 [cargo(1)](cargo.html), [cargo-generate-lockfile(1)](cargo-generate-lockfile.html), [cargo-metadata(1)](cargo-metadata.html)

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -207,5 +207,15 @@ cargo pkgid https://github.com/rust\-lang/crates.io\-index#foo
 .fi
 .RE
 .RE
+.sp
+.RS 4
+\h'-04' 4.\h'+01'Retrieve package specification for \fBfoo\fR from a local package:
+.sp
+.RS 4
+.nf
+cargo pkgid file:///path/to/local/package#foo
+.fi
+.RE
+.RE
 .SH "SEE ALSO"
 \fBcargo\fR(1), \fBcargo\-generate\-lockfile\fR(1), \fBcargo\-metadata\fR(1)

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -54,6 +54,7 @@ fn suggestion_bad_pkgid() {
             "#,
         )
         .file("src/lib.rs", "")
+        .file("cratesio", "")
         .build();
 
     p.cargo("generate-lockfile").run();
@@ -106,6 +107,21 @@ error: invalid package ID specification: `./Cargo.toml`
 
 Caused by:
   package ID specification `./Cargo.toml` looks like a file path, maybe try file://[..]/Cargo.toml
+",
+        )
+        .run();
+
+    // Bad file URL with simliar name.
+    p.cargo("pkgid './cratesio'")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: invalid package ID specification: `./cratesio`
+
+<tab>Did you mean `crates-io`?
+
+Caused by:
+  package ID specification `./cratesio` looks like a file path, maybe try file://[..]/cratesio
 ",
         )
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -96,4 +96,17 @@ Did you mean one of these?
 ",
         )
         .run();
+
+    // Bad file URL.
+    p.cargo("pkgid ./Cargo.toml")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: invalid package ID specification: `./Cargo.toml`
+
+Caused by:
+  package ID specification `./Cargo.toml` looks like a file path, maybe try file://[..]/Cargo.toml
+",
+        )
+        .run();
 }


### PR DESCRIPTION
Resolves https://github.com/rust-lang/cargo/issues/9041

Not sure which commit breaks this. Cargo shipped with rust 1.46 didn't unwrap on a `None` but 1.47 did. Even checkouted to 149022b1d8f382e69c1616f6a46b69ebf59e2dea (cargo of rust 1.46), it still unwrap unexpectedly.



So I ended up following the [Specification grammer](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html#specification-grammar) to make sure there is a `host` in the pkgid urls.

<details>
<summary>See console output</summary>

cargo of rust 1.46
```console
$ cargo +1.46 -vV
cargo 1.46.0 (149022b1d 2020-07-17)
release: 1.46.0
commit-hash: 149022b1d8f382e69c1616f6a46b69ebf59e2dea
commit-date: 2020-07-17

$ cargo +1.46 pkgid /path
error: package ID specification `/path` matched no packages
```

cargo of rust 1.47

```console
$ cargo +1.47 -vV
cargo 1.47.0 (f3c7e066a 2020-08-28)
release: 1.47.0
commit-hash: f3c7e066ad66e05439cf8eab165a2de580b41aaf
commit-date: 2020-08-28

$ cargo +1.47 pkgid /path
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/tools/cargo/src/cargo/core/package_id_spec.rs:234:50
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

cargo on commit 149022b1d8f382e69c1616f6a46b69ebf59e2dea

```console
$ git checkout 149022b1d8f382e69c1616f6a46b69ebf59e2dea
$ cargo run -- pkgid /path
   Compiling cargo-platform v0.1.1 ([..]/cargo/crates/cargo-platform)
   Compiling crates-io v0.31.1 ([..]/cargo/crates/crates-io)
   Compiling cargo v0.47.0 ([..]/cargo)
    Finished dev [unoptimized + debuginfo] target(s) in 22.90s
     Running `target/debug/cargo pkgid /path`
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src/cargo/core/package_id_spec.rs:234:50
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
</details>

