### PR TITLE
Fix --feature pkg/feat for V1 resolver for non-member.

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1091,7 +1091,8 @@ impl<'cfg> Workspace<'cfg> {
         for feature in requested_features.features.iter() {
             if let Some(index) = feature.find('/') {
                 let name = &feature[..index];
-                if specs.iter().any(|spec| spec.name() == name) {
+                let is_member = self.members().any(|member| member.name() == name);
+                if is_member && specs.iter().any(|spec| spec.name() == name) {
                     member_specific_features
                         .entry(name)
                         .or_default()


### PR DESCRIPTION
#8997 had an unintended regression where `-p foo --feature foo/feat` syntax where `foo` is an **optional non-member** fails with an error that `foo` did not match any packages.  The issue is that the member/feature selection routine needed to slot this into the features for the package in the current working directory (it was incorrectly treating `foo` as a workspace member).

V2 outright does not allow specifying features for non-workspace members.

Fixes #9265