### PR TITLE
Update tar dependency to 0.4.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"
 strip-ansi-escapes = "0.1.0"
-tar = { version = "0.4.26", default-features = false }
+tar = { version = "0.4.35", default-features = false }
 tempfile = "3.0"
 termcolor = "1.1"
 toml = "0.5.7"

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -537,6 +537,8 @@ fn tar(
                 header.set_entry_type(EntryType::file());
                 header.set_mode(0o644);
                 header.set_size(contents.len() as u64);
+                // use something nonzero to avoid rust-lang/cargo#9512
+                header.set_mtime(1);
                 header.set_cksum();
                 ar.append_data(&mut header, &ar_path, contents.as_bytes())
                     .with_context(|| format!("could not archive source file `{}`", rel_str))?;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -2000,9 +2000,10 @@ fn reproducible_output() {
     let mut archive = Archive::new(decoder);
     for ent in archive.entries().unwrap() {
         let ent = ent.unwrap();
+        println!("checking {:?}", ent.path());
         let header = ent.header();
         assert_eq!(header.mode().unwrap(), 0o644);
-        assert_eq!(header.mtime().unwrap(), 0);
+        assert!(header.mtime().unwrap() != 0);
         assert_eq!(header.username().unwrap().unwrap(), "");
         assert_eq!(header.groupname().unwrap().unwrap(), "");
     }


### PR DESCRIPTION
Pulls in a fix which should avoid 0 mtime files from showing up.

Closes #9512