### PR TITLE
extra-link-arg: support all link types

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -571,6 +571,27 @@ impl BuildOutput {
                         warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
                     }
                 }
+                "rustc-link-arg-tests" => {
+                    if extra_link_arg {
+                        linker_args.push((Some(LinkType::Test), value));
+                    } else {
+                        warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
+                    }
+                }
+                "rustc-link-arg-benches" => {
+                    if extra_link_arg {
+                        linker_args.push((Some(LinkType::Bench), value));
+                    } else {
+                        warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
+                    }
+                }
+                "rustc-link-arg-examples" => {
+                    if extra_link_arg {
+                        linker_args.push((Some(LinkType::Example), value));
+                    } else {
+                        warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
+                    }
+                }
                 "rustc-link-arg" => {
                     if extra_link_arg {
                         linker_args.push((None, value));

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -1,9 +1,9 @@
 //! Tests for -Zextra-link-arg.
 
-use cargo_test_support::{basic_bin_manifest, project};
+use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, project};
 
 #[cargo_test]
-fn build_script_extra_link_arg_bin() {
+fn build_script_extra_link_arg_bins() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
@@ -22,6 +22,81 @@ fn build_script_extra_link_arg_bin() {
         .without_status()
         .with_stderr_contains(
             "[RUNNING] `rustc --crate-name foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_script_extra_link_arg_tests() {
+    let p = project()
+        .file("Cargo.toml", &basic_lib_manifest("foo"))
+        .file("src/lib.rs", "")
+        .file("tests/test_foo.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-link-arg-tests=--this-is-a-bogus-flag");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("test -Zextra-link-arg -v")
+        .masquerade_as_nightly_cargo()
+        .without_status()
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name test_foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_script_extra_link_arg_benches() {
+    let p = project()
+        .file("Cargo.toml", &basic_lib_manifest("foo"))
+        .file("src/lib.rs", "")
+        .file("benches/bench_foo.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-link-arg-benches=--this-is-a-bogus-flag");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("bench -Zextra-link-arg -v")
+        .masquerade_as_nightly_cargo()
+        .without_status()
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name bench_foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn build_script_extra_link_arg_examples() {
+    let p = project()
+        .file("Cargo.toml", &basic_lib_manifest("foo"))
+        .file("src/lib.rs", "")
+        .file("examples/example_foo.rs", "fn main() {}")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:rustc-link-arg-examples=--this-is-a-bogus-flag");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("build -Zextra-link-arg -v --examples")
+        .masquerade_as_nightly_cargo()
+        .without_status()
+        .with_stderr_contains(
+            "[RUNNING] `rustc --crate-name example_foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
         )
         .run();
 }


### PR DESCRIPTION
This commit adds support for the remaining link types to `-Zextra-link-arg`:

```
rustc-link-arg-tests
rustc-link-arg-benches
rustc-link-arg-examples
```

This would be useful in PyO3, where users writing Python extension modules (which do link against libpython) want to run cargo tests for extension module. As executables, these tests need to link against libpython.