### PR TITLE
Bump index cache version to deal with semver metadata version mismatch.

### DIFF
--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -692,8 +692,16 @@ impl Summaries {
 // * `2`: Added the "index format version" field so that if the index format
 //   changes, different versions of cargo won't get confused reading each
 //   other's caches.
+// * `3`: Bumped the version to work around a issue where multiple versions of
+//   a package were published that differ only by semver metadata. For
+//   example, openssl-src 110.0.0 and 110.0.0+1.1.0f. Previously, the cache
+//   would be incorrectly populated with two entries, both 110.0.0. After
+//   this, the metadata will be correctly included. This isn't really a format
+//   change, just a version bump to clear the incorrect cache entries. Note:
+//   the index shouldn't allow these, but unfortunately crates.io doesn't
+//   check it.
 
-const CURRENT_CACHE_VERSION: u8 = 2;
+const CURRENT_CACHE_VERSION: u8 = 3;
 
 impl<'a> SummariesCache<'a> {
     fn parse(data: &'a [u8], last_index_update: &str) -> CargoResult<SummariesCache<'a>> {


### PR DESCRIPTION
#9467 has uncovered an issue with how versions are handled in the index cache.  When using a debug build of Cargo, it may panic due to the [cache contents changing](https://github.com/rust-lang/cargo/blob/5c455130b6001c7f54e872e161c27f6e996aff1f/src/cargo/sources/registry/index.rs#L606-L619).  The particular problem I am running into is that the index has an entry for `openssl-src 110.0.0` and `110.0.0+1.1.0f`. This is due to an issue with crates.io where it allows publishing multiple versions with the same metadata (https://github.com/rust-lang/crates.io/issues/1059).  Cargos before #9467 would populate the index cache with two entries, both with version `110.0.0`.  Afterwards, there are two separate entries (`110.0.0` and `110.0.0+1.1.0f`).

The change here is to bump the index cache version so that new versions of cargo will clear the cache, and won't trigger the assertion.

This may be a bit of a heavy-handed solution, as I think this only affects debug builds of cargo.  However, I instantly started running into this problem, so I suspect it will be a real annoyance for anyone developing cargo. Happy to discuss other possible solutions.
