### PR TITLE
Improve performance of git status check in `cargo package`.

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2760,7 +2760,7 @@ to proceed despite [..]
     git::commit(&repo);
     git_project.cargo("package --no-verify").run();
     // Modify within nested submodule.
-    git_project.change_file("src/bar/mod.rs", "//test");
+    git_project.change_file("src/bar/new_file.rs", "//test");
     git_project
         .cargo("package --no-verify")
         .with_status(101)
@@ -2770,7 +2770,7 @@ to proceed despite [..]
 See [..]
 [ERROR] 1 files in the working directory contain changes that were not yet committed into git:
 
-src/bar/mod.rs
+src/bar/new_file.rs
 
 to proceed despite [..]
 ",


### PR DESCRIPTION
The check for a dirty repository during packaging/publishing is quite slow. It was calling `status_file` for every packaged file, which is very expensive. I have a directory that had about 10,000 untracked files. Previously, cargo would hang for over 2 minutes without any output. With this PR, it finishes in 0.3 seconds. 

The solution here is to collect the status information once, and then compare the package list against it. 

One subtle point is that it does not use `recurse_untracked_dirs`, and instead relies on a primitive `starts_with` comparison, which I believe should be equivalent.

This still includes an inefficient n^2 algorithm, but I am too lazy to make a better approach.

I'm moderately confident this is pretty much the same as before (at least, all the scenarios I could think of).
