### PR TITLE
Fix build-std updating the index on every build.

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -105,7 +105,16 @@ fn basic() {
         .build();
 
     p.cargo("check").build_std().target_host().run();
-    p.cargo("build").build_std().target_host().run();
+    p.cargo("build")
+        .build_std()
+        .target_host()
+        // Importantly, this should not say [UPDATING]
+        // There have been multiple bugs where every build triggers and update.
+        .with_stderr(
+            "[COMPILING] foo v0.0.1 [..]\n\
+             [FINISHED] dev [..]",
+        )
+        .run();
     p.cargo("run").build_std().target_host().run();
     p.cargo("test").build_std().target_host().run();
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/83776 has caused a problem where build-std will update the index on every build. That PR added `std_detect` from the `stdarch` submodule as a path dependency of `std`. However, since `stdarch` has a workspace of its own, an exclusion had to be added to `Cargo.toml` so that it does not treat `std_detect` as a workspace member (because nested workspaces are not supported).

The problem is that the std `Cargo.lock` file is built thinking that `std_detect` is *not* a workspace member. This means that its dev-dependencies are not included. However, when cargo resolves the std workspace, it doesn't know that `std_detect` should be excluded, so it considers it a workspace member (because it is a path dependency). This means that it expects the dev-dependencies to be in Cargo.lock. Because they are missing, it ends up poisoning the registry and triggering an update:

> poisoning registry `https://github.com/rust-lang/crates.io-index` because std_detect v0.1.5 (/Users/eric/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/stdarch/crates/std_detect) looks like it changed auxv

The solution here is to skip dev-dependencies if they are not actively being resolved, even if the package is a workspace member.

This has happened before (#8962), so I have updated the test to check for it.

There are some alternative solutions I considered:

* Add support for nested workspaces. 😄 
* Use a symlink to `std_detect` in the `rust-lang/rust` repository so that it appears to cargo as-if it is "outside" of the stdarch workspace, and thus can be treated like a normal workspace member (and remove the "exclude"). That seems a little hacky.

Fixes #9390
