### PR TITLE
Link to the new rustc tests chapter.

### DIFF
--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -19,9 +19,12 @@ the two dashes (`--`) are passed to the benchmark binaries and thus to
 _libtest_ (rustc's built in unit-test and micro-benchmarking framework). If
 you are passing arguments to both Cargo and the binary, the ones after `--` go
 to the binary, the ones before go to Cargo. For details about libtest's
-arguments see the output of `cargo bench -- --help`.  As an example, this will
-run only the benchmark named `foo` (and skip other similarly named benchmarks
-like `foobar`):
+arguments see the output of `cargo bench -- --help` and check out the rustc
+book's chapter on how tests work at
+<https://doc.rust-lang.org/rustc/tests/index.html>.
+
+As an example, this will run only the benchmark named `foo` (and skip other
+similarly named benchmarks like `foobar`):
 
     cargo bench -- foo --exact
 

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -19,7 +19,8 @@ dashes (`--`) are passed to the test binaries and thus to _libtest_ (rustc's
 built in unit-test and micro-benchmarking framework).  If you're passing
 arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.  For details about libtest's arguments see the
-output of `cargo test -- --help`.
+output of `cargo test -- --help` and check out the rustc book's chapter on
+how tests work at <https://doc.rust-lang.org/rustc/tests/index.html>.
 
 As an example, this will filter for tests with `foo` in their name and run them
 on 3 threads in parallel:

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -15,8 +15,11 @@ DESCRIPTION
        framework). If you are passing arguments to both Cargo and the binary,
        the ones after -- go to the binary, the ones before go to Cargo. For
        details about libtest's arguments see the output of cargo bench --
-       --help. As an example, this will run only the benchmark named foo (and
-       skip other similarly named benchmarks like foobar):
+       --help and check out the rustc book's chapter on how tests work at
+       <https://doc.rust-lang.org/rustc/tests/index.html>.
+
+       As an example, this will run only the benchmark named foo (and skip
+       other similarly named benchmarks like foobar):
 
            cargo bench -- foo --exact
 

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -14,7 +14,9 @@ DESCRIPTION
        (rustc's built in unit-test and micro-benchmarking framework). If you're
        passing arguments to both Cargo and the binary, the ones after -- go to
        the binary, the ones before go to Cargo. For details about libtest's
-       arguments see the output of cargo test -- --help.
+       arguments see the output of cargo test -- --help and check out the rustc
+       book's chapter on how tests work at
+       <https://doc.rust-lang.org/rustc/tests/index.html>.
 
        As an example, this will filter for tests with foo in their name and run
        them on 3 threads in parallel:

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -19,9 +19,12 @@ the two dashes (`--`) are passed to the benchmark binaries and thus to
 _libtest_ (rustc's built in unit-test and micro-benchmarking framework). If
 you are passing arguments to both Cargo and the binary, the ones after `--` go
 to the binary, the ones before go to Cargo. For details about libtest's
-arguments see the output of `cargo bench -- --help`.  As an example, this will
-run only the benchmark named `foo` (and skip other similarly named benchmarks
-like `foobar`):
+arguments see the output of `cargo bench -- --help` and check out the rustc
+book's chapter on how tests work at
+<https://doc.rust-lang.org/rustc/tests/index.html>.
+
+As an example, this will run only the benchmark named `foo` (and skip other
+similarly named benchmarks like `foobar`):
 
     cargo bench -- foo --exact
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -19,7 +19,8 @@ dashes (`--`) are passed to the test binaries and thus to _libtest_ (rustc's
 built in unit-test and micro-benchmarking framework).  If you're passing
 arguments to both Cargo and the binary, the ones after `--` go to the binary,
 the ones before go to Cargo.  For details about libtest's arguments see the
-output of `cargo test -- --help`.
+output of `cargo test -- --help` and check out the rustc book's chapter on
+how tests work at <https://doc.rust-lang.org/rustc/tests/index.html>.
 
 As an example, this will filter for tests with `foo` in their name and run them
 on 3 threads in parallel:

--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -94,11 +94,13 @@ There are two styles of tests within a Cargo project:
   access to its *public* API.
 
 Tests are run with the [`cargo test`] command. By default, Cargo and `rustc`
-use the libtest harness which is responsible for collecting functions
+use the [libtest harness] which is responsible for collecting functions
 annotated with the [`#[test]` attribute][test-attribute] and executing them in
 parallel, reporting the success and failure of each test. See [the `harness`
 field](#the-harness-field) if you want to use a different harness or test
 strategy.
+
+[libtest harness]: ../../rustc/tests/index.html
 
 #### Integration tests
 

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -15,9 +15,12 @@ the two dashes (\fB\-\-\fR) are passed to the benchmark binaries and thus to
 \fIlibtest\fR (rustc's built in unit\-test and micro\-benchmarking framework). If
 you are passing arguments to both Cargo and the binary, the ones after \fB\-\-\fR go
 to the binary, the ones before go to Cargo. For details about libtest's
-arguments see the output of \fBcargo bench \-\- \-\-help\fR\&.  As an example, this will
-run only the benchmark named \fBfoo\fR (and skip other similarly named benchmarks
-like \fBfoobar\fR):
+arguments see the output of \fBcargo bench \-\- \-\-help\fR and check out the rustc
+book's chapter on how tests work at
+<https://doc.rust\-lang.org/rustc/tests/index.html>\&.
+.sp
+As an example, this will run only the benchmark named \fBfoo\fR (and skip other
+similarly named benchmarks like \fBfoobar\fR):
 .sp
 .RS 4
 .nf

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -15,7 +15,8 @@ dashes (\fB\-\-\fR) are passed to the test binaries and thus to \fIlibtest\fR (r
 built in unit\-test and micro\-benchmarking framework).  If you're passing
 arguments to both Cargo and the binary, the ones after \fB\-\-\fR go to the binary,
 the ones before go to Cargo.  For details about libtest's arguments see the
-output of \fBcargo test \-\- \-\-help\fR\&.
+output of \fBcargo test \-\- \-\-help\fR and check out the rustc book's chapter on
+how tests work at <https://doc.rust\-lang.org/rustc/tests/index.html>\&.
 .sp
 As an example, this will filter for tests with \fBfoo\fR in their name and run them
 on 3 threads in parallel:


### PR DESCRIPTION
There's a new chapter in the rustc book on how the libtest harness works, and the command-line options it offers. This adds a few links to that new chapter in the cargo book.
