### PR TITLE
Explain `cargo install` is not for libraries

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -305,7 +305,12 @@ fn install_one(
     // *something* to install. Explicit `--bin` or `--example` flags will be
     // checked at the start of `compile_ws`.
     if !opts.filter.is_specific() && !pkg.targets().iter().any(|t| t.is_bin()) {
-        bail!("specified package `{}` has no binaries", pkg);
+        bail!(
+            "there is nothing to install in `{}`, because it has no binaries\n\
+             `cargo install` is only for installing programs, and can't be used with libraries.\n\
+             To use a library crate, add it as a dependency in a Cargo project instead.",
+            pkg
+        );
     }
 
     // Helper for --no-track flag to make sure it doesn't overwrite anything.

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -567,8 +567,9 @@ fn no_binaries() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] specified package `foo v0.0.1 ([..])` has no binaries
-",
+[ERROR] there is nothing to install in `foo v0.0.1 ([..])`, because it has no binaries[..]
+[..]
+[..]",
         )
         .run();
 }


### PR DESCRIPTION
On a few occasions I've seen novice users assume that `cargo install` works like `npm install` or `apt install`, and they're confused that they can't use library dependencies this way.

I've expanded the error message to hopefully clarify the misconception.

