### PR TITLE
Fix #4482 and #9449: set Fossil ignore and clean settings locally

### DIFF
--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -95,21 +95,6 @@ impl FossilRepo {
             .arg(db_fname)
             .exec()?;
 
-        // set `target` as ignoreable and cleanable
-        ProcessBuilder::new("fossil")
-            .cwd(cwd)
-            .arg("settings")
-            .arg("ignore-glob")
-            .arg("target")
-            .exec()?;
-
-        ProcessBuilder::new("fossil")
-            .cwd(cwd)
-            .arg("settings")
-            .arg("clean-glob")
-            .arg("target")
-            .exec()?;
-
         Ok(FossilRepo)
     }
 }


### PR DESCRIPTION
This aims to close #4482 and close #9449.

Context: currently, the Fossil extension for `cargo new` would call `fossil settings [...]` in order to configure the created repository to ignore and allow cleaning the `target` build directory. However, as #9449 shows, it is ran from the CWD, which is probably outside of the repo, therefore it modifies global settings instead of local ones. This PR fixes that by writing the settings to local versioned files as the issue recommends.

Furthermore, as #9449 notes, configuring the repository's ignore settings only in `util::vcs::FossilRepo::init` means it is not done when the repository is not new and makes it harder to maintain equivalent support for VCS ignore system implementations. It also completely ignores the `--lib` CLI option which adds `Cargo.lock` to the ignore list for Git and Mercurial.

Therefore, the following modifications have been performed, using [the Fossil documentation](https://fossil-scm.org/home/doc/trunk/www/globs.md) as a reference for the ignore syntax:

 * All settings logic has been removed from `FossilRepo::init`.
 * `ops::cargo_new::IgnoreList::push` now requires a third argument for Fossil-specific glob syntax that is stored in a new `fossil_ignore` field.
 * `IgnoreList::format_new` uses the `fossil_ignore` field when needed just like any other VCS.
 * `IgnoreList::format_existing` handles Fossil separately for a few operations as its glob syntax does not support comments, so any lines starting with `#` cannot be included: the configurations can only be merged here.
 * `write_ignore_file` has been modified a bit as well to enable writing to two files for Fossil specifically in order to keep supporting its cleaning feature. The return type of the function is now `CargoResult<()>` instead `CargoResult<String>`: it makes the implementation easier and as the return value was actually not used, I figured it would be okay to do so, plus that return value would not make too much sense anymore for Fossil because of the two possibly different file contents.
 * `mk` has been updated to provide the correct ignore glob to `IgnoreList::push` for Fossil.