### PR TITLE
fix clippy warnings

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -788,8 +788,7 @@ impl RustDocFingerprint {
         doc_dirs
             .iter()
             .filter(|path| path.exists())
-            .map(|path| paths::remove_dir_all(&path))
-            .collect::<CargoResult<()>>()
+            .try_for_each(|path| paths::remove_dir_all(&path))
     }
 
     /// This function checks whether the latest version of `Rustc` used to compile this

--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -170,7 +170,7 @@ impl Context {
             // package again, which should only affect performance, but that
             // should be rare. Cycles should still be detected since those
             // will have `DepFeatures` edges.
-            RequestedFeatures::CliFeatures(_) => return Ok(false),
+            RequestedFeatures::CliFeatures(_) => Ok(false),
             RequestedFeatures::DepFeatures {
                 features,
                 uses_default_features,

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -333,7 +333,7 @@ fn build_requirements<'a, 'b: 'a>(
                 }
             } else {
                 for fv in features.iter() {
-                    if let Err(e) = reqs.require_value(&fv) {
+                    if let Err(e) = reqs.require_value(fv) {
                         return Err(e.into_activate_error(parent, s));
                     }
                 }

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -367,7 +367,7 @@ impl ResolvedFeatures {
                 // The new resolver should never add features.
                 assert_eq!(new_features.difference(&old_features).next(), None);
                 let removed_features: BTreeSet<_> =
-                    old_features.difference(&new_features).cloned().collect();
+                    old_features.difference(new_features).cloned().collect();
                 if removed_features.is_empty() {
                     None
                 } else {
@@ -386,7 +386,7 @@ impl ResolvedFeatures {
                 };
                 // The new resolver should never add dependencies.
                 assert_eq!(new_deps.difference(&old_deps).next(), None);
-                let removed_deps: BTreeSet<_> = old_deps.difference(&new_deps).cloned().collect();
+                let removed_deps: BTreeSet<_> = old_deps.difference(new_deps).cloned().collect();
                 if removed_deps.is_empty() {
                     None
                 } else {

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -624,7 +624,7 @@ fn activate(
         }
     }
 
-    let activated = cx.flag_activated(&candidate, &opts, parent)?;
+    let activated = cx.flag_activated(&candidate, opts, parent)?;
 
     let candidate = match registry.replacement_summary(candidate_pid) {
         Some(replace) => {
@@ -633,7 +633,7 @@ fn activate(
             // does. TBH it basically cause panics in the test suite if
             // `parent` is passed through here and `[replace]` is otherwise
             // on life support so it's not critical to fix bugs anyway per se.
-            if cx.flag_activated(replace, &opts, None)? && activated {
+            if cx.flag_activated(replace, opts, None)? && activated {
                 return Ok(None);
             }
             trace!(
@@ -654,7 +654,7 @@ fn activate(
 
     let now = Instant::now();
     let (used_features, deps) =
-        &*registry.build_deps(cx, parent.map(|p| p.0.package_id()), &candidate, &opts)?;
+        &*registry.build_deps(cx, parent.map(|p| p.0.package_id()), &candidate, opts)?;
 
     // Record what list of features is active for this package.
     if !used_features.is_empty() {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -404,7 +404,7 @@ impl<'cfg> Workspace<'cfg> {
                             /* platform */ None,
                             // NOTE: Since we use ConfigRelativePath, this root isn't used as
                             // any relative paths are resolved before they'd be joined with root.
-                            &Path::new("unused-relative-path"),
+                            Path::new("unused-relative-path"),
                             self.unstable_features(),
                             /* kind */ None,
                         )
@@ -436,7 +436,7 @@ impl<'cfg> Workspace<'cfg> {
             return Ok(from_manifest.clone());
         }
         if from_manifest.is_empty() {
-            return Ok(from_config.clone());
+            return Ok(from_config);
         }
 
         // We could just chain from_manifest and from_config,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -791,12 +791,13 @@ impl CompileFilter {
     }
 
     pub fn is_all_targets(&self) -> bool {
-        match *self {
+        matches!(
+            *self,
             CompileFilter::Only {
-                all_targets: true, ..
-            } => true,
-            _ => false,
-        }
+                all_targets: true,
+                ..
+            }
+        )
     }
 
     pub(crate) fn contains_glob_patterns(&self) -> bool {

--- a/src/cargo/ops/cargo_config.rs
+++ b/src/cargo/ops/cargo_config.rs
@@ -123,14 +123,14 @@ fn print_toml(config: &Config, opts: &GetOptions<'_>, key: &ConfigKey, cv: &CV) 
         format!(" # {}", def)
     };
     match cv {
-        CV::Boolean(val, def) => drop_println!(config, "{} = {}{}", key, val, origin(&def)),
-        CV::Integer(val, def) => drop_println!(config, "{} = {}{}", key, val, origin(&def)),
+        CV::Boolean(val, def) => drop_println!(config, "{} = {}{}", key, val, origin(def)),
+        CV::Integer(val, def) => drop_println!(config, "{} = {}{}", key, val, origin(def)),
         CV::String(val, def) => drop_println!(
             config,
             "{} = {}{}",
             key,
             toml::to_string(&val).unwrap(),
-            origin(&def)
+            origin(def)
         ),
         CV::List(vals, _def) => {
             if opts.show_origin {
@@ -145,13 +145,13 @@ fn print_toml(config: &Config, opts: &GetOptions<'_>, key: &ConfigKey, cv: &CV) 
             }
         }
         CV::Table(table, _def) => {
-            let mut key_vals: Vec<_> = table.into_iter().collect();
-            key_vals.sort_by(|a, b| a.0.cmp(&b.0));
+            let mut key_vals: Vec<_> = table.iter().collect();
+            key_vals.sort_by(|a, b| a.0.cmp(b.0));
             for (table_key, val) in key_vals {
                 let mut subkey = key.clone();
                 // push or push_sensitive shouldn't matter here, since this is
                 // not dealing with environment variables.
-                subkey.push(&table_key);
+                subkey.push(table_key);
                 print_toml(config, opts, &subkey, val);
             }
         }
@@ -205,7 +205,7 @@ fn print_json(config: &Config, key: &ConfigKey, cv: &CV, include_key: bool) {
             CV::Integer(val, _def) => json!(val),
             CV::String(val, _def) => json!(val),
             CV::List(vals, _def) => {
-                let jvals: Vec<_> = vals.into_iter().map(|(val, _def)| json!(val)).collect();
+                let jvals: Vec<_> = vals.iter().map(|(val, _def)| json!(val)).collect();
                 json!(jvals)
             }
             CV::Table(map, _def) => {

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -703,21 +703,19 @@ fn remove_orphaned_bins(
     let all_self_names = exe_names(pkg, &filter);
     let mut to_remove: HashMap<PackageId, BTreeSet<String>> = HashMap::new();
     // For each package that we stomped on.
-    for other_pkg in duplicates.values() {
+    for other_pkg in duplicates.values().flatten() {
         // Only for packages with the same name.
-        if let Some(other_pkg) = other_pkg {
-            if other_pkg.name() == pkg.name() {
-                // Check what the old package had installed.
-                if let Some(installed) = tracker.installed_bins(*other_pkg) {
-                    // If the old install has any names that no longer exist,
-                    // add them to the list to remove.
-                    for installed_name in installed {
-                        if !all_self_names.contains(installed_name.as_str()) {
-                            to_remove
-                                .entry(*other_pkg)
-                                .or_default()
-                                .insert(installed_name.clone());
-                        }
+        if other_pkg.name() == pkg.name() {
+            // Check what the old package had installed.
+            if let Some(installed) = tracker.installed_bins(*other_pkg) {
+                // If the old install has any names that no longer exist,
+                // add them to the list to remove.
+                for installed_name in installed {
+                    if !all_self_names.contains(installed_name.as_str()) {
+                        to_remove
+                            .entry(*other_pkg)
+                            .or_default()
+                            .insert(installed_name.clone());
                     }
                 }
             }

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -492,7 +492,7 @@ impl InstallInfo {
     fn is_up_to_date(&self, opts: &CompileOptions, target: &str, exes: &BTreeSet<String>) -> bool {
         self.features == feature_set(&opts.cli_features.features)
             && self.all_features == opts.cli_features.all_features
-            && self.no_default_features == !opts.cli_features.uses_default_features
+            && self.no_default_features != opts.cli_features.uses_default_features
             && self.profile.as_str() == opts.build_config.requested_profile.as_str()
             && (self.target.is_none() || self.target.as_deref() == Some(target))
             && &self.bins == exes

--- a/src/cargo/util/config/key.rs
+++ b/src/cargo/util/config/key.rs
@@ -103,9 +103,9 @@ impl fmt::Display for ConfigKey {
 }
 
 fn escape_key_part<'a>(part: &'a str) -> Cow<'a, str> {
-    let ok = part.chars().all(|c| match c {
-        'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' => true,
-        _ => false,
+    let ok = part.chars().all(|c| {
+        matches!(c,
+        'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_')
     });
     if ok {
         Cow::Borrowed(part)

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3985,7 +3985,7 @@ fn build_script_scan_eacces() {
         .file("secrets/stuff", "")
         .build();
     let path = p.root().join("secrets");
-    fs::set_permissions(&path, fs::Permissions::from_mode(0)).unwrap();
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o0)).unwrap();
     // The last "Caused by" is a string from libc such as the following:
     //   Permission denied (os error 13)
     p.cargo("build")

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -201,7 +201,7 @@ fn itarget_proc_macro() {
     Package::new("hostdep", "1.0.0").publish();
     Package::new("pm", "1.0.0")
         .proc_macro(true)
-        .target_dep("hostdep", "1.0", &rustc_host())
+        .target_dep("hostdep", "1.0", rustc_host())
         .file("src/lib.rs", "extern crate hostdep;")
         .publish();
     let p = project()
@@ -1203,7 +1203,7 @@ fn build_dep_activated() {
     Package::new("targetdep", "1.0.0").publish();
     Package::new("hostdep", "1.0.0")
         // Check that "for_host" is sticky.
-        .target_dep("somedep", "1.0", &rustc_host())
+        .target_dep("somedep", "1.0", rustc_host())
         .feature("feat1", &[])
         .file(
             "src/lib.rs",

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -164,7 +164,7 @@ fn test_multi_crate() {
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
 
     // Find '--id <ID>' in the output
-    let mut iter = stderr.split(" ");
+    let mut iter = stderr.split(' ');
     iter.find(|w| *w == "--id").unwrap();
     let id = iter
         .next()

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -2358,7 +2358,7 @@ fn filter_platform() {
     }
     "#
     .replace("$ALT_TRIPLE", alt_target)
-    .replace("$HOST_TRIPLE", &host_target)
+    .replace("$HOST_TRIPLE", host_target)
     .replace("$FOO_DEPS", &foo_deps.to_string());
 
     // We're going to be checking that we don't download excessively,
@@ -2483,7 +2483,7 @@ fn filter_platform() {
 }
 "#
             .replace("$ALT_TRIPLE", alt_target)
-            .replace("$HOST_TRIPLE", &host_target)
+            .replace("$HOST_TRIPLE", host_target)
             .replace("$ALT_DEP", alt_dep)
             .replace("$CFG_DEP", cfg_dep)
             .replace("$HOST_DEP", host_dep)
@@ -2648,7 +2648,7 @@ fn filter_platform() {
   "metadata": null
 }
 "#
-            .replace("$HOST_TRIPLE", &host_target)
+            .replace("$HOST_TRIPLE", host_target)
             .replace("$HOST_DEP", host_dep)
             .replace("$NORMAL_DEP", normal_dep)
             .replace("$FOO", &foo),
@@ -2749,7 +2749,7 @@ fn filter_platform() {
   "metadata": null
 }
 "#
-            .replace("$HOST_TRIPLE", &host_target)
+            .replace("$HOST_TRIPLE", host_target)
             .replace("$CFG_DEP", cfg_dep)
             .replace("$HOST_DEP", host_dep)
             .replace("$NORMAL_DEP", normal_dep)

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -36,7 +36,7 @@ fn simple_build() {
         .run();
 
     assert!(p.target_bin(t1, "foo").is_file());
-    assert!(p.target_bin(&t2, "foo").is_file());
+    assert!(p.target_bin(t2, "foo").is_file());
 }
 
 #[cargo_test]
@@ -140,5 +140,5 @@ fn same_value_twice() {
         .masquerade_as_nightly_cargo()
         .run();
 
-    assert!(p.target_bin(&t, "foo").is_file());
+    assert!(p.target_bin(t, "foo").is_file());
 }

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -367,7 +367,7 @@ fn filters_target() {
     Package::new("build_target_dep", "1.0.0").publish();
     Package::new("build_host_dep", "1.0.0")
         .target_dep("targetdep", "1.0", alternate())
-        .target_dep("hostdep", "1.0", &rustc_host())
+        .target_dep("hostdep", "1.0", rustc_host())
         .publish();
     Package::new("pm_target", "1.0.0")
         .proc_macro(true)


### PR DESCRIPTION
fixes these clippy warnings:

map_collect_result_unit
needless_borrow
needless_return
into_iter_on_ref
manual_flatten
match_like_matches_macro
bool_comparison