### PR TITLE
testsuite: Use split debuginfo on macos.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1583,6 +1583,14 @@ fn _process(t: &OsStr) -> cargo::util::ProcessBuilder {
         }
     }
 
+    if cfg!(target_os = "macos") {
+        // This makes the test suite run substantially faster.
+        p.env("CARGO_PROFILE_DEV_SPLIT_DEBUGINFO", "unpacked")
+            .env("CARGO_PROFILE_TEST_SPLIT_DEBUGINFO", "unpacked")
+            .env("CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO", "unpacked")
+            .env("CARGO_PROFILE_BENCH_SPLIT_DEBUGINFO", "unpacked");
+    }
+
     p.cwd(&paths::root())
         .env("HOME", paths::home())
         .env("CARGO_HOME", paths::home().join(".cargo"))

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1656,9 +1656,7 @@ fn lto_build() {
         --emit=[..]link \
         -C opt-level=3 \
         -C lto \
-        -C metadata=[..] \
-        --out-dir [CWD]/target/release/deps \
-        -L dependency=[CWD]/target/release/deps`
+        [..]
 [FINISHED] release [optimized] target(s) in [..]
 ",
         )

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -493,8 +493,8 @@ fn cdylib_and_rlib() {
 [FRESH] registry-shared v0.0.1
 [FRESH] bar v0.0.0 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo [..]-C embed-bitcode=no --test[..]
-[RUNNING] `rustc --crate-name a [..]-C embed-bitcode=no --test[..]
+[RUNNING] `rustc --crate-name foo [..]-C embed-bitcode=no [..]--test[..]
+[RUNNING] `rustc --crate-name a [..]-C embed-bitcode=no [..]--test[..]
 [FINISHED] [..]
 [RUNNING] [..]
 [RUNNING] [..]
@@ -520,8 +520,8 @@ fn cdylib_and_rlib() {
 [RUNNING] `rustc --crate-name registry_shared [..]-C embed-bitcode=no[..]
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar [..]--crate-type cdylib --crate-type rlib [..]-C embed-bitcode=no[..]
-[RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no --test[..]
-[RUNNING] `rustc --crate-name b [..]-C embed-bitcode=no --test[..]
+[RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no [..]--test[..]
+[RUNNING] `rustc --crate-name b [..]-C embed-bitcode=no [..]--test[..]
 [FINISHED] [..]
 [RUNNING] [..]target/release/deps/bar-[..]
 [RUNNING] [..]target/release/deps/b-[..]
@@ -552,8 +552,8 @@ fn dylib() {
 [FRESH] registry-shared v0.0.1
 [FRESH] bar v0.0.0 [..]
 [COMPILING] foo [..]
-[RUNNING] `rustc --crate-name foo [..]-C embed-bitcode=no --test[..]
-[RUNNING] `rustc --crate-name a [..]-C embed-bitcode=no --test[..]
+[RUNNING] `rustc --crate-name foo [..]-C embed-bitcode=no [..]--test[..]
+[RUNNING] `rustc --crate-name a [..]-C embed-bitcode=no [..]--test[..]
 [FINISHED] [..]
 [RUNNING] [..]
 [RUNNING] [..]
@@ -578,8 +578,8 @@ fn dylib() {
 [FRESH] registry-shared v0.0.1
 [FRESH] registry v0.0.1
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no --test[..]
-[RUNNING] `rustc --crate-name b [..]-C embed-bitcode=no --test[..]
+[RUNNING] `rustc --crate-name bar [..]-C embed-bitcode=no [..]--test[..]
+[RUNNING] `rustc --crate-name b [..]-C embed-bitcode=no [..]--test[..]
 [FINISHED] [..]
 [RUNNING] [..]
 [RUNNING] [..]


### PR DESCRIPTION
This switches the testsuite to use "unpacked" debuginfo on macos, which is a substantial performance boost. On my system, the testsuite runs 1.55 times faster with this change.  Along with #9206, total testsuite time is 3.1 times faster.
 