### PR TITLE
Improve two error messages

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -395,7 +395,7 @@ impl<'de> de::Deserialize<'de> for TomlOptLevel {
                     Ok(TomlOptLevel(value.to_string()))
                 } else {
                     Err(E::custom(format!(
-                        "must be an integer, `z`, or `s`, \
+                        "must be `0`, `1`, `2`, `3`, `s` or `z`, \
                          but found the string: \"{}\"",
                         value
                     )))
@@ -553,7 +553,7 @@ impl TomlProfile {
         if let Some(panic) = &self.panic {
             if panic != "unwind" && panic != "abort" {
                 bail!(
-                    "`panic` setting of `{}` is not a valid setting,\
+                    "`panic` setting of `{}` is not a valid setting, \
                      must be `unwind` or `abort`",
                     panic
                 );

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -583,7 +583,7 @@ opt-level = 'foo'
 error in [..]/.cargo/config: could not load config key `profile.dev.opt-level`
 
 Caused by:
-  must be an integer, `z`, or `s`, but found the string: \"foo\"",
+  must be `0`, `1`, `2`, `3`, `s` or `z`, but found the string: \"foo\"",
     );
 
     let config = ConfigBuilder::new()
@@ -596,7 +596,7 @@ Caused by:
 error in environment variable `CARGO_PROFILE_DEV_OPT_LEVEL`: could not load config key `profile.dev.opt-level`
 
 Caused by:
-  must be an integer, `z`, or `s`, but found the string: \"asdf\"",
+  must be `0`, `1`, `2`, `3`, `s` or `z`, but found the string: \"asdf\"",
     );
 }
 


### PR DESCRIPTION
The first error message saying "an integer" is confusing because if you give it `4` it's an integer but it will still complain that it must be an integer. So it's more specific now and tells you that it actually needs to be `1`, `2` or `3`.
In the second error there was a space missing. It says `is not a valid setting,must be`.