### PR TITLE
Add support for preview features

### DIFF
--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -67,6 +67,7 @@ proptest! {
                 false,
                 false,
                 &None,
+                &[],
                 &["minimal-versions".to_string()],
                 &[],
             )
@@ -577,6 +578,7 @@ fn test_resolving_minimum_version_with_transitive_deps() {
             false,
             false,
             &None,
+            &[],
             &["minimal-versions".to_string()],
             &[],
         )

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -210,6 +210,10 @@ fn config_configure(
     let frozen = args.is_present("frozen") || global_args.frozen;
     let locked = args.is_present("locked") || global_args.locked;
     let offline = args.is_present("offline") || global_args.offline;
+    let mut preview = global_args.preview;
+    if let Some(values) = args.values_of("enable-preview") {
+        preview.extend(values.map(|s| s.to_string()));
+    }
     let mut unstable_flags = global_args.unstable_flags;
     if let Some(values) = args.values_of("unstable-features") {
         unstable_flags.extend(values.map(|s| s.to_string()));
@@ -226,6 +230,7 @@ fn config_configure(
         locked,
         offline,
         arg_target_dir,
+        &preview,
         &unstable_flags,
         &config_args,
     )?;
@@ -254,6 +259,7 @@ struct GlobalArgs {
     frozen: bool,
     locked: bool,
     offline: bool,
+    preview: Vec<String>,
     unstable_flags: Vec<String>,
     config_args: Vec<String>,
 }
@@ -267,6 +273,7 @@ impl GlobalArgs {
             frozen: args.is_present("frozen"),
             locked: args.is_present("locked"),
             offline: args.is_present("offline"),
+            preview: args.values_of_lossy("enable-preview").unwrap_or_default(),
             unstable_flags: args
                 .values_of_lossy("unstable-features")
                 .unwrap_or_default(),
@@ -350,6 +357,14 @@ See 'cargo help <command>' for more information on a specific command.\n",
                 "Override a configuration value (unstable)",
             )
             .global(true),
+        )
+        .arg(
+            Arg::with_name("enable-preview")
+                .help("Enable unstable (nightly-only) Cargo features or flags that are in preview on the stable toolchain")
+                .long("enable-preview")
+                .value_name("FEATURE_OR_FLAG")
+                .multiple(true)
+                .global(true),
         )
         .arg(
             Arg::with_name("unstable-features")

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -63,9 +63,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         compile_opts.build_config.export_dir = Some(out_dir);
     }
     if compile_opts.build_config.export_dir.is_some() {
-        config
-            .cli_unstable()
-            .fail_if_stable_opt("--out-dir", 6790)?;
+        config.fail_if_stable_opt("--out-dir", 6790)?;
     }
     ops::compile(&ws, &compile_opts)?;
     Ok(())

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -27,9 +27,7 @@ pub fn cli() -> App {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
-    config
-        .cli_unstable()
-        .fail_if_stable_command(config, "config", 9301)?;
+    config.fail_if_stable_command(config, "config", 9301)?;
     match args.subcommand() {
         ("get", Some(args)) => {
             let opts = cargo_config::GetOptions {

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -11,9 +11,7 @@ pub fn cli() -> App {
 
 pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if !config.cli_unstable().credential_process {
-        config
-            .cli_unstable()
-            .fail_if_stable_command(config, "logout", 8933)?;
+        config.fail_if_stable_command(config, "logout", 8933)?;
     }
     config.load_credentials()?;
     ops::registry_logout(config, args.value_of("registry").map(String::from))?;

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -73,9 +73,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         Some(target_args)
     };
     if let Some(opt_value) = args.value_of(PRINT_ARG_NAME) {
-        config
-            .cli_unstable()
-            .fail_if_stable_opt(PRINT_ARG_NAME, 8923)?;
+        config.fail_if_stable_opt(PRINT_ARG_NAME, 8923)?;
         ops::print(&ws, &compile_opts, opt_value)?;
     } else {
         ops::compile(&ws, &compile_opts)?;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -473,18 +473,13 @@ pub trait ArgMatchesExt {
         build_config.unit_graph = self._is_present("unit-graph");
         build_config.future_incompat_report = self._is_present("future-incompat-report");
         if build_config.build_plan {
-            config
-                .cli_unstable()
-                .fail_if_stable_opt("--build-plan", 5579)?;
+            config.fail_if_stable_opt("--build-plan", 5579)?;
         };
         if build_config.unit_graph {
-            config
-                .cli_unstable()
-                .fail_if_stable_opt("--unit-graph", 8002)?;
+            config.fail_if_stable_opt("--unit-graph", 8002)?;
         }
         if build_config.future_incompat_report {
             config
-                .cli_unstable()
                 // TODO: Tracking issue
                 .fail_if_stable_opt("--future-incompat-report", 9241)?;
 
@@ -519,9 +514,7 @@ pub trait ArgMatchesExt {
         };
 
         if !opts.honor_rust_version {
-            config
-                .cli_unstable()
-                .fail_if_stable_opt("--ignore-rust-version", 8072)?;
+            config.fail_if_stable_opt("--ignore-rust-version", 8072)?;
         }
 
         if let Some(ws) = workspace {

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -18,6 +18,7 @@ use std::path::{Path, PathBuf};
 pub struct ConfigBuilder {
     env: HashMap<String, String>,
     unstable: Vec<String>,
+    preview: Vec<String>,
     config_args: Vec<String>,
     cwd: Option<PathBuf>,
     enable_nightly_features: bool,
@@ -28,6 +29,7 @@ impl ConfigBuilder {
         ConfigBuilder {
             env: HashMap::new(),
             unstable: Vec::new(),
+            preview: Vec::new(),
             config_args: Vec::new(),
             cwd: None,
             enable_nightly_features: false,
@@ -37,6 +39,13 @@ impl ConfigBuilder {
     /// Passes a `-Z` flag.
     pub fn unstable_flag(&mut self, s: impl Into<String>) -> &mut Self {
         self.unstable.push(s.into());
+        self
+    }
+
+    /// Passes a `--enable-preview` flag.
+    #[allow(dead_code)]
+    pub fn enable_preview(&mut self, s: impl Into<String>) -> &mut Self {
+        self.preview.push(s.into());
         self
     }
 
@@ -54,7 +63,9 @@ impl ConfigBuilder {
 
     /// Passes a `--config` flag.
     pub fn config_arg(&mut self, arg: impl Into<String>) -> &mut Self {
-        if !self.unstable.iter().any(|s| s == "unstable-options") {
+        if !self.unstable.iter().any(|s| s == "unstable-options")
+            && !self.preview.iter().any(|s| s == "--config")
+        {
             // --config is current unstable
             self.unstable_flag("unstable-options");
         }
@@ -91,6 +102,7 @@ impl ConfigBuilder {
             false,
             false,
             &None,
+            &self.preview,
             &self.unstable,
             &self.config_args,
         )?;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -88,6 +88,7 @@ mod path;
 mod paths;
 mod pkgid;
 mod plugins;
+mod preview;
 mod proc_macro;
 mod profile_config;
 mod profile_custom;

--- a/tests/testsuite/preview.rs
+++ b/tests/testsuite/preview.rs
@@ -1,0 +1,130 @@
+//! Tests for preview features and options.
+
+use cargo_test_support::registry::Package;
+use cargo_test_support::{basic_manifest, project};
+
+#[cargo_test]
+fn option_config() {
+    // This is out_dir::out_dir_is_a_file, but without nightly.
+
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [enable-preview]
+                "--out-dir" = true
+        "#,
+        )
+        .file("out", "")
+        .build();
+
+    p.cargo("build --out-dir out")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] failed to create directory [..]")
+        .run();
+}
+
+#[cargo_test]
+fn option_out_dir() {
+    // This is out_dir::out_dir_is_a_file, but without nightly.
+
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .file("out", "")
+        .build();
+
+    p.cargo("build --enable-preview=--out-dir --out-dir out")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] failed to create directory [..]")
+        .run();
+}
+
+#[cargo_test]
+fn feature_config() {
+    // This is patch::from_config, but without nightly.
+
+    Package::new("bar", "0.1.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                bar = "0.1.0"
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [patch.crates-io]
+                bar = { path = 'bar' }
+
+                [enable-preview]
+                patch-in-config = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
+        .file("bar/src/lib.rs", r#""#)
+        .build();
+
+    p.cargo("build")
+        .with_stderr(
+            "\
+[UPDATING] `[ROOT][..]` index
+[COMPILING] bar v0.1.1 ([..])
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn feature_patch_in_config() {
+    // This is patch::from_config, but without nightly.
+
+    Package::new("bar", "0.1.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                bar = "0.1.0"
+            "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [patch.crates-io]
+                bar = { path = 'bar' }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.1"))
+        .file("bar/src/lib.rs", r#""#)
+        .build();
+
+    p.cargo("build --enable-preview=patch-in-config")
+        .with_stderr(
+            "\
+[UPDATING] `[ROOT][..]` index
+[COMPILING] bar v0.1.1 ([..])
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
This is an experimental implementation of a feature that adds _preview
features_ to Cargo. A preview feature is one that is still considered
unstable, but is available on stable/beta for testing behind a new flag,
`--enable-preview` that requires you explicitly enumerate the features
to enable.

The core idea is that the Cargo team would specifically designate
a small set (potentially zero at any given point in time) of features as
"available for preview", subject to criteria that ensure that a preview
period of a feature is both worthwile and won't cause undue breakage. A
rough framework for how to think of these was proposed in
https://internals.rust-lang.org/t/survey-of-high-impact-features/14536.

This implementation exists mainly to get feedback on whether the
approach taken here is reasonable from a code point-of-view. Before this
feature lands (if it does), it would have to go through an RFC process.

For the initial implementation, I have designated one unstable feature
(`patch-in-config`) and one unstable option (`--out-dir`) as "preview".
This choice was based on some of the internals discussion linked above,
but is in no way final.