### PR TITLE
Use serde's error message option to avoid implementing `Deserialize`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ percent-encoding = "2.0"
 rustfix = "0.5.0"
 same-file = "1"
 semver = { version = "0.10", features = ["serde"] }
-serde = { version = "1.0.82", features = ["derive"] }
+serde = { version = "1.0.123", features = ["derive"] }
 serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -419,51 +419,11 @@ impl ser::Serialize for TomlOptLevel {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
-#[serde(untagged)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(untagged, expecting = "expected a boolean or an integer")]
 pub enum U32OrBool {
     U32(u32),
     Bool(bool),
-}
-
-impl<'de> de::Deserialize<'de> for U32OrBool {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        struct Visitor;
-
-        impl<'de> de::Visitor<'de> for Visitor {
-            type Value = U32OrBool;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("a boolean or an integer")
-            }
-
-            fn visit_bool<E>(self, b: bool) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(U32OrBool::Bool(b))
-            }
-
-            fn visit_i64<E>(self, u: i64) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(U32OrBool::U32(u as u32))
-            }
-
-            fn visit_u64<E>(self, u: u64) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(U32OrBool::U32(u as u32))
-            }
-        }
-
-        deserializer.deserialize_any(Visitor)
-    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default, Eq, PartialEq)]
@@ -770,44 +730,11 @@ impl<'de> de::Deserialize<'de> for StringOrVec {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
-#[serde(untagged)]
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(untagged, expecting = "expected a boolean or a string")]
 pub enum StringOrBool {
     String(String),
     Bool(bool),
-}
-
-impl<'de> de::Deserialize<'de> for StringOrBool {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        struct Visitor;
-
-        impl<'de> de::Visitor<'de> for Visitor {
-            type Value = StringOrBool;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("a boolean or a string")
-            }
-
-            fn visit_bool<E>(self, b: bool) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(StringOrBool::Bool(b))
-            }
-
-            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
-            where
-                E: de::Error,
-            {
-                Ok(StringOrBool::String(s.to_string()))
-            }
-        }
-
-        deserializer.deserialize_any(Visitor)
-    }
 }
 
 #[derive(PartialEq, Clone, Debug, Serialize)]

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1309,7 +1309,7 @@ fn bad_debuginfo() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: string \"a\", expected a boolean or an integer for [..]
+  expected a boolean or an integer for [..]
 ",
         )
         .run();
@@ -1338,7 +1338,7 @@ fn bad_opt_level() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: integer `3`, expected a boolean or a string for key [..]
+  expected a boolean or a string for key [..]
 ",
         )
         .run();


### PR DESCRIPTION
This is a cleanup based on https://github.com/serde-rs/serde/issues/1883, which fell out of https://github.com/rust-lang/cargo/pull/8664

It looks like this changes the resulting error messages. I'll leave it up to you to decide if the tradeoff makes sense here. Maybe the correct answer here is to make `serde`'s error messages include more details (e.g. `invalid type: int`).