### PR TITLE
Fix a `BorrowMut` error when stdout is closed

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -748,13 +748,14 @@ impl<'cfg> DrainState<'cfg> {
             }
         }
         if cx.bcx.build_config.emit_json() {
+            let mut shell = cx.bcx.config.shell();
             let msg = machine_message::BuildFinished {
                 success: error.is_none(),
             }
             .to_json_string();
-            if let Err(e) = writeln!(cx.bcx.config.shell().out(), "{}", msg) {
+            if let Err(e) = writeln!(shell.out(), "{}", msg) {
                 if error.is_some() {
-                    crate::display_error(&e.into(), &mut cx.bcx.config.shell());
+                    crate::display_error(&e.into(), &mut shell);
                 } else {
                     return Some(e.into());
                 }


### PR DESCRIPTION
There was one location in the job queue where the shell is borrowed
twice by accident, so instead hold the same borrow over both locations.

Closes #9220