### PR TITLE
docs: update default edition value

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -131,7 +131,7 @@ suites, benchmarks, binaries, examples, etc.
 edition = '2018'
 ```
 
-If the `edition` key is not set in your `Cargo.toml`, Cargo will default to 2015.
+If the `edition` key is not set in your `Cargo.toml`, Cargo will default to 2018.
 
 #### The `description` field
 


### PR DESCRIPTION
Hi 👋 ,

### What's changing

Looks like the default `edition` value has changed from `2015` to `2018` along the way. Here, we're making sure the docs are showing the correct value.

### Way to reproduce/confirm

(considering you have Docker installed)

```bash
# run a new Ubuntu container
docker run -it --rm ubuntu /bin/bash

# install curl
apt-get update -qq && apt-get install -yqq curl

# install Rust and Cargo
curl https://sh.rustup.rs -sSf | sh
source $HOME/.cargo/env

# create a new folder and initialise a new project
mkdir edition
cd edition/
cargo init

# check the edition value in newly created Cargo.toml
cat Cargo.toml 
```

The output should be something like

```toml
[package]
name = "edition"
version = "0.1.0"
authors = []
edition = "2018"

# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

[dependencies]
```

I hope this makes sense and helps a bit.

Best,
G.
