### PR TITLE
Add temporary fix for rustup on windows in CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,10 @@ jobs:
           other: i686-pc-windows-gnu
     steps:
     - uses: actions/checkout@v2
+    - name: Update Rustup (temporary workaround)
+      run: rustup self update
+      shell: bash
+      if: startsWith(matrix.os, 'windows')
     - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: rustup target add ${{ matrix.other }}
     - run: rustup component add rustc-dev llvm-tools-preview rust-docs


### PR DESCRIPTION
This adds a temporary fix for rustup on the Windows CI runners. The GitHub image updated to rustup 1.24.1 which has an issue (https://github.com/rust-lang/rustup/issues/2759) causing them to fail.  This is fixed in 1.24.2.  I believe the images are updated on roughly a weekly basis, and from what I can see the image just downloads the most recently release, so hopefully this will be fixed on GitHub's side in roughly a week. Until then, this will force rustup to update.

Note: Self updates aren't available on macOS images, but they seem to work on the others.
