### PR TITLE
WIP: Add `cargo completions` command for shell completions.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -264,7 +264,7 @@ impl GlobalArgs {
     }
 }
 
-fn cli() -> App {
+pub fn cli() -> App {
     let is_rustup = std::env::var_os("RUSTUP_HOME").is_some();
     let usage = if is_rustup {
         "cargo [+toolchain] [OPTIONS] [SUBCOMMAND]"

--- a/src/bin/cargo/commands/complete.rs
+++ b/src/bin/cargo/commands/complete.rs
@@ -1,0 +1,26 @@
+use crate::command_prelude::*;
+
+use clap::Shell;
+
+pub fn cli() -> App {
+    subcommand("complete")
+        .about("Generate completion file for a shell")
+        .arg(
+            Arg::with_name("shell")
+                .takes_value(true)
+                .required(true)
+                .help("The shell to generate a completion file for")
+        )
+        .after_help("Run `cargo help complete` for more detailed information.\n")
+}
+
+pub fn exec(_config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
+    let shell_name = args.value_of("shell").unwrap();
+    let shell: Shell = shell_name.parse()
+        // TODO - proper error handling
+        .expect(&format!("unknown shell: {}", shell_name));
+
+    crate::cli::cli().gen_completions_to("cargo", shell, &mut std::io::stdout());
+
+    Ok(())
+}

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -6,6 +6,7 @@ pub fn builtin() -> Vec<App> {
         build::cli(),
         check::cli(),
         clean::cli(),
+        complete::cli(),
         describe_future_incompatibilities::cli(),
         doc::cli(),
         fetch::cli(),
@@ -45,6 +46,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches<'_>) -> Cli
         "build" => build::exec,
         "check" => check::exec,
         "clean" => clean::exec,
+        "complete" => complete::exec,
         "describe-future-incompatibilities" => describe_future_incompatibilities::exec,
         "doc" => doc::exec,
         "fetch" => fetch::exec,
@@ -84,6 +86,7 @@ pub mod bench;
 pub mod build;
 pub mod check;
 pub mod clean;
+pub mod complete;
 pub mod describe_future_incompatibilities;
 pub mod doc;
 pub mod fetch;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -12,7 +12,7 @@ use cargo::core::shell::Shell;
 use cargo::util::{self, closest_msg, command_prelude, CargoResult, CliResult, Config};
 use cargo::util::{CliError, ProcessError};
 
-mod cli;
+pub mod cli;
 mod commands;
 
 use crate::command_prelude::*;


### PR DESCRIPTION
Solves #6645

Should help with #9086. Might help with #8871, #7864, and #5759 if [dynamic completion support](https://github.com/clap-rs/clap/issues/1232) is added to clap.

The "WIP" part is because this is my first cargo PR and I don't know the conventions. In particular, I don't know how errors should be handled, so the PR has a big nasty `.expect` right in the middle.

Also, I'm using the imperative syntax because it's what existing code does, but I feel like I should be using `#[derive(Clap)]` instead? I dunno.

## TODO

- [ ] Fix error handling.
- [ ] Fix rustfmt errors.