### PR TITLE
Add additional test for CJK progress width

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -393,6 +393,11 @@ fn test_progress_status() {
         format.progress_status(3, 4, "：每個漢字佔據了兩個字元"),
         Some("[=============>     ] 3/4：每個漢字佔據了...".to_string())
     );
+    assert_eq!(
+        // handle breaking at middle of character
+        format.progress_status(3, 4, "：-每個漢字佔據了兩個字元"),
+        Some("[=============>     ] 3/4：-每個漢字佔據了...".to_string())
+    );
 }
 
 #[test]


### PR DESCRIPTION
Not clear if CJK test hit boundary, since CJK characters have double width,
if we show an example with an extra single width means one of them hit
character boundary to be able to test ellipsis handling.