### PR TITLE
Add some validation to rustc-link-arg

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -6,7 +6,7 @@ use crate::core::{profiles::ProfileRoot, PackageId};
 use crate::util::errors::CargoResult;
 use crate::util::machine_message::{self, Message};
 use crate::util::{internal, profile};
-use anyhow::Context as _;
+use anyhow::{bail, Context as _};
 use cargo_platform::Cfg;
 use cargo_util::paths;
 use std::collections::hash_map::{Entry, HashMap};
@@ -543,7 +543,7 @@ impl BuildOutput {
             let (key, value) = match (key, value) {
                 (Some(a), Some(b)) => (a, b.trim_end()),
                 // Line started with `cargo:` but didn't match `key=value`.
-                _ => anyhow::bail!("Wrong output in {}: `{}`", whence, line),
+                _ => bail!("Wrong output in {}: `{}`", whence, line),
             };
 
             // This will rewrite paths if the target directory has been moved.
@@ -552,7 +552,7 @@ impl BuildOutput {
                 script_out_dir.to_str().unwrap(),
             );
 
-            // Keep in sync with TargetConfig::new.
+            // Keep in sync with TargetConfig::parse_links_overrides.
             match key {
                 "rustc-flags" => {
                     let (paths, links) = BuildOutput::parse_rustc_flags(&value, &whence)?;
@@ -632,7 +632,7 @@ impl BuildOutput {
                         } else {
                             // Setting RUSTC_BOOTSTRAP would change the behavior of the crate.
                             // Abort with an error.
-                            anyhow::bail!("Cannot set `RUSTC_BOOTSTRAP={}` from {}.\n\
+                            bail!("Cannot set `RUSTC_BOOTSTRAP={}` from {}.\n\
                                 note: Crates cannot set `RUSTC_BOOTSTRAP` themselves, as doing so would subvert the stability guarantees of Rust for your project.\n\
                                 help: If you're sure you want to do this in your project, set the environment variable `RUSTC_BOOTSTRAP={}` before running cargo instead.",
                                 val,
@@ -683,7 +683,7 @@ impl BuildOutput {
                 if value.is_empty() {
                     value = match flags_iter.next() {
                         Some(v) => v,
-                        None => anyhow::bail! {
+                        None => bail! {
                             "Flag in rustc-flags has no value in {}: {}",
                             whence,
                             value
@@ -699,7 +699,7 @@ impl BuildOutput {
                     _ => unreachable!(),
                 };
             } else {
-                anyhow::bail!(
+                bail!(
                     "Only `-l` and `-L` flags are allowed in {}: `{}`",
                     whence,
                     value
@@ -715,7 +715,7 @@ impl BuildOutput {
         let val = iter.next();
         match (name, val) {
             (Some(n), Some(v)) => Ok((n.to_owned(), v.to_owned())),
-            _ => anyhow::bail!("Variable rustc-env has no value in {}: {}", whence, value),
+            _ => bail!("Variable rustc-env has no value in {}: {}", whence, value),
         }
     }
 }

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -165,4 +165,21 @@ The package foo v0.0.1 ([ROOT]/foo) does not have a bin target with the name `ab
 ",
         )
         .run();
+
+    p.change_file(
+        "build.rs",
+        r#"fn main() { println!("cargo:rustc-link-arg-bin=abc"); }"#,
+    );
+
+    p.cargo("check -Zextra-link-arg")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+error: invalid instruction `cargo:rustc-link-arg-bin=abc` from build script of `foo v0.0.1 ([ROOT]/foo)`
+The instruction should have the form cargo:rustc-link-arg-bin=BIN=ARG
+",
+        )
+        .run();
 }

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -113,3 +113,56 @@ fn build_script_extra_link_arg_warn_without_flag() {
         .with_stderr_contains("warning: cargo:rustc-link-arg requires -Zextra-link-arg flag")
         .run();
 }
+
+#[cargo_test]
+fn link_arg_missing_target() {
+    // Errors when a given target doesn't exist.
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"fn main() { println!("cargo:rustc-link-arg-cdylib=--bogus"); }"#,
+        )
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr("\
+[COMPILING] foo [..]
+error: invalid instruction `cargo:rustc-link-arg-cdylib` from build script of `foo v0.0.1 ([ROOT]/foo)`
+The package foo v0.0.1 ([ROOT]/foo) does not have a cdylib target.
+")
+        .run();
+
+    p.change_file(
+        "build.rs",
+        r#"fn main() { println!("cargo:rustc-link-arg-bins=--bogus"); }"#,
+    );
+
+    p.cargo("check -Zextra-link-arg")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr("\
+[COMPILING] foo [..]
+error: invalid instruction `cargo:rustc-link-arg-bins` from build script of `foo v0.0.1 ([ROOT]/foo)`
+The package foo v0.0.1 ([ROOT]/foo) does not have a bin target.
+")
+        .run();
+
+    p.change_file(
+        "build.rs",
+        r#"fn main() { println!("cargo:rustc-link-arg-bin=abc=--bogus"); }"#,
+    );
+
+    p.cargo("check -Zextra-link-arg")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+error: invalid instruction `cargo:rustc-link-arg-bin` from build script of `foo v0.0.1 ([ROOT]/foo)`
+The package foo v0.0.1 ([ROOT]/foo) does not have a bin target with the name `abc`.
+",
+        )
+        .run();
+}


### PR DESCRIPTION
This adds some validation, so that if a `cargo:rustc-link-arg-*` build script instruction specifies a target that doesn't exist, it will generate an error.  This also changes a parse warning to an error if the `=` is missing from BIN=ARG.

I intentionally did not bother to add the validation to config overrides, as it is a bit trickier to do, and that feature is very rarely used (AFAIK), and I'm uncertain if rustc-link-arg is really useful in that context.

cc #9426