### PR TITLE
3 typos and some capitalization

### DIFF
--- a/src/doc/src/faq.md
+++ b/src/doc/src/faq.md
@@ -165,7 +165,7 @@ are often surprised when Cargo attempts to fetch resources from the network, and
 hence the request for Cargo to work offline comes up frequently.
 
 Cargo, at its heart, will not attempt to access the network unless told to do
-so. That is, if no crates comes from crates.io, a git repository, or some other
+so. That is, if no crates come from crates.io, a git repository, or some other
 network location, Cargo will never attempt to make a network connection. As a
 result, if Cargo attempts to touch the network, then it's because it needs to
 fetch a required resource.
@@ -245,7 +245,7 @@ Some issues we've seen historically which can cause crates to get rebuilt are:
   uses timestamps on files to govern whether rebuilding needs to happen, but if
   you're using a nonstandard filesystem it may be affecting the timestamps
   somehow (e.g. truncating them, causing them to drift, etc). In this scenario,
-  feel free to open an issue and we can see if we can accomodate the filesystem
+  feel free to open an issue and we can see if we can accommodate the filesystem
   somehow.
 
 * A concurrent build process is either deleting artifacts or modifying files.

--- a/src/doc/src/faq.md
+++ b/src/doc/src/faq.md
@@ -125,7 +125,7 @@ compatibility). If Cargo used all of the dependencies' `Cargo.lock` files,
 then multiple copies of the library could be used, and perhaps even a version
 conflict.
 
-In other words, libraries specify semver requirements for their dependencies but
+In other words, libraries specify SemVer requirements for their dependencies but
 cannot see the full picture. Only end products like binaries have a full
 picture to decide what versions of dependencies should be used.
 

--- a/src/doc/src/guide/why-cargo-exists.md
+++ b/src/doc/src/guide/why-cargo-exists.md
@@ -55,7 +55,7 @@ invocation. Furthermore, Cargo will automatically fetch from a
 [*registry*][def-registry] any dependencies we have defined for our artifact,
 and arrange for them to be incorporated into our build as needed.
 
-It is only a slight exageration to say that once you know how to build one
+It is only a slight exaggeration to say that once you know how to build one
 Cargo-based project, you know how to build *all* of them.
 
 [def-artifact]:         ../appendix/glossary.md#artifact         '"artifact" (glossary entry)'

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -21,12 +21,12 @@ system:
 * `RUSTC` — Instead of running `rustc`, Cargo will execute this specified
   compiler instead. See [`build.rustc`] to set via config.
 * `RUSTC_WRAPPER` — Instead of simply running `rustc`, Cargo will execute this
-  specified wrapper instead, passing as its commandline arguments the rustc
+  specified wrapper instead, passing as its command-line arguments the rustc
   invocation, with the first argument being `rustc`. Useful to set up a build
   cache tool such as `sccache`. See [`build.rustc-wrapper`] to set via config.
 * `RUSTC_WORKSPACE_WRAPPER` — Instead of simply running `rustc`, Cargo will
   execute this specified wrapper instead for workspace members only, passing
-  as its commandline arguments the rustc invocation, with the first argument
+  as its command-line arguments the rustc invocation, with the first argument
   being `rustc`. It affects the filename hash so that artifacts produced by
   the wrapper are cached separately. See [`build.rustc-workspace-wrapper`]
   to set via config.

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -316,7 +316,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
 * `TARGET` — the target triple that is being compiled for. Native code should be
              compiled for this triple. See the [Target Triple] description
              for more information.
-* `HOST` — the host triple of the rust compiler.
+* `HOST` — the host triple of the Rust compiler.
 * `NUM_JOBS` — the parallelism specified as the top-level parallelism. This can
                be useful to pass a `-j` parameter to a system like `make`. Note
                that care should be taken when interpreting this environment

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -98,11 +98,11 @@ Versioning](https://semver.org/), so make sure you follow some basic rules:
 
 See the [Resolver] chapter for more information on how Cargo uses versions to
 resolve dependencies, and for guidelines on setting your own version. See the
-[Semver compatibility] chapter for more details on exactly what constitutes a
+[SemVer compatibility] chapter for more details on exactly what constitutes a
 breaking change.
 
 [Resolver]: resolver.md
-[Semver compatibility]: semver.md
+[SemVer compatibility]: semver.md
 
 <a id="the-authors-field-optional"></a>
 #### The `authors` field

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -207,7 +207,7 @@ generated if dev-dependencies are skipped.
 > versions for direct dependencies.
 
 When a `Cargo.lock` file is generated, the `-Z minimal-versions` flag will
-resolve the dependencies to the minimum semver version that will satisfy the
+resolve the dependencies to the minimum SemVer version that will satisfy the
 requirements (instead of the greatest version).
 
 The intended use-case of this flag is to check, during continuous integration,


### PR DESCRIPTION
3 typos and...

Most of the docs use "command-line" instead of "commandline", changed where it made sense (in plain text).

Most of the docs also use "SemVer" instead of "semver", changed for consistency except for the "semver trick" (consistent with context).

I believe these are the correct files to change, since none of these changes are in doc/man?