### PR TITLE
Change precedence of `build-override`

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -522,17 +522,21 @@ fn merge_toml_overrides(
     profile: &mut Profile,
     toml: &TomlProfile,
 ) {
-    if unit_for.is_for_host() {
-        if let Some(build_override) = &toml.build_override {
-            merge_profile(profile, build_override);
-        }
-    }
-    if let Some(overrides) = toml.package.as_ref() {
+    if let Some(overrides) = &toml.package {
         if !is_member {
             if let Some(all) = overrides.get(&ProfilePackageSpec::All) {
                 merge_profile(profile, all);
             }
         }
+    }
+
+    if unit_for.is_for_host() {
+        if let Some(build_override) = &toml.build_override {
+            merge_profile(profile, build_override);
+        }
+    }
+
+    if let Some(overrides) = &toml.package {
         if let Some(pkg_id) = pkg_id {
             let mut matches = overrides
                 .iter()

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -207,6 +207,7 @@ fn profile_override_hierarchy() {
     // m3: 4 (as build.rs dependency)
     // m3: 1 (as [profile.dev] as workspace member)
     // dep: 3 (as [profile.dev.package."*"] as non-workspace member)
+    // dep: 4 (as [profile.dev.build-override])
     // m1 build.rs: 4 (as [profile.dev.build-override])
     // m2 build.rs: 2 (as [profile.dev.package.m2])
     // m2: 2 (as [profile.dev.package.m2])
@@ -217,6 +218,7 @@ fn profile_override_hierarchy() {
 [COMPILING] dep [..]
 [RUNNING] `rustc --crate-name m3 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]
 [RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=3 [..]
+[RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]
 [RUNNING] `rustc --crate-name m3 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=1 [..]
 [RUNNING] `rustc --crate-name build_script_build m1/build.rs [..] --crate-type bin --emit=[..]link[..]-C codegen-units=4 [..]
 [COMPILING] m2 [..]


### PR DESCRIPTION
If you specify both `build-override` and `package."*"` then the glob profile has higher precedence than the `build-override` one which is much more specific. In practice this means that very often the `build-override` is just completely ignored and all the proc macro crates get compiled without the `build-override` actually doing anything. This usually results in `debug` builds taking much longer than they should, often even longer than `release` builds. This Pull Request fixes this precedence issue.

Fixes #9351