### PR TITLE
doc: Fix spelling worksapce->workspace

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -117,7 +117,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let version = args.value_of("version");
     let root = args.value_of("root");
 
-    // We only provide worksapce information for local crate installation from
+    // We only provide workspace information for local crate installation from
     // one of the following sources:
     // - From current working directory (only work for edition 2015).
     // - From a specific local file path.

--- a/src/doc/src/guide/build-cache.md
+++ b/src/doc/src/guide/build-cache.md
@@ -2,7 +2,7 @@
 
 Cargo stores the output of a build into the "target" directory. By default,
 this is the directory named `target` in the root of your
-[*workspace*][def-worksapce]. To change the location, you can set the
+[*workspace*][def-workspace]. To change the location, you can set the
 `CARGO_TARGET_DIR` [environment variable], the [`build.target-dir`] config
 value, or the `--target-dir` command-line flag.
 


### PR DESCRIPTION
only in comments or documentation