### PR TITLE
Always use full metadata hash for -C metadata.

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -391,9 +391,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// Returns the metadata hash for a RunCustomBuild unit.
     pub fn get_run_build_script_metadata(&self, unit: &Unit) -> Metadata {
         assert!(unit.mode.is_run_custom_build());
-        self.files()
-            .metadata(unit)
-            .expect("build script should always have hash")
+        self.files().metadata(unit)
     }
 
     pub fn is_primary_package(&self, unit: &Unit) -> bool {


### PR DESCRIPTION
This changes it so that cargo always uses the full metadata hash for `-C metadata`. This ensures that even if a unit isn't using `-C extra-filename` that the symbol hashing uses all the fields used in the other cases.

This fixes an issue on macOS where a combination of split-debuginfo and incremental caused the same `.o` filenames to be used, which caused corruption in the incremental cache (see issue for details).

Fixes #9353.