### PR TITLE
Fix a few clippy warnings

### DIFF
--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -215,13 +215,13 @@ pub fn can_run_on_host() -> bool {
     // simulator.
     if cfg!(target_os = "macos") {
         if CAN_RUN_ON_HOST.load(Ordering::SeqCst) {
-            return true;
+            true
         } else {
             println!("Note: Cannot run on host, skipping.");
-            return false;
+            false
         }
     } else {
         assert!(CAN_RUN_ON_HOST.load(Ordering::SeqCst));
-        return true;
+        true
     }
 }

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -222,7 +222,7 @@ impl RegistryBuilder {
             .alternative_api_url(&api_url)
             .build();
 
-        let t = thread::spawn(move || {
+        thread::spawn(move || {
             let mut conn = BufReader::new(server.accept().unwrap().0);
             let headers: Vec<_> = (&mut conn)
                 .lines()
@@ -243,9 +243,7 @@ impl RegistryBuilder {
             )
             .unwrap();
             stream.write_all(response).unwrap();
-        });
-
-        t
+        })
     }
 }
 

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1692,8 +1692,10 @@ pub fn parse_dep_info(
             return Ok(None);
         }
     };
-    let mut ret = RustcDepInfo::default();
-    ret.env = info.env;
+    let mut ret = RustcDepInfo {
+        env: info.env,
+        ..Default::default()
+    };
     for (ty, path) in info.files {
         let path = match ty {
             DepInfoPathType::PackageRootRelative => pkg_root.join(path),
@@ -1823,8 +1825,10 @@ pub fn translate_dep_info(
 
     let target_root = target_root.canonicalize()?;
     let pkg_root = pkg_root.canonicalize()?;
-    let mut on_disk_info = EncodedDepInfo::default();
-    on_disk_info.env = depinfo.env;
+    let mut on_disk_info = EncodedDepInfo {
+        env: depinfo.env,
+        ..Default::default()
+    };
 
     // This is a bit of a tricky statement, but here we're *removing* the
     // dependency on environment variables that were defined specifically for

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -414,8 +414,10 @@ impl Features {
         config: &Config,
         warnings: &mut Vec<String>,
     ) -> CargoResult<Features> {
-        let mut ret = Features::default();
-        ret.nightly_features_allowed = config.nightly_features_allowed;
+        let mut ret = Features {
+            nightly_features_allowed: config.nightly_features_allowed,
+            ..Default::default()
+        };
         for feature in features {
             ret.add(feature, config, warnings)?;
             ret.activated.push(feature.to_string());

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -388,12 +388,13 @@ impl Profiles {
     /// profile flags don't cause `build.rs` to needlessly run multiple
     /// times).
     pub fn get_profile_run_custom_build(&self, for_unit_profile: &Profile) -> Profile {
-        let mut result = Profile::default();
-        result.name = for_unit_profile.name;
-        result.root = for_unit_profile.root;
-        result.debuginfo = for_unit_profile.debuginfo;
-        result.opt_level = for_unit_profile.opt_level;
-        result
+        Profile {
+            name: for_unit_profile.name,
+            root: for_unit_profile.root,
+            debuginfo: for_unit_profile.debuginfo,
+            opt_level: for_unit_profile.opt_level,
+            ..Default::default()
+        }
     }
 
     /// This returns the base profile. This is currently used for the

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -60,7 +60,7 @@ pub fn run(
                 .into_iter()
                 .map(|(_pkg, target)| target.name())
                 .collect();
-            names.sort();
+            names.sort_unstable();
             anyhow::bail!(
                 "`cargo run` could not determine which binary to run. \
                  Use the `--bin` option to specify a binary, \

--- a/src/cargo/util/config/key.rs
+++ b/src/cargo/util/config/key.rs
@@ -102,7 +102,7 @@ impl fmt::Display for ConfigKey {
     }
 }
 
-fn escape_key_part<'a>(part: &'a str) -> Cow<'a, str> {
+fn escape_key_part(part: &str) -> Cow<'_, str> {
     let ok = part.chars().all(|c| {
         matches!(c,
         'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_')

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -26,7 +26,7 @@ fn get_available_targets<'a>(
         .map(Target::name)
         .collect();
 
-    targets.sort();
+    targets.sort_unstable();
 
     Ok(targets)
 }

--- a/tests/internal.rs
+++ b/tests/internal.rs
@@ -6,12 +6,7 @@ fn check_forbidden_code() {
     // Do not use certain macros, functions, etc.
     if !cargo_util::is_ci() {
         // Only check these on CI, otherwise it could be annoying.
-        use std::io::Write;
-        writeln!(
-            std::io::stderr(),
-            "\nSkipping check_forbidden_code test, set CI=1 to enable"
-        )
-        .unwrap();
+        eprintln!("\nSkipping check_forbidden_code test, set CI=1 to enable");
         return;
     }
     let root_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1875,15 +1875,11 @@ fn long_file_names() {
         if let Err(e) = File::create(&test_path) {
             // write to stderr directly to avoid output from being captured
             // and always display text, even without --nocapture
-            use std::io::Write;
-            writeln!(
-                std::io::stderr(),
+            eprintln!(
                 "\nSkipping long_file_names test, this OS or filesystem does not \
                 appear to support long file paths: {:?}\n{:?}",
-                e,
-                test_path
-            )
-            .unwrap();
+                e, test_path
+            );
             return;
         }
     }

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -10,11 +10,11 @@ use std::fmt::Write;
 fn require(enabled_features: &[&str], disabled_features: &[&str]) -> String {
     let mut s = String::new();
     for feature in enabled_features {
-        write!(s, "#[cfg(not(feature=\"{feature}\"))] compile_error!(\"expected feature {feature} to be enabled\");\n",
+        writeln!(s, "#[cfg(not(feature=\"{feature}\"))] compile_error!(\"expected feature {feature} to be enabled\");",
             feature=feature).unwrap();
     }
     for feature in disabled_features {
-        write!(s, "#[cfg(feature=\"{feature}\")] compile_error!(\"did not expect feature {feature} to be enabled\");\n",
+        writeln!(s, "#[cfg(feature=\"{feature}\")] compile_error!(\"did not expect feature {feature} to be enabled\");",
             feature=feature).unwrap();
     }
     s


### PR DESCRIPTION
These are the ones that looked uncontroversial, but a few remain.

warning: unneeded `return` statement
   --> crates/cargo-test-support/src/cross_compile.rs:218:13
warning: returning the result of a `let` binding from a block
   --> crates/cargo-test-support/src/registry.rs:248:9
warning: field assignment outside of initializer for an instance created with Default::default()
    --> src/cargo/core/compiler/fingerprint.rs:1696:5
warning: field assignment outside of initializer for an instance created with Default::default()
    --> src/cargo/core/compiler/fingerprint.rs:1827:5
warning: field assignment outside of initializer for an instance created with Default::default()
   --> src/cargo/core/features.rs:418:9
warning: field assignment outside of initializer for an instance created with Default::default()
   --> src/cargo/core/profiles.rs:392:9
warning: used `sort` on primitive type `str`
  --> src/cargo/ops/cargo_run.rs:63:13
warning: explicit lifetimes given in parameter types where they could be elided (or replaced with `'_` if needed by type declaration)
   --> src/cargo/util/config/key.rs:105:1
warning: used `sort` on primitive type `str`
  --> src/cargo/util/workspace.rs:29:5
warning: use of `writeln!(stderr(), ...).unwrap()`
  --> tests/internal.rs:10:9
warning: use of `writeln!(stderr(), ...).unwrap()`. Consider using `eprintln!` instead
    --> tests/testsuite/package.rs:1879:13
warning: using `write!()` with a format string that ends in a single newline
  --> tests/testsuite/weak_dep_features.rs:13:9
warning: using `write!()` with a format string that ends in a single newline
  --> tests/testsuite/weak_dep_features.rs:17:9