### PR TITLE
Make it more clear which module is being tested when running cargo test

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use crate::core::compiler::{Compilation, CompileKind, Doctest, UnitOutput};
 use crate::core::shell::Verbosity;
-use crate::core::Workspace;
+use crate::core::{TargetKind, Workspace};
 use crate::ops;
 use crate::util::errors::CargoResult;
 use crate::util::{CargoTestError, Config, ProcessError, Test};
@@ -85,7 +85,24 @@ fn run_unit_tests(
     } in compilation.tests.iter()
     {
         let test = unit.target.name().to_string();
-        let exe_display = path.strip_prefix(cwd).unwrap_or(path).display();
+
+        let test_path = unit.target.src_path().path().unwrap();
+        let exe_display = if let TargetKind::Test = unit.target.kind() {
+            format!(
+                "{} ({})",
+                test_path
+                    .strip_prefix(unit.pkg.root())
+                    .unwrap_or(&test_path)
+                    .display(),
+                path.strip_prefix(cwd).unwrap_or(path).display()
+            )
+        } else {
+            format!(
+                "unittests ({})",
+                path.strip_prefix(cwd).unwrap_or(path).display()
+            )
+        };
+
         let mut cmd = compilation.target_process(path, unit.kind, &unit.pkg, *script_meta)?;
         cmd.args(test_args);
         if unit.target.harness() && config.shell().verbosity() == Verbosity::Quiet {

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -45,7 +45,7 @@ fn cargo_bench_simple() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench_hello ... bench: [..]")
         .run();
@@ -91,8 +91,8 @@ fn bench_bench_implicit() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
-[RUNNING] target/release/deps/mybench-[..][EXE]
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
+[RUNNING] [..] (target/release/deps/mybench-[..][EXE])
 ",
         )
         .with_stdout_contains("test run2 ... bench: [..]")
@@ -139,7 +139,7 @@ fn bench_bin_implicit() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
 ",
         )
         .with_stdout_contains("test run1 ... bench: [..]")
@@ -176,7 +176,7 @@ fn bench_tarname() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/bin2-[..][EXE]
+[RUNNING] [..] (target/release/deps/bin2-[..][EXE])
 ",
         )
         .with_stdout_contains("test run2 ... bench: [..]")
@@ -344,7 +344,7 @@ fn cargo_bench_failing_test() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])[..]
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_either_contains(
             "[..]thread '[..]' panicked at 'assertion failed: `(left == right)`[..]",
@@ -416,8 +416,8 @@ fn bench_with_lib_dep() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
-[RUNNING] target/release/deps/baz-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
+[RUNNING] [..] (target/release/deps/baz-[..][EXE])",
         )
         .with_stdout_contains("test lib_bench ... bench: [..]")
         .with_stdout_contains("test bin_bench ... bench: [..]")
@@ -481,7 +481,7 @@ fn bench_with_deep_lib_dep() {
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/bar-[..][EXE]",
+[RUNNING] [..] (target/release/deps/bar-[..][EXE])",
         )
         .with_stdout_contains("test bar_bench ... bench: [..]")
         .run();
@@ -538,8 +538,8 @@ fn external_bench_explicit() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
-[RUNNING] target/release/deps/bench-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
+[RUNNING] [..] (target/release/deps/bench-[..][EXE])",
         )
         .with_stdout_contains("test internal_bench ... bench: [..]")
         .with_stdout_contains("test external_bench ... bench: [..]")
@@ -585,8 +585,8 @@ fn external_bench_implicit() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
-[RUNNING] target/release/deps/external-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
+[RUNNING] [..] (target/release/deps/external-[..][EXE])",
         )
         .with_stdout_contains("test internal_bench ... bench: [..]")
         .with_stdout_contains("test external_bench ... bench: [..]")
@@ -664,7 +664,7 @@ For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
 ",
         )
         .run();
@@ -711,7 +711,7 @@ fn pass_through_command_line() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bar ... bench: [..]")
         .run();
@@ -719,7 +719,7 @@ fn pass_through_command_line() {
     p.cargo("bench foo")
         .with_stderr(
             "[FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test foo ... bench: [..]")
         .run();
@@ -804,8 +804,8 @@ fn lib_bin_same_name() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains_n("test [..] ... bench: [..]", 2)
         .run();
@@ -853,8 +853,8 @@ fn lib_with_standard_name() {
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/syntax-[..][EXE]
-[RUNNING] target/release/deps/bench-[..][EXE]",
+[RUNNING] [..] (target/release/deps/syntax-[..][EXE])
+[RUNNING] [..] (target/release/deps/bench-[..][EXE])",
         )
         .with_stdout_contains("test foo_bench ... bench: [..]")
         .with_stdout_contains("test bench ... bench: [..]")
@@ -905,7 +905,7 @@ fn lib_with_standard_name2() {
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/syntax-[..][EXE]",
+[RUNNING] [..] (target/release/deps/syntax-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
         .run();
@@ -1040,7 +1040,7 @@ fn bench_twice_with_build_cmd() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test foo ... bench: [..]")
         .run();
@@ -1048,7 +1048,7 @@ fn bench_twice_with_build_cmd() {
     p.cargo("bench")
         .with_stderr(
             "[FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test foo ... bench: [..]")
         .run();
@@ -1175,7 +1175,7 @@ fn test_a_bench() {
             "\
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/b-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/b-[..][EXE])",
         )
         .with_stdout_contains("test foo ... ok")
         .run();
@@ -1251,9 +1251,9 @@ fn test_bench_no_fail_fast() {
 
     p.cargo("bench --no-fail-fast -- --test-threads=1")
         .with_status(101)
-        .with_stderr_contains("[RUNNING] target/release/deps/foo-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/foo-[..][EXE])")
         .with_stdout_contains("running 2 tests")
-        .with_stderr_contains("[RUNNING] target/release/deps/foo-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/foo-[..][EXE])")
         .with_stdout_contains("test bench_hello [..]")
         .with_stdout_contains("test bench_nope [..]")
         .run();
@@ -1345,9 +1345,9 @@ fn test_bench_multiple_packages() {
         .build();
 
     p.cargo("bench -p bar -p baz")
-        .with_stderr_contains("[RUNNING] target/release/deps/bbaz-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/bbaz-[..][EXE])")
         .with_stdout_contains("test bench_baz ... bench: [..]")
-        .with_stderr_contains("[RUNNING] target/release/deps/bbar-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/bbar-[..][EXE])")
         .with_stdout_contains("test bench_bar ... bench: [..]")
         .run();
 }
@@ -1402,9 +1402,9 @@ fn bench_all_workspace() {
         .build();
 
     p.cargo("bench --workspace")
-        .with_stderr_contains("[RUNNING] target/release/deps/bar-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/bar-[..][EXE])")
         .with_stdout_contains("test bench_bar ... bench: [..]")
-        .with_stderr_contains("[RUNNING] target/release/deps/foo-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/foo-[..][EXE])")
         .with_stdout_contains("test bench_foo ... bench: [..]")
         .run();
 }
@@ -1553,9 +1553,9 @@ fn bench_all_virtual_manifest() {
 
     // The order in which bar and baz are built is not guaranteed
     p.cargo("bench --workspace")
-        .with_stderr_contains("[RUNNING] target/release/deps/baz-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/baz-[..][EXE])")
         .with_stdout_contains("test bench_baz ... bench: [..]")
-        .with_stderr_contains("[RUNNING] target/release/deps/bar-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/bar-[..][EXE])")
         .with_stdout_contains("test bench_bar ... bench: [..]")
         .run();
 }
@@ -1606,9 +1606,9 @@ fn bench_virtual_manifest_glob() {
 
     // The order in which bar and baz are built is not guaranteed
     p.cargo("bench -p '*z'")
-        .with_stderr_contains("[RUNNING] target/release/deps/baz-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/baz-[..][EXE])")
         .with_stdout_contains("test bench_baz ... bench: [..]")
-        .with_stderr_does_not_contain("[RUNNING] target/release/deps/bar-[..][EXE]")
+        .with_stderr_does_not_contain("[RUNNING] [..] (target/release/deps/bar-[..][EXE])")
         .with_stdout_does_not_contain("test bench_bar ... bench: [..]")
         .run();
 }
@@ -1699,9 +1699,9 @@ fn bench_virtual_manifest_all_implied() {
     // The order in which bar and baz are built is not guaranteed
 
     p.cargo("bench")
-        .with_stderr_contains("[RUNNING] target/release/deps/baz-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/baz-[..][EXE])")
         .with_stdout_contains("test bench_baz ... bench: [..]")
-        .with_stderr_contains("[RUNNING] target/release/deps/bar-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/release/deps/bar-[..][EXE])")
         .with_stdout_contains("test bench_bar ... bench: [..]")
         .run();
 }

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -350,8 +350,8 @@ fn cross_tests() {
             "\
 [COMPILING] foo v0.0.0 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
-[RUNNING] target/{triple}/debug/deps/bar-[..][EXE]",
+[RUNNING] [..] (target/{triple}/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/{triple}/debug/deps/bar-[..][EXE])",
             triple = target
         ))
         .with_stdout_contains("test test_foo ... ok")
@@ -380,7 +380,7 @@ fn no_cross_doctests() {
     let host_output = "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ";
 
@@ -395,7 +395,7 @@ fn no_cross_doctests() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/{triple}/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/{triple}/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ",
             triple = target
@@ -1060,8 +1060,8 @@ fn cross_test_dylib() {
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/{arch}/debug/deps/foo-[..][EXE]
-[RUNNING] target/{arch}/debug/deps/test-[..][EXE]",
+[RUNNING] [..] (target/{arch}/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/{arch}/debug/deps/test-[..][EXE])",
             arch = cross_compile::alternate()
         ))
         .with_stdout_contains_n("test foo ... ok", 2)

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -252,7 +252,7 @@ fn changing_profiles_caches_targets() {
             "\
 [..]Compiling foo v0.0.1 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
+[RUNNING] [..] (target[..]debug[..]deps[..]foo-[..][EXE])
 [DOCTEST] foo
 ",
         )
@@ -268,7 +268,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr(
             "\
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]debug[..]deps[..]foo-[..][EXE]
+[RUNNING] [..] (target[..]debug[..]deps[..]foo-[..][EXE])
 ",
         )
         .run();
@@ -2441,7 +2441,7 @@ fn linking_interrupted() {
             "\
 [COMPILING] foo [..]
 [FINISHED] [..]
-[RUNNING] target/debug/deps/t1[..]
+[RUNNING] tests/t1.rs (target/debug/deps/t1[..])
 ",
         )
         .run();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1301,7 +1301,7 @@ fn dev_deps_with_testing() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test tests::foo ... ok")
         .run();

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -187,7 +187,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
         .run();
@@ -770,7 +770,7 @@ fn dev_deps_no_rebuild_lib() {
 [COMPILING] [..] v0.5.0 ([CWD][..])
 [COMPILING] [..] v0.5.0 ([CWD][..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
         .run();

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -294,7 +294,7 @@ fn test_default_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -308,7 +308,7 @@ fn test_default_features() {
         .with_stderr(
             "\
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -351,7 +351,7 @@ fn test_arg_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -392,7 +392,7 @@ fn test_multiple_required_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo_2-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo_2-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -402,8 +402,8 @@ fn test_multiple_required_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo_1-[..][EXE]
-[RUNNING] target/debug/deps/foo_2-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo_1-[..][EXE])
+[RUNNING] [..] (target/debug/deps/foo_2-[..][EXE])",
         )
         .with_stdout_contains_n("test test ... ok", 2)
         .run();
@@ -457,7 +457,7 @@ fn bench_default_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
         .run();
@@ -471,7 +471,7 @@ fn bench_default_features() {
         .with_stderr(
             "\
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
         .run();
@@ -529,7 +529,7 @@ fn bench_arg_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
         .run();
@@ -595,7 +595,7 @@ fn bench_multiple_required_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo_2-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo_2-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
         .run();
@@ -605,8 +605,8 @@ fn bench_multiple_required_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo_1-[..][EXE]
-[RUNNING] target/release/deps/foo_2-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo_1-[..][EXE])
+[RUNNING] [..] (target/release/deps/foo_2-[..][EXE])",
         )
         .with_stdout_contains_n("test bench ... bench: [..]", 2)
         .run();
@@ -861,7 +861,7 @@ fn dep_feature_in_toml() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -874,7 +874,7 @@ fn dep_feature_in_toml() {
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
             )
             .with_stdout_contains("test bench ... bench: [..]")
             .run();
@@ -1003,7 +1003,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bin_is_built ... ok")
         .run();
@@ -1021,7 +1021,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
             )
             .with_stdout_contains("test bench ... bench: [..]")
             .run();
@@ -1075,7 +1075,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
         .run();
@@ -1095,7 +1095,7 @@ error[E0463]: can't find crate for `bar`",
                 "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] bench [optimized] target(s) in [..]
-[RUNNING] target/release/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/release/deps/foo-[..][EXE])",
             )
             .with_stdout_contains("running 0 tests")
             .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -42,7 +42,7 @@ fn cargo_test_simple() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test_hello ... ok")
         .run();
@@ -309,7 +309,7 @@ fn cargo_test_failing_test_in_bin() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [ERROR] test failed, to rerun pass '--bin foo'",
         )
         .with_stdout_contains(
@@ -357,8 +357,8 @@ fn cargo_test_failing_test_in_test() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/footest-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/footest-[..][EXE])
 [ERROR] test failed, to rerun pass '--test footest'",
         )
         .with_stdout_contains("running 0 tests")
@@ -396,7 +396,7 @@ fn cargo_test_failing_test_in_lib() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [ERROR] test failed, to rerun pass '--lib'",
         )
         .with_stdout_contains(
@@ -470,8 +470,8 @@ fn test_with_lib_dep() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/baz-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/baz-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test lib_test ... ok")
@@ -524,7 +524,7 @@ fn test_with_deep_lib_dep() {
 [COMPILING] bar v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target[..]
+[RUNNING] [..] (target[..])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test bar_test ... ok")
@@ -573,8 +573,8 @@ fn external_test_explicit() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/test-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/test-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test internal_test ... ok")
@@ -633,8 +633,8 @@ fn external_test_implicit() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/external-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/external-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test internal_test ... ok")
@@ -674,7 +674,7 @@ fn pass_through_command_line() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
         .with_stdout_contains("running 1 test")
@@ -685,7 +685,7 @@ fn pass_through_command_line() {
         .with_stderr(
             "\
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
         .with_stdout_contains("running 1 test")
@@ -750,8 +750,8 @@ fn lib_bin_same_name() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains_n("test [..] ... ok", 2)
@@ -791,8 +791,8 @@ fn lib_with_standard_name() {
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/syntax-[..][EXE]
-[RUNNING] target/debug/deps/test-[..][EXE]
+[RUNNING] [..] (target/debug/deps/syntax-[..][EXE])
+[RUNNING] [..] (target/debug/deps/test-[..][EXE])
 [DOCTEST] syntax",
         )
         .with_stdout_contains("test foo_test ... ok")
@@ -837,7 +837,7 @@ fn lib_with_standard_name2() {
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/syntax-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/syntax-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -878,7 +878,7 @@ fn lib_without_name() {
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/syntax-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/syntax-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
@@ -1190,8 +1190,8 @@ fn test_dylib() {
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/test-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/test-[..][EXE])",
         )
         .with_stdout_contains_n("test foo ... ok", 2)
         .run();
@@ -1201,8 +1201,8 @@ fn test_dylib() {
         .with_stderr(
             "\
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/test-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/test-[..][EXE])",
         )
         .with_stdout_contains_n("test foo ... ok", 2)
         .run();
@@ -1230,7 +1230,7 @@ fn test_twice_with_build_cmd() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test foo ... ok")
@@ -1241,7 +1241,7 @@ fn test_twice_with_build_cmd() {
         .with_stderr(
             "\
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test foo ... ok")
@@ -1258,7 +1258,7 @@ fn test_then_build() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test foo ... ok")
@@ -1313,7 +1313,7 @@ fn test_run_specific_bin_target() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/bin2-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/bin2-[..][EXE])",
         )
         .with_stdout_contains("test test2 ... ok")
         .run();
@@ -1354,7 +1354,7 @@ fn test_run_implicit_bin_target() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/mybin-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/mybin-[..][EXE])",
         )
         .with_stdout_contains("test test_in_bin ... ok")
         .run();
@@ -1374,7 +1374,7 @@ fn test_run_specific_test_target() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/b-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/b-[..][EXE])",
         )
         .with_stdout_contains("test test_b ... ok")
         .run();
@@ -1414,8 +1414,8 @@ fn test_run_implicit_test_target() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/mybin-[..][EXE]
-[RUNNING] target/debug/deps/mytest-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/mybin-[..][EXE])
+[RUNNING] [..] (target/debug/deps/mytest-[..][EXE])",
         )
         .with_stdout_contains("test test_in_test ... ok")
         .run();
