### PR TITLE
Add `cargo config` subcommand.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ semver = { version = "0.10", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
+shell-escape = "0.1.4"
 strip-ansi-escapes = "0.1.0"
 tar = { version = "0.4.26", default-features = false }
 tempfile = "3.0"

--- a/crates/cargo-test-support/src/publish.rs
+++ b/crates/cargo-test-support/src/publish.rs
@@ -76,7 +76,7 @@ fn _validate_upload(
     let actual_json = serde_json::from_slice(&json_bytes).expect("uploaded JSON should be valid");
     let expected_json = serde_json::from_str(expected_json).expect("expected JSON does not parse");
 
-    if let Err(e) = find_json_mismatch(&expected_json, &actual_json) {
+    if let Err(e) = find_json_mismatch(&expected_json, &actual_json, None) {
         panic!("{}", e);
     }
 

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -1,0 +1,48 @@
+use crate::command_prelude::*;
+use cargo::ops::cargo_config;
+
+pub fn cli() -> App {
+    subcommand("config")
+        .about("Inspect configuration values")
+        .after_help("Run `cargo help config` for more detailed information.\n")
+        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand(
+            subcommand("get")
+                .arg(Arg::with_name("key").help("The config key to display"))
+                .arg(
+                    opt("format", "Display format")
+                        .possible_values(cargo_config::ConfigFormat::POSSIBLE_VALUES)
+                        .default_value("toml"),
+                )
+                .arg(opt(
+                    "show-origin",
+                    "Display where the config value is defined",
+                ))
+                .arg(
+                    opt("merged", "Whether or not to merge config values")
+                        .possible_values(&["yes", "no"])
+                        .default_value("yes"),
+                ),
+        )
+}
+
+pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
+    config
+        .cli_unstable()
+        .fail_if_stable_command(config, "config", 9301)?;
+    match args.subcommand() {
+        ("get", Some(args)) => {
+            let opts = cargo_config::GetOptions {
+                key: args.value_of("key"),
+                format: args.value_of("format").unwrap().parse()?,
+                show_origin: args.is_present("show-origin"),
+                merged: args.value_of("merged") == Some("yes"),
+            };
+            cargo_config::get(config, &opts)?;
+        }
+        (cmd, _) => {
+            panic!("unexpected command `{}`", cmd)
+        }
+    }
+    Ok(())
+}

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -6,6 +6,7 @@ pub fn builtin() -> Vec<App> {
         build::cli(),
         check::cli(),
         clean::cli(),
+        config::cli(),
         describe_future_incompatibilities::cli(),
         doc::cli(),
         fetch::cli(),
@@ -45,6 +46,7 @@ pub fn builtin_exec(cmd: &str) -> Option<fn(&mut Config, &ArgMatches<'_>) -> Cli
         "build" => build::exec,
         "check" => check::exec,
         "clean" => clean::exec,
+        "config" => config::exec,
         "describe-future-incompatibilities" => describe_future_incompatibilities::exec,
         "doc" => doc::exec,
         "fetch" => fetch::exec,
@@ -84,6 +86,7 @@ pub mod bench;
 pub mod build;
 pub mod check;
 pub mod clean;
+pub mod config;
 pub mod describe_future_incompatibilities;
 pub mod doc;
 pub mod fetch;

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -765,9 +765,8 @@ impl CliUnstable {
         Ok(())
     }
 
-    /// Generates an error if `-Z unstable-options` was not used.
-    /// Intended to be used when a user passes a command-line flag that
-    /// requires `-Z unstable-options`.
+    /// Generates an error if `-Z unstable-options` was not used for a new,
+    /// unstable command-line flag.
     pub fn fail_if_stable_opt(&self, flag: &str, issue: u32) -> CargoResult<()> {
         if !self.unstable_options {
             let see = format!(
@@ -798,6 +797,43 @@ impl CliUnstable {
             }
         }
         Ok(())
+    }
+
+    /// Generates an error if `-Z unstable-options` was not used for a new,
+    /// unstable subcommand.
+    pub fn fail_if_stable_command(
+        &self,
+        config: &Config,
+        command: &str,
+        issue: u32,
+    ) -> CargoResult<()> {
+        if self.unstable_options {
+            return Ok(());
+        }
+        let see = format!(
+            "See https://github.com/rust-lang/cargo/issues/{} for more \
+            information about the `cargo {}` command.",
+            issue, command
+        );
+        if config.nightly_features_allowed {
+            bail!(
+                "the `cargo {}` command is unstable, pass `-Z unstable-options` to enable it\n\
+                 {}",
+                command,
+                see
+            );
+        } else {
+            bail!(
+                "the `cargo {}` command is unstable, and only available on the \
+                 nightly channel of Cargo, but this is the `{}` channel\n\
+                 {}\n\
+                 {}",
+                command,
+                channel(),
+                SEE_CHANNELS,
+                see
+            );
+        }
     }
 }
 

--- a/src/cargo/ops/cargo_config.rs
+++ b/src/cargo/ops/cargo_config.rs
@@ -1,0 +1,314 @@
+//! Implementation of `cargo config` subcommand.
+
+use crate::drop_println;
+use crate::util::config::{Config, ConfigKey, ConfigValue as CV, Definition};
+use crate::util::errors::CargoResult;
+use anyhow::{bail, format_err, Error};
+use serde_json::json;
+use std::borrow::Cow;
+use std::fmt;
+use std::str::FromStr;
+
+pub enum ConfigFormat {
+    Toml,
+    Json,
+    JsonValue,
+}
+
+impl ConfigFormat {
+    /// For clap.
+    pub const POSSIBLE_VALUES: &'static [&'static str] = &["toml", "json", "json-value"];
+}
+
+impl FromStr for ConfigFormat {
+    type Err = Error;
+    fn from_str(s: &str) -> CargoResult<Self> {
+        match s {
+            "toml" => Ok(ConfigFormat::Toml),
+            "json" => Ok(ConfigFormat::Json),
+            "json-value" => Ok(ConfigFormat::JsonValue),
+            f => bail!("unknown config format `{}`", f),
+        }
+    }
+}
+
+impl fmt::Display for ConfigFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            ConfigFormat::Toml => write!(f, "toml"),
+            ConfigFormat::Json => write!(f, "json"),
+            ConfigFormat::JsonValue => write!(f, "json-value"),
+        }
+    }
+}
+
+/// Options for `cargo config get`.
+pub struct GetOptions<'a> {
+    pub key: Option<&'a str>,
+    pub format: ConfigFormat,
+    pub show_origin: bool,
+    pub merged: bool,
+}
+
+pub fn get(config: &Config, opts: &GetOptions<'_>) -> CargoResult<()> {
+    if opts.show_origin {
+        if !matches!(opts.format, ConfigFormat::Toml) {
+            bail!(
+                "the `{}` format does not support --show-origin, try the `toml` format instead",
+                opts.format
+            );
+        }
+    }
+    let key = match opts.key {
+        Some(key) => ConfigKey::from_str(key),
+        None => ConfigKey::new(),
+    };
+    if opts.merged {
+        let cv = config
+            .get_cv_with_env(&key)?
+            .ok_or_else(|| format_err!("config value `{}` is not set", key))?;
+        match opts.format {
+            ConfigFormat::Toml => {
+                print_toml(config, opts, &key, &cv);
+                if let Some(env) = maybe_env(config, &key, &cv) {
+                    print_toml_env(config, &env);
+                }
+            }
+            ConfigFormat::Json => print_json(config, &key, &cv, true),
+            ConfigFormat::JsonValue => print_json(config, &key, &cv, false),
+        }
+    } else {
+        match &opts.format {
+            ConfigFormat::Toml => print_toml_unmerged(config, opts, &key)?,
+            format => bail!(
+                "the `{}` format does not support --merged=no, try the `toml` format instead",
+                format
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Checks for environment variables that might be used.
+fn maybe_env<'config>(
+    config: &'config Config,
+    key: &ConfigKey,
+    cv: &CV,
+) -> Option<Vec<(&'config String, &'config String)>> {
+    // Only fetching a table is unable to load env values. Leaf entries should
+    // work properly.
+    match cv {
+        CV::Table(_map, _def) => {}
+        _ => return None,
+    }
+    let mut env: Vec<_> = config
+        .env()
+        .iter()
+        .filter(|(env_key, _val)| env_key.starts_with(&format!("{}_", key.as_env_key())))
+        .collect();
+    env.sort_by_key(|x| x.0);
+    if env.is_empty() {
+        None
+    } else {
+        Some(env)
+    }
+}
+
+fn print_toml(config: &Config, opts: &GetOptions<'_>, key: &ConfigKey, cv: &CV) {
+    let origin = |def: &Definition| -> String {
+        if !opts.show_origin {
+            return "".to_string();
+        }
+        format!(" # {}", def)
+    };
+    match cv {
+        CV::Boolean(val, def) => drop_println!(config, "{} = {}{}", key, val, origin(&def)),
+        CV::Integer(val, def) => drop_println!(config, "{} = {}{}", key, val, origin(&def)),
+        CV::String(val, def) => drop_println!(
+            config,
+            "{} = {}{}",
+            key,
+            toml::to_string(&val).unwrap(),
+            origin(&def)
+        ),
+        CV::List(vals, _def) => {
+            if opts.show_origin {
+                drop_println!(config, "{} = [", key);
+                for (val, def) in vals {
+                    drop_println!(config, "    {}, # {}", toml::to_string(&val).unwrap(), def);
+                }
+                drop_println!(config, "]");
+            } else {
+                let vals: Vec<&String> = vals.iter().map(|x| &x.0).collect();
+                drop_println!(config, "{} = {}", key, toml::to_string(&vals).unwrap());
+            }
+        }
+        CV::Table(table, _def) => {
+            let mut key_vals: Vec<_> = table.into_iter().collect();
+            key_vals.sort_by(|a, b| a.0.cmp(&b.0));
+            for (table_key, val) in key_vals {
+                let mut subkey = key.clone();
+                // push or push_sensitive shouldn't matter here, since this is
+                // not dealing with environment variables.
+                subkey.push(&table_key);
+                print_toml(config, opts, &subkey, val);
+            }
+        }
+    }
+}
+
+fn print_toml_env(config: &Config, env: &[(&String, &String)]) {
+    drop_println!(
+        config,
+        "# The following environment variables may affect the loaded values."
+    );
+    for (env_key, env_value) in env {
+        let val = shell_escape::escape(Cow::Borrowed(env_value));
+        drop_println!(config, "# {}={}", env_key, val);
+    }
+}
+
+fn print_json(config: &Config, key: &ConfigKey, cv: &CV, include_key: bool) {
+    let json_value = if key.is_root() || !include_key {
+        match cv {
+            CV::Boolean(val, _def) => json!(val),
+            CV::Integer(val, _def) => json!(val),
+            CV::String(val, _def) => json!(val),
+            CV::List(vals, _def) => {
+                let jvals: Vec<_> = vals.into_iter().map(|(val, _def)| json!(val)).collect();
+                json!(jvals)
+            }
+            CV::Table(map, _def) => {
+                let mut root_table = json!({});
+                for (key, val) in map {
+                    json_add(&mut root_table, key, val);
+                }
+                root_table
+            }
+        }
+    } else {
+        let mut parts: Vec<_> = key.parts().collect();
+        let last_part = parts.pop().unwrap();
+        let mut root_table = json!({});
+        // Create a JSON object with nested keys up to the value being displayed.
+        let mut table = &mut root_table;
+        for part in parts {
+            table[part] = json!({});
+            table = table.get_mut(part).unwrap();
+        }
+        json_add(table, last_part, cv);
+        root_table
+    };
+    drop_println!(config, "{}", serde_json::to_string(&json_value).unwrap());
+
+    // Helper for recursively converting a CV to JSON.
+    fn json_add(table: &mut serde_json::Value, key: &str, cv: &CV) {
+        match cv {
+            CV::Boolean(val, _def) => table[key] = json!(val),
+            CV::Integer(val, _def) => table[key] = json!(val),
+            CV::String(val, _def) => table[key] = json!(val),
+            CV::List(vals, _def) => {
+                let jvals: Vec<_> = vals.into_iter().map(|(val, _def)| json!(val)).collect();
+                table[key] = json!(jvals);
+            }
+            CV::Table(val, _def) => {
+                table
+                    .as_object_mut()
+                    .unwrap()
+                    .insert(key.to_string(), json!({}));
+                let inner_table = &mut table[&key];
+                for (t_key, t_cv) in val {
+                    json_add(inner_table, t_key, t_cv);
+                }
+            }
+        }
+    }
+}
+
+fn print_toml_unmerged(config: &Config, opts: &GetOptions<'_>, key: &ConfigKey) -> CargoResult<()> {
+    let print_table = |cv: &CV| {
+        drop_println!(config, "# {}", cv.definition());
+        print_toml(config, opts, &ConfigKey::new(), cv);
+        drop_println!(config, "");
+    };
+    // This removes entries from the given CV so that all that remains is the
+    // given key. Returns false if no entries were found.
+    fn trim_cv(mut cv: &mut CV, key: &ConfigKey) -> CargoResult<bool> {
+        for (i, part) in key.parts().enumerate() {
+            match cv {
+                CV::Table(map, _def) => {
+                    map.retain(|key, _value| key == part);
+                    match map.get_mut(part) {
+                        Some(val) => cv = val,
+                        None => return Ok(false),
+                    }
+                }
+                _ => {
+                    let mut key_so_far = ConfigKey::new();
+                    for part in key.parts().take(i) {
+                        key_so_far.push(part);
+                    }
+                    bail!(
+                        "expected table for configuration key `{}`, \
+                         but found {} in {}",
+                        key_so_far,
+                        cv.desc(),
+                        cv.definition()
+                    )
+                }
+            }
+        }
+        Ok(match cv {
+            CV::Table(map, _def) => !map.is_empty(),
+            _ => true,
+        })
+    }
+
+    let mut cli_args = config.cli_args_as_table()?;
+    if trim_cv(&mut cli_args, key)? {
+        print_table(&cli_args);
+    }
+
+    // This slurps up some extra env vars that aren't technically part of the
+    // "config" (or are special-cased). I'm personally fine with just keeping
+    // them here, though it might be confusing. The vars I'm aware of:
+    //
+    // * CARGO
+    // * CARGO_HOME
+    // * CARGO_NAME
+    // * CARGO_EMAIL
+    // * CARGO_INCREMENTAL
+    // * CARGO_TARGET_DIR
+    // * CARGO_CACHE_RUSTC_INFO
+    //
+    // All of these except CARGO, CARGO_HOME, and CARGO_CACHE_RUSTC_INFO are
+    // actually part of the config, but they are special-cased in the code.
+    //
+    // TODO: It might be a good idea to teach the Config loader to support
+    // environment variable aliases so that these special cases are less
+    // special, and will just naturally get loaded as part of the config.
+    let mut env: Vec<_> = config
+        .env()
+        .iter()
+        .filter(|(env_key, _val)| env_key.starts_with(key.as_env_key()))
+        .collect();
+    if !env.is_empty() {
+        env.sort_by_key(|x| x.0);
+        drop_println!(config, "# Environment variables");
+        for (key, value) in env {
+            // Displaying this in "shell" syntax instead of TOML, since that
+            // somehow makes more sense to me.
+            let val = shell_escape::escape(Cow::Borrowed(value));
+            drop_println!(config, "# {}={}", key, val);
+        }
+        drop_println!(config, "");
+    }
+
+    let unmerged = config.load_values_unmerged()?;
+    for mut cv in unmerged {
+        if trim_cv(&mut cv, key)? {
+            print_table(&cv);
+        }
+    }
+    Ok(())
+}

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -31,6 +31,7 @@ pub use self::vendor::{vendor, VendorOptions};
 
 mod cargo_clean;
 mod cargo_compile;
+pub mod cargo_config;
 mod cargo_doc;
 mod cargo_fetch;
 mod cargo_generate_lockfile;

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1091,38 +1091,6 @@ The 2021 edition will set the default [resolver version] to "2".
 [edition]: ../../edition-guide/index.html
 [resolver version]: resolver.md#resolver-versions
 
-<script>
-(function() {
-    var fragments = {
-        "#edition": "manifest.html#the-edition-field",
-        "#compile-progress": "config.html#termprogresswhen",
-        "#rename-dependency": "specifying-dependencies.html#renaming-dependencies-in-cargotoml",
-        "#alternate-registries": "registries.html",
-        "#offline-mode": "../commands/cargo.html",
-        "#publish-lockfile": "../commands/cargo-package.html",
-        "#default-run": "manifest.html#the-default-run-field",
-        "#cache-messages": "https://github.com/rust-lang/cargo/pull/7450",
-        "#install-upgrade": "../commands/cargo-install.html",
-        "#profile-overrides": "profiles.html#overrides",
-        "#config-profiles": "config.html#profile",
-        "#crate-versions": "https://github.com/rust-lang/cargo/pull/8509",
-        "#features": "features.html#feature-resolver-version-2",
-        "#package-features": "features.html#resolver-version-2-command-line-flags",
-        "#resolver": "resolver.html#resolver-versions",
-    };
-    var target = fragments[window.location.hash];
-    if (target) {
-        if (target.startsWith('https')) {
-          window.location.replace(target);
-        } else {
-          var url = window.location.toString();
-          var base = url.substring(0, url.lastIndexOf('/'));
-          window.location.replace(base + "/" + target);
-        }
-    }
-})();
-</script>
-
 ### future incompat report
 * RFC: [#2834](https://github.com/rust-lang/rfcs/blob/master/text/2834-cargo-report-future-incompat.md)
 * rustc Tracking Issue: [#71249](https://github.com/rust-lang/rust/issues/71249)
@@ -1181,3 +1149,35 @@ lowest precedence.
 
 Relative `path` dependencies in such a `[patch]` section are resolved
 relative to the configuration file they appear in.
+
+<script>
+(function() {
+    var fragments = {
+        "#edition": "manifest.html#the-edition-field",
+        "#compile-progress": "config.html#termprogresswhen",
+        "#rename-dependency": "specifying-dependencies.html#renaming-dependencies-in-cargotoml",
+        "#alternate-registries": "registries.html",
+        "#offline-mode": "../commands/cargo.html",
+        "#publish-lockfile": "../commands/cargo-package.html",
+        "#default-run": "manifest.html#the-default-run-field",
+        "#cache-messages": "https://github.com/rust-lang/cargo/pull/7450",
+        "#install-upgrade": "../commands/cargo-install.html",
+        "#profile-overrides": "profiles.html#overrides",
+        "#config-profiles": "config.html#profile",
+        "#crate-versions": "https://github.com/rust-lang/cargo/pull/8509",
+        "#features": "features.html#feature-resolver-version-2",
+        "#package-features": "features.html#resolver-version-2-command-line-flags",
+        "#resolver": "resolver.html#resolver-versions",
+    };
+    var target = fragments[window.location.hash];
+    if (target) {
+        if (target.startsWith('https')) {
+          window.location.replace(target);
+        } else {
+          var url = window.location.toString();
+          var base = url.substring(0, url.lastIndexOf('/'));
+          window.location.replace(base + "/" + target);
+        }
+    }
+})();
+</script>

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1150,6 +1150,23 @@ lowest precedence.
 Relative `path` dependencies in such a `[patch]` section are resolved
 relative to the configuration file they appear in.
 
+## `cargo config`
+
+* Original Issue: [#2362](https://github.com/rust-lang/cargo/issues/2362)
+* Tracking Issue: [#9301](https://github.com/rust-lang/cargo/issues/9301)
+
+The `cargo config` subcommand provides a way to display the configuration
+files that cargo loads. It currently includes the `get` subcommand which
+can take an optional config value to display.
+
+```console
+cargo +nightly -Zunstable-options config get build.rustflags
+```
+
+If no config value is included, it will display all config values. See the
+`--help` output for more options available.
+
+
 <script>
 (function() {
     var fragments = {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1391,16 +1391,16 @@ fn bad_target_cfg() {
         .with_stderr(
             "\
 [ERROR] error in [..]/foo/.cargo/config: \
-could not load config key `target.cfg(not(target_os = \"none\")).runner`
+could not load config key `target.\"cfg(not(target_os = /\"none/\"))\".runner`
 
 Caused by:
   error in [..]/foo/.cargo/config: \
-  could not load config key `target.cfg(not(target_os = \"none\")).runner`
+  could not load config key `target.\"cfg(not(target_os = /\"none/\"))\".runner`
 
 Caused by:
-  invalid configuration for key `target.cfg(not(target_os = \"none\")).runner`
+  invalid configuration for key `target.\"cfg(not(target_os = /\"none/\"))\".runner`
   expected a string or array of strings, but found a boolean for \
-  `target.cfg(not(target_os = \"none\")).runner` in [..]/foo/.cargo/config
+  `target.\"cfg(not(target_os = /\"none/\"))\".runner` in [..]/foo/.cargo/config
 ",
         )
         .run();

--- a/tests/testsuite/cargo_config.rs
+++ b/tests/testsuite/cargo_config.rs
@@ -1,0 +1,510 @@
+//! Tests for the `cargo config` command.
+
+use super::config::write_config_at;
+use cargo_test_support::paths;
+use std::fs;
+use std::path::PathBuf;
+
+fn cargo_process(s: &str) -> cargo_test_support::Execs {
+    let mut p = cargo_test_support::cargo_process(s);
+    // Clear out some of the environment added by the default cargo_process so
+    // the tests don't need to deal with it.
+    p.env_remove("CARGO_PROFILE_DEV_SPLIT_DEBUGINFO")
+        .env_remove("CARGO_PROFILE_TEST_SPLIT_DEBUGINFO")
+        .env_remove("CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO")
+        .env_remove("CARGO_PROFILE_BENCH_SPLIT_DEBUGINFO")
+        .env_remove("CARGO_INCREMENTAL");
+    p
+}
+
+#[cargo_test]
+fn gated() {
+    cargo_process("config get")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr("\
+error: the `cargo config` command is unstable, pass `-Z unstable-options` to enable it
+See https://github.com/rust-lang/cargo/issues/9301 for more information about the `cargo config` command.
+")
+        .run();
+}
+
+fn common_setup() -> PathBuf {
+    write_config_at(
+        paths::home().join(".cargo/config.toml"),
+        "
+        [alias]
+        foo = \"abc --xyz\"
+        [build]
+        jobs = 99
+        rustflags = [\"--flag-global\"]
+        [profile.dev]
+        opt-level = 3
+        [profile.dev.package.foo]
+        opt-level = 1
+        [target.'cfg(target_os = \"linux\")']
+        runner = \"runme\"
+
+        # How unknown keys are handled.
+        [extra-table]
+        somekey = \"somevalue\"
+        ",
+    );
+    let sub_folder = paths::root().join("foo/.cargo");
+    write_config_at(
+        sub_folder.join("config.toml"),
+        "
+        [alias]
+        sub-example = [\"sub\", \"example\"]
+        [build]
+        rustflags = [\"--flag-directory\"]
+        ",
+    );
+    sub_folder
+}
+
+#[cargo_test]
+fn get_toml() {
+    // Notes:
+    // - The "extra-table" is shown without a warning. I'm not sure how that
+    //   should be handled, since displaying warnings could cause problems
+    //   with ingesting the output.
+    // - Environment variables aren't loaded. :(
+    let sub_folder = common_setup();
+    cargo_process("config get -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_ALIAS_BAR", "cat dog")
+        .env("CARGO_BUILD_JOBS", "100")
+        // The weird forward slash in the linux line is due to testsuite normalization.
+        .with_stdout(
+            "\
+alias.foo = \"abc --xyz\"
+alias.sub-example = [\"sub\", \"example\"]
+build.jobs = 99
+build.rustflags = [\"--flag-directory\", \"--flag-global\"]
+extra-table.somekey = \"somevalue\"
+profile.dev.opt-level = 3
+profile.dev.package.foo.opt-level = 1
+target.\"cfg(target_os = /\"linux/\")\".runner = \"runme\"
+# The following environment variables may affect the loaded values.
+# CARGO_ALIAS_BAR=[..]cat dog[..]
+# CARGO_BUILD_JOBS=100
+# CARGO_HOME=[ROOT]/home/.cargo
+",
+        )
+        .with_stderr("")
+        .run();
+
+    // Env keys work if they are specific.
+    cargo_process("config get build.jobs -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_BUILD_JOBS", "100")
+        .with_stdout("build.jobs = 100")
+        .with_stderr("")
+        .run();
+
+    // Array value.
+    cargo_process("config get build.rustflags -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout("build.rustflags = [\"--flag-directory\", \"--flag-global\"]")
+        .with_stderr("")
+        .run();
+
+    // Sub-table
+    cargo_process("config get profile -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout(
+            "\
+profile.dev.opt-level = 3
+profile.dev.package.foo.opt-level = 1
+",
+        )
+        .with_stderr("")
+        .run();
+
+    // Specific profile entry.
+    cargo_process("config get profile.dev.opt-level -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout("profile.dev.opt-level = 3")
+        .with_stderr("")
+        .run();
+
+    // A key that isn't set.
+    cargo_process("config get build.rustc -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stdout("")
+        .with_stderr("error: config value `build.rustc` is not set")
+        .run();
+
+    // A key that is not part of Cargo's config schema.
+    cargo_process("config get not.set -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stdout("")
+        .with_stderr("error: config value `not.set` is not set")
+        .run();
+}
+
+#[cargo_test]
+fn get_json() {
+    // Notes:
+    // - This does not show env vars at all. :(
+    let all_json = r#"
+            {
+              "alias": {
+                "foo": "abc --xyz",
+                "sub-example": [
+                  "sub",
+                  "example"
+                ]
+              },
+              "build": {
+                "jobs": 99,
+                "rustflags": [
+                  "--flag-directory",
+                  "--flag-global"
+                ]
+              },
+              "extra-table": {
+                "somekey": "somevalue"
+              },
+              "profile": {
+                "dev": {
+                  "opt-level": 3,
+                  "package": {
+                    "foo": {
+                      "opt-level": 1
+                    }
+                  }
+                }
+              },
+              "target": {
+                "cfg(target_os = \"linux\")": {
+                  "runner": "runme"
+                }
+              }
+            }
+            "#;
+    let sub_folder = common_setup();
+    cargo_process("config get --format=json -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_ALIAS_BAR", "cat dog")
+        .env("CARGO_BUILD_JOBS", "100")
+        .with_json(all_json)
+        .with_stderr("")
+        .run();
+
+    // json-value is the same for the entire root table
+    cargo_process("config get --format=json-value -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_json(all_json)
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --format=json build.jobs -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_json(
+            r#"
+            {"build": {"jobs": 99}}
+            "#,
+        )
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --format=json-value build.jobs -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout("99")
+        .with_stderr("")
+        .run();
+}
+
+#[cargo_test]
+fn show_origin_toml() {
+    let sub_folder = common_setup();
+    cargo_process("config get --show-origin -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout(
+            "\
+alias.foo = \"abc --xyz\" # [ROOT]/home/.cargo/config.toml
+alias.sub-example = [
+    \"sub\", # [ROOT]/foo/.cargo/config.toml
+    \"example\", # [ROOT]/foo/.cargo/config.toml
+]
+build.jobs = 99 # [ROOT]/home/.cargo/config.toml
+build.rustflags = [
+    \"--flag-directory\", # [ROOT]/foo/.cargo/config.toml
+    \"--flag-global\", # [ROOT]/home/.cargo/config.toml
+]
+extra-table.somekey = \"somevalue\" # [ROOT]/home/.cargo/config.toml
+profile.dev.opt-level = 3 # [ROOT]/home/.cargo/config.toml
+profile.dev.package.foo.opt-level = 1 # [ROOT]/home/.cargo/config.toml
+target.\"cfg(target_os = /\"linux/\")\".runner = \"runme\" # [ROOT]/home/.cargo/config.toml
+# The following environment variables may affect the loaded values.
+# CARGO_HOME=[ROOT]/home/.cargo
+",
+        )
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --show-origin build.rustflags -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
+        .with_stdout(
+            "\
+build.rustflags = [
+    \"--flag-directory\", # [ROOT]/foo/.cargo/config.toml
+    \"--flag-global\", # [ROOT]/home/.cargo/config.toml
+    \"env1\", # environment variable `CARGO_BUILD_RUSTFLAGS`
+    \"env2\", # environment variable `CARGO_BUILD_RUSTFLAGS`
+]
+",
+        )
+        .with_stderr("")
+        .run();
+}
+
+#[cargo_test]
+fn show_origin_toml_cli() {
+    let sub_folder = common_setup();
+    cargo_process("config get --show-origin build.jobs -Zunstable-options --config build.jobs=123")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_BUILD_JOBS", "1")
+        .with_stdout("build.jobs = 123 # --config cli option")
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --show-origin build.rustflags -Zunstable-options --config")
+        .arg("build.rustflags=[\"cli1\",\"cli2\"]")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
+        .with_stdout(
+            "\
+build.rustflags = [
+    \"--flag-directory\", # [ROOT]/foo/.cargo/config.toml
+    \"--flag-global\", # [ROOT]/home/.cargo/config.toml
+    \"cli1\", # --config cli option
+    \"cli2\", # --config cli option
+    \"env1\", # environment variable `CARGO_BUILD_RUSTFLAGS`
+    \"env2\", # environment variable `CARGO_BUILD_RUSTFLAGS`
+]
+",
+        )
+        .with_stderr("")
+        .run();
+}
+
+#[cargo_test]
+fn show_origin_json() {
+    let sub_folder = common_setup();
+    cargo_process("config get --show-origin --format=json -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr("error: the `json` format does not support --show-origin, try the `toml` format instead")
+        .run();
+}
+
+#[cargo_test]
+fn unmerged_toml() {
+    let sub_folder = common_setup();
+    cargo_process("config get --merged=no -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_ALIAS_BAR", "cat dog")
+        .env("CARGO_BUILD_JOBS", "100")
+        .with_stdout(
+            "\
+# Environment variables
+# CARGO=[..]
+# CARGO_ALIAS_BAR=[..]cat dog[..]
+# CARGO_BUILD_JOBS=100
+# CARGO_HOME=[ROOT]/home/.cargo
+
+# [ROOT]/foo/.cargo/config.toml
+alias.sub-example = [\"sub\", \"example\"]
+build.rustflags = [\"--flag-directory\"]
+
+# [ROOT]/home/.cargo/config.toml
+alias.foo = \"abc --xyz\"
+build.jobs = 99
+build.rustflags = [\"--flag-global\"]
+extra-table.somekey = \"somevalue\"
+profile.dev.opt-level = 3
+profile.dev.package.foo.opt-level = 1
+target.\"cfg(target_os = /\"linux/\")\".runner = \"runme\"
+
+",
+        )
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --merged=no build.rustflags -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
+        .with_stdout(
+            "\
+# Environment variables
+# CARGO_BUILD_RUSTFLAGS=[..]env1 env2[..]
+
+# [ROOT]/foo/.cargo/config.toml
+build.rustflags = [\"--flag-directory\"]
+
+# [ROOT]/home/.cargo/config.toml
+build.rustflags = [\"--flag-global\"]
+
+",
+        )
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --merged=no does.not.exist -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stderr("")
+        .with_stderr("")
+        .run();
+
+    cargo_process("config get --merged=no build.rustflags.extra -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "error: expected table for configuration key `build.rustflags`, \
+             but found array in [ROOT]/foo/.cargo/config.toml",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn unmerged_toml_cli() {
+    let sub_folder = common_setup();
+    cargo_process("config get --merged=no build.rustflags -Zunstable-options --config")
+        .arg("build.rustflags=[\"cli1\",\"cli2\"]")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
+        .with_stdout(
+            "\
+# --config cli option
+build.rustflags = [\"cli1\", \"cli2\"]
+
+# Environment variables
+# CARGO_BUILD_RUSTFLAGS=[..]env1 env2[..]
+
+# [ROOT]/foo/.cargo/config.toml
+build.rustflags = [\"--flag-directory\"]
+
+# [ROOT]/home/.cargo/config.toml
+build.rustflags = [\"--flag-global\"]
+
+",
+        )
+        .with_stderr("")
+        .run();
+}
+
+#[cargo_test]
+fn unmerged_json() {
+    let sub_folder = common_setup();
+    cargo_process("config get --merged=no --format=json -Zunstable-options")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "error: the `json` format does not support --merged=no, try the `toml` format instead",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn includes() {
+    let sub_folder = common_setup();
+    fs::write(
+        sub_folder.join("config.toml"),
+        "
+        include = 'other.toml'
+        [build]
+        rustflags = [\"--flag-directory\"]
+        ",
+    )
+    .unwrap();
+    fs::write(
+        sub_folder.join("other.toml"),
+        "
+        [build]
+        rustflags = [\"--flag-other\"]
+        ",
+    )
+    .unwrap();
+
+    cargo_process("config get build.rustflags -Zunstable-options -Zconfig-include")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout(r#"build.rustflags = ["--flag-other", "--flag-directory", "--flag-global"]"#)
+        .with_stderr("")
+        .run();
+
+    cargo_process(
+        "config get build.rustflags --show-origin=yes -Zunstable-options -Zconfig-include",
+    )
+    .cwd(&sub_folder.parent().unwrap())
+    .masquerade_as_nightly_cargo()
+    .with_stdout(
+        "\
+build.rustflags = [
+    \"--flag-other\", # [ROOT]/foo/.cargo/other.toml
+    \"--flag-directory\", # [ROOT]/foo/.cargo/config.toml
+    \"--flag-global\", # [ROOT]/home/.cargo/config.toml
+]
+",
+    )
+    .with_stderr("")
+    .run();
+
+    cargo_process("config get --merged=no -Zunstable-options -Zconfig-include")
+        .cwd(&sub_folder.parent().unwrap())
+        .masquerade_as_nightly_cargo()
+        .with_stdout(
+            "\
+# Environment variables
+# CARGO=[..]
+# CARGO_HOME=[ROOT]/home/.cargo
+
+# [ROOT]/foo/.cargo/other.toml
+build.rustflags = [\"--flag-other\"]
+
+# [ROOT]/foo/.cargo/config.toml
+build.rustflags = [\"--flag-directory\"]
+include = \"other.toml\"
+
+# [ROOT]/home/.cargo/config.toml
+alias.foo = \"abc --xyz\"
+build.jobs = 99
+build.rustflags = [\"--flag-global\"]
+extra-table.somekey = \"somevalue\"
+profile.dev.opt-level = 3
+profile.dev.package.foo.opt-level = 1
+target.\"cfg(target_os = /\"linux/\")\".runner = \"runme\"
+
+",
+        )
+        .with_stderr("")
+        .run();
+}

--- a/tests/testsuite/cargo_config.rs
+++ b/tests/testsuite/cargo_config.rs
@@ -200,7 +200,14 @@ fn get_json() {
         .env("CARGO_ALIAS_BAR", "cat dog")
         .env("CARGO_BUILD_JOBS", "100")
         .with_json(all_json)
-        .with_stderr("")
+        .with_stderr(
+            "\
+note: The following environment variables may affect the loaded values.
+CARGO_ALIAS_BAR=[..]cat dog[..]
+CARGO_BUILD_JOBS=100
+CARGO_HOME=[ROOT]/home/.cargo
+",
+        )
         .run();
 
     // json-value is the same for the entire root table
@@ -208,7 +215,12 @@ fn get_json() {
         .cwd(&sub_folder.parent().unwrap())
         .masquerade_as_nightly_cargo()
         .with_json(all_json)
-        .with_stderr("")
+        .with_stderr(
+            "\
+note: The following environment variables may affect the loaded values.
+CARGO_HOME=[ROOT]/home/.cargo
+",
+        )
         .run();
 
     cargo_process("config get --format=json build.jobs -Zunstable-options")

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -24,6 +24,7 @@ mod build_script_extra_link_arg;
 mod cache_messages;
 mod cargo_alias_config;
 mod cargo_command;
+mod cargo_config;
 mod cargo_env_config;
 mod cargo_features;
 mod cargo_targets;


### PR DESCRIPTION
This adds an initial version of the `cargo config` command as discussed in #2362.

Closes #2362