### PR TITLE
use arg bin "Name" for install from git

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -82,10 +82,16 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         config.reload_rooted_at(config.home().clone().into_path_unlocked())?;
     }
 
-    let krates = args
+    let mut krates = args
         .values_of("crate")
         .unwrap_or_default()
         .collect::<Vec<_>>();
+
+    if krates.is_empty() && args.is_present("git") && args.is_present("bin") {
+        if let Some(bin) = args.value_of("bin") {
+            krates.push(bin);
+        }
+    }
 
     let mut from_cwd = false;
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -217,7 +217,7 @@ fn pick_max_version() {
 }
 
 #[cargo_test]
-fn installs_beta_version_by_explicit_name_from_git() {
+fn installs_beta_version_by_crate_name_from_git() {
     let p = git::repo(&paths::root().join("foo"))
         .file("Cargo.toml", &basic_manifest("foo", "0.3.0-beta.1"))
         .file("src/main.rs", "fn main() {}")
@@ -228,6 +228,24 @@ fn installs_beta_version_by_explicit_name_from_git() {
         .arg("foo")
         .run();
     assert_has_installed_exe(cargo_home(), "foo");
+}
+
+#[cargo_test]
+fn installs_beta_version_by_bin_name_from_git() {
+    let p = git::repo(&paths::root().join("foo"))
+        .file("Cargo.toml", &basic_manifest("foo", "0.3.0-beta.1"))
+        .file("src/main.rs", "fn main() {}")
+        .file("src/bar/Cargo.toml", &basic_manifest("bar", "0.3.0-beta.1"))
+        .file("src/bar/src/main.rs", "fn main() {}")
+        .build();
+
+    cargo_process("install --git")
+        .arg(p.url().to_string())
+        .arg("--bin")
+        .arg("bar")
+        .run();
+    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_has_installed_exe(cargo_home(), "bar");
 }
 
 #[cargo_test]
@@ -1245,7 +1263,7 @@ fn uninstall_multiple_and_specifying_bin() {
 }
 
 #[cargo_test]
-fn uninstall_with_empty_pakcage_option() {
+fn uninstall_with_empty_package_option() {
     cargo_process("uninstall -p")
         .with_status(101)
         .with_stderr(


### PR DESCRIPTION
This is to address fixes #4830.

I left existing functionality which uses crate arg when present.  But when crate is not present and bin name is specified it will now use the provided bin name.

I was going to fix the bins arg which is also not working but that proved to be significantly harder, and this is my first contribution.  