### PR TITLE
Fix #9350 (cargo build -Z help is missing options)

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -31,9 +31,21 @@ pub fn main(config: &mut Config) -> CliResult {
 
     if args.value_of("unstable-features") == Some("help") {
         let options = CliUnstable::help();
-        let help_lines: Vec<String> = options.iter().map(|(option_name, option_help_message)| {
-            format!("-Z {} -- {}", option_name, option_help_message)
-        }).collect();
+        let longest_option = options
+            .iter()
+            .map(|(option_name, _)| option_name.len())
+            .max()
+            .unwrap_or(0);
+        let help_lines: Vec<String> = options
+            .iter()
+            .map(|(option_name, option_help_message)| {
+                let padding = " ".repeat(longest_option - option_name.len()); // safe to substract
+                format!(
+                    "    -Z {}{} -- {}",
+                    option_name, padding, option_help_message
+                )
+            })
+            .collect();
         let joined = help_lines.join("\n");
         drop_println!(
             config,
@@ -42,8 +54,9 @@ Available unstable (nightly-only) flags:
 
 {}
 
-Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
-        , joined);
+Run with 'cargo -Z [FLAG] [SUBCOMMAND]'",
+            joined
+        );
         if !config.nightly_features_allowed {
             drop_println!(
                 config,

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -1,4 +1,4 @@
-use cargo::core::features;
+use cargo::core::{features, CliUnstable};
 use cargo::{self, drop_print, drop_println, CliResult, Config};
 use clap::{AppSettings, Arg, ArgMatches};
 
@@ -30,26 +30,20 @@ pub fn main(config: &mut Config) -> CliResult {
     };
 
     if args.value_of("unstable-features") == Some("help") {
+        let options = CliUnstable::help();
+        let help_lines: Vec<String> = options.iter().map(|(option_name, option_help_message)| {
+            format!("-Z {} -- {}", option_name, option_help_message)
+        }).collect();
+        let joined = help_lines.join("\n");
         drop_println!(
             config,
             "
 Available unstable (nightly-only) flags:
 
-    -Z allow-features      -- Allow *only* the listed unstable features
-    -Z avoid-dev-deps      -- Avoid installing dev-dependencies if possible
-    -Z extra-link-arg      -- Allow `cargo:rustc-link-arg` in build scripts
-    -Z minimal-versions    -- Install minimal dependency versions instead of maximum
-    -Z no-index-update     -- Do not update the registry, avoids a network request for benchmarking
-    -Z unstable-options    -- Allow the usage of unstable options
-    -Z timings             -- Display concurrency information
-    -Z doctest-xcompile    -- Compile and run doctests for non-host target using runner config
-    -Z terminal-width      -- Provide a terminal width to rustc for error truncation
-    -Z namespaced-features -- Allow features with `dep:` prefix
-    -Z weak-dep-features   -- Allow `dep_name?/feature` feature syntax
-    -Z patch-in-config     -- Allow `[patch]` sections in .cargo/config.toml files
+{}
 
 Run with 'cargo -Z [FLAG] [SUBCOMMAND]'"
-        );
+        , joined);
         if !config.nightly_features_allowed {
             drop_println!(
                 config,

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -808,7 +808,7 @@ impl<'cfg> DrainState<'cfg> {
     }
 
     fn emit_future_incompat(&mut self, cx: &mut Context<'_, '_>) {
-        if cx.bcx.config.cli_unstable().enable_future_incompat_feature {
+        if cx.bcx.config.cli_unstable().future_incompat_report {
             if self.per_crate_future_incompat_reports.is_empty() {
                 drop(
                     cx.bcx

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -936,7 +936,7 @@ fn build_base_args(
             .env("RUSTC_BOOTSTRAP", "1");
     }
 
-    if bcx.config.cli_unstable().enable_future_incompat_feature {
+    if bcx.config.cli_unstable().future_incompat_report {
         cmd.arg("-Z").arg("emit-future-incompat-report");
     }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -595,7 +595,7 @@ cli_options!(
     pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
     pub features: Option<Vec<String>>  = (HIDDEN),
     pub jobserver_per_rustc: bool = (HIDDEN),
-    pub minimal_versions: bool = ("Install minimal dependency versions instead of maximum"),
+    pub minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
     pub mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
     pub multitarget: bool = ("Allow passing multiple `--target` flags to the cargo subcommand selected"),
     pub named_profiles: bool = ("Allow defining custom profiles"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -538,51 +538,67 @@ impl Features {
     }
 }
 
-/// A parsed representation of all unstable flags that Cargo accepts.
-///
-/// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
-/// gating unstable functionality to Cargo. These flags are only available on
-/// the nightly channel of Cargo.
-#[derive(Default, Debug, Deserialize)]
-#[serde(default, rename_all = "kebab-case")]
-pub struct CliUnstable {
+macro_rules! help_struct {
+    ($name: ident, $($visibility: vis $element: ident: $ty: ty = ($help: literal $(, #[$meta:meta])?)),*) => {
+        /// A parsed representation of all unstable flags that Cargo accepts.
+        ///
+        /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
+        /// gating unstable functionality to Cargo. These flags are only available on
+        /// the nightly channel of Cargo.
+        #[derive(Default, Debug, Deserialize)]
+        #[serde(default, rename_all = "kebab-case")]
+        pub struct $name {
+            $(
+                $(#[$meta])?
+                $visibility $element: $ty
+            ),*
+        }
+        impl $name {
+            pub fn help() -> Vec<(&'static str, &'static str)> {
+                let fields = vec![$((stringify!($element), $help)),*];
+                fields
+            }
+        }
+    }
+}
+
+help_struct!(CliUnstable,
     // Permanently unstable features:
-    pub allow_features: Option<BTreeSet<String>>,
-    pub print_im_a_teapot: bool,
+    pub allow_features: Option<BTreeSet<String>> = ("Allow *only* the listed unstable features"),
+    pub print_im_a_teapot: bool= (""),
 
     // All other unstable features.
     // Please keep this list lexiographically ordered.
-    pub advanced_env: bool,
-    pub avoid_dev_deps: bool,
-    pub binary_dep_depinfo: bool,
-    #[serde(deserialize_with = "deserialize_build_std")]
-    pub build_std: Option<Vec<String>>,
-    pub build_std_features: Option<Vec<String>>,
-    pub config_include: bool,
-    pub configurable_env: bool,
-    pub credential_process: bool,
-    pub doctest_in_workspace: bool,
-    pub doctest_xcompile: bool,
-    pub dual_proc_macros: bool,
-    pub enable_future_incompat_feature: bool,
-    pub extra_link_arg: bool,
-    pub features: Option<Vec<String>>,
-    pub jobserver_per_rustc: bool,
-    pub minimal_versions: bool,
-    pub mtime_on_use: bool,
-    pub multitarget: bool,
-    pub named_profiles: bool,
-    pub namespaced_features: bool,
-    pub no_index_update: bool,
-    pub panic_abort_tests: bool,
-    pub patch_in_config: bool,
-    pub rustdoc_map: bool,
-    pub separate_nightlies: bool,
-    pub terminal_width: Option<Option<usize>>,
-    pub timings: Option<Vec<String>>,
-    pub unstable_options: bool,
-    pub weak_dep_features: bool,
-}
+    pub advanced_env: bool= (""),
+    pub avoid_dev_deps: bool= ("Avoid installing dev-dependencies if possible"),
+    pub binary_dep_depinfo: bool= (""),
+    pub build_std: Option<Vec<String>> = ("", #[serde(deserialize_with = "deserialize_build_std")]),
+    pub build_std_features: Option<Vec<String>> = (""),
+    pub config_include: bool= (""),
+    pub configurable_env: bool= (""),
+    pub credential_process: bool= (""),
+    pub doctest_in_workspace: bool= (""),
+    pub doctest_xcompile: bool= ("Compile and run doctests for non-host target using runner config"),
+    pub dual_proc_macros: bool= (""),
+    pub enable_future_incompat_feature: bool= (""),
+    pub extra_link_arg: bool= ("Allow `cargo:rustc-link-arg` in build scripts"),
+    pub features: Option<Vec<String>> = (""),
+    pub jobserver_per_rustc: bool= (""),
+    pub minimal_versions: bool= ("Install minimal dependency versions instead of maximum"),
+    pub mtime_on_use: bool= (""),
+    pub multitarget: bool= (""),
+    pub named_profiles: bool= (""),
+    pub namespaced_features: bool= ("Allow features with `dep:` prefix"),
+    pub no_index_update: bool= ("Do not update the registry, avoids a network request for benchmarking"),
+    pub panic_abort_tests: bool= (""),
+    pub patch_in_config: bool= ("Allow `[patch]` sections in .cargo/config.toml files"),
+    pub rustdoc_map: bool= (""),
+    pub separate_nightlies: bool= (""),
+    pub terminal_width: Option<Option<usize>> = ("Provide a terminal width to rustc for error truncation"),
+    pub timings: Option<Vec<String>> = ("Display concurrency information"),
+    pub unstable_options: bool= ("Allow the usage of unstable options"),
+    pub weak_dep_features: bool= ("Allow `dep_name?/feature` feature syntax")
+);
 
 const STABILIZED_COMPILE_PROGRESS: &str = "The progress bar is now always \
     enabled when used on an interactive console.\n\

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -601,7 +601,7 @@ cli_options!(
     pub named_profiles: bool = ("Allow defining custom profiles"),
     pub namespaced_features: bool = ("Allow features with `dep:` prefix"),
     pub no_index_update: bool = ("Do not update the registry, avoids a network request for benchmarking"),
-    pub panic_abort_tests: bool = ("Enable nightly support to compile test harness crates with -Cpanic=abort"),
+    pub panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     pub patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
     pub rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     pub separate_nightlies: bool = (HIDDEN),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -590,7 +590,7 @@ cli_options!(
     pub credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
     pub doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
-    pub dual_proc_macros: bool = ("TODO"),
+    pub dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
     pub enable_future_incompat_feature: bool = ("TODO"),
     pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
     pub features: Option<Vec<String>>  = (HIDDEN),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -539,23 +539,27 @@ impl Features {
     }
 }
 
-macro_rules! cli_options {
+macro_rules! unstable_cli_options {
     (
-        $(#[$struct_meta:meta])*
-        $name: ident,
         $(
             $(#[$meta:meta])?
-            $visibility: vis $element: ident: $ty: ty = ($help: expr )
+            $element: ident: $ty: ty = ($help: expr )
         ),*
     ) => {
-        $(#[$struct_meta])*
-        pub struct $name {
+        /// A parsed representation of all unstable flags that Cargo accepts.
+        ///
+        /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
+        /// gating unstable functionality to Cargo. These flags are only available on
+        /// the nightly channel of Cargo.
+        #[derive(Default, Debug, Deserialize)]
+        #[serde(default, rename_all = "kebab-case")]
+        pub struct CliUnstable {
             $(
                 $(#[$meta])?
-                $visibility $element: $ty
+                pub $element: $ty
             ),*
         }
-        impl $name {
+        impl CliUnstable {
             pub fn help() -> Vec<(&'static str, &'static str)> {
                 let fields = vec![$((stringify!($element), $help)),*];
                 fields
@@ -564,51 +568,43 @@ macro_rules! cli_options {
     }
 }
 
-cli_options!(
-    /// A parsed representation of all unstable flags that Cargo accepts.
-    ///
-    /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
-    /// gating unstable functionality to Cargo. These flags are only available on
-    /// the nightly channel of Cargo.
-    #[derive(Default, Debug, Deserialize)]
-    #[serde(default, rename_all = "kebab-case")]
-    CliUnstable,
+unstable_cli_options!(
     // Permanently unstable features:
-    pub allow_features: Option<BTreeSet<String>> = ("Allow *only* the listed unstable features"),
-    pub print_im_a_teapot: bool= (HIDDEN),
+    allow_features: Option<BTreeSet<String>> = ("Allow *only* the listed unstable features"),
+    print_im_a_teapot: bool= (HIDDEN),
 
     // All other unstable features.
     // Please keep this list lexiographically ordered.
-    pub advanced_env: bool = (HIDDEN),
-    pub avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
-    pub binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
+    advanced_env: bool = (HIDDEN),
+    avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
+    binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     #[serde(deserialize_with = "deserialize_build_std")]
-    pub build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
-    pub build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
-    pub config_include: bool = ("Enable the `include` key in config files"),
-    pub configurable_env: bool = ("Enable the [env] section in the .cargo/config.toml file"),
-    pub credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
-    pub doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
-    pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
-    pub dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
-    pub future_incompat_report: bool = ("Enable creation of a future-incompat report for all dependencies"),
-    pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
-    pub features: Option<Vec<String>>  = (HIDDEN),
-    pub jobserver_per_rustc: bool = (HIDDEN),
-    pub minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
-    pub mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
-    pub multitarget: bool = ("Allow passing multiple `--target` flags to the cargo subcommand selected"),
-    pub named_profiles: bool = ("Allow defining custom profiles"),
-    pub namespaced_features: bool = ("Allow features with `dep:` prefix"),
-    pub no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
-    pub panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
-    pub patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
-    pub rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
-    pub separate_nightlies: bool = (HIDDEN),
-    pub terminal_width: Option<Option<usize>>  = ("Provide a terminal width to rustc for error truncation"),
-    pub timings: Option<Vec<String>>  = ("Display concurrency information"),
-    pub unstable_options: bool = ("Allow the usage of unstable options"),
-    pub weak_dep_features: bool = ("Allow `dep_name?/feature` feature syntax")
+    build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
+    build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
+    config_include: bool = ("Enable the `include` key in config files"),
+    configurable_env: bool = ("Enable the [env] section in the .cargo/config.toml file"),
+    credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
+    doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
+    doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
+    dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
+    future_incompat_report: bool = ("Enable creation of a future-incompat report for all dependencies"),
+    extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
+    features: Option<Vec<String>>  = (HIDDEN),
+    jobserver_per_rustc: bool = (HIDDEN),
+    minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
+    mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
+    multitarget: bool = ("Allow passing multiple `--target` flags to the cargo subcommand selected"),
+    named_profiles: bool = ("Allow defining custom profiles"),
+    namespaced_features: bool = ("Allow features with `dep:` prefix"),
+    no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
+    panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
+    patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
+    rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
+    separate_nightlies: bool = (HIDDEN),
+    terminal_width: Option<Option<usize>>  = ("Provide a terminal width to rustc for error truncation"),
+    timings: Option<Vec<String>>  = ("Display concurrency information"),
+    unstable_options: bool = ("Allow the usage of unstable options"),
+    weak_dep_features: bool = ("Allow `dep_name?/feature` feature syntax")
 );
 
 const STABILIZED_COMPILE_PROGRESS: &str = "The progress bar is now always \

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -105,6 +105,7 @@ use crate::util::errors::CargoResult;
 use crate::util::{indented_lines, iter_join};
 use crate::Config;
 
+pub const HIDDEN: &str = "";
 pub const SEE_CHANNELS: &str =
     "See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information \
      about Rust release channels.";
@@ -542,7 +543,10 @@ macro_rules! cli_options {
     (
         $(#[$struct_meta:meta])*
         $name: ident,
-        $($visibility: vis $element: ident: $ty: ty = ($help: literal $(, #[$meta:meta])?)),*
+        $(
+            $(#[$meta:meta])?
+            $visibility: vis $element: ident: $ty: ty = ($help: expr )
+        ),*
     ) => {
         $(#[$struct_meta])*
         pub struct $name {
@@ -571,35 +575,36 @@ cli_options!(
     CliUnstable,
     // Permanently unstable features:
     pub allow_features: Option<BTreeSet<String>> = ("Allow *only* the listed unstable features"),
-    pub print_im_a_teapot: bool= (""),
+    pub print_im_a_teapot: bool= (HIDDEN),
 
     // All other unstable features.
     // Please keep this list lexiographically ordered.
-    pub advanced_env: bool = (""),
+    pub advanced_env: bool = (HIDDEN),
     pub avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
-    pub binary_dep_depinfo: bool = (""),
-    pub build_std: Option<Vec<String>>  = ("", #[serde(deserialize_with = "deserialize_build_std")]),
-    pub build_std_features: Option<Vec<String>>  = (""),
-    pub config_include: bool = (""),
-    pub configurable_env: bool = (""),
-    pub credential_process: bool = (""),
-    pub doctest_in_workspace: bool = (""),
+    pub binary_dep_depinfo: bool = ("Track binary dependencies change"),
+    #[serde(deserialize_with = "deserialize_build_std")]
+    pub build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
+    pub build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
+    pub config_include: bool = ("Enable the `include` key in config files"),
+    pub configurable_env: bool = ("Enable the [env] section in the .cargo/config.toml file"),
+    pub credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
+    pub doctest_in_workspace: bool = ("TODO"),
     pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
-    pub dual_proc_macros: bool = (""),
-    pub enable_future_incompat_feature: bool = (""),
+    pub dual_proc_macros: bool = ("TODO"),
+    pub enable_future_incompat_feature: bool = ("TODO"),
     pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
-    pub features: Option<Vec<String>>  = (""),
-    pub jobserver_per_rustc: bool = (""),
+    pub features: Option<Vec<String>>  = (HIDDEN),
+    pub jobserver_per_rustc: bool = ("TODO"),
     pub minimal_versions: bool = ("Install minimal dependency versions instead of maximum"),
-    pub mtime_on_use: bool = (""),
-    pub multitarget: bool = (""),
-    pub named_profiles: bool = (""),
+    pub mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
+    pub multitarget: bool = ("Allow passing multiple `--target` flags to the cargo subcommand selected"),
+    pub named_profiles: bool = ("Allow defining custom profiles"),
     pub namespaced_features: bool = ("Allow features with `dep:` prefix"),
     pub no_index_update: bool = ("Do not update the registry, avoids a network request for benchmarking"),
-    pub panic_abort_tests: bool = (""),
+    pub panic_abort_tests: bool = ("Enable nightly support to compile test harness crates with -Cpanic=abort"),
     pub patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
-    pub rustdoc_map: bool = (""),
-    pub separate_nightlies: bool = (""),
+    pub rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
+    pub separate_nightlies: bool = (HIDDEN),
     pub terminal_width: Option<Option<usize>>  = ("Provide a terminal width to rustc for error truncation"),
     pub timings: Option<Vec<String>>  = ("Display concurrency information"),
     pub unstable_options: bool = ("Allow the usage of unstable options"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -588,7 +588,7 @@ cli_options!(
     pub config_include: bool = ("Enable the `include` key in config files"),
     pub configurable_env: bool = ("Enable the [env] section in the .cargo/config.toml file"),
     pub credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
-    pub doctest_in_workspace: bool = ("TODO"),
+    pub doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     pub dual_proc_macros: bool = ("TODO"),
     pub enable_future_incompat_feature: bool = ("TODO"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -581,7 +581,7 @@ cli_options!(
     // Please keep this list lexiographically ordered.
     pub advanced_env: bool = (HIDDEN),
     pub avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
-    pub binary_dep_depinfo: bool = ("Track binary dependencies change"),
+    pub binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     #[serde(deserialize_with = "deserialize_build_std")]
     pub build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     pub build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -594,7 +594,7 @@ cli_options!(
     pub enable_future_incompat_feature: bool = ("Enable creation of a future-incompat report for all dependencies"),
     pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
     pub features: Option<Vec<String>>  = (HIDDEN),
-    pub jobserver_per_rustc: bool = ("TODO"),
+    pub jobserver_per_rustc: bool = (HIDDEN),
     pub minimal_versions: bool = ("Install minimal dependency versions instead of maximum"),
     pub mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
     pub multitarget: bool = ("Allow passing multiple `--target` flags to the cargo subcommand selected"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -68,7 +68,6 @@
 //!    get an instance of `CliUnstable` and check if the option has been
 //!    enabled on the `CliUnstable` instance. Nightly gating is already
 //!    handled, so no need to worry about that.
-//! 4. Update the `-Z help` documentation in the `main` function.
 //!
 //! ## Stabilization
 //!
@@ -83,9 +82,9 @@
 //!   2. `-Z unstable-options`: Find the call to `fail_if_stable_opt` and
 //!      remove it. Be sure to update the man pages if necessary.
 //!   3. `-Z` flag: Change the parsing code in [`CliUnstable::add`] to call
-//!      `stabilized_warn` or `stabilized_err`. Remove it from the `-Z help`
-//!      docs in the `main` function. Remove the `(unstable)` note in the
-//!      clap help text if necessary.
+//!      `stabilized_warn` or `stabilized_err` and remove the field from
+//!      `CliUnstable. Remove the `(unstable)` note in the clap help text if
+//!      necessary.
 //! 2. Remove `masquerade_as_nightly_cargo` from any tests, and remove
 //!    `cargo-features` from `Cargo.toml` test files if any.
 //! 3. Remove the docs from unstable.md and update the redirect at the bottom

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -600,7 +600,7 @@ cli_options!(
     pub multitarget: bool = ("Allow passing multiple `--target` flags to the cargo subcommand selected"),
     pub named_profiles: bool = ("Allow defining custom profiles"),
     pub namespaced_features: bool = ("Allow features with `dep:` prefix"),
-    pub no_index_update: bool = ("Do not update the registry, avoids a network request for benchmarking"),
+    pub no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
     pub panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     pub patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
     pub rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -591,7 +591,7 @@ cli_options!(
     pub doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     pub dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
-    pub enable_future_incompat_feature: bool = ("TODO"),
+    pub enable_future_incompat_feature: bool = ("Enable creation of a future-incompat report for all dependencies"),
     pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
     pub features: Option<Vec<String>>  = (HIDDEN),
     pub jobserver_per_rustc: bool = ("TODO"),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -591,7 +591,7 @@ cli_options!(
     pub doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     pub dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
-    pub enable_future_incompat_feature: bool = ("Enable creation of a future-incompat report for all dependencies"),
+    pub future_incompat_report: bool = ("Enable creation of a future-incompat report for all dependencies"),
     pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
     pub features: Option<Vec<String>>  = (HIDDEN),
     pub jobserver_per_rustc: bool = (HIDDEN),
@@ -825,7 +825,7 @@ impl CliUnstable {
             "config-profile" => stabilized_warn(k, "1.43", STABILIZED_CONFIG_PROFILE),
             "crate-versions" => stabilized_warn(k, "1.47", STABILIZED_CRATE_VERSIONS),
             "package-features" => stabilized_warn(k, "1.51", STABILIZED_PACKAGE_FEATURES),
-            "future-incompat-report" => self.enable_future_incompat_feature = parse_empty(k, v)?,
+            "future-incompat-report" => self.future_incompat_report = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -538,15 +538,13 @@ impl Features {
     }
 }
 
-macro_rules! help_struct {
-    ($name: ident, $($visibility: vis $element: ident: $ty: ty = ($help: literal $(, #[$meta:meta])?)),*) => {
-        /// A parsed representation of all unstable flags that Cargo accepts.
-        ///
-        /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
-        /// gating unstable functionality to Cargo. These flags are only available on
-        /// the nightly channel of Cargo.
-        #[derive(Default, Debug, Deserialize)]
-        #[serde(default, rename_all = "kebab-case")]
+macro_rules! cli_options {
+    (
+        $(#[$struct_meta:meta])*
+        $name: ident,
+        $($visibility: vis $element: ident: $ty: ty = ($help: literal $(, #[$meta:meta])?)),*
+    ) => {
+        $(#[$struct_meta])*
         pub struct $name {
             $(
                 $(#[$meta])?
@@ -562,42 +560,50 @@ macro_rules! help_struct {
     }
 }
 
-help_struct!(CliUnstable,
+cli_options!(
+    /// A parsed representation of all unstable flags that Cargo accepts.
+    ///
+    /// Cargo, like `rustc`, accepts a suite of `-Z` flags which are intended for
+    /// gating unstable functionality to Cargo. These flags are only available on
+    /// the nightly channel of Cargo.
+    #[derive(Default, Debug, Deserialize)]
+    #[serde(default, rename_all = "kebab-case")]
+    CliUnstable,
     // Permanently unstable features:
     pub allow_features: Option<BTreeSet<String>> = ("Allow *only* the listed unstable features"),
     pub print_im_a_teapot: bool= (""),
 
     // All other unstable features.
     // Please keep this list lexiographically ordered.
-    pub advanced_env: bool= (""),
-    pub avoid_dev_deps: bool= ("Avoid installing dev-dependencies if possible"),
-    pub binary_dep_depinfo: bool= (""),
-    pub build_std: Option<Vec<String>> = ("", #[serde(deserialize_with = "deserialize_build_std")]),
-    pub build_std_features: Option<Vec<String>> = (""),
-    pub config_include: bool= (""),
-    pub configurable_env: bool= (""),
-    pub credential_process: bool= (""),
-    pub doctest_in_workspace: bool= (""),
-    pub doctest_xcompile: bool= ("Compile and run doctests for non-host target using runner config"),
-    pub dual_proc_macros: bool= (""),
-    pub enable_future_incompat_feature: bool= (""),
-    pub extra_link_arg: bool= ("Allow `cargo:rustc-link-arg` in build scripts"),
-    pub features: Option<Vec<String>> = (""),
-    pub jobserver_per_rustc: bool= (""),
-    pub minimal_versions: bool= ("Install minimal dependency versions instead of maximum"),
-    pub mtime_on_use: bool= (""),
-    pub multitarget: bool= (""),
-    pub named_profiles: bool= (""),
-    pub namespaced_features: bool= ("Allow features with `dep:` prefix"),
-    pub no_index_update: bool= ("Do not update the registry, avoids a network request for benchmarking"),
-    pub panic_abort_tests: bool= (""),
-    pub patch_in_config: bool= ("Allow `[patch]` sections in .cargo/config.toml files"),
-    pub rustdoc_map: bool= (""),
-    pub separate_nightlies: bool= (""),
-    pub terminal_width: Option<Option<usize>> = ("Provide a terminal width to rustc for error truncation"),
-    pub timings: Option<Vec<String>> = ("Display concurrency information"),
-    pub unstable_options: bool= ("Allow the usage of unstable options"),
-    pub weak_dep_features: bool= ("Allow `dep_name?/feature` feature syntax")
+    pub advanced_env: bool = (""),
+    pub avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
+    pub binary_dep_depinfo: bool = (""),
+    pub build_std: Option<Vec<String>>  = ("", #[serde(deserialize_with = "deserialize_build_std")]),
+    pub build_std_features: Option<Vec<String>>  = (""),
+    pub config_include: bool = (""),
+    pub configurable_env: bool = (""),
+    pub credential_process: bool = (""),
+    pub doctest_in_workspace: bool = (""),
+    pub doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
+    pub dual_proc_macros: bool = (""),
+    pub enable_future_incompat_feature: bool = (""),
+    pub extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
+    pub features: Option<Vec<String>>  = (""),
+    pub jobserver_per_rustc: bool = (""),
+    pub minimal_versions: bool = ("Install minimal dependency versions instead of maximum"),
+    pub mtime_on_use: bool = (""),
+    pub multitarget: bool = (""),
+    pub named_profiles: bool = (""),
+    pub namespaced_features: bool = ("Allow features with `dep:` prefix"),
+    pub no_index_update: bool = ("Do not update the registry, avoids a network request for benchmarking"),
+    pub panic_abort_tests: bool = (""),
+    pub patch_in_config: bool = ("Allow `[patch]` sections in .cargo/config.toml files"),
+    pub rustdoc_map: bool = (""),
+    pub separate_nightlies: bool = (""),
+    pub terminal_width: Option<Option<usize>>  = ("Provide a terminal width to rustc for error truncation"),
+    pub timings: Option<Vec<String>>  = ("Display concurrency information"),
+    pub unstable_options: bool = ("Allow the usage of unstable options"),
+    pub weak_dep_features: bool = ("Allow `dep_name?/feature` feature syntax")
 );
 
 const STABILIZED_COMPILE_PROGRESS: &str = "The progress bar is now always \

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -488,7 +488,7 @@ pub trait ArgMatchesExt {
                 // TODO: Tracking issue
                 .fail_if_stable_opt("--future-incompat-report", 9241)?;
 
-            if !config.cli_unstable().enable_future_incompat_feature {
+            if !config.cli_unstable().future_incompat_report {
                 anyhow::bail!(
                     "Usage of `--future-incompat-report` requires `-Z future-incompat-report`"
                 )

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -49,7 +49,7 @@ fn z_flags_help() {
     // all the `-Z` flags.
     cargo_process("-Z help")
         .with_stdout_contains(
-            "    -Z allow_features[..]-- Allow *only* the listed unstable features",
+            "    -Z allow-features[..]-- Allow *only* the listed unstable features",
         )
         .run();
 }

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -49,7 +49,7 @@ fn z_flags_help() {
     // all the `-Z` flags.
     cargo_process("-Z help")
         .with_stdout_contains(
-            "    -Z allow_features                 -- Allow *only* the listed unstable features",
+            "    -Z allow_features[..]-- Allow *only* the listed unstable features",
         )
         .run();
 }

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -48,7 +48,9 @@ fn z_flags_help() {
     // Test that the output of `cargo -Z help` shows a different help screen with
     // all the `-Z` flags.
     cargo_process("-Z help")
-        .with_stdout_contains("    -Z unstable-options    -- Allow the usage of unstable options")
+        .with_stdout_contains(
+            "    -Z allow_features                 -- Allow *only* the listed unstable features",
+        )
         .run();
 }
 


### PR DESCRIPTION
> Do not merge yet, some options are still undocumented.

Fix #9350 (cargo build -Z help is missing options)

Add a procedural macro to declare `CliUnstable` struct and provide help messages instead of hard-coding help in `src/bin/cargo/cli.rs`

> Flags documentation: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html

Feedback welcome