### PR TITLE
Stabilize `[env]` sections

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -345,17 +345,15 @@ impl<'cfg> Compilation<'cfg> {
             .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
             .cwd(pkg.root());
 
-        if self.config.cli_unstable().configurable_env {
-            // Apply any environment variables from the config
-            for (key, value) in self.config.env_config()?.iter() {
-                // never override a value that has already been set by cargo
-                if cmd.get_envs().contains_key(key) {
-                    continue;
-                }
+        // Apply any environment variables from the config
+        for (key, value) in self.config.env_config()?.iter() {
+            // never override a value that has already been set by cargo
+            if cmd.get_envs().contains_key(key) {
+                continue;
+            }
 
-                if value.is_force() || env::var_os(key).is_none() {
-                    cmd.env(key, value.resolve(self.config));
-                }
+            if value.is_force() || env::var_os(key).is_none() {
+                cmd.env(key, value.resolve(self.config));
             }
         }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -627,7 +627,6 @@ unstable_cli_options!(
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
     config_include: bool = ("Enable the `include` key in config files"),
-    configurable_env: bool = ("Enable the [env] section in the .cargo/config.toml file"),
     credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
     doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
@@ -690,6 +689,8 @@ const STABILIZED_FEATURES: &str = "The new feature resolver is now available \
 
 const STABILIZED_EXTRA_LINK_ARG: &str = "Additional linker arguments are now \
     supported without passing this flag.";
+
+const STABILIZED_CONFIGURABLE_ENV: &str = "The [env] section is now always enabled.";
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
@@ -833,7 +834,6 @@ impl CliUnstable {
             "doctest-in-workspace" => self.doctest_in_workspace = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
-            "configurable-env" => self.configurable_env = parse_empty(k, v)?,
             "host-config" => self.host_config = parse_empty(k, v)?,
             "target-applies-to-host" => self.target_applies_to_host = parse_empty(k, v)?,
             "patch-in-config" => self.patch_in_config = parse_empty(k, v)?,
@@ -871,6 +871,7 @@ impl CliUnstable {
             "crate-versions" => stabilized_warn(k, "1.47", STABILIZED_CRATE_VERSIONS),
             "package-features" => stabilized_warn(k, "1.51", STABILIZED_PACKAGE_FEATURES),
             "extra-link-arg" => stabilized_warn(k, "1.56", STABILIZED_EXTRA_LINK_ARG),
+            "configurable-env" => stabilized_warn(k, "1.56", STABILIZED_CONFIGURABLE_ENV),
             "future-incompat-report" => self.future_incompat_report = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -79,6 +79,14 @@ pipelining = true             # rustc pipelining
 browser = "chromium"          # browser to use with `cargo doc --open`,
                               # overrides the `BROWSER` environment variable
 
+[env]
+# Set ENV_VAR_NAME=value for any process run by Cargo
+ENV_VAR_NAME = "value"
+# Set even if already present in environment
+ENV_VAR_NAME_2 = { value = "value", force = true }
+# Value is relative to .cargo directory containing `config.toml`, make absolute
+ENV_VAR_NAME_3 = { value = "relative/path", relative = true }
+
 [cargo-new]
 vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
 
@@ -468,6 +476,30 @@ Specifies the source control system to use for initializing a new repository.
 Valid values are `git`, `hg` (for Mercurial), `pijul`, `fossil` or `none` to
 disable this behavior. Defaults to `git`, or `none` if already inside a VCS
 repository. Can be overridden with the `--vcs` CLI option.
+
+### `[env]`
+
+The `[env]` section allows you to set additional environment variables for
+build scripts, rustc invocations, `cargo run` and `cargo build`.
+
+```toml
+[env]
+OPENSSL_DIR = "/opt/openssl"
+```
+
+By default, the variables specified will not override values that already exist
+in the environment. This behavior can be changed by setting the `force` flag.
+
+Setting the `relative` flag evaluates the value as a config-relative path that
+is relative to the parent directory of the `.cargo` directory that contains the
+`config.toml` file. The value of the environment variable will be the full
+absolute path.
+
+```toml
+[env]
+TMPDIR = { value = "/home/tmp", force = true }
+OPENSSL_DIR = { value = "vendor/openssl", relative = true }
+```
 
 #### `[http]`
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1234,33 +1234,6 @@ the `--future-incompat-report` flag. The developer should then update their
 dependencies to a version where the issue is fixed, or work with the
 developers of the dependencies to help resolve the issue.
 
-### configurable-env
-* Original Pull Request: [#9175](https://github.com/rust-lang/cargo/pull/9175)
-* Tracking Issue: [#9539](https://github.com/rust-lang/cargo/issues/9539)
-
-The `-Z configurable-env` flag enables the `[env]` section in the
-`.cargo/config.toml` file. This section allows you to set additional environment
-variables for build scripts, rustc invocations, `cargo run` and `cargo build`.
-
-```toml
-[env]
-OPENSSL_DIR = "/opt/openssl"
-```
-
-By default, the variables specified will not override values that already exist
-in the environment. This behavior can be changed by setting the `force` flag.
-
-Setting the `relative` flag evaluates the value as a config-relative path that
-is relative to the parent directory of the `.cargo` directory that contains the
-`config.toml` file. The value of the environment variable will be the full
-absolute path.
-
-```toml
-[env]
-TMPDIR = { value = "/home/tmp", force = true }
-OPENSSL_DIR = { value = "vendor/openssl", relative = true }
-```
-
 ### patch-in-config
 * Original Pull Request: [#9204](https://github.com/rust-lang/cargo/pull/9204)
 * Tracking Issue: [#9269](https://github.com/rust-lang/cargo/issues/9269)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1413,3 +1413,10 @@ The `extra-link-arg` feature to specify additional linker arguments in build
 scripts has been stabilized in the 1.56 release. See the [build script
 documentation](build-scripts.md#outputs-of-the-build-script) for more
 information on specifying extra linker arguments.
+
+### configurable-env
+
+The `configurable-env` feature to specify environment variables in Cargo
+configuration has been stabilized in the 1.56 release. See the [config
+documentation](config.html#env) for more information about configuring
+environment variables.

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -25,8 +25,7 @@ fn env_basic() {
         )
         .build();
 
-    p.cargo("run -Zconfigurable-env")
-        .masquerade_as_nightly_cargo()
+    p.cargo("run")
         .with_stdout_contains("compile-time:Hello")
         .with_stdout_contains("run-time:Hello")
         .run();
@@ -52,8 +51,7 @@ fn env_invalid() {
         )
         .build();
 
-    p.cargo("build -Zconfigurable-env")
-        .masquerade_as_nightly_cargo()
+    p.cargo("build")
         .with_status(101)
         .with_stderr_contains("[..]could not load config key `env.ENV_TEST_BOOL`")
         .run();
@@ -85,8 +83,7 @@ fn env_force() {
         )
         .build();
 
-    p.cargo("run -Zconfigurable-env")
-        .masquerade_as_nightly_cargo()
+    p.cargo("run")
         .env("ENV_TEST_FORCED", "from-env")
         .env("ENV_TEST_UNFORCED", "from-env")
         .env("ENV_TEST_UNFORCED_DEFAULT", "from-env")
@@ -127,9 +124,7 @@ fn env_relative() {
         )
         .build();
 
-    p.cargo("run -Zconfigurable-env")
-        .masquerade_as_nightly_cargo()
-        .run();
+    p.cargo("run").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
`[env]` sections seem to work as advertised.