@@ -1455,8 +1455,8 @@ fn test_run_implicit_bench_target() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/mybin-[..][EXE]
-[RUNNING] target/debug/deps/mybench-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/mybin-[..][EXE])
+[RUNNING] [..] (target/debug/deps/mybench-[..][EXE])",
         )
         .with_stdout_contains("test test_in_bench ... ok")
         .run();
@@ -1598,7 +1598,7 @@ fn test_no_harness() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/bar-[..][EXE]
+[RUNNING] [..] (target/debug/deps/bar-[..][EXE])
 ",
         )
         .run();
@@ -1670,8 +1670,8 @@ fn selective_testing() {
             "\
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/d1-[..][EXE]
-[RUNNING] target/debug/deps/d1-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/d1-[..][EXE])
+[RUNNING] [..] (target/debug/deps/d1-[..][EXE])",
         )
         .with_stdout_contains_n("running 0 tests", 2)
         .run();
@@ -1682,8 +1682,8 @@ fn selective_testing() {
             "\
 [COMPILING] d2 v0.0.1 ([CWD]/d2)
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/d2-[..][EXE]
-[RUNNING] target/debug/deps/d2-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/d2-[..][EXE])
+[RUNNING] [..] (target/debug/deps/d2-[..][EXE])",
         )
         .with_stdout_contains_n("running 0 tests", 2)
         .run();
