### PR TITLE
pass extra args to rustdoc from `cargo doc`

### DIFF
--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -6,6 +6,7 @@ pub fn cli() -> App {
     subcommand("doc")
         .about("Build a package's documentation")
         .arg(opt("quiet", "No output printed to stdout").short("q"))
+        .arg(Arg::with_name("args").multiple(true).help("Rustdoc flags"))
         .arg(opt(
             "open",
             "Opens the docs in a browser after the operation",
@@ -43,6 +44,13 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     let mut compile_opts =
         args.compile_options(config, mode, Some(&ws), ProfileChecking::Checked)?;
     compile_opts.rustdoc_document_private_items = args.is_present("document-private-items");
+
+    let target_args = values(args, "args");
+    compile_opts.target_rustdoc_args = if target_args.is_empty() {
+        None
+    } else {
+        Some(target_args)
+    };
 
     let doc_opts = DocOptions {
         open_result: args.is_present("open"),

--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -7,12 +7,13 @@ cargo-doc - Build a package's documentation
 
 ## SYNOPSIS
 
-`cargo doc` [_options_]
+`cargo doc` [_options_] [`--` _args_]
 
 ## DESCRIPTION
 
 Build the documentation for the local package and all dependencies. The output
-is placed in `target/doc` in rustdoc's usual format.
+is placed in `target/doc` in rustdoc's usual format. The specified _args_ will
+all be passed to the final rustdoc invocation.
 
 ## OPTIONS
 


### PR DESCRIPTION
This PR allow passing args to `rustdoc` when running `cargo doc`.

My goal is to be able to run `cargo doc -- -D warnings` to fail on `rustdoc` warnings.

Code is very much copied from https://github.com/rust-lang/cargo/blob/d1baf0d81d0e4f91881de8e544c71fb49f623047/src/bin/cargo/commands/rustdoc.rs#L49-L54