### PR TITLE
Only deny the `unused_mut` lint

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -553,7 +553,7 @@ fn fix_deny_warnings_but_not_others() {
         .file(
             "src/lib.rs",
             "
-                #![deny(warnings)]
+                #![deny(unused_mut)]
 
                 pub fn foo() -> u32 {
                     let mut x = 3;


### PR DESCRIPTION
This is needed for rust-lang/rust#83004 to pass CI.