### PR TITLE
Don't panic when printing JSON with non-utf8 paths

### DIFF
--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -51,7 +51,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let location = ProjectLocation { root };
 
     match MessageFormat::parse(args)? {
-        MessageFormat::Json => config.shell().print_json(&location),
+        MessageFormat::Json => config.shell().print_json(&location)?,
         MessageFormat::Plain => drop_println!(config, "{}", location.root),
     }
 

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -53,6 +53,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     };
 
     let result = ops::output_metadata(&ws, &options)?;
-    config.shell().print_json(&result);
+    config.shell().print_json(&result)?;
     Ok(())
 }

--- a/src/bin/cargo/commands/read_manifest.rs
+++ b/src/bin/cargo/commands/read_manifest.rs
@@ -15,6 +15,8 @@ Deprecated, use `cargo metadata --no-deps` instead.\
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let ws = args.workspace(config)?;
-    config.shell().print_json(&ws.current()?.serialized(config));
+    config
+        .shell()
+        .print_json(&ws.current()?.serialized(config))?;
     Ok(())
 }

--- a/src/bin/cargo/commands/verify_project.rs
+++ b/src/bin/cargo/commands/verify_project.rs
@@ -15,12 +15,12 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if let Err(e) = args.workspace(config) {
         let mut h = HashMap::new();
         h.insert("invalid".to_string(), e.to_string());
-        config.shell().print_json(&h);
+        config.shell().print_json(&h)?;
         process::exit(1)
     }
 
     let mut h = HashMap::new();
     h.insert("success".to_string(), "true".to_string());
-    config.shell().print_json(&h);
+    config.shell().print_json(&h)?;
     Ok(())
 }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -342,9 +342,12 @@ impl Shell {
         Ok(())
     }
 
-    pub fn print_json<T: serde::ser::Serialize>(&mut self, obj: &T) {
-        let encoded = serde_json::to_string(&obj).unwrap();
+    pub fn print_json<T: serde::ser::Serialize>(&mut self, obj: &T) -> CargoResult<()> {
+        // Path may fail to serialize to JSON ...
+        let encoded = serde_json::to_string(&obj)?;
+        // ... but don't fail due to a closed pipe.
         drop(writeln!(self.out(), "{}", encoded));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Before:

    λ cd \Xff/foo/ && cargo verify-project && cargo metadata
    {"success":"true"}
    warning: please specify `--format-version` flag explicitly to avoid compatibility problems
    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error("path contains invalid UTF-8 characters", line: 0, column: 0)', /rustc/a5a775e3f9e8043dad405e00aee0ae60882a7b71/src/tools/cargo/src/cargo/core/shell.rs:346:51
    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

After:

    λ cd \Xff/foo/ && $cargo verify-project && $cargo metadata
    {"success":"true"}
    warning: please specify `--format-version` flag explicitly to avoid compatibility problems
    error: path contains invalid UTF-8 characters

I am pretty  sure that this has zero real-world impact, but the diff is
small, so why not handle it?