### PR TITLE
[beta] backports for 1.51

### DIFF
--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -177,7 +177,7 @@ rustup does not appear to be installed. Make sure that the appropriate
         },
     }
 
-    panic!(message);
+    panic!("{}", message);
 }
 
 /// The alternate target-triple to build with.

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -56,6 +56,8 @@ pub struct NewCrate {
     pub repository: Option<String>,
     pub badges: BTreeMap<String, BTreeMap<String, String>>,
     pub links: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub v: Option<u32>,
 }
 
 #[derive(Serialize)]

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -119,17 +119,15 @@ pub fn install(
         // able to run these commands.
         let dst = root.join("bin").into_path_unlocked();
         let path = env::var_os("PATH").unwrap_or_default();
-        for path in env::split_paths(&path) {
-            if path == dst {
-                return Ok(());
-            }
-        }
+        let dst_in_path = env::split_paths(&path).any(|path| path == dst);
 
-        config.shell().warn(&format!(
-            "be sure to add `{}` to your PATH to be \
+        if !dst_in_path {
+            config.shell().warn(&format!(
+                "be sure to add `{}` to your PATH to be \
              able to run the installed binaries",
-            dst.display()
-        ))?;
+                dst.display()
+            ))?;
+        }
     }
 
     if scheduled_error {

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -305,6 +305,7 @@ fn transmit(
             license_file: license_file.clone(),
             badges: badges.clone(),
             links: links.clone(),
+            v: None,
         },
         tarball,
     );

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -269,6 +269,24 @@ pub struct RegistryPackage<'a> {
     /// Added early 2018 (see <https://github.com/rust-lang/cargo/pull/4978>),
     /// can be `None` if published before then.
     links: Option<InternedString>,
+    /// The schema version for this entry.
+    ///
+    /// If this is None, it defaults to version 1. Entries with unknown
+    /// versions are ignored.
+    ///
+    /// This provides a method to safely introduce changes to index entries
+    /// and allow older versions of cargo to ignore newer entries it doesn't
+    /// understand. This is honored as of 1.51, so unfortunately older
+    /// versions will ignore it, and potentially misinterpret version 1 and
+    /// newer entries.
+    ///
+    /// The intent is that versions older than 1.51 will work with a
+    /// pre-existing `Cargo.lock`, but they may not correctly process `cargo
+    /// update` or build a lock from scratch. In that case, cargo may
+    /// incorrectly select a new package that uses a new index format. A
+    /// workaround is to downgrade any packages that are incompatible with the
+    /// `--precise` flag of `cargo update`.
+    v: Option<u32>,
 }
 
 #[test]

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -365,5 +365,5 @@ fn closed_output_ok() {
         .unwrap();
     let status = child.wait().unwrap();
     assert!(status.success());
-    assert!(s.is_empty(), s);
+    assert!(s.is_empty(), "{}", s);
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -370,7 +370,11 @@ fn finds_git_author() {
 
     let toml = paths::root().join("foo/Cargo.toml");
     let contents = fs::read_to_string(&toml).unwrap();
-    assert!(contents.contains(r#"authors = ["foo <gitfoo>"]"#), contents);
+    assert!(
+        contents.contains(r#"authors = ["foo <gitfoo>"]"#),
+        "{}",
+        contents
+    );
 }
 
 #[cargo_test]
@@ -411,7 +415,11 @@ fn finds_git_author_in_included_config() {
     cargo_process("new foo/bar").run();
     let toml = paths::root().join("foo/bar/Cargo.toml");
     let contents = fs::read_to_string(&toml).unwrap();
-    assert!(contents.contains(r#"authors = ["foo <bar>"]"#), contents,);
+    assert!(
+        contents.contains(r#"authors = ["foo <bar>"]"#),
+        "{}",
+        contents
+    );
 }
 
 #[cargo_test]
@@ -632,7 +640,7 @@ fn new_with_blank_email() {
         .run();
 
     let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(contents.contains(r#"authors = ["Sen"]"#), contents);
+    assert!(contents.contains(r#"authors = ["Sen"]"#), "{}", contents);
 }
 
 #[cargo_test]


### PR DESCRIPTION
Beta backports for the following:

* Fix panic with doc collision orphan. (#9142)
    * This is an important regression that is fairly easy to hit.
* Do not exit prematurely if anything failed installing. (#9185)
    * This is not a regression, but I think an important fix.
* Add schema field to the index (#9161)
    * This is only the first commit from the PR which checks for the `v` field in the index, and skips entries that are not understood. The reason to backport is to get this in as early as possible so that if we do decide to start using it in the future, it works as early as possible.  This otherwise doesn't do anything, so I think it should be safe.
* Fix warnings of the new non_fmt_panic lint (#9148)
    * Fixes CI for a new warning in nightly.
  