### PR TITLE
Add `--future-incompat-report` support to `cargo test`

### DIFF
--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -56,6 +56,7 @@ pub fn cli() -> App {
         .arg_ignore_rust_version()
         .arg_message_format()
         .arg_unit_graph()
+        .arg_future_incompat_report()
         .after_help("Run `cargo help test` for more detailed information.\n")
 }
 

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -62,7 +62,7 @@ fn test_single_crate() {
         .file("src/main.rs", "fn main() { [true].into_iter(); }")
         .build();
 
-    for command in &["build", "check", "rustc"] {
+    for command in &["build", "check", "rustc", "test"] {
         p.cargo(command).arg("-Zfuture-incompat-report")
             .masquerade_as_nightly_cargo()
             .with_stderr_contains("  = note: `#[warn(array_into_iter)]` on by default")
@@ -108,7 +108,7 @@ fn test_multi_crate() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    for command in &["build", "check", "rustc"] {
+    for command in &["build", "check", "rustc", "test"] {
         p.cargo(command).arg("-Zfuture-incompat-report")
             .masquerade_as_nightly_cargo()
             .with_stderr_does_not_contain("[..]array_into_iter[..]")


### PR DESCRIPTION
This was missed in the original PR