### PR TITLE
Use ANSI clear-to-EOL if color is force-enabled

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -185,10 +185,7 @@ impl Shell {
 
     /// Erase from cursor to end of line.
     pub fn err_erase_line(&mut self) {
-        if let ShellOut::Stream {
-            stderr_tty: true, ..
-        } = self.output
-        {
+        if self.err_supports_color() {
             imp::err_erase_line(self);
             self.needs_clear = false;
         }


### PR DESCRIPTION
When running cargo with output not going to a TTY, and with the progress
bar and color force-enabled, this makes cargo clean up its right-aligned
output properly.

This doesn't fix the case where progress is force-enabled and color
isn't, but it fixes the case where both are force-enabled.