@@ -1694,7 +1694,7 @@ fn selective_testing() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
         .run();
@@ -1875,7 +1875,7 @@ fn selective_testing_with_docs() {
             "\
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/d1[..][EXE]
+[RUNNING] [..] (target/debug/deps/d1[..][EXE])
 [DOCTEST] d1",
         )
         .with_stdout_contains_n("running 0 tests", 2)
@@ -2038,7 +2038,7 @@ fn doctest_feature() {
             "\
 [COMPILING] foo [..]
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("running 0 tests")
@@ -2115,7 +2115,7 @@ fn filter_no_doc_tests() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
         .run();
@@ -2241,7 +2241,7 @@ fn cyclic_dev_dep_doc_test() {
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo[..][EXE]
+[RUNNING] [..] (target/debug/deps/foo[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("running 0 tests")
@@ -2337,13 +2337,13 @@ fn no_fail_fast() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..][EXE]
-[RUNNING] target/debug/deps/test_add_one-[..][EXE]",
+[RUNNING] [..] (target/debug/deps/foo-[..][EXE])
+[RUNNING] [..] (target/debug/deps/test_add_one-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
         .with_stderr_contains(
             "\
-[RUNNING] target/debug/deps/test_sub_one-[..][EXE]
+[RUNNING] [..] (target/debug/deps/test_sub_one-[..][EXE])
 [DOCTEST] foo",
         )
         .with_stdout_contains("test result: FAILED. [..]")
@@ -2405,8 +2405,8 @@ fn test_multiple_packages() {
     let p = p.build();
 
     p.cargo("test -p d1 -p d2")
-        .with_stderr_contains("[RUNNING] target/debug/deps/d1-[..][EXE]")
-        .with_stderr_contains("[RUNNING] target/debug/deps/d2-[..][EXE]")
+        .with_stderr_contains("[RUNNING] [..] (target/debug/deps/d1-[..][EXE])")
+        .with_stderr_contains("[RUNNING] [..] (target/debug/deps/d2-[..][EXE])")
         .with_stdout_contains_n("running 0 tests", 2)
         .run();
 }
@@ -3690,7 +3690,7 @@ fn doctest_skip_staticlib() {
             "\
 [COMPILING] foo [..]
 [FINISHED] test [..]
-[RUNNING] target/debug/deps/foo-[..]",
+[RUNNING] [..] (target/debug/deps/foo-[..])",
         )
         .run();
 }
@@ -3718,7 +3718,7 @@ pub fn foo() -> u8 { 1 }
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..]
+[RUNNING] [..] (target/debug/deps/foo-[..])
 [DOCTEST] foo
 ",
         )
@@ -3742,7 +3742,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]
         .with_stderr(
             "\
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] target/debug/deps/foo-[..]\n",
+[RUNNING] [..] (target/debug/deps/foo-[..])\n",
         )
         .with_stdout(
             "


### PR DESCRIPTION
I recently asked in zulip if this is a good idea, as I find it hard to find the module thats being tested from the complex path with the hash. 

Output of `cargo test`:
```
2021-02-21 13:29:33 I > ~/repos/cargo/target/debug/cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.42s
     Running unittests (target/debug/deps/test_tests-759130ea61f71571)

running 1 test
test tests::unit_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in
0.00s

     Running tests2/lib.rs (target/debug/deps/integration_tests-6b7f9fcd1721f083)

running 2 tests
test tests2_lib ... ok
test second_test::tests2_second ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in
0.00s

     Running tests/lib.rs (target/debug/deps/lib-d2be6d29597c2790)

running 2 tests
test second_test::tests_i_am_run_twice ... ok
test tests_lib ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in
0.00s
...
```
