### PR TITLE
refactor: remove `CargoResultExt`

### DIFF
--- a/src/bin/cargo/commands/describe_future_incompatibilities.rs
+++ b/src/bin/cargo/commands/describe_future_incompatibilities.rs
@@ -1,8 +1,7 @@
 use crate::command_prelude::*;
-use anyhow::anyhow;
+use anyhow::{anyhow, Context as _};
 use cargo::core::compiler::future_incompat::{OnDiskReport, FUTURE_INCOMPAT_FILE};
 use cargo::drop_eprint;
-use cargo::util::CargoResultExt;
 use std::io::Read;
 
 pub fn cli() -> App {
@@ -37,9 +36,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     report_file
         .file()
         .read_to_string(&mut file_contents)
-        .chain_err(|| "failed to read report")?;
+        .with_context(|| "failed to read report")?;
     let on_disk_report: OnDiskReport =
-        serde_json::from_str(&file_contents).chain_err(|| "failed to load report")?;
+        serde_json::from_str(&file_contents).with_context(|| "failed to load report")?;
 
     let id = args.value_of("id").unwrap();
     if id != on_disk_report.id {

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -143,7 +143,7 @@ impl CompileTarget {
         // with different paths always produce the same result.
         let path = Path::new(name)
             .canonicalize()
-            .with_context(|| anyhow::format_err!("target path {:?} is not a valid file", name))?;
+            .with_context(|| format!("target path {:?} is not a valid file", name))?;
 
         let name = path
             .into_os_string()

--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -1,8 +1,8 @@
 use crate::core::Target;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{Config, StableHasher};
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fs;
@@ -143,7 +143,7 @@ impl CompileTarget {
         // with different paths always produce the same result.
         let path = Path::new(name)
             .canonicalize()
-            .chain_err(|| anyhow::format_err!("target path {:?} is not a valid file", name))?;
+            .with_context(|| anyhow::format_err!("target path {:?} is not a valid file", name))?;
 
         let name = path
             .into_os_string()

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -3,10 +3,11 @@ use super::{fingerprint, Context, LinkType, Unit};
 use crate::core::compiler::context::Metadata;
 use crate::core::compiler::job_queue::JobState;
 use crate::core::{profiles::ProfileRoot, PackageId};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::machine_message::{self, Message};
 use crate::util::{internal, profile};
+use anyhow::Context as _;
 use cargo_platform::Cfg;
 use cargo_util::paths;
 use std::collections::hash_map::{Entry, HashMap};
@@ -308,7 +309,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
         // If we have an old build directory, then just move it into place,
         // otherwise create it!
         paths::create_dir_all(&script_out_dir)
-            .chain_err(|| "failed to create script output directory for build command")?;
+            .with_context(|| "failed to create script output directory for build command")?;
 
         // For all our native lib dependencies, pick up their metadata to pass
         // along to this custom build command. We're also careful to augment our
@@ -370,7 +371,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
                 },
                 true,
             )
-            .chain_err(|| format!("failed to run custom build command for `{}`", pkg_descr));
+            .with_context(|| format!("failed to run custom build command for `{}`", pkg_descr));
 
         if let Err(error) = output {
             insert_warnings_in_build_outputs(

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -321,7 +321,7 @@ use std::str;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use anyhow::{bail, format_err};
+use anyhow::{bail, format_err, Context as _};
 use cargo_util::{paths, ProcessBuilder};
 use filetime::FileTime;
 use log::{debug, info};
@@ -332,7 +332,7 @@ use serde::{Deserialize, Serialize};
 use crate::core::compiler::unit_graph::UnitDep;
 use crate::core::Package;
 use crate::util;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{internal, path_args, profile};
 
@@ -1286,7 +1286,7 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
     let target_root = target_root(cx);
     let local = if unit.mode.is_doc() {
         // rustdoc does not have dep-info files.
-        let fingerprint = pkg_fingerprint(cx.bcx, &unit.pkg).chain_err(|| {
+        let fingerprint = pkg_fingerprint(cx.bcx, &unit.pkg).with_context(|| {
             format!(
                 "failed to determine package fingerprint for documenting {}",
                 unit.pkg
@@ -1375,7 +1375,7 @@ fn calculate_run_custom_build(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoRes
     let local = (gen_local)(
         deps,
         Some(&|| {
-            pkg_fingerprint(cx.bcx, &unit.pkg).chain_err(|| {
+            pkg_fingerprint(cx.bcx, &unit.pkg).with_context(|| {
                 format!(
                     "failed to determine package fingerprint for build script for {}",
                     unit.pkg
@@ -1643,7 +1643,7 @@ fn compare_old_fingerprint(
 
     let old_fingerprint_json = paths::read(&loc.with_extension("json"))?;
     let old_fingerprint: Fingerprint = serde_json::from_str(&old_fingerprint_json)
-        .chain_err(|| internal("failed to deserialize json"))?;
+        .with_context(|| internal("failed to deserialize json"))?;
     // Fingerprint can be empty after a failed rebuild (see comment in prepare_target).
     if !old_fingerprint_short.is_empty() {
         debug_assert_eq!(util::to_hex(old_fingerprint.hash()), old_fingerprint_short);

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -28,7 +28,7 @@ use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::Error;
+use anyhow::{Context as _, Error};
 use lazycell::LazyCell;
 use log::debug;
 
@@ -54,7 +54,7 @@ pub use crate::core::compiler::unit::{Unit, UnitInterner};
 use crate::core::manifest::TargetSourcePath;
 use crate::core::profiles::{PanicStrategy, Profile, Strip};
 use crate::core::{Feature, PackageId, Target};
-use crate::util::errors::{CargoResult, CargoResultExt, VerboseError};
+use crate::util::errors::{CargoResult, VerboseError};
 use crate::util::interning::InternedString;
 use crate::util::machine_message::{self, Message};
 use crate::util::{add_path_args, internal, iter_join_onto, profile};
@@ -331,7 +331,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                 },
             )
             .map_err(verbose_if_simple_exit_code)
-            .chain_err(|| format!("could not compile `{}`", name))?;
+            .with_context(|| format!("could not compile `{}`", name))?;
         }
 
         if rustc_dep_info_loc.exists() {
@@ -345,7 +345,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                 // Do not track source files in the fingerprint for registry dependencies.
                 is_local,
             )
-            .chain_err(|| {
+            .with_context(|| {
                 internal(format!(
                     "could not parse/generate dep info at: {}",
                     rustc_dep_info_loc.display()
@@ -665,7 +665,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
                 },
                 false,
             )
-            .chain_err(|| format!("could not document `{}`", name))?;
+            .with_context(|| format!("could not document `{}`", name))?;
         Ok(())
     }))
 }

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -8,7 +8,8 @@ use crate::core::compiler::BuildContext;
 use crate::core::PackageId;
 use crate::util::cpu::State;
 use crate::util::machine_message::{self, Message};
-use crate::util::{CargoResult, CargoResultExt, Config};
+use crate::util::{CargoResult, Config};
+use anyhow::Context as _;
 use cargo_util::paths;
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
@@ -324,7 +325,7 @@ impl<'cfg> Timings<'cfg> {
             .sort_unstable_by(|a, b| a.start.partial_cmp(&b.start).unwrap());
         if self.report_html {
             self.report_html(bcx, error)
-                .chain_err(|| "failed to save timing report")?;
+                .with_context(|| "failed to save timing report")?;
         }
         Ok(())
     }

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -1,3 +1,4 @@
+use anyhow::Context as _;
 use cargo_platform::Platform;
 use log::trace;
 use semver::ReqParseError;
@@ -8,7 +9,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 
 use crate::core::{PackageId, SourceId, Summary};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::Config;
 
@@ -132,7 +133,7 @@ this warning.
         }
         Err(e) => {
             let err: CargoResult<VersionReq> = Err(e.into());
-            let v: VersionReq = err.chain_err(|| {
+            let v: VersionReq = err.with_context(|| {
                 format!(
                     "failed to parse the version requirement `{}` for dependency `{}`",
                     req, name

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -498,10 +498,8 @@ impl Manifest {
             self.unstable_features
                 .require(Feature::test_dummy_unstable())
                 .with_context(|| {
-                    anyhow::format_err!(
-                        "the `im-a-teapot` manifest key is unstable and may \
-                         not work properly in England"
-                    )
+                    "the `im-a-teapot` manifest key is unstable and may \
+                     not work properly in England"
                 })?;
         }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use anyhow::Context as _;
 use semver::Version;
 use serde::ser;
 use serde::Serialize;
@@ -496,7 +497,7 @@ impl Manifest {
         if self.im_a_teapot.is_some() {
             self.unstable_features
                 .require(Feature::test_dummy_unstable())
-                .chain_err(|| {
+                .with_context(|| {
                     anyhow::format_err!(
                         "the `im-a-teapot` manifest key is unstable and may \
                          not work properly in England"

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -26,7 +26,7 @@ use crate::core::{Dependency, Manifest, PackageId, SourceId, Target};
 use crate::core::{SourceMap, Summary, Workspace};
 use crate::ops;
 use crate::util::config::PackageCacheLock;
-use crate::util::errors::{CargoResult, CargoResultExt, HttpNot200};
+use crate::util::errors::{CargoResult, HttpNot200};
 use crate::util::interning::InternedString;
 use crate::util::network::Retry;
 use crate::util::{self, internal, Config, Progress, ProgressStyle};
@@ -416,7 +416,7 @@ impl<'cfg> PackageSet<'cfg> {
         let multiplexing = config.http_config()?.multiplexing.unwrap_or(true);
         multi
             .pipelining(false, multiplexing)
-            .chain_err(|| "failed to enable multiplexing/pipelining in curl")?;
+            .with_context(|| "failed to enable multiplexing/pipelining in curl")?;
 
         // let's not flood crates.io with connections
         multi.set_max_host_connections(2)?;
@@ -612,7 +612,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
     /// the package is ready and doesn't need to be downloaded.
     pub fn start(&mut self, id: PackageId) -> CargoResult<Option<&'a Package>> {
         self.start_inner(id)
-            .chain_err(|| format!("failed to download `{}`", id))
+            .with_context(|| format!("failed to download `{}`", id))
     }
 
     fn start_inner(&mut self, id: PackageId) -> CargoResult<Option<&'a Package>> {
@@ -636,7 +636,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             .ok_or_else(|| internal(format!("couldn't find source for `{}`", id)))?;
         let pkg = source
             .download(id)
-            .chain_err(|| anyhow::format_err!("unable to get packages from source"))?;
+            .with_context(|| anyhow::format_err!("unable to get packages from source"))?;
         let (url, descriptor) = match pkg {
             MaybePackage::Ready(pkg) => {
                 debug!("{} doesn't need a download", id);
@@ -810,7 +810,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                         }
                         Ok(())
                     })
-                    .chain_err(|| format!("failed to download from `{}`", dl.url))?
+                    .with_context(|| format!("failed to download from `{}`", dl.url))?
             };
             match ret {
                 Some(()) => break (dl, data),
@@ -908,7 +908,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                 self.set
                     .multi
                     .perform()
-                    .chain_err(|| "failed to perform http requests")
+                    .with_context(|| "failed to perform http requests")
             })?;
             debug!("handles remaining: {}", n);
             let results = &mut self.results;
@@ -935,7 +935,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             self.set
                 .multi
                 .wait(&mut [], timeout)
-                .chain_err(|| "failed to wait on curl `Multi`")?;
+                .with_context(|| "failed to wait on curl `Multi`")?;
         }
     }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -636,7 +636,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             .ok_or_else(|| internal(format!("couldn't find source for `{}`", id)))?;
         let pkg = source
             .download(id)
-            .with_context(|| anyhow::format_err!("unable to get packages from source"))?;
+            .with_context(|| "unable to get packages from source")?;
         let (url, descriptor) = match pkg {
             MaybePackage::Ready(pkg) => {
                 debug!("{} doesn't need a download", id);

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -87,7 +87,7 @@ impl PackageIdSpec {
         let i: Vec<_> = i.into_iter().collect();
         let spec = PackageIdSpec::parse(spec).with_context(|| {
             let suggestion = lev_distance::closest_msg(spec, i.iter(), |id| id.name().as_str());
-            anyhow::format_err!("invalid package ID specification: `{}`{}", spec, suggestion)
+            format!("invalid package ID specification: `{}`{}", spec, suggestion)
         })?;
         spec.query(i)
     }

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use semver::Version;
 use serde::{de, ser};
 use url::Url;
 
 use crate::core::PackageId;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::lev_distance;
 use crate::util::{validate_package_name, IntoUrl, ToSemver};
@@ -85,7 +85,7 @@ impl PackageIdSpec {
         I: IntoIterator<Item = PackageId>,
     {
         let i: Vec<_> = i.into_iter().collect();
-        let spec = PackageIdSpec::parse(spec).chain_err(|| {
+        let spec = PackageIdSpec::parse(spec).with_context(|| {
             let suggestion = lev_distance::closest_msg(spec, i.iter(), |id| id.name().as_str());
             anyhow::format_err!("invalid package ID specification: `{}`{}", spec, suggestion)
         })?;

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1,11 +1,10 @@
 use crate::core::compiler::{CompileKind, CompileMode, Unit};
 use crate::core::resolver::features::FeaturesFor;
 use crate::core::{Feature, PackageId, PackageIdSpec, Resolve, Shell, Target, Workspace};
-use crate::util::errors::CargoResultExt;
 use crate::util::interning::InternedString;
 use crate::util::toml::{ProfilePackageSpec, StringOrBool, TomlProfile, TomlProfiles, U32OrBool};
 use crate::util::{closest_msg, config, CargoResult, Config};
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::Hash;
 use std::{cmp, env, fmt, hash};
@@ -1142,7 +1141,7 @@ fn get_config_profile(ws: &Workspace<'_>, name: &str) -> CargoResult<Option<Toml
     profile
         .val
         .validate(name, ws.unstable_features(), &mut warnings)
-        .chain_err(|| {
+        .with_context(|| {
             anyhow::format_err!(
                 "config profile `{}` is not valid (defined in `{}`)",
                 name,

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1142,10 +1142,9 @@ fn get_config_profile(ws: &Workspace<'_>, name: &str) -> CargoResult<Option<Toml
         .val
         .validate(name, ws.unstable_features(), &mut warnings)
         .with_context(|| {
-            anyhow::format_err!(
+            format!(
                 "config profile `{}` is not valid (defined in `{}`)",
-                name,
-                profile.definition
+                name, profile.definition
             )
         })?;
     for warning in warnings {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -3,10 +3,10 @@ use std::collections::{HashMap, HashSet};
 use crate::core::PackageSet;
 use crate::core::{Dependency, PackageId, Source, SourceId, SourceMap, Summary};
 use crate::sources::config::SourceConfigMap;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{profile, CanonicalUrl, Config};
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use log::{debug, trace};
 use semver::VersionReq;
 use url::Url;
@@ -281,7 +281,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                 // normally would and then ask it directly for the list of summaries
                 // corresponding to this `dep`.
                 self.ensure_loaded(dep.source_id(), Kind::Normal)
-                    .chain_err(|| {
+                    .with_context(|| {
                         anyhow::format_err!(
                             "failed to load source for dependency `{}`",
                             dep.package_name()
@@ -293,14 +293,16 @@ impl<'cfg> PackageRegistry<'cfg> {
                     .get_mut(dep.source_id())
                     .expect("loaded source not present");
                 let summaries = source.query_vec(dep)?;
-                let (summary, should_unlock) =
-                    summary_for_patch(orig_patch, locked, summaries, source).chain_err(|| {
-                        format!(
-                            "patch for `{}` in `{}` failed to resolve",
-                            orig_patch.package_name(),
-                            url,
-                        )
-                    })?;
+                let (summary, should_unlock) = summary_for_patch(
+                    orig_patch, locked, summaries, source,
+                )
+                .with_context(|| {
+                    format!(
+                        "patch for `{}` in `{}` failed to resolve",
+                        orig_patch.package_name(),
+                        url,
+                    )
+                })?;
                 debug!(
                     "patch summary is {:?} should_unlock={:?}",
                     summary, should_unlock
@@ -320,7 +322,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                 Ok(summary)
             })
             .collect::<CargoResult<Vec<_>>>()
-            .chain_err(|| anyhow::format_err!("failed to resolve patches for `{}`", url))?;
+            .with_context(|| anyhow::format_err!("failed to resolve patches for `{}`", url))?;
 
         let mut name_and_version = HashSet::new();
         for summary in unlocked_summaries.iter() {
@@ -388,7 +390,7 @@ impl<'cfg> PackageRegistry<'cfg> {
             let _p = profile::start(format!("updating: {}", source_id));
             self.sources.get_mut(source_id).unwrap().update()
         })()
-        .chain_err(|| anyhow::format_err!("Unable to update {}", source_id))?;
+        .with_context(|| anyhow::format_err!("Unable to update {}", source_id))?;
         Ok(())
     }
 
@@ -539,7 +541,7 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
 
                 // Ensure the requested source_id is loaded
                 self.ensure_loaded(dep.source_id(), Kind::Normal)
-                    .chain_err(|| {
+                    .with_context(|| {
                         anyhow::format_err!(
                             "failed to load source for dependency `{}`",
                             dep.package_name()

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -282,7 +282,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                 // corresponding to this `dep`.
                 self.ensure_loaded(dep.source_id(), Kind::Normal)
                     .with_context(|| {
-                        anyhow::format_err!(
+                        format!(
                             "failed to load source for dependency `{}`",
                             dep.package_name()
                         )
@@ -322,7 +322,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                 Ok(summary)
             })
             .collect::<CargoResult<Vec<_>>>()
-            .with_context(|| anyhow::format_err!("failed to resolve patches for `{}`", url))?;
+            .with_context(|| format!("failed to resolve patches for `{}`", url))?;
 
         let mut name_and_version = HashSet::new();
         for summary in unlocked_summaries.iter() {
@@ -390,7 +390,7 @@ impl<'cfg> PackageRegistry<'cfg> {
             let _p = profile::start(format!("updating: {}", source_id));
             self.sources.get_mut(source_id).unwrap().update()
         })()
-        .with_context(|| anyhow::format_err!("Unable to update {}", source_id))?;
+        .with_context(|| format!("Unable to update {}", source_id))?;
         Ok(())
     }
 
@@ -542,7 +542,7 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
                 // Ensure the requested source_id is loaded
                 self.ensure_loaded(dep.source_id(), Kind::Normal)
                     .with_context(|| {
-                        anyhow::format_err!(
+                        format!(
                             "failed to load source for dependency `{}`",
                             dep.package_name()
                         )

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -225,7 +225,7 @@ impl<'a> RegistryQueryer<'a> {
             .into_iter()
             .map(|(dep, features)| {
                 let candidates = self.query(&dep).with_context(|| {
-                    anyhow::format_err!(
+                    format!(
                         "failed to get `{}` as a dependency of {}",
                         dep.package_name(),
                         describe_path(&cx.parents.path_to_bottom(&candidate.package_id())),

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -16,8 +16,10 @@ use crate::core::resolver::{
     ActivateError, ActivateResult, CliFeatures, RequestedFeatures, ResolveOpts,
 };
 use crate::core::{Dependency, FeatureValue, PackageId, PackageIdSpec, Registry, Summary};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
+
+use anyhow::Context as _;
 use log::debug;
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -222,7 +224,7 @@ impl<'a> RegistryQueryer<'a> {
         let mut deps = deps
             .into_iter()
             .map(|(dep, features)| {
-                let candidates = self.query(&dep).chain_err(|| {
+                let candidates = self.query(&dep).with_context(|| {
                     anyhow::format_err!(
                         "failed to get `{}` as a dependency of {}",
                         dep.package_name(),

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -113,10 +113,10 @@
 
 use super::{Resolve, ResolveVersion};
 use crate::core::{Dependency, GitReference, Package, PackageId, SourceId, Workspace};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{internal, Graph};
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use log::debug;
 use serde::de;
 use serde::ser;
@@ -333,7 +333,7 @@ impl EncodableResolve {
             let k = &k[prefix.len()..];
             let enc_id: EncodablePackageId = k
                 .parse()
-                .chain_err(|| internal("invalid encoding of checksum in lockfile"))?;
+                .with_context(|| internal("invalid encoding of checksum in lockfile"))?;
             let id = match lookup_id(&enc_id) {
                 Some(id) => id,
                 _ => continue,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::slice;
 
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use glob::glob;
 use log::debug;
 use url::Url;
@@ -18,7 +18,7 @@ use crate::core::{Dependency, Edition, FeatureValue, PackageId, PackageIdSpec};
 use crate::core::{EitherManifest, Package, SourceId, VirtualManifest};
 use crate::ops;
 use crate::sources::{PathSource, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
-use crate::util::errors::{CargoResult, CargoResultExt, ManifestError};
+use crate::util::errors::{CargoResult, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::toml::{read_manifest, TomlDependency, TomlProfiles};
 use crate::util::{config::ConfigRelativePath, Config, Filesystem, IntoUrl};
@@ -386,7 +386,7 @@ impl<'cfg> Workspace<'cfg> {
                     .config
                     .get_registry_index(url)
                     .or_else(|_| url.into_url())
-                    .chain_err(|| {
+                    .with_context(|| {
                         format!("[patch] entry `{}` should be a URL or registry name", url)
                     })?,
             };
@@ -1415,11 +1415,13 @@ impl WorkspaceRootConfig {
             Some(p) => p,
             None => return Ok(Vec::new()),
         };
-        let res =
-            glob(path).chain_err(|| anyhow::format_err!("could not parse pattern `{}`", &path))?;
+        let res = glob(path)
+            .with_context(|| anyhow::format_err!("could not parse pattern `{}`", &path))?;
         let res = res
             .map(|p| {
-                p.chain_err(|| anyhow::format_err!("unable to match path to pattern `{}`", &path))
+                p.with_context(|| {
+                    anyhow::format_err!("unable to match path to pattern `{}`", &path)
+                })
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(res)

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1415,14 +1415,9 @@ impl WorkspaceRootConfig {
             Some(p) => p,
             None => return Ok(Vec::new()),
         };
-        let res = glob(path)
-            .with_context(|| anyhow::format_err!("could not parse pattern `{}`", &path))?;
+        let res = glob(path).with_context(|| format!("could not parse pattern `{}`", &path))?;
         let res = res
-            .map(|p| {
-                p.with_context(|| {
-                    anyhow::format_err!("unable to match path to pattern `{}`", &path)
-                })
-            })
+            .map(|p| p.with_context(|| format!("unable to match path to pattern `{}`", &path)))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(res)
     }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -2,10 +2,12 @@ use crate::core::compiler::{CompileKind, CompileMode, Layout, RustcTargetData};
 use crate::core::profiles::Profiles;
 use crate::core::{PackageIdSpec, TargetKind, Workspace};
 use crate::ops;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::lev_distance;
 use crate::util::Config;
+
+use anyhow::Context as _;
 use cargo_util::paths;
 use std::fs;
 use std::path::Path;
@@ -223,13 +225,13 @@ fn rm_rf(path: &Path, config: &Config) -> CargoResult<()> {
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
         paths::remove_dir_all(path)
-            .chain_err(|| anyhow::format_err!("could not remove build directory"))?;
+            .with_context(|| anyhow::format_err!("could not remove build directory"))?;
     } else if m.is_ok() {
         config
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
         paths::remove_file(path)
-            .chain_err(|| anyhow::format_err!("failed to remove build artifact"))?;
+            .with_context(|| anyhow::format_err!("failed to remove build artifact"))?;
     }
     Ok(())
 }

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -224,14 +224,12 @@ fn rm_rf(path: &Path, config: &Config) -> CargoResult<()> {
         config
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
-        paths::remove_dir_all(path)
-            .with_context(|| anyhow::format_err!("could not remove build directory"))?;
+        paths::remove_dir_all(path).with_context(|| "could not remove build directory")?;
     } else if m.is_ok() {
         config
             .shell()
             .verbose(|shell| shell.status("Removing", path.display()))?;
-        paths::remove_file(path)
-            .with_context(|| anyhow::format_err!("failed to remove build artifact"))?;
+        paths::remove_file(path).with_context(|| "failed to remove build artifact")?;
     }
     Ok(())
 }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -7,10 +7,11 @@ use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, Freshness, U
 use crate::core::{Dependency, Edition, Package, PackageId, Source, SourceId, Workspace};
 use crate::ops::common_for_install_and_uninstall::*;
 use crate::sources::{GitSource, PathSource, SourceConfigMap};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::{Config, Filesystem, Rustc, ToSemver};
 use crate::{drop_println, ops};
-use anyhow::{bail, format_err};
+
+use anyhow::{bail, format_err, Context as _};
 use cargo_util::paths;
 use semver::VersionReq;
 use tempfile::Builder as TempFileBuilder;
@@ -350,7 +351,7 @@ fn install_one(
     check_yanked_install(&ws)?;
 
     let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
-    let compile = ops::compile_ws(&ws, opts, &exec).chain_err(|| {
+    let compile = ops::compile_ws(&ws, opts, &exec).with_context(|| {
         if let Some(td) = td_opt.take() {
             // preserve the temporary directory, so the user can inspect it
             td.into_path();
@@ -420,7 +421,7 @@ fn install_one(
         let src = staging_dir.path().join(bin);
         let dst = dst.join(bin);
         config.shell().status("Installing", dst.display())?;
-        fs::rename(&src, &dst).chain_err(|| {
+        fs::rename(&src, &dst).with_context(|| {
             format_err!("failed to move `{}` to `{}`", src.display(), dst.display())
         })?;
         installed.bins.push(dst);
@@ -435,7 +436,7 @@ fn install_one(
                 let src = staging_dir.path().join(bin);
                 let dst = dst.join(bin);
                 config.shell().status("Replacing", dst.display())?;
-                fs::rename(&src, &dst).chain_err(|| {
+                fs::rename(&src, &dst).with_context(|| {
                     format_err!("failed to move `{}` to `{}`", src.display(), dst.display())
                 })?;
                 successful_bins.insert(bin.to_string());
@@ -463,7 +464,7 @@ fn install_one(
         }
 
         match tracker.save() {
-            Err(err) => replace_result.chain_err(|| err)?,
+            Err(err) => replace_result.with_context(|| err)?,
             Ok(_) => replace_result?,
         }
     }
@@ -736,7 +737,7 @@ fn remove_orphaned_bins(
                     ),
                 )?;
                 paths::remove_file(&full_path)
-                    .chain_err(|| format!("failed to remove {:?}", full_path))?;
+                    .with_context(|| format!("failed to remove {:?}", full_path))?;
             }
         }
     }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -357,7 +357,7 @@ fn install_one(
             td.into_path();
         }
 
-        format_err!(
+        format!(
             "failed to compile `{}`, intermediate artifacts can be \
              found at `{}`",
             pkg,
@@ -422,7 +422,7 @@ fn install_one(
         let dst = dst.join(bin);
         config.shell().status("Installing", dst.display())?;
         fs::rename(&src, &dst).with_context(|| {
-            format_err!("failed to move `{}` to `{}`", src.display(), dst.display())
+            format!("failed to move `{}` to `{}`", src.display(), dst.display())
         })?;
         installed.bins.push(dst);
         successful_bins.insert(bin.to_string());
@@ -437,7 +437,7 @@ fn install_one(
                 let dst = dst.join(bin);
                 config.shell().status("Replacing", dst.display())?;
                 fs::rename(&src, &dst).with_context(|| {
-                    format_err!("failed to move `{}` to `{}`", src.display(), dst.display())
+                    format!("failed to move `{}` to `{}`", src.display(), dst.display())
                 })?;
                 successful_bins.insert(bin.to_string());
             }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -1,7 +1,8 @@
 use crate::core::{Edition, Shell, Workspace};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 use crate::util::{restricted_names, Config};
+use anyhow::Context as _;
 use cargo_util::paths;
 use serde::de;
 use serde::Deserialize;
@@ -416,7 +417,7 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         registry: opts.registry.as_deref(),
     };
 
-    mk(config, &mkopts).chain_err(|| {
+    mk(config, &mkopts).with_context(|| {
         anyhow::format_err!(
             "Failed to create package `{}` at `{}`",
             name,
@@ -500,7 +501,7 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         registry: opts.registry.as_deref(),
     };
 
-    mk(config, &mkopts).chain_err(|| {
+    mk(config, &mkopts).with_context(|| {
         anyhow::format_err!(
             "Failed to create package `{}` at `{}`",
             name,

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -418,7 +418,7 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     };
 
     mk(config, &mkopts).with_context(|| {
-        anyhow::format_err!(
+        format!(
             "Failed to create package `{}` at `{}`",
             name,
             path.display()
@@ -502,7 +502,7 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     };
 
     mk(config, &mkopts).with_context(|| {
-        anyhow::format_err!(
+        format!(
             "Failed to create package `{}` at `{}`",
             name,
             path.display()

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -123,7 +123,7 @@ pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Option
         .status("Packaging", pkg.package_id().to_string())?;
     dst.file().set_len(0)?;
     tar(ws, ar_files, dst.file(), &filename)
-        .with_context(|| anyhow::format_err!("failed to prepare local package for uploading"))?;
+        .with_context(|| "failed to prepare local package for uploading")?;
     if opts.verify {
         dst.seek(SeekFrom::Start(0))?;
         run_verify(ws, &dst, opts).with_context(|| "failed to verify package tarball")?

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -11,10 +11,11 @@ use crate::core::resolver::CliFeatures;
 use crate::core::{Feature, Shell, Verbosity, Workspace};
 use crate::core::{Package, PackageId, PackageSet, Resolve, Source, SourceId};
 use crate::sources::PathSource;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::toml::TomlManifest;
 use crate::util::{self, restricted_names, Config, FileLock};
 use crate::{drop_println, ops};
+use anyhow::Context as _;
 use cargo_util::paths;
 use flate2::read::GzDecoder;
 use flate2::{Compression, GzBuilder};
@@ -122,17 +123,17 @@ pub fn package(ws: &Workspace<'_>, opts: &PackageOpts<'_>) -> CargoResult<Option
         .status("Packaging", pkg.package_id().to_string())?;
     dst.file().set_len(0)?;
     tar(ws, ar_files, dst.file(), &filename)
-        .chain_err(|| anyhow::format_err!("failed to prepare local package for uploading"))?;
+        .with_context(|| anyhow::format_err!("failed to prepare local package for uploading"))?;
     if opts.verify {
         dst.seek(SeekFrom::Start(0))?;
-        run_verify(ws, &dst, opts).chain_err(|| "failed to verify package tarball")?
+        run_verify(ws, &dst, opts).with_context(|| "failed to verify package tarball")?
     }
     dst.seek(SeekFrom::Start(0))?;
     {
         let src_path = dst.path();
         let dst_path = dst.parent().join(&filename);
         fs::rename(&src_path, &dst_path)
-            .chain_err(|| "failed to move temporary tarball into final location")?;
+            .with_context(|| "failed to move temporary tarball into final location")?;
     }
     Ok(Some(dst))
 }
@@ -501,16 +502,16 @@ fn tar(
         let mut header = Header::new_gnu();
         match contents {
             FileContents::OnDisk(disk_path) => {
-                let mut file = File::open(&disk_path).chain_err(|| {
+                let mut file = File::open(&disk_path).with_context(|| {
                     format!("failed to open for archiving: `{}`", disk_path.display())
                 })?;
-                let metadata = file.metadata().chain_err(|| {
+                let metadata = file.metadata().with_context(|| {
                     format!("could not learn metadata for: `{}`", disk_path.display())
                 })?;
                 header.set_metadata_in_mode(&metadata, HeaderMode::Deterministic);
                 header.set_cksum();
                 ar.append_data(&mut header, &ar_path, &mut file)
-                    .chain_err(|| {
+                    .with_context(|| {
                         format!("could not archive source file `{}`", disk_path.display())
                     })?;
             }
@@ -525,7 +526,7 @@ fn tar(
                 header.set_size(contents.len() as u64);
                 header.set_cksum();
                 ar.append_data(&mut header, &ar_path, contents.as_bytes())
-                    .chain_err(|| format!("could not archive source file `{}`", rel_str))?;
+                    .with_context(|| format!("could not archive source file `{}`", rel_str))?;
             }
         }
     }
@@ -739,7 +740,7 @@ fn hash_all(path: &Path) -> CargoResult<HashMap<PathBuf, u64>> {
         }
         Ok(result)
     }
-    let result = wrap(path).chain_err(|| format!("failed to verify output at {:?}", path))?;
+    let result = wrap(path).with_context(|| format!("failed to verify output at {:?}", path))?;
     Ok(result)
 }
 

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -5,14 +5,14 @@ use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
-use anyhow::{bail, format_err};
+use anyhow::{bail, format_err, Context as _};
 use serde::{Deserialize, Serialize};
 
 use crate::core::compiler::Freshness;
 use crate::core::{Dependency, FeatureValue, Package, PackageId, Source, SourceId};
 use crate::ops::{self, CompileFilter, CompileOptions};
 use crate::sources::PathSource;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::Config;
 use crate::util::{FileLock, Filesystem};
 
@@ -102,10 +102,10 @@ impl InstallTracker {
                 Ok(CrateListingV1::default())
             } else {
                 Ok(toml::from_str(&contents)
-                    .chain_err(|| format_err!("invalid TOML found for metadata"))?)
+                    .with_context(|| format_err!("invalid TOML found for metadata"))?)
             }
         })()
-        .chain_err(|| {
+        .with_context(|| {
             format_err!(
                 "failed to parse crate metadata at `{}`",
                 v1_lock.path().to_string_lossy()
@@ -119,12 +119,12 @@ impl InstallTracker {
                 CrateListingV2::default()
             } else {
                 serde_json::from_str(&contents)
-                    .chain_err(|| format_err!("invalid JSON found for metadata"))?
+                    .with_context(|| format_err!("invalid JSON found for metadata"))?
             };
             v2.sync_v1(&v1);
             Ok(v2)
         })()
-        .chain_err(|| {
+        .with_context(|| {
             format_err!(
                 "failed to parse crate metadata at `{}`",
                 v2_lock.path().to_string_lossy()
@@ -278,14 +278,14 @@ impl InstallTracker {
 
     /// Save tracking information to disk.
     pub fn save(&self) -> CargoResult<()> {
-        self.v1.save(&self.v1_lock).chain_err(|| {
+        self.v1.save(&self.v1_lock).with_context(|| {
             format_err!(
                 "failed to write crate metadata at `{}`",
                 self.v1_lock.path().to_string_lossy()
             )
         })?;
 
-        self.v2.save(&self.v2_lock).chain_err(|| {
+        self.v2.save(&self.v2_lock).with_context(|| {
             format_err!(
                 "failed to write crate metadata at `{}`",
                 self.v2_lock.path().to_string_lossy()

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -101,12 +101,11 @@ impl InstallTracker {
             if contents.is_empty() {
                 Ok(CrateListingV1::default())
             } else {
-                Ok(toml::from_str(&contents)
-                    .with_context(|| format_err!("invalid TOML found for metadata"))?)
+                Ok(toml::from_str(&contents).with_context(|| "invalid TOML found for metadata")?)
             }
         })()
         .with_context(|| {
-            format_err!(
+            format!(
                 "failed to parse crate metadata at `{}`",
                 v1_lock.path().to_string_lossy()
             )
@@ -119,13 +118,13 @@ impl InstallTracker {
                 CrateListingV2::default()
             } else {
                 serde_json::from_str(&contents)
-                    .with_context(|| format_err!("invalid JSON found for metadata"))?
+                    .with_context(|| "invalid JSON found for metadata")?
             };
             v2.sync_v1(&v1);
             Ok(v2)
         })()
         .with_context(|| {
-            format_err!(
+            format!(
                 "failed to parse crate metadata at `{}`",
                 v2_lock.path().to_string_lossy()
             )
@@ -279,14 +278,14 @@ impl InstallTracker {
     /// Save tracking information to disk.
     pub fn save(&self) -> CargoResult<()> {
         self.v1.save(&self.v1_lock).with_context(|| {
-            format_err!(
+            format!(
                 "failed to write crate metadata at `{}`",
                 self.v1_lock.path().to_string_lossy()
             )
         })?;
 
         self.v2.save(&self.v2_lock).with_context(|| {
-            format_err!(
+            format!(
                 "failed to write crate metadata at `{}`",
                 self.v2_lock.path().to_string_lossy()
             )

--- a/src/cargo/ops/registry/auth.rs
+++ b/src/cargo/ops/registry/auth.rs
@@ -1,9 +1,8 @@
 //! Registry authentication support.
 
 use crate::sources::CRATES_IO_REGISTRY;
-use crate::util::{config, CargoResult, CargoResultExt, Config};
-use anyhow::bail;
-use anyhow::format_err;
+use crate::util::{config, CargoResult, Config};
+use anyhow::{bail, format_err, Context as _};
 use cargo_util::ProcessError;
 use std::io::{Read, Write};
 use std::path::PathBuf;
@@ -135,7 +134,7 @@ fn run_command(
         }
         Action::Erase => {}
     }
-    let mut child = cmd.spawn().chain_err(|| {
+    let mut child = cmd.spawn().with_context(|| {
         let verb = match action {
             Action::Get => "fetch",
             Action::Store(_) => "store",
@@ -158,7 +157,7 @@ fn run_command(
                 .as_mut()
                 .unwrap()
                 .read_to_string(&mut buffer)
-                .chain_err(|| {
+                .with_context(|| {
                     format!(
                         "failed to read token from registry credential process `{}`",
                         exe.display()
@@ -177,7 +176,7 @@ fn run_command(
             token = Some(buffer);
         }
         Action::Store(token) => {
-            writeln!(child.stdin.as_ref().unwrap(), "{}", token).chain_err(|| {
+            writeln!(child.stdin.as_ref().unwrap(), "{}", token).with_context(|| {
                 format!(
                     "failed to send token to registry credential process `{}`",
                     exe.display()
@@ -186,7 +185,7 @@ fn run_command(
         }
         Action::Erase => {}
     }
-    let status = child.wait().chain_err(|| {
+    let status = child.wait().with_context(|| {
         format!(
             "registry credential process `{}` exit failure",
             exe.display()

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -23,8 +23,9 @@ use crate::core::{
 };
 use crate::ops;
 use crate::sources::PathSource;
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::{profile, CanonicalUrl};
+use anyhow::Context as _;
 use log::{debug, trace};
 use std::collections::HashSet;
 
@@ -412,7 +413,7 @@ pub fn add_overrides<'a>(
     for (path, definition) in paths {
         let id = SourceId::for_path(&path)?;
         let mut source = PathSource::new_recursive(&path, id, ws.config());
-        source.update().chain_err(|| {
+        source.update().with_context(|| {
             format!(
                 "failed to update path override `{}` \
                  (defined in `{}`)",

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -28,8 +28,7 @@ pub fn vendor(ws: &Workspace<'_>, opts: &VendorOptions<'_>) -> CargoResult<()> {
         extra_workspaces.push(ws);
     }
     let workspaces = extra_workspaces.iter().chain(Some(ws)).collect::<Vec<_>>();
-    let vendor_config =
-        sync(config, &workspaces, opts).with_context(|| "failed to sync".to_string())?;
+    let vendor_config = sync(config, &workspaces, opts).with_context(|| "failed to sync")?;
 
     if config.shell().verbosity() != Verbosity::Quiet {
         crate::drop_eprint!(

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -2,8 +2,8 @@ use crate::core::shell::Verbosity;
 use crate::core::{GitReference, Workspace};
 use crate::ops;
 use crate::sources::path::PathSource;
-use crate::util::{CargoResult, CargoResultExt, Config};
-use anyhow::bail;
+use crate::util::{CargoResult, Config};
+use anyhow::{bail, Context as _};
 use cargo_util::{paths, Sha256};
 use serde::Serialize;
 use std::collections::HashSet;
@@ -29,7 +29,7 @@ pub fn vendor(ws: &Workspace<'_>, opts: &VendorOptions<'_>) -> CargoResult<()> {
     }
     let workspaces = extra_workspaces.iter().chain(Some(ws)).collect::<Vec<_>>();
     let vendor_config =
-        sync(config, &workspaces, opts).chain_err(|| "failed to sync".to_string())?;
+        sync(config, &workspaces, opts).with_context(|| "failed to sync".to_string())?;
 
     if config.shell().verbosity() != Verbosity::Quiet {
         crate::drop_eprint!(
@@ -104,11 +104,11 @@ fn sync(
     // crate to work with.
     for ws in workspaces {
         let (packages, resolve) =
-            ops::resolve_ws(ws).chain_err(|| "failed to load pkg lockfile")?;
+            ops::resolve_ws(ws).with_context(|| "failed to load pkg lockfile")?;
 
         packages
             .get_many(resolve.iter())
-            .chain_err(|| "failed to download packages")?;
+            .with_context(|| "failed to download packages")?;
 
         for pkg in resolve.iter() {
             // Don't delete actual source code!
@@ -136,11 +136,11 @@ fn sync(
     // tables about them.
     for ws in workspaces {
         let (packages, resolve) =
-            ops::resolve_ws(ws).chain_err(|| "failed to load pkg lockfile")?;
+            ops::resolve_ws(ws).with_context(|| "failed to load pkg lockfile")?;
 
         packages
             .get_many(resolve.iter())
-            .chain_err(|| "failed to download packages")?;
+            .with_context(|| "failed to download packages")?;
 
         for pkg in resolve.iter() {
             // No need to vendor path crates since they're already in the
@@ -152,7 +152,7 @@ fn sync(
                 pkg,
                 packages
                     .get_one(pkg)
-                    .chain_err(|| "failed to fetch package")?
+                    .with_context(|| "failed to fetch package")?
                     .clone(),
             );
 
@@ -216,7 +216,7 @@ fn sync(
         let paths = pathsource.list_files(pkg)?;
         let mut map = BTreeMap::new();
         cp_sources(src, &paths, &dst, &mut map, &mut tmp_buf)
-            .chain_err(|| format!("failed to copy over vendored sources for: {}", id))?;
+            .with_context(|| format!("failed to copy over vendored sources for: {}", id))?;
 
         // Finally, emit the metadata about this package
         let json = serde_json::json!({
@@ -341,7 +341,7 @@ fn cp_sources(
 }
 
 fn copy_and_checksum(src_path: &Path, dst_path: &Path, buf: &mut [u8]) -> CargoResult<String> {
-    let mut src = File::open(src_path).chain_err(|| format!("failed to open {:?}", src_path))?;
+    let mut src = File::open(src_path).with_context(|| format!("failed to open {:?}", src_path))?;
     let mut dst_opts = OpenOptions::new();
     dst_opts.write(true).create(true).truncate(true);
     #[cfg(unix)]
@@ -349,25 +349,25 @@ fn copy_and_checksum(src_path: &Path, dst_path: &Path, buf: &mut [u8]) -> CargoR
         use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
         let src_metadata = src
             .metadata()
-            .chain_err(|| format!("failed to stat {:?}", src_path))?;
+            .with_context(|| format!("failed to stat {:?}", src_path))?;
         dst_opts.mode(src_metadata.mode());
     }
     let mut dst = dst_opts
         .open(dst_path)
-        .chain_err(|| format!("failed to create {:?}", dst_path))?;
+        .with_context(|| format!("failed to create {:?}", dst_path))?;
     // Not going to bother setting mode on pre-existing files, since there
     // shouldn't be any under normal conditions.
     let mut cksum = Sha256::new();
     loop {
         let n = src
             .read(buf)
-            .chain_err(|| format!("failed to read from {:?}", src_path))?;
+            .with_context(|| format!("failed to read from {:?}", src_path))?;
         if n == 0 {
             break Ok(cksum.finish_hex());
         }
         let data = &buf[..n];
         cksum.update(data);
         dst.write_all(data)
-            .chain_err(|| format!("failed to write to {:?}", dst_path))?;
+            .with_context(|| format!("failed to write to {:?}", dst_path))?;
     }
 }

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -7,9 +7,9 @@
 use crate::core::{GitReference, PackageId, Source, SourceId};
 use crate::sources::{ReplacedSource, CRATES_IO_REGISTRY};
 use crate::util::config::{self, ConfigRelativePath, OptValue};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::{Config, IntoUrl};
-use anyhow::bail;
+use anyhow::{bail, Context as _};
 use log::debug;
 use std::collections::{HashMap, HashSet};
 use url::Url;
@@ -280,7 +280,7 @@ restore the source replacement configuration to continue the build
         return Ok(());
 
         fn url(val: &config::Value<String>, key: &str) -> CargoResult<Url> {
-            let url = val.val.into_url().chain_err(|| {
+            let url = val.val.into_url().with_context(|| {
                 format!(
                     "configuration key `{}` specified an invalid \
                      URL (in {})",

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -9,27 +9,6 @@ use std::path::PathBuf;
 
 pub type CargoResult<T> = anyhow::Result<T>;
 
-// TODO: should delete this trait and just use `with_context` instead
-pub trait CargoResultExt<T, E> {
-    fn chain_err<F, D>(self, f: F) -> CargoResult<T>
-    where
-        F: FnOnce() -> D,
-        D: fmt::Display + Send + Sync + 'static;
-}
-
-impl<T, E> CargoResultExt<T, E> for Result<T, E>
-where
-    E: Into<Error>,
-{
-    fn chain_err<F, D>(self, f: F) -> CargoResult<T>
-    where
-        F: FnOnce() -> D,
-        D: fmt::Display + Send + Sync + 'static,
-    {
-        self.map_err(|e| e.into().context(f()))
-    }
-}
-
 #[derive(Debug)]
 pub struct HttpNot200 {
     pub code: u32,

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -5,7 +5,7 @@ pub use self::canonical_url::CanonicalUrl;
 pub use self::config::{homedir, Config, ConfigValue};
 pub use self::dependency_queue::DependencyQueue;
 pub use self::diagnostic_server::RustfixDiagnosticServer;
-pub use self::errors::{internal, CargoResult, CargoResultExt, CliResult, Test};
+pub use self::errors::{internal, CargoResult, CliResult, Test};
 pub use self::errors::{CargoTestError, CliError};
 pub use self::flock::{FileLock, Filesystem};
 pub use self::graph::Graph;

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -222,10 +222,10 @@ impl Cache {
                 .with_context(|| format!("could not execute process {} (never executed)", cmd))?;
             let stdout = String::from_utf8(output.stdout)
                 .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
-                .with_context(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
+                .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;
             let stderr = String::from_utf8(output.stderr)
                 .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
-                .with_context(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
+                .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;
             self.data.outputs.insert(
                 key,
                 Output {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -4,12 +4,13 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
+use anyhow::Context as _;
 use cargo_util::{paths, ProcessBuilder, ProcessError};
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 
 use crate::util::interning::InternedString;
-use crate::util::{profile, CargoResult, CargoResultExt, StableHasher};
+use crate::util::{profile, CargoResult, StableHasher};
 
 /// Information on the `rustc` executable
 #[derive(Debug)]
@@ -66,7 +67,7 @@ impl Rustc {
         };
 
         let host = InternedString::new(extract("host: ")?);
-        let version = semver::Version::parse(extract("release: ")?).chain_err(|| {
+        let version = semver::Version::parse(extract("release: ")?).with_context(|| {
             format!(
                 "rustc version does not appear to be a valid semver version, from:\n{}",
                 verbose_version
@@ -218,13 +219,13 @@ impl Cache {
             let output = cmd
                 .build_command()
                 .output()
-                .chain_err(|| format!("could not execute process {} (never executed)", cmd))?;
+                .with_context(|| format!("could not execute process {} (never executed)", cmd))?;
             let stdout = String::from_utf8(output.stdout)
                 .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
-                .chain_err(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
+                .with_context(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
             let stderr = String::from_utf8(output.stderr)
                 .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
-                .chain_err(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
+                .with_context(|| anyhow::anyhow!("`{}` didn't return utf8 output", cmd))?;
             self.data.outputs.insert(
                 key,
                 Output {

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -20,8 +20,10 @@ use super::{
 };
 use crate::core::compiler::CrateType;
 use crate::core::{Edition, Feature, Features, Target};
-use crate::util::errors::{CargoResult, CargoResultExt};
+use crate::util::errors::CargoResult;
 use crate::util::restricted_names;
+
+use anyhow::Context as _;
 
 pub fn targets(
     features: &Features,
@@ -787,11 +789,11 @@ fn configure(features: &Features, toml: &TomlTarget, target: &mut Target) -> Car
     if let Some(edition) = toml.edition.clone() {
         features
             .require(Feature::edition())
-            .chain_err(|| "editions are unstable")?;
+            .with_context(|| "editions are unstable")?;
         target.set_edition(
             edition
                 .parse()
-                .chain_err(|| "failed to parse the `edition` key")?,
+                .with_context(|| "failed to parse the `edition` key")?,
         );
     }
     Ok(())


### PR DESCRIPTION
All `chain_err` -> `with_context` are done by IDE refactoring.

- Remove `CargoResultExt`.
- Call `format!` instead of `anyhow::format_err!` to reduce unnecessary macro expansions.
https://github.com/rust-lang/cargo/blob/e870eac9967b132825116525476d6875c305e4d8/src/cargo/util/errors.rs#L12-L18