### PR TITLE
Detect changes for JSON spec targets.

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -137,6 +137,7 @@ impl TargetInfo {
             kind,
             "RUSTFLAGS",
         )?;
+        let extra_fingerprint = kind.fingerprint_hash();
         let mut process = rustc.process();
         process
             .arg("-")
@@ -163,14 +164,17 @@ impl TargetInfo {
             process.arg("--crate-type").arg(crate_type.as_str());
         }
         let supports_split_debuginfo = rustc
-            .cached_output(process.clone().arg("-Csplit-debuginfo=packed"))
+            .cached_output(
+                process.clone().arg("-Csplit-debuginfo=packed"),
+                extra_fingerprint,
+            )
             .is_ok();
 
         process.arg("--print=sysroot");
         process.arg("--print=cfg");
 
         let (output, error) = rustc
-            .cached_output(&process)
+            .cached_output(&process, extra_fingerprint)
             .chain_err(|| "failed to run `rustc` to learn about target-specific information")?;
 
         let mut lines = output.lines();


### PR DESCRIPTION
This adds the contents of a JSON spec target file to the fingerprint hash so that changing the contents will trigger a rebuild. This also deals with the target info cache in a similar fashion.

Closes #2616
