### PR TITLE
Add trim-path cargo manifest option

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -772,6 +772,7 @@ fn build_base_args(
         ref panic,
         incremental,
         strip,
+        trim_path,
         ..
     } = unit.profile;
     let test = unit.mode.is_any_test();
@@ -923,6 +924,15 @@ fn build_base_args(
 
     if strip != Strip::None {
         cmd.arg("-Z").arg(format!("strip={}", strip));
+    }
+
+    if let Some(trim_path) = trim_path {
+        let from = cx.bcx.ws.package_root();
+        let from = from.parent().unwrap_or(from);
+        let mut arg = from.as_os_str().to_os_string();
+        arg.push("=");
+        arg.push(trim_path);
+        cmd.arg("--remap-path-prefix").arg(arg);
     }
 
     if unit.is_std {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -385,6 +385,9 @@ features! {
     // Allow to specify whether binaries should be stripped.
     (unstable, strip, "", "reference/unstable.html#profile-strip-option"),
 
+    // Allow trimming the paths in debuginfo and macros.
+    (unstable, trimpath, "", "reference/unstable.html#profile-trim-path-option"),
+
     // Specifying a minimal 'rust-version' attribute for crates
     (unstable, rust_version, "", "reference/unstable.html#rust-version"),
 

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -611,6 +611,11 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
         Some(StringOrBool::String(ref n)) if is_off(n.as_str()) => Strip::None,
         Some(StringOrBool::String(ref n)) => Strip::Named(InternedString::new(n)),
     };
+    profile.trim_path = match toml.trim_path {
+        Some(StringOrBool::Bool(true)) => Some(InternedString::new("/")),
+        None | Some(StringOrBool::Bool(false)) => None,
+        Some(StringOrBool::String(ref n)) => Some(InternedString::new(n)),
+    }
 }
 
 /// The root profile (dev/release).
@@ -643,6 +648,7 @@ pub struct Profile {
     pub incremental: bool,
     pub panic: PanicStrategy,
     pub strip: Strip,
+    pub trim_path: Option<InternedString>,
 }
 
 impl Default for Profile {
@@ -661,6 +667,7 @@ impl Default for Profile {
             incremental: false,
             panic: PanicStrategy::Unwind,
             strip: Strip::None,
+            trim_path: None,
         }
     }
 }
@@ -687,6 +694,7 @@ compact_debug! {
                 incremental
                 panic
                 strip
+                trim_path
             )]
         }
     }
@@ -774,6 +782,7 @@ impl Profile {
             self.incremental,
             self.panic,
             self.strip,
+            self.trim_path,
         )
     }
 }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -342,6 +342,11 @@ impl<'cfg> Workspace<'cfg> {
             .unwrap_or(&self.current_manifest)
     }
 
+    /// Returns the current path to the package root
+    pub fn package_root(&self) -> &Path {
+        self.current_manifest.parent().unwrap()
+    }
+
     /// Returns the root Package or VirtualManifest.
     pub fn root_maybe(&self) -> &MaybePackage {
         self.packages.get(self.root_manifest())

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -443,6 +443,7 @@ pub struct TomlProfile {
     pub dir_name: Option<InternedString>,
     pub inherits: Option<InternedString>,
     pub strip: Option<StringOrBool>,
+    pub trim_path: Option<StringOrBool>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd, Hash)]
@@ -562,6 +563,11 @@ impl TomlProfile {
         if self.strip.is_some() {
             features.require(Feature::strip())?;
         }
+
+        if self.trim_path.is_some() {
+            features.require(Feature::trimpath())?;
+        }
+
         Ok(())
     }
 
@@ -688,6 +694,10 @@ impl TomlProfile {
 
         if let Some(v) = &profile.strip {
             self.strip = Some(v.clone());
+        }
+
+        if let Some(v) = &profile.trim_path {
+            self.trim_path = Some(v.clone());
         }
     }
 }

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -219,6 +219,24 @@ whether or not [`rpath`] is enabled.
 [`-C rpath` flag]: ../../rustc/codegen-options/index.html#rpath
 [`rpath`]: https://en.wikipedia.org/wiki/Rpath
 
+#### trim-path
+
+The `trim-path` setting controls the [`--remap-path-prefix` flag] to trim everything
+before the package root from debuginfo and macros.
+
+This option can either be a boolean or a string.
+
+* When this option is false, no paths are remapped.
+* When this option is true, the package root is trimmed from paths.
+* When this option is a string, the package root is trimmed from paths and the
+specifed string is preappended instead.
+
+This option is only available on the [nightly channel].
+
+[nightly channel]: ../../book/appendix-07-nightly-rust.html
+[`--remap-path-prefix` flag]:  ../../rustc/command-line-arguments.html#--remap-path-prefix-remap-source-names-in-output
+
+
 ### Default profiles
 
 #### dev
@@ -240,6 +258,7 @@ panic = 'unwind'
 incremental = true
 codegen-units = 256
 rpath = false
+trim-path = false
 ```
 
 #### release
@@ -262,6 +281,7 @@ panic = 'unwind'
 incremental = false
 codegen-units = 16
 rpath = false
+trim-path = false
 ```
 
 #### test
@@ -283,6 +303,7 @@ panic = 'unwind'    # This setting is always ignored.
 incremental = true
 codegen-units = 256
 rpath = false
+trim-path = false
 ```
 
 #### bench
@@ -304,6 +325,7 @@ panic = 'unwind'    # This setting is always ignored.
 incremental = false
 codegen-units = 16
 rpath = false
+trim-path = false
 ```
 
 #### Build Dependencies

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -79,7 +79,8 @@ fn simple() {
                     "incremental": false,
                     "panic": "unwind",
                     "strip": "none",
-                    "split_debuginfo": "{...}"
+                    "split_debuginfo": "{...}",
+                    "trim_path": null
                   },
                   "platform": null,
                   "mode": "build",
@@ -123,7 +124,8 @@ fn simple() {
                     "incremental": false,
                     "panic": "unwind",
                     "strip": "none",
-                    "split_debuginfo": "{...}"
+                    "split_debuginfo": "{...}",
+                    "trim_path": null
                   },
                   "platform": null,
                   "mode": "build",
@@ -167,7 +169,8 @@ fn simple() {
                     "incremental": false,
                     "panic": "unwind",
                     "strip": "none",
-                    "split_debuginfo": "{...}"
+                    "split_debuginfo": "{...}",
+                    "trim_path": null
                   },
                   "platform": null,
                   "mode": "build",
@@ -204,7 +207,8 @@ fn simple() {
                     "incremental": false,
                     "panic": "unwind",
                     "strip": "none",
-                    "split_debuginfo": "{...}"
+                    "split_debuginfo": "{...}",
+                    "trim_path": null
                   },
                   "platform": null,
                   "mode": "build",


### PR DESCRIPTION
This option uses rustc's --remap-path-prefix to trim everything above
the package root from the path prefix. Optionally you can also specify a
value to replace the path with.

For example, say you have a project in /home/projects/foo.

Without this option, the filepath for the main file would be:
/home/projects/foo/src/main.rs

By setting `trim-path = true` this becomes: foo/src/main.rs

By setting `trim-path = "/usr/lib/debug/` this becomes: /usr/lib/debug/foo/src/main.rs

This allows the user's home directory to be removed from paths in the
binary. And for distributions to point the paths to where they store
debug code.