### PR TITLE
Fix collision doc tests randomly failing.

### DIFF
--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -146,7 +146,7 @@ fn collision_doc() {
         .file("foo2/src/lib.rs", "")
         .build();
 
-    p.cargo("doc")
+    p.cargo("doc -j=1")
         .with_stderr_contains(
             "\
 [WARNING] output filename collision.
@@ -407,7 +407,7 @@ fn collision_doc_sources() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("doc")
+    p.cargo("doc -j=1")
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
@@ -524,7 +524,7 @@ fn collision_with_root() {
         .file("foo-macro/src/lib.rs", "")
         .build();
 
-    p.cargo("doc")
+    p.cargo("doc -j=1")
         .with_stderr_unordered("\
 [UPDATING] [..]
 [DOWNLOADING] crates ...


### PR DESCRIPTION
This fixes some tests that were randomly failing on CI. The cause is that #9419 added a remove_dir_all on the `doc` directory. However, if two jobs are trying to write to that directory at the same time, this can cause errors.  The failure rate is low (a little over 1%), and I was unable to reproduce locally (only on GitHub's CI and only on the Windows job). 

The solution is to run the jobs with -j1 so they run serially.

 I only saw errors for `collision_doc_sources`, but to be on the safe side I added j1 to similar tests.
