### PR TITLE
Fix publication of packages with metadata and resolver

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -815,8 +815,11 @@ pub struct TomlProject {
     license: Option<String>,
     license_file: Option<String>,
     repository: Option<String>,
-    metadata: Option<toml::Value>,
     resolver: Option<String>,
+
+    // Note that this field must come last due to the way toml serialization
+    // works which requires tables to be emitted after all values.
+    metadata: Option<toml::Value>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -825,8 +828,11 @@ pub struct TomlWorkspace {
     #[serde(rename = "default-members")]
     default_members: Option<Vec<String>>,
     exclude: Option<Vec<String>>,
-    metadata: Option<toml::Value>,
     resolver: Option<String>,
+
+    // Note that this field must come last due to the way toml serialization
+    // works which requires tables to be emitted after all values.
+    metadata: Option<toml::Value>,
 }
 
 impl TomlProject {

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1954,3 +1954,25 @@ fn reproducible_output() {
         assert_eq!(header.groupname().unwrap().unwrap(), "");
     }
 }
+
+#[cargo_test]
+fn package_with_resolver_and_metadata() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                resolver = '2'
+
+                [package.metadata.docs.rs]
+                all-features = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("package").run();
+}


### PR DESCRIPTION
This commit fixes an issue where packages which specify `resolver = '2'`
cannot be packaged if they also have a `package.metadata` table. The
issue is that the `toml` serialization implementation serializes fields
in order which requires that tables be emitted last.