### PR TITLE
Refactor feature handling, and improve error messages.

### DIFF
--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -44,9 +44,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     };
 
     let options = OutputMetadataOptions {
-        features: values(args, "features"),
-        all_features: args.is_present("all-features"),
-        no_default_features: args.is_present("no-default-features"),
+        cli_features: args.cli_features()?,
         no_deps: args.is_present("no-deps"),
         filter_platforms: args._values_of("filter-platform"),
         version,

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -45,9 +45,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             allow_dirty: args.is_present("allow-dirty"),
             targets: args.targets(),
             jobs: args.jobs()?,
-            features: args._values_of("features"),
-            all_features: args.is_present("all-features"),
-            no_default_features: args.is_present("no-default-features"),
+            cli_features: args.cli_features()?,
         },
     )?;
     Ok(())

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -45,9 +45,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
             jobs: args.jobs()?,
             dry_run: args.is_present("dry-run"),
             registry,
-            features: args._values_of("features"),
-            all_features: args.is_present("all-features"),
-            no_default_features: args.is_present("no-default-features"),
+            cli_features: args.cli_features()?,
         },
     )?;
     Ok(())

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -190,9 +190,7 @@ subtree of the package given to -p.\n\
     let charset = tree::Charset::from_str(args.value_of("charset").unwrap())
         .map_err(|e| anyhow::anyhow!("{}", e))?;
     let opts = tree::TreeOptions {
-        features: values(args, "features"),
-        all_features: args.is_present("all-features"),
-        no_default_features: args.is_present("no-default-features"),
+        cli_features: args.cli_features()?,
         packages,
         target,
         edge_kinds,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -3,8 +3,8 @@
 use crate::core::compiler::UnitInterner;
 use crate::core::compiler::{CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::profiles::{Profiles, UnitFor};
-use crate::core::resolver::features::{FeaturesFor, RequestedFeatures, ResolvedFeatures};
-use crate::core::resolver::{HasDevUnits, ResolveOpts};
+use crate::core::resolver::features::{CliFeatures, FeaturesFor, ResolvedFeatures};
+use crate::core::resolver::HasDevUnits;
 use crate::core::{Dependency, PackageId, PackageSet, Resolve, SourceId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::errors::CargoResult;
@@ -107,18 +107,14 @@ pub fn resolve_std<'cfg>(
             "default".to_string(),
         ],
     };
-    // dev_deps setting shouldn't really matter here.
-    let opts = ResolveOpts::new(
-        /*dev_deps*/ false,
-        RequestedFeatures::from_command_line(
-            &features, /*all_features*/ false, /*uses_default_features*/ false,
-        ),
-    );
+    let cli_features = CliFeatures::from_command_line(
+        &features, /*all_features*/ false, /*uses_default_features*/ false,
+    )?;
     let resolve = ops::resolve_ws_with_opts(
         &std_ws,
         target_data,
         requested_targets,
-        &opts,
+        &cli_features,
         &specs,
         HasDevUnits::No,
         crate::core::resolver::features::ForceAllTargets::No,

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -1,6 +1,7 @@
 use super::dep_cache::RegistryQueryer;
 use super::errors::ActivateResult;
 use super::types::{ConflictMap, ConflictReason, FeaturesSet, ResolveOpts};
+use super::RequestedFeatures;
 use crate::core::{Dependency, PackageId, SourceId, Summary};
 use crate::util::interning::InternedString;
 use crate::util::Graph;
@@ -160,23 +161,32 @@ impl Context {
             }
         }
         debug!("checking if {} is already activated", summary.package_id());
-        if opts.features.all_features {
-            return Ok(false);
+        match &opts.features {
+            // This returns `false` for CliFeatures just for simplicity. It
+            // would take a bit of work to compare since they are not in the
+            // same format as DepFeatures (and that may be expensive
+            // performance-wise). Also, it should only occur once for a root
+            // package. The only drawback is that it may re-activate a root
+            // package again, which should only affect performance, but that
+            // should be rare. Cycles should still be detected since those
+            // will have `DepFeatures` edges.
+            RequestedFeatures::CliFeatures(_) => return Ok(false),
+            RequestedFeatures::DepFeatures {
+                features,
+                uses_default_features,
+            } => {
+                let has_default_feature = summary.features().contains_key("default");
+                Ok(match self.resolve_features.get(&id) {
+                    Some(prev) => {
+                        features.is_subset(prev)
+                            && (!uses_default_features
+                                || prev.contains("default")
+                                || !has_default_feature)
+                    }
+                    None => features.is_empty() && (!uses_default_features || !has_default_feature),
+                })
+            }
         }
-
-        let has_default_feature = summary.features().contains_key("default");
-        Ok(match self.resolve_features.get(&id) {
-            Some(prev) => {
-                opts.features.features.is_subset(prev)
-                    && (!opts.features.uses_default_features
-                        || prev.contains("default")
-                        || !has_default_feature)
-            }
-            None => {
-                opts.features.features.is_empty()
-                    && (!opts.features.uses_default_features || !has_default_feature)
-            }
-        })
     }
 
     /// If the package is active returns the `ContextAge` when it was added

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -1,4 +1,4 @@
-use super::features::RequestedFeatures;
+use super::features::{CliFeatures, RequestedFeatures};
 use crate::core::{Dependency, PackageId, Summary};
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
@@ -133,6 +133,7 @@ pub struct ResolveOpts {
     /// Whether or not dev-dependencies should be included.
     ///
     /// This may be set to `false` by things like `cargo install` or `-Z avoid-dev-deps`.
+    /// It also gets set to `false` when activating dependencies in the resolver.
     pub dev_deps: bool,
     /// Set of features requested on the command-line.
     pub features: RequestedFeatures,
@@ -143,7 +144,7 @@ impl ResolveOpts {
     pub fn everything() -> ResolveOpts {
         ResolveOpts {
             dev_deps: true,
-            features: RequestedFeatures::new_all(true),
+            features: RequestedFeatures::CliFeatures(CliFeatures::new_all(true)),
         }
     }
 

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::slice;
 
+use anyhow::bail;
 use glob::glob;
 use log::debug;
 use url::Url;
@@ -152,7 +153,7 @@ impl<'cfg> Workspace<'cfg> {
         ws.target_dir = config.target_dir()?;
 
         if manifest_path.is_relative() {
-            anyhow::bail!(
+            bail!(
                 "manifest_path:{:?} is not an absolute path. Please provide an absolute path.",
                 manifest_path
             )
@@ -523,7 +524,7 @@ impl<'cfg> Workspace<'cfg> {
                     return Ok(Some(root_config.clone()));
                 }
 
-                _ => anyhow::bail!(
+                _ => bail!(
                     "root of a workspace inferred but wasn't a root: {}",
                     root_path.display()
                 ),
@@ -663,7 +664,7 @@ impl<'cfg> Workspace<'cfg> {
                     if exclude {
                         continue;
                     }
-                    anyhow::bail!(
+                    bail!(
                         "package `{}` is listed in workspace’s default-members \
                          but is not a member.",
                         path.display()
@@ -785,7 +786,7 @@ impl<'cfg> Workspace<'cfg> {
                 MaybePackage::Virtual(_) => continue,
             };
             if let Some(prev) = names.insert(name, member) {
-                anyhow::bail!(
+                bail!(
                     "two packages named `{}` in this workspace:\n\
                          - {}\n\
                          - {}",
@@ -810,7 +811,7 @@ impl<'cfg> Workspace<'cfg> {
             .collect();
         match roots.len() {
             1 => Ok(()),
-            0 => anyhow::bail!(
+            0 => bail!(
                 "`package.workspace` configuration points to a crate \
                  which is not configured with [workspace]: \n\
                  configuration at: {}\n\
@@ -819,7 +820,7 @@ impl<'cfg> Workspace<'cfg> {
                 self.root_manifest.as_ref().unwrap().display()
             ),
             _ => {
-                anyhow::bail!(
+                bail!(
                     "multiple workspace roots found in the same workspace:\n{}",
                     roots
                         .iter()
@@ -840,7 +841,7 @@ impl<'cfg> Workspace<'cfg> {
 
             match root {
                 Some(root) => {
-                    anyhow::bail!(
+                    bail!(
                         "package `{}` is a member of the wrong workspace\n\
                          expected: {}\n\
                          actual:   {}",
@@ -850,7 +851,7 @@ impl<'cfg> Workspace<'cfg> {
                     );
                 }
                 None => {
-                    anyhow::bail!(
+                    bail!(
                         "workspace member `{}` is not hierarchically below \
                          the workspace root `{}`",
                         member.display(),
@@ -907,7 +908,7 @@ impl<'cfg> Workspace<'cfg> {
                 }
             }
         };
-        anyhow::bail!(
+        bail!(
             "current package believes it's in a workspace when it's not:\n\
                  current:   {}\n\
                  workspace: {}\n\n{}\n\
@@ -963,7 +964,7 @@ impl<'cfg> Workspace<'cfg> {
     pub fn load(&self, manifest_path: &Path) -> CargoResult<Package> {
         match self.packages.maybe_get(manifest_path) {
             Some(&MaybePackage::Package(ref p)) => return Ok(p.clone()),
-            Some(&MaybePackage::Virtual(_)) => anyhow::bail!("cannot load workspace root"),
+            Some(&MaybePackage::Virtual(_)) => bail!("cannot load workspace root"),
             None => {}
         }
 
@@ -1143,7 +1144,7 @@ impl<'cfg> Workspace<'cfg> {
                 && !requested_features.all_features
                 && requested_features.uses_default_features)
             {
-                anyhow::bail!("cannot specify features for packages outside of workspace");
+                bail!("cannot specify features for packages outside of workspace");
             }
             // Add all members from the workspace so we can ensure `-p nonmember`
             // is in the resolve graph.
@@ -1159,7 +1160,7 @@ impl<'cfg> Workspace<'cfg> {
                 .copied()
                 .collect();
             // TODO: typo suggestions would be good here.
-            anyhow::bail!(
+            bail!(
                 "none of the selected packages contains these features: {}",
                 missing.join(", ")
             );

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,5 +1,5 @@
 use crate::core::compiler::RustcTargetData;
-use crate::core::resolver::{features::RequestedFeatures, HasDevUnits, ResolveOpts};
+use crate::core::resolver::HasDevUnits;
 use crate::core::{Shell, Workspace};
 use crate::ops;
 use crate::util::CargoResult;
@@ -19,20 +19,12 @@ pub struct DocOptions {
 /// Main method for `cargo doc`.
 pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
     let specs = options.compile_opts.spec.to_package_id_specs(ws)?;
-    let opts = ResolveOpts::new(
-        /*dev_deps*/ true,
-        RequestedFeatures::from_command_line(
-            &options.compile_opts.features,
-            options.compile_opts.all_features,
-            !options.compile_opts.no_default_features,
-        ),
-    );
     let target_data = RustcTargetData::new(ws, &options.compile_opts.build_config.requested_kinds)?;
     let ws_resolve = ops::resolve_ws_with_opts(
         ws,
         &target_data,
         &options.compile_opts.build_config.requested_kinds,
-        &opts,
+        &options.compile_opts.cli_features,
         &specs,
         HasDevUnits::No,
         crate::core::resolver::features::ForceAllTargets::No,

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -4,7 +4,7 @@ use log::debug;
 use termcolor::Color::{self, Cyan, Green, Red};
 
 use crate::core::registry::PackageRegistry;
-use crate::core::resolver::ResolveOpts;
+use crate::core::resolver::features::{CliFeatures, HasDevUnits};
 use crate::core::{PackageId, PackageIdSpec};
 use crate::core::{Resolve, SourceId, Workspace};
 use crate::ops;
@@ -25,7 +25,8 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
     let mut resolve = ops::resolve_with_previous(
         &mut registry,
         ws,
-        &ResolveOpts::everything(),
+        &CliFeatures::new_all(true),
+        HasDevUnits::Yes,
         None,
         None,
         &[],
@@ -61,7 +62,8 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                     ops::resolve_with_previous(
                         &mut registry,
                         ws,
-                        &ResolveOpts::everything(),
+                        &CliFeatures::new_all(true),
+                        HasDevUnits::Yes,
                         None,
                         None,
                         &[],
@@ -115,7 +117,8 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     let mut resolve = ops::resolve_with_previous(
         &mut registry,
         ws,
-        &ResolveOpts::everything(),
+        &CliFeatures::new_all(true),
+        HasDevUnits::Yes,
         Some(&previous_resolve),
         Some(&to_avoid),
         &[],

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -12,6 +12,7 @@ use log::debug;
 use tar::{Archive, Builder, EntryType, Header, HeaderMode};
 
 use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};
+use crate::core::resolver::CliFeatures;
 use crate::core::{Feature, Shell, Verbosity, Workspace};
 use crate::core::{Package, PackageId, PackageSet, Resolve, Source, SourceId};
 use crate::sources::PathSource;
@@ -29,9 +30,7 @@ pub struct PackageOpts<'cfg> {
     pub verify: bool,
     pub jobs: Option<u32>,
     pub targets: Vec<String>,
-    pub features: Vec<String>,
-    pub all_features: bool,
-    pub no_default_features: bool,
+    pub cli_features: CliFeatures,
 }
 
 const VCS_INFO_FILE: &str = ".cargo_vcs_info.json";
@@ -690,9 +689,7 @@ fn run_verify(ws: &Workspace<'_>, tar: &FileLock, opts: &PackageOpts<'_>) -> Car
         &ws,
         &ops::CompileOptions {
             build_config: BuildConfig::new(config, opts.jobs, &opts.targets, CompileMode::Build)?,
-            features: opts.features.clone(),
-            no_default_features: opts.no_default_features,
-            all_features: opts.all_features,
+            cli_features: opts.cli_features.clone(),
             spec: ops::Packages::Packages(Vec::new()),
             filter: ops::CompileFilter::Default {
                 required_features_filterable: true,

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -15,6 +15,7 @@ use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 
 use crate::core::dependency::DepKind;
 use crate::core::manifest::ManifestMetadata;
+use crate::core::resolver::CliFeatures;
 use crate::core::source::Source;
 use crate::core::{Package, SourceId, Workspace};
 use crate::ops;
@@ -51,9 +52,7 @@ pub struct PublishOpts<'cfg> {
     pub targets: Vec<String>,
     pub dry_run: bool,
     pub registry: Option<String>,
-    pub features: Vec<String>,
-    pub all_features: bool,
-    pub no_default_features: bool,
+    pub cli_features: CliFeatures,
 }
 
 pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
@@ -111,9 +110,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
             allow_dirty: opts.allow_dirty,
             targets: opts.targets.clone(),
             jobs: opts.jobs,
-            features: opts.features.clone(),
-            all_features: opts.all_features,
-            no_default_features: opts.no_default_features,
+            cli_features: opts.cli_features.clone(),
         },
     )?
     .unwrap();

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1,4 +1,5 @@
 use crate::core::compiler::{BuildConfig, MessageFormat};
+use crate::core::resolver::CliFeatures;
 use crate::core::{Edition, Workspace};
 use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
 use crate::sources::CRATES_IO_REGISTRY;
@@ -495,9 +496,7 @@ pub trait ArgMatchesExt {
 
         let opts = CompileOptions {
             build_config,
-            features: self._values_of("features"),
-            all_features: self._is_present("all-features"),
-            no_default_features: self._is_present("no-default-features"),
+            cli_features: self.cli_features()?,
             spec,
             filter: CompileFilter::from_raw_arguments(
                 self._is_present("lib"),
@@ -537,6 +536,14 @@ pub trait ArgMatchesExt {
         }
 
         Ok(opts)
+    }
+
+    fn cli_features(&self) -> CargoResult<CliFeatures> {
+        CliFeatures::from_command_line(
+            &self._values_of("features"),
+            self._is_present("all-features"),
+            !self._is_present("no-default-features"),
+        )
     }
 
     fn compile_options_for_single_package(


### PR DESCRIPTION
This changes the way feature strings are handled with an eye towards fixing some improper handling and to improve error messages. The key change is to stop treating all features as free-form strings and instead try to handle them as typed values. This helps avoid needing to deal with parsing different feature syntax (like `dep:` or `foo/bar`) or forgetting to handle it properly.

Overview of refactoring changes:

* `RequestedFeatures` changed to an enum to differentiate between features coming from the command-line, and those that are from a dependency.
* Moved parsing of CLI features to an earlier stage (now stored in `CompileOptions`), and ensures that they are properly handled as `FeatureValue` instead of strings.
* Pushed some feature validation earlier. For example, `DetailedTomlDependency` now validates things so you can see the location for the errant `Cargo.toml` (previously some validation was deep in the resolver, which provided poor errors).

This is a pretty large PR, but at the core it is just changing `RequestedFeatures` and then dealing with the fallout from that. Hopefully this is an improvement overall.

List of user-visible changes:

* Fix handling in resolver V2 of `--features bar?/feat` and `--features dep:bar`
* Better error handling for `bar/feat` and `dep:bar` in dependency declarations.
* Feature keys in the `[features]` table can no longer contain slashes.
* Fixed a minor issue with `cargo tree -e features --all-features -Z namespaced-features`
* Fixed a panic with `cargo tree` involving `-Z weak-dep-features`

I did a small amount of benchmarking, and I wasn't able to record much of a difference.
