### PR TITLE
Configure hosts separately from targets when --target is specified.

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -700,11 +700,7 @@ impl<'cfg> RustcTargetData<'cfg> {
         if requested_kinds.iter().any(CompileKind::is_host) {
             let ct = CompileTarget::new(&rustc.host)?;
             target_info.insert(ct, host_info.clone());
-            if target_applies_to_host {
-                target_config.insert(ct, host_config.clone());
-            } else {
-                target_config.insert(ct, config.target_cfg_triple(&rustc.host)?);
-            };
+            target_config.insert(ct, config.target_cfg_triple(&rustc.host)?);
         };
 
         let mut res = RustcTargetData {

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -712,17 +712,6 @@ impl<'cfg> RustcTargetData<'cfg> {
             }
         };
 
-        for kind in requested_kinds {
-            if let CompileKind::Target(target) = *kind {
-                let tcfg = config.target_cfg_triple(target.short_name())?;
-                target_config.insert(target, tcfg);
-                target_info.insert(
-                    target,
-                    TargetInfo::new(config, requested_kinds, &rustc, *kind)?,
-                );
-            }
-        }
-
         let mut res = RustcTargetData {
             rustc,
             config,

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -694,11 +694,21 @@ impl<'cfg> RustcTargetData<'cfg> {
         let host_config = if requested_kinds.iter().any(CompileKind::is_host) {
             let ct = CompileTarget::new(&rustc.host)?;
             target_info.insert(ct, host_info.clone());
-            let target_host_config = config.target_cfg_triple(&rustc.host)?;
-            target_config.insert(ct, target_host_config.clone());
+            let target_host_config = if config.target_applies_to_host() {
+                let target_cfg_clone = config.target_cfg_triple(&rustc.host)?;
+                target_config.insert(ct, target_cfg_clone.clone());
+                target_cfg_clone
+            } else {
+                target_config.insert(ct, config.target_cfg_triple(&rustc.host)?);
+                config.host_cfg_triple(&rustc.host)?
+            };
             target_host_config
         } else {
-            config.host_cfg_triple(&rustc.host)?
+            if config.target_applies_to_host() {
+                config.target_cfg_triple(&rustc.host)?
+            } else {
+                config.host_cfg_triple(&rustc.host)?
+            }
         };
 
         for kind in requested_kinds {

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -691,14 +691,11 @@ impl<'cfg> RustcTargetData<'cfg> {
         // `--target` flag is not specified. Since the unit_dependency code
         // needs access to the target config data, create a copy so that it
         // can be found. See `rebuild_unit_graph_shared` for why this is done.
-        let target_applies_to_host = config.target_applies_to_host();
-        if target_applies_to_host.is_err() {
-            return Err(target_applies_to_host.unwrap_err());
-        }
+        let target_applies_to_host = config.target_applies_to_host()?;
         let host_config = if requested_kinds.iter().any(CompileKind::is_host) {
             let ct = CompileTarget::new(&rustc.host)?;
             target_info.insert(ct, host_info.clone());
-            let target_host_config = if target_applies_to_host.unwrap() {
+            let target_host_config = if target_applies_to_host {
                 let target_cfg_clone = config.target_cfg_triple(&rustc.host)?;
                 target_config.insert(ct, target_cfg_clone.clone());
                 target_cfg_clone
@@ -708,7 +705,7 @@ impl<'cfg> RustcTargetData<'cfg> {
             };
             target_host_config
         } else {
-            if target_applies_to_host.unwrap() {
+            if target_applies_to_host {
                 config.target_cfg_triple(&rustc.host)?
             } else {
                 config.host_cfg_triple(&rustc.host)?

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -600,6 +600,7 @@ unstable_cli_options!(
     namespaced_features: bool = ("Allow features with `dep:` prefix"),
     no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
+    host_config: bool = ("Enable the [host] section in the .cargo/config.toml file"),
     patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     separate_nightlies: bool = (HIDDEN),
@@ -787,6 +788,7 @@ impl CliUnstable {
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
             "configurable-env" => self.configurable_env = parse_empty(k, v)?,
+            "host-config" => self.host_config = parse_empty(k, v)?,
             "patch-in-config" => self.patch_in_config = parse_empty(k, v)?,
             "features" => {
                 // For now this is still allowed (there are still some

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -601,6 +601,7 @@ unstable_cli_options!(
     no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     host_config: bool = ("Enable the [host] section in the .cargo/config.toml file"),
+    target_applies_to_host: bool = ("Enable the `target-applies-to-host` key in the .cargo/config.toml file"),
     patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     separate_nightlies: bool = (HIDDEN),
@@ -789,6 +790,7 @@ impl CliUnstable {
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
             "configurable-env" => self.configurable_env = parse_empty(k, v)?,
             "host-config" => self.host_config = parse_empty(k, v)?,
+            "target-applies-to-host" => self.target_applies_to_host = parse_empty(k, v)?,
             "patch-in-config" => self.patch_in_config = parse_empty(k, v)?,
             "features" => {
                 // For now this is still allowed (there are still some

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1486,6 +1486,11 @@ impl Config {
             .try_borrow_with(|| self.get::<RustdocExternMap>("doc.extern-map"))
     }
 
+    /// Returns true if the `[target]` table should be applied to host targets.
+    pub fn target_applies_to_host(&self) -> bool {
+        target::get_target_applies_to_host(self)
+    }
+
     /// Returns the `[host]` table definition for the given target triple.
     pub fn host_cfg_triple(&self, target: &str) -> CargoResult<TargetConfig> {
         target::load_host_triple(self, target)

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1486,6 +1486,11 @@ impl Config {
             .try_borrow_with(|| self.get::<RustdocExternMap>("doc.extern-map"))
     }
 
+    /// Returns the `[host]` table definition for the given target triple.
+    pub fn host_cfg_triple(&self, target: &str) -> CargoResult<TargetConfig> {
+        target::load_host_triple(self, target)
+    }
+
     /// Returns the `[target]` table definition for the given target triple.
     pub fn target_cfg_triple(&self, target: &str) -> CargoResult<TargetConfig> {
         target::load_target_triple(self, target)

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1487,7 +1487,7 @@ impl Config {
     }
 
     /// Returns true if the `[target]` table should be applied to host targets.
-    pub fn target_applies_to_host(&self) -> bool {
+    pub fn target_applies_to_host(&self) -> CargoResult<bool> {
         target::get_target_applies_to_host(self)
     }
 

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -67,15 +67,10 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
 /// Returns true if the `[target]` table should be applied to host targets.
 pub(super) fn get_target_applies_to_host(config: &Config) -> CargoResult<bool> {
     if config.cli_unstable().target_applies_to_host {
-        let target_applies_to_host = config.get::<bool>("target-applies-to-host");
-        if target_applies_to_host.is_ok() {
-            Ok(target_applies_to_host.unwrap())
+        if let Ok(target_applies_to_host) = config.get::<bool>("target-applies-to-host") {
+            Ok(target_applies_to_host)
         } else {
-            if config.cli_unstable().host_config {
-                Ok(false)
-            } else {
-                Ok(true)
-            }
+            Ok(!config.cli_unstable().host_config)
         }
     } else {
         if config.cli_unstable().host_config {
@@ -91,9 +86,10 @@ pub(super) fn get_target_applies_to_host(config: &Config) -> CargoResult<bool> {
 /// Loads a single `[host]` table for the given triple.
 pub(super) fn load_host_triple(config: &Config, triple: &str) -> CargoResult<TargetConfig> {
     if config.cli_unstable().host_config {
-        let host_triple_key = ConfigKey::from_str(&format!("host.{}", triple));
+        let host_triple_prefix = format!("host.{}", triple);
+        let host_triple_key = ConfigKey::from_str(&host_triple_prefix);
         let host_prefix = match config.get_cv(&host_triple_key)? {
-            Some(_) => format!("host.{}", triple),
+            Some(_) => host_triple_prefix,
             None => "host".to_string(),
         };
         load_config_table(config, &host_prefix)

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -64,6 +64,20 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
     Ok(result)
 }
 
+/// Returns true if the `[target]` table should be applied to host targets.
+pub(super) fn get_target_applies_to_host(config: &Config) -> bool {
+    let target_applies_to_host = config.get::<bool>("target-applies-to-host");
+    if target_applies_to_host.is_ok() {
+        target_applies_to_host.unwrap()
+    } else {
+        if config.cli_unstable().host_config {
+            false
+        } else {
+            true
+        }
+    }
+}
+
 /// Loads a single `[host]` table for the given triple.
 pub(super) fn load_host_triple(config: &Config, triple: &str) -> CargoResult<TargetConfig> {
     if config.cli_unstable().host_config {

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -66,12 +66,21 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
 
 /// Loads a single `[host]` table for the given triple.
 pub(super) fn load_host_triple(config: &Config, triple: &str) -> CargoResult<TargetConfig> {
-    let host_triple_key = ConfigKey::from_str(&format!("host.{}", triple));
-    let host_prefix = match config.get_cv(&host_triple_key)? {
-        Some(_) => format!("host.{}", triple),
-        None => "host".to_string(),
-    };
-    load_config_table(config, &host_prefix)
+    if config.cli_unstable().host_config {
+        let host_triple_key = ConfigKey::from_str(&format!("host.{}", triple));
+        let host_prefix = match config.get_cv(&host_triple_key)? {
+            Some(_) => format!("host.{}", triple),
+            None => "host".to_string(),
+        };
+        load_config_table(config, &host_prefix)
+    } else {
+        Ok(TargetConfig {
+            runner: None,
+            rustflags: None,
+            linker: None,
+            links_overrides: BTreeMap::new(),
+        })
+    }
 }
 
 /// Loads a single `[target]` table for the given triple.

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -66,45 +66,31 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
 
 /// Loads a single `[host]` table for the given triple.
 pub(super) fn load_host_triple(config: &Config, triple: &str) -> CargoResult<TargetConfig> {
-    // This needs to get each field individually because it cannot fetch the
-    // struct all at once due to `links_overrides`. Can't use `serde(flatten)`
-    // because it causes serde to use `deserialize_map` which means the config
-    // deserializer does not know which keys to deserialize, which means
-    // environment variables would not work.
     let host_triple_key = ConfigKey::from_str(&format!("host.{}", triple));
     let host_prefix = match config.get_cv(&host_triple_key)? {
         Some(_) => format!("host.{}", triple),
         None => "host".to_string(),
     };
-    let runner: OptValue<PathAndArgs> = config.get(&format!("{}.runner", host_prefix))?;
-    let rustflags: OptValue<StringList> = config.get(&format!("{}.rustflags", host_prefix))?;
-    let linker: OptValue<ConfigRelativePath> = config.get(&format!("{}.linker", host_prefix))?;
-    // Links do not support environment variables.
-    let target_key = ConfigKey::from_str(&host_prefix);
-    let links_overrides = match config.get_table(&target_key)? {
-        Some(links) => parse_links_overrides(&target_key, links.val, config)?,
-        None => BTreeMap::new(),
-    };
-    Ok(TargetConfig {
-        runner,
-        rustflags,
-        linker,
-        links_overrides,
-    })
+    load_config_table(config, &host_prefix)
 }
 
 /// Loads a single `[target]` table for the given triple.
 pub(super) fn load_target_triple(config: &Config, triple: &str) -> CargoResult<TargetConfig> {
+    load_config_table(config, &format!("target.{}", triple))
+}
+
+/// Loads a single table for the given prefix.
+fn load_config_table(config: &Config, prefix: &str) -> CargoResult<TargetConfig> {
     // This needs to get each field individually because it cannot fetch the
     // struct all at once due to `links_overrides`. Can't use `serde(flatten)`
     // because it causes serde to use `deserialize_map` which means the config
     // deserializer does not know which keys to deserialize, which means
     // environment variables would not work.
-    let runner: OptValue<PathAndArgs> = config.get(&format!("target.{}.runner", triple))?;
-    let rustflags: OptValue<StringList> = config.get(&format!("target.{}.rustflags", triple))?;
-    let linker: OptValue<ConfigRelativePath> = config.get(&format!("target.{}.linker", triple))?;
+    let runner: OptValue<PathAndArgs> = config.get(&format!("{}.runner", prefix))?;
+    let rustflags: OptValue<StringList> = config.get(&format!("{}.rustflags", prefix))?;
+    let linker: OptValue<ConfigRelativePath> = config.get(&format!("{}.linker", prefix))?;
     // Links do not support environment variables.
-    let target_key = ConfigKey::from_str(&format!("target.{}", triple));
+    let target_key = ConfigKey::from_str(prefix);
     let links_overrides = match config.get_table(&target_key)? {
         Some(links) => parse_links_overrides(&target_key, links.val, config)?,
         None => BTreeMap::new(),

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -641,6 +641,39 @@ cargo +nightly -Zunstable-options -Zconfig-include --config somefile.toml build
 
 CLI paths are relative to the current working directory.
 
+### host-config
+* Original Pull Request: [#9322](https://github.com/rust-lang/cargo/pull/9322)
+* Tracking Issue: [#3349](https://github.com/rust-lang/cargo/issues/3349)
+
+The `host` key in a config file can be used pass flags to host build targets
+such as build scripts that must run on the host system instead of the target
+system when cross compiling. It supports both generic and host arch specific
+tables. Matching host arch tables take precedence over generic host tables.
+
+It requires the `-Zhost-config` command-line option.
+
+```toml
+# .cargo/config
+cargo-features = ["host-config"]
+
+[host]
+linker = "/path/to/host/linker"
+[host.x86_64-unknown-linux-gnu]
+linker = "/path/to/host/arch/linker"
+[target.x86_64-unknown-linux-gnu]
+linker = "/path/to/target/linker"
+```
+
+The generic `host` table above will be entirely ignored when building on a
+`x86_64-unknown-linux-gnu` host as the `host.x86_64-unknown-linux-gnu` table
+takes precedence.
+
+This feature requires a `--target` to be specified.
+
+```console
+cargo +nightly -Zunstable-options -Zhost-config --config somefile.toml build --target x86_64-unknown-linux-gnu
+```
+
 ### unit-graph
 * Tracking Issue: [#8002](https://github.com/rust-lang/cargo/issues/8002)
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -643,6 +643,7 @@ CLI paths are relative to the current working directory.
 
 ### target-applies-to-host
 * Original Pull Request: [#9322](https://github.com/rust-lang/cargo/pull/9322)
+* Tracking Issue: [#9453](https://github.com/rust-lang/cargo/issues/9453)
 
 The `target-applies-to-host` key in a config file can be used set the desired
 behavior for passing target config flags to build scripts.
@@ -664,7 +665,7 @@ cargo +nightly -Ztarget-applies-to-host build --target x86_64-unknown-linux-gnu
 
 ### host-config
 * Original Pull Request: [#9322](https://github.com/rust-lang/cargo/pull/9322)
-* Tracking Issue: [#3349](https://github.com/rust-lang/cargo/issues/3349)
+* Tracking Issue: [#9452](https://github.com/rust-lang/cargo/issues/9452)
 
 The `host` key in a config file can be used pass flags to host build targets
 such as build scripts that must run on the host system instead of the target

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -641,6 +641,27 @@ cargo +nightly -Zunstable-options -Zconfig-include --config somefile.toml build
 
 CLI paths are relative to the current working directory.
 
+### target-applies-to-host
+* Original Pull Request: [#9322](https://github.com/rust-lang/cargo/pull/9322)
+
+The `target-applies-to-host` key in a config file can be used set the desired
+behavior for passing target config flags to build scripts.
+
+It requires the `-Ztarget-applies-to-host` command-line option.
+
+The current default for `target-applies-to-host` is `true`, which will be
+changed to `false` in the future, if `-Zhost-config` is used the new `false`
+default will be set for `target-applies-to-host`.
+
+```toml
+# config.toml
+target-applies-to-host = false
+```
+
+```console
+cargo +nightly -Ztarget-applies-to-host build --target x86_64-unknown-linux-gnu
+```
+
 ### host-config
 * Original Pull Request: [#9322](https://github.com/rust-lang/cargo/pull/9322)
 * Tracking Issue: [#3349](https://github.com/rust-lang/cargo/issues/3349)
@@ -650,12 +671,11 @@ such as build scripts that must run on the host system instead of the target
 system when cross compiling. It supports both generic and host arch specific
 tables. Matching host arch tables take precedence over generic host tables.
 
-It requires the `-Zhost-config` command-line option.
+It requires the `-Zhost-config` and `-Ztarget-applies-to-host` command-line
+options to be set.
 
 ```toml
-# .cargo/config
-cargo-features = ["host-config"]
-
+# config.toml
 [host]
 linker = "/path/to/host/linker"
 [host.x86_64-unknown-linux-gnu]
@@ -668,10 +688,11 @@ The generic `host` table above will be entirely ignored when building on a
 `x86_64-unknown-linux-gnu` host as the `host.x86_64-unknown-linux-gnu` table
 takes precedence.
 
-This feature requires a `--target` to be specified.
+Setting `-Zhost-config` changes the default for `target-applies-to-host` to
+`false` from `true`.
 
 ```console
-cargo +nightly -Zunstable-options -Zhost-config --config somefile.toml build --target x86_64-unknown-linux-gnu
+cargo +nightly -Ztarget-applies-to-host -Zhost-config build --target x86_64-unknown-linux-gnu
 ```
 
 ### unit-graph

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -266,17 +266,20 @@ fn custom_build_env_var_rustc_linker_bad_host() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build --verbose --target")
-        .arg(&target)
-        .with_status(101)
-        .with_stderr_contains(
-            "\
+    if cargo_test_support::is_nightly() {
+        p.cargo("build -Z host-config --verbose --target")
+            .arg(&target)
+            .masquerade_as_nightly_cargo()
+            .with_status(101)
+            .with_stderr_contains(
+                "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/linker [..]`
 [ERROR] linker `[..]/path/to/host/linker` not found
 "
-        )
-        .run();
+            )
+            .run();
+    }
 }
 
 #[cargo_test]
@@ -311,17 +314,20 @@ fn custom_build_env_var_rustc_linker_bad_host_with_arch() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build --verbose --target")
-        .arg(&target)
-        .with_status(101)
-        .with_stderr_contains(
-            "\
+    if cargo_test_support::is_nightly() {
+        p.cargo("build -Z host-config --verbose --target")
+            .arg(&target)
+            .masquerade_as_nightly_cargo()
+            .with_status(101)
+            .with_stderr_contains(
+                "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/arch/linker [..]`
 [ERROR] linker `[..]/path/to/host/arch/linker` not found
 "
-        )
-        .run();
+            )
+            .run();
+    }
 }
 
 #[cargo_test]
@@ -355,7 +361,12 @@ fn custom_build_env_var_rustc_linker_cross_arch_host() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build --verbose --target").arg(&target).run();
+    if cargo_test_support::is_nightly() {
+        p.cargo("build -Z host-config --verbose --target")
+            .arg(&target)
+            .masquerade_as_nightly_cargo()
+            .run();
+    }
 }
 
 #[cargo_test]
@@ -391,17 +402,20 @@ fn custom_build_env_var_rustc_linker_bad_cross_arch_host() {
         .build();
 
     // build.rs should fail due to bad host linker being set
-    p.cargo("build --verbose --target")
-        .arg(&target)
-        .with_status(101)
-        .with_stderr_contains(
-            "\
+    if cargo_test_support::is_nightly() {
+        p.cargo("build -Z host-config --verbose --target")
+            .arg(&target)
+            .masquerade_as_nightly_cargo()
+            .with_status(101)
+            .with_stderr_contains(
+                "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin [..]-C linker=[..]/path/to/host/linker [..]`
 [ERROR] linker `[..]/path/to/host/linker` not found
 "
-        )
-        .run();
+            )
+            .run();
+    }
 }
 
 #[cargo_test]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -234,7 +234,12 @@ fn custom_build_env_var_rustc_linker_host_target() {
 
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
-    p.cargo("build --target").arg(&target).run();
+    if cargo_test_support::is_nightly() {
+        p.cargo("build -Z target-applies-to-host --target")
+            .arg(&target)
+            .masquerade_as_nightly_cargo()
+            .run();
+    }
 }
 
 #[cargo_test]
@@ -266,10 +271,13 @@ fn custom_build_env_var_rustc_linker_host_target_env() {
 
     // no crate type set => linker never called => build succeeds if and
     // only if build.rs succeeds, despite linker binary not existing.
-    p.cargo("build --target")
-        .env("CARGO_TARGET_APPLIES_TO_HOST", "false")
-        .arg(&target)
-        .run();
+    if cargo_test_support::is_nightly() {
+        p.cargo("build -Z target-applies-to-host --target")
+            .env("CARGO_TARGET_APPLIES_TO_HOST", "false")
+            .arg(&target)
+            .masquerade_as_nightly_cargo()
+            .run();
+    }
 }
 
 #[cargo_test]
@@ -304,7 +312,7 @@ fn custom_build_env_var_rustc_linker_host_target_with_bad_host_config() {
 
     // build.rs should fail due to bad target linker being set
     if cargo_test_support::is_nightly() {
-        p.cargo("build -Z host-config --verbose --target")
+        p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
             .masquerade_as_nightly_cargo()
             .with_status(101)
@@ -350,7 +358,7 @@ fn custom_build_env_var_rustc_linker_bad_host() {
 
     // build.rs should fail due to bad host linker being set
     if cargo_test_support::is_nightly() {
-        p.cargo("build -Z host-config --verbose --target")
+        p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
             .masquerade_as_nightly_cargo()
             .with_status(101)
@@ -398,7 +406,7 @@ fn custom_build_env_var_rustc_linker_bad_host_with_arch() {
 
     // build.rs should fail due to bad host linker being set
     if cargo_test_support::is_nightly() {
-        p.cargo("build -Z host-config --verbose --target")
+        p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
             .masquerade_as_nightly_cargo()
             .with_status(101)
@@ -445,7 +453,7 @@ fn custom_build_env_var_rustc_linker_cross_arch_host() {
 
     // build.rs should fail due to bad host linker being set
     if cargo_test_support::is_nightly() {
-        p.cargo("build -Z host-config --verbose --target")
+        p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
             .masquerade_as_nightly_cargo()
             .run();
@@ -486,7 +494,7 @@ fn custom_build_env_var_rustc_linker_bad_cross_arch_host() {
 
     // build.rs should fail due to bad host linker being set
     if cargo_test_support::is_nightly() {
-        p.cargo("build -Z host-config --verbose --target")
+        p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
             .masquerade_as_nightly_cargo()
             .with_status(101)


### PR DESCRIPTION
This prevents target configs from accidentally being picked up when cross compiling from hosts that have the same architecture as their targets.

closes #3349