### PR TITLE
mention RUSTFLAGS in -Z unknown error

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -759,7 +759,11 @@ impl CliUnstable {
             "crate-versions" => stabilized_warn(k, "1.47", STABILIZED_CRATE_VERSIONS),
             "package-features" => stabilized_warn(k, "1.51", STABILIZED_PACKAGE_FEATURES),
             "future-incompat-report" => self.enable_future_incompat_feature = parse_empty(k, v)?,
-            _ => bail!("unknown `-Z` flag specified: {}", k),
+            _ => bail!(
+                "unknown `-Z` flag specified: {0} (if meant for rustc and not cargo, \
+                 try rerunning with RUSTFLAGS=\"-Z {0}\")",
+                k
+            ),
         }
 
         Ok(())

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -297,7 +297,10 @@ fn z_flags_rejected() {
     p.cargo("build -Zarg")
         .masquerade_as_nightly_cargo()
         .with_status(101)
-        .with_stderr("error: unknown `-Z` flag specified: arg")
+        .with_stderr(
+            "error: unknown `-Z` flag specified: arg (if meant for rustc \
+            and not cargo, try rerunning with RUSTFLAGS=\"-Z arg\")",
+        )
         .run();
 
     p.cargo("build -Zprint-im-a-teapot")


### PR DESCRIPTION
#5546 suggests only doing this if the provided flag is a valid -Z arg for rustc, which would be better but also more complex to determine. this should be good enough as is, IMO.