### PR TITLE
Minor update to registry API error messages.

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -155,13 +155,13 @@ impl fmt::Display for ResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ResponseError::Curl(e) => write!(f, "{}", e),
-            ResponseError::Api { code, errors } => write!(
-                f,
-                "api errors (status {} {}): {}",
-                code,
-                reason(*code),
-                errors.join(", ")
-            ),
+            ResponseError::Api { code, errors } => {
+                f.write_str("the remote server responded with an error")?;
+                if *code != 200 {
+                    write!(f, " (status {} {})", code, reason(*code))?;
+                };
+                write!(f, ": {}", errors.join(", "))
+            }
             ResponseError::Code {
                 code,
                 headers,

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -81,7 +81,10 @@ fn simple_add() {
         .with_status(101)
         .with_stderr(
             "    Updating `[..]` index
-error: failed to invite owners to crate foo: EOF while parsing a value at line 1 column 0",
+error: failed to invite owners to crate `foo` on registry at file://[..]
+
+Caused by:
+  EOF while parsing a value at line 1 column 0",
         )
         .run();
 }
@@ -111,7 +114,7 @@ fn simple_remove() {
         .with_stderr(
             "    Updating `[..]` index
        Owner removing [\"username\"] from crate foo
-error: failed to remove owners from crate foo
+error: failed to remove owners from crate `foo` on registry at file://[..]
 
 Caused by:
   EOF while parsing a value at line 1 column 0",

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -39,7 +39,7 @@ fn simple() {
         .with_stderr(
             "    Updating `[..]` index
       Unyank foo:0.0.1
-error: failed to undo a yank
+error: failed to undo a yank from the registry at file:///[..]
 
 Caused by:
   EOF while parsing a value at line 1 column 0",


### PR DESCRIPTION
This is a minor update to the registry API errors, trying to make them a little clearer and more helpful. My concerns were:

* `api errors (status 200 OK): some error message` — why was there both an error and 200 OK?
* `api errors` — What is an "api error" anyways?  The user is probably not familiar with the "registry API".
* Adds the URL of the server it is actually talking to, in case you may be confused when using a registry other than crates.io. This also tries to make it clearer that the message is coming from the remote server, and not cargo itself.
