### PR TITLE
testsuite: Improve performance when using rustup.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1582,6 +1582,16 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
             p.env_remove(&k);
         }
     }
+    if env::var_os("RUSTUP_TOOLCHAIN").is_some() {
+        // Override the PATH to avoid executing the rustup wrapper thousands
+        // of times. This makes the testsuite run substantially faster.
+        let path = env::var_os("PATH").unwrap_or_default();
+        let paths = env::split_paths(&path);
+        let mut outer_cargo = PathBuf::from(env::var_os("CARGO").unwrap());
+        outer_cargo.pop();
+        let new_path = env::join_paths(std::iter::once(outer_cargo).chain(paths)).unwrap();
+        p.env("PATH", new_path);
+    }
 
     p.cwd(&paths::root())
         .env("HOME", paths::home())

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -19,7 +19,7 @@ use semver::Version;
 use std::fs;
 
 fn tc_process(cmd: &str, toolchain: &str) -> ProcessBuilder {
-    if toolchain == "this" {
+    let mut p = if toolchain == "this" {
         if cmd == "cargo" {
             process(&cargo_exe())
         } else {
@@ -29,7 +29,10 @@ fn tc_process(cmd: &str, toolchain: &str) -> ProcessBuilder {
         let mut cmd = process(cmd);
         cmd.arg(format!("+{}", toolchain));
         cmd
-    }
+    };
+    // Reset PATH since `process` modifies it to remove rustup.
+    p.env("PATH", std::env::var_os("PATH").unwrap());
+    p
 }
 
 /// Returns a sorted list of all toolchains.


### PR DESCRIPTION
The rustup wrapper adds a considerable amount of overhead when running processes like `rustc`.  This overrides `PATH` when running the testsuite to prioritize the actual executables to avoid the wrapper.

I'm not 100% confident this won't break something somewhere, but it seems like it should be safe.

In my tests, this makes the testsuite 1.5 to 1.7 times faster.