### PR TITLE
Update clippy lint allow set.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! See https://rust-lang.github.io/cargo/contrib/ for a guide on writing tests.
 
-#![allow(clippy::needless_doctest_main)] // according to @ehuss this lint is fussy
-#![allow(clippy::inefficient_to_string)] // this causes suggestions that result in `(*s).to_string()`
+#![allow(clippy::all)]
+#![warn(clippy::needless_borrow)]
+#![warn(clippy::redundant_clone)]
 
 use std::env;
 use std::ffi::OsStr;
@@ -831,8 +832,8 @@ impl Execs {
             Some(_) => Err(format!(
                 "exited with {:?}\n--- stdout\n{}\n--- stderr\n{}",
                 code,
-                String::from_utf8_lossy(&stdout),
-                String::from_utf8_lossy(&stderr)
+                String::from_utf8_lossy(stdout),
+                String::from_utf8_lossy(stderr)
             )),
         }
     }

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -192,7 +192,7 @@ impl RegistryBuilder {
                 alt_dl_url(),
                 self.alt_api_url
                     .as_ref()
-                    .map_or_else(alt_api_url, |url| Url::parse(&url).expect("valid url")),
+                    .map_or_else(alt_api_url, |url| Url::parse(url).expect("valid url")),
                 alt_api_path(),
             );
         }

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -1,5 +1,4 @@
-#![allow(unknown_lints)]
-#![allow(clippy::identity_op)] // used for vertical alignment
+#![allow(clippy::all)]
 
 use std::collections::BTreeMap;
 use std::fmt;

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -1,5 +1,4 @@
-#![allow(clippy::many_single_char_names)]
-#![allow(clippy::needless_range_loop)] // false positives
+#![allow(clippy::all)]
 
 use std::cell::RefCell;
 use std::cmp::PartialEq;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)] // while we're getting used to 2018
-#![allow(clippy::redundant_closure)] // there's a false positive
+#![allow(clippy::all)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::redundant_clone)]
 

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,6 +1,7 @@
-#![cfg_attr(test, deny(warnings))]
-// While we're getting used to 2018:
+// For various reasons, some idioms are still allow'ed, but we would like to
+// test and enforce them.
 #![warn(rust_2018_idioms)]
+#![cfg_attr(test, deny(warnings))]
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,34 +1,11 @@
 #![cfg_attr(test, deny(warnings))]
 // While we're getting used to 2018:
 #![warn(rust_2018_idioms)]
-// Clippy isn't enforced by CI (@alexcrichton isn't a fan).
-#![allow(clippy::blacklisted_name)] // frequently used in tests
-#![allow(clippy::cognitive_complexity)] // large project
-#![allow(clippy::derive_hash_xor_eq)] // there's an intentional incoherence
-#![allow(clippy::explicit_into_iter_loop)] // explicit loops are clearer
-#![allow(clippy::explicit_iter_loop)] // explicit loops are clearer
-#![allow(clippy::identity_op)] // used for vertical alignment
-#![allow(clippy::implicit_hasher)] // large project
-#![allow(clippy::large_enum_variant)] // large project
-#![allow(clippy::new_without_default)] // explicit is maybe clearer
-#![allow(clippy::redundant_closure)] // closures can be less verbose
-#![allow(clippy::redundant_closure_call)] // closures over try catch blocks
-#![allow(clippy::too_many_arguments)] // large project
-#![allow(clippy::type_complexity)] // there's an exceptionally complex type
-#![allow(clippy::wrong_self_convention)] // perhaps `Rc` should be special-cased in Clippy?
-#![allow(clippy::write_with_newline)] // too pedantic
-#![allow(clippy::inefficient_to_string)] // this causes suggestions that result in `(*s).to_string()`
-#![allow(clippy::collapsible_if)] // too pedantic
+// Due to some of the default clippy lints being somewhat subjective and not
+// necessarily an improvement, we prefer to not use them at this time.
+#![allow(clippy::all)]
 #![warn(clippy::needless_borrow)]
-// Unit is now interned, and would probably be better as pass-by-copy, but
-// doing so causes a lot of & and * shenanigans that makes the code arguably
-// less clear and harder to read.
-#![allow(clippy::trivially_copy_pass_by_ref)]
-// exhaustively destructuring ensures future fields are handled
-#![allow(clippy::unneeded_field_pattern)]
-// false positives in target-specific code, for details see
-// https://github.com/rust-lang/cargo/pull/7251#pullrequestreview-274914270
-#![allow(clippy::useless_conversion)]
+#![warn(clippy::redundant_clone)]
 
 use crate::core::shell::Verbosity::Verbose;
 use crate::core::Shell;

--- a/tests/internal.rs
+++ b/tests/internal.rs
@@ -1,4 +1,7 @@
 //! Tests for internal code checks.
+
+#![allow(clippy::all)]
+
 use std::fs;
 
 #[test]

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,4 +1,5 @@
-#![warn(rust_2018_idioms)] // while we're getting used to 2018
+// See src/cargo/lib.rs for notes on these lint settings.
+#![warn(rust_2018_idioms)]
 #![allow(clippy::all)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::redundant_clone)]

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,12 +1,8 @@
 #![warn(rust_2018_idioms)] // while we're getting used to 2018
-#![cfg_attr(feature = "deny-warnings", deny(warnings))]
-#![allow(clippy::blacklisted_name)]
-#![allow(clippy::explicit_iter_loop)]
-#![allow(clippy::redundant_closure)]
-#![allow(clippy::blocks_in_if_conditions)] // clippy doesn't agree with rustfmt 😂
-#![allow(clippy::inefficient_to_string)] // this causes suggestions that result in `(*s).to_string()`
+#![allow(clippy::all)]
 #![warn(clippy::needless_borrow)]
 #![warn(clippy::redundant_clone)]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 
 #[macro_use]
 extern crate cargo_test_macro;


### PR DESCRIPTION
This updates the clippy lints to default allow. We would prefer not to take clippy lint PRs at this time as there are a number of false positives and subjective style changes that we would rather not review.

I left a couple lints as `warn` that I have found useful when refactoring.
