### PR TITLE
Give one more example for the --featuers CLI

### DIFF
--- a/src/doc/src/reference/features.md
+++ b/src/doc/src/reference/features.md
@@ -369,6 +369,9 @@ For example:
 # This command is allowed with resolver = "2", regardless of which directory
 # you are in.
 cargo build -p foo -p bar --features foo-feat,bar-feat
+
+# This explicit equivalent works with any resolver version:
+cargo build -p foo -p bar --features foo/foo-feat,bar/bar-feat
 ```
 
 Additionally, with `resolver = "1"`, the `--no-default-features` flag only


### PR DESCRIPTION
The previous example confused me because I thought that `foo-feat` is
the syntax for `foo/feat`. The "explicit" example should clarify that.

closes #9305