### PR TITLE
`cargo tree -e no-proc-macro` to hide procedural macro dependencies

### DIFF
--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -205,6 +205,10 @@ subtree of the package given to -p.\n\
         no_proc_macro,
     };
 
+    if opts.graph_features && opts.duplicates {
+        return Err(format_err!("the `-e features` flag does not support `--duplicates`").into());
+    }
+
     tree::build_and_print(&ws, &opts)?;
     Ok(())
 }

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -8,7 +8,7 @@ use crate::core::{Package, PackageId, PackageIdSpec, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::{CargoResult, Config};
 use crate::{drop_print, drop_println};
-use anyhow::{bail, Context};
+use anyhow::Context;
 use graph::Graph;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
@@ -124,9 +124,6 @@ static ASCII_SYMBOLS: Symbols = Symbols {
 
 /// Entry point for the `cargo tree` command.
 pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()> {
-    if opts.graph_features && opts.duplicates {
-        bail!("the `-e features` flag does not support `--duplicates`");
-    }
     let requested_targets = match &opts.target {
         Target::All | Target::Host => Vec::new(),
         Target::Specific(t) => t.clone(),

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -102,8 +102,10 @@ The dependency kinds to display. Takes a comma separated list of values:
 - `no-normal` — Do not include normal dependencies.
 - `no-build` — Do not include build dependencies.
 - `no-dev` — Do not include development dependencies.
+- `no-proc-macro` — Do not include procedural macro dependencies.
 
-The `no-` prefixed options cannot be mixed with the other dependency kinds.
+The `normal`, `build`, `dev`, and `all` dependency kinds cannot be mixed with
+`no-normal`, `no-build`, or `no-dev` dependency kinds.
 
 The default is `normal,build,dev`.
 {{/option}}

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -99,8 +99,10 @@ OPTIONS
 
            o  no-dev — Do not include development dependencies.
 
-           The no- prefixed options cannot be mixed with the other dependency
-           kinds.
+           o  no-proc-macro — Do not include procedural macro dependencies.
+
+           The normal, build, dev, and all dependency kinds cannot be mixed
+           with no-normal, no-build, or no-dev dependency kinds.
 
            The default is normal,build,dev.
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -103,8 +103,10 @@ kind given, then it will automatically include the other dependency kinds.</li>
 <li><code>no-normal</code> — Do not include normal dependencies.</li>
 <li><code>no-build</code> — Do not include build dependencies.</li>
 <li><code>no-dev</code> — Do not include development dependencies.</li>
+<li><code>no-proc-macro</code> — Do not include procedural macro dependencies.</li>
 </ul>
-<p>The <code>no-</code> prefixed options cannot be mixed with the other dependency kinds.</p>
+<p>The <code>normal</code>, <code>build</code>, <code>dev</code>, and <code>all</code> dependency kinds cannot be mixed with
+<code>no-normal</code>, <code>no-build</code>, or <code>no-dev</code> dependency kinds.</p>
 <p>The default is <code>normal,build,dev</code>.</dd>
 
 

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -129,7 +129,12 @@ kind given, then it will automatically include the other dependency kinds.
 \h'-04'\(bu\h'+02'\fBno\-dev\fR \[em] Do not include development dependencies.
 .RE
 .sp
-The \fBno\-\fR prefixed options cannot be mixed with the other dependency kinds.
+.RS 4
+\h'-04'\(bu\h'+02'\fBno\-proc\-macro\fR \[em] Do not include procedural macro dependencies.
+.RE
+.sp
+The \fBnormal\fR, \fBbuild\fR, \fBdev\fR, and \fBall\fR dependency kinds cannot be mixed with
+\fBno\-normal\fR, \fBno\-build\fR, or \fBno\-dev\fR dependency kinds.
 .sp
 The default is \fBnormal,build,dev\fR\&.
 .RE


### PR DESCRIPTION
Probably resolves #9165 

`cargo tree -e no-proc-macro` now hides procedural macro dependencies. 

Note that when passed with `--invert <spec>`, the spec's reverse proc-macro dependencies are also hidden. Is this desired result?

