### PR TITLE
track_caller on custom assert functions

### DIFF
--- a/crates/cargo-test-support/src/install.rs
+++ b/crates/cargo-test-support/src/install.rs
@@ -6,10 +6,12 @@ use std::path::{Path, PathBuf};
 /// has been installed. Example usage:
 ///
 ///     assert_has_installed_exe(cargo_home(), "foo");
+#[track_caller]
 pub fn assert_has_installed_exe<P: AsRef<Path>>(path: P, name: &'static str) {
     assert!(check_has_installed_exe(path, name));
 }
 
+#[track_caller]
 pub fn assert_has_not_installed_exe<P: AsRef<Path>>(path: P, name: &'static str) {
     assert!(!check_has_installed_exe(path, name));
 }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -732,6 +732,7 @@ impl Execs {
         self
     }
 
+    #[track_caller]
     pub fn run(&mut self) {
         self.ran = true;
         let p = (&self.process_builder).clone().unwrap();
@@ -740,6 +741,7 @@ impl Execs {
         }
     }
 
+    #[track_caller]
     pub fn run_output(&mut self, output: &Output) {
         self.ran = true;
         if let Err(e) = self.match_output(output) {

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -969,12 +969,14 @@ fn meta_test_multiple_versions_strategy() {
 }
 
 /// Assert `xs` contains `elems`
+#[track_caller]
 pub fn assert_contains<A: PartialEq>(xs: &[A], elems: &[A]) {
     for elem in elems {
         assert!(xs.contains(elem));
     }
 }
 
+#[track_caller]
 pub fn assert_same<A: PartialEq>(a: &[A], b: &[A]) {
     assert_eq!(a.len(), b.len());
     assert_contains(b, a);

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -2,6 +2,7 @@
 
 use cargo_test_support::{basic_bin_manifest, main_file, project};
 
+#[track_caller]
 fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
@@ -20,6 +21,7 @@ fn assert_not_a_cargo_toml(command: &str, manifest_path_argument: &str) {
         .run();
 }
 
+#[track_caller]
 fn assert_cargo_toml_doesnt_exist(command: &str, manifest_path_argument: &str) {
     let p = project().build();
     let expected_path = manifest_path_argument

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -409,6 +409,7 @@ fn package_cleans_all_the_things() {
 }
 
 // Ensures that all files for the package have been deleted.
+#[track_caller]
 fn assert_all_clean(build_dir: &Path) {
     let walker = walkdir::WalkDir::new(build_dir).into_iter();
     for entry in walker.filter_entry(|e| {

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -189,6 +189,7 @@ fn symlink_config_to_config_toml() {
     t!(symlink_file(&toml_path, &symlink_path));
 }
 
+#[track_caller]
 pub fn assert_error<E: Borrow<anyhow::Error>>(error: E, msgs: &str) {
     let causes = error
         .borrow()
@@ -206,6 +207,7 @@ pub fn assert_error<E: Borrow<anyhow::Error>>(error: E, msgs: &str) {
     assert_match(msgs, &causes);
 }
 
+#[track_caller]
 pub fn assert_match(expected: &str, actual: &str) {
     if !normalized_lines_match(expected, actual, None) {
         panic!(

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use std::str;
 
 // Helper for testing dep-info files in the fingerprint dir.
+#[track_caller]
 fn assert_deps(project: &Project, fingerprint: &str, test_cb: impl Fn(&Path, &[(u8, &str)])) {
     let mut files = project
         .glob(fingerprint)

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -12,6 +12,7 @@ fn oldest_lockfile_still_works() {
     }
 }
 
+#[track_caller]
 fn assert_lockfiles_eq(expected: &str, actual: &str) {
     for (l, r) in expected.lines().zip(actual.lines()) {
         assert!(lines_match(l, r), "Lines differ:\n{}\n\n{}", l, r);


### PR DESCRIPTION
This makes test helper functions point to the failing test, rather than internals of a function that did some checking.

