### PR TITLE
tests: Tolerate "exit status" in error messages

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -37,7 +37,7 @@ fn custom_build_script_failed() {
 [ERROR] failed to run custom build command for `foo v0.5.0 ([CWD])`
 
 Caused by:
-  process didn't exit successfully: `[..]/build-script-build` (exit code: 101)",
+  process didn't exit successfully: `[..]/build-script-build` (exit [..]: 101)",
         )
         .run();
 }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -118,7 +118,7 @@ fn exit_code() {
     );
     if !cfg!(unix) {
         output.push_str(
-            "[ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)",
+            "[ERROR] process didn't exit successfully: `target[..]foo[..]` (exit [..]: 2)",
         );
     }
     p.cargo("run").with_status(2).with_stderr(output).run();
@@ -140,7 +140,7 @@ fn exit_code_verbose() {
     );
     if !cfg!(unix) {
         output.push_str(
-            "[ERROR] process didn't exit successfully: `target[..]foo[..]` (exit code: 2)",
+            "[ERROR] process didn't exit successfully: `target[..]foo[..]` (exit [..]: 2)",
         );
     }
 


### PR DESCRIPTION
"exit code" is wrong terminology on Unix.  I am trying to fix this in Rust stdlib in https://github.com/rust-lang/rust/pull/83462 but this currently breaks the cargo test suite.

See that MR for full explanation of the change.