### PR TITLE
Add GitHub link to contributor guide.

### DIFF
--- a/src/doc/contrib/book.toml
+++ b/src/doc/contrib/book.toml
@@ -1,3 +1,6 @@
 [book]
 title = "Cargo Contributor Guide"
 authors = ["Eric Huss"]
+
+[output.html]
+git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/contrib/src"


### PR DESCRIPTION
This adds a small icon on each page that links back to the GitHub source.