### PR TITLE
Consolidate doc collision detection.

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -51,6 +51,9 @@ pub struct Compilation<'cfg> {
     /// An array of all cdylibs created.
     pub cdylibs: Vec<UnitOutput>,
 
+    /// The crate names of the root units specified on the command-line.
+    pub root_crate_names: Vec<String>,
+
     /// All directories for the output of native build commands.
     ///
     /// This is currently used to drive some entries which are added to the
@@ -136,6 +139,7 @@ impl<'cfg> Compilation<'cfg> {
             tests: Vec::new(),
             binaries: Vec::new(),
             cdylibs: Vec::new(),
+            root_crate_names: Vec::new(),
             extra_env: HashMap::new(),
             to_doc_test: Vec::new(),
             config: bcx.config,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -1092,6 +1092,9 @@ fn generate_targets(
     // It is computed by the set of enabled features for the package plus
     // every enabled feature of every enabled dependency.
     let mut features_map = HashMap::new();
+    // This needs to be a set to de-duplicate units. Due to the way the
+    // targets are filtered, it is possible to have duplicate proposals for
+    // the same thing.
     let mut units = HashSet::new();
     for Proposal {
         pkg,
@@ -1136,7 +1139,10 @@ fn generate_targets(
         }
         // else, silently skip target.
     }
-    Ok(units.into_iter().collect())
+    let mut units: Vec<_> = units.into_iter().collect();
+    // Keep the roots in a consistent order, which helps with checking test output.
+    units.sort_unstable();
+    Ok(units)
 }
 
 /// Warns if a target's required-features references a feature that doesn't exist.

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,12 +1,11 @@
-use crate::core::resolver::HasDevUnits;
 use crate::core::{Shell, Workspace};
 use crate::ops;
+use crate::util::config::PathAndArgs;
 use crate::util::CargoResult;
-use crate::{core::compiler::RustcTargetData, util::config::PathAndArgs};
 use serde::Deserialize;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
-use std::{collections::HashMap, path::PathBuf};
 
 /// Strongly typed options for the `cargo doc` command.
 #[derive(Debug)]
@@ -26,64 +25,11 @@ struct CargoDocConfig {
 
 /// Main method for `cargo doc`.
 pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
-    let specs = options.compile_opts.spec.to_package_id_specs(ws)?;
-    let target_data = RustcTargetData::new(ws, &options.compile_opts.build_config.requested_kinds)?;
-    let ws_resolve = ops::resolve_ws_with_opts(
-        ws,
-        &target_data,
-        &options.compile_opts.build_config.requested_kinds,
-        &options.compile_opts.cli_features,
-        &specs,
-        HasDevUnits::No,
-        crate::core::resolver::features::ForceAllTargets::No,
-    )?;
-
-    let ids = ws_resolve.targeted_resolve.specs_to_ids(&specs)?;
-    let pkgs = ws_resolve.pkg_set.get_many(ids)?;
-
-    let mut lib_names = HashMap::new();
-    let mut bin_names = HashMap::new();
-    let mut names = Vec::new();
-    for package in &pkgs {
-        for target in package.targets().iter().filter(|t| t.documented()) {
-            if target.is_lib() {
-                if let Some(prev) = lib_names.insert(target.crate_name(), package) {
-                    anyhow::bail!(
-                        "The library `{}` is specified by packages `{}` and \
-                         `{}` but can only be documented once. Consider renaming \
-                         or marking one of the targets as `doc = false`.",
-                        target.crate_name(),
-                        prev,
-                        package
-                    );
-                }
-            } else if let Some(prev) = bin_names.insert(target.crate_name(), package) {
-                anyhow::bail!(
-                    "The binary `{}` is specified by packages `{}` and \
-                     `{}` but can be documented only once. Consider renaming \
-                     or marking one of the targets as `doc = false`.",
-                    target.crate_name(),
-                    prev,
-                    package
-                );
-            }
-            names.push(target.crate_name());
-        }
-    }
-
-    let open_kind = if options.open_result {
-        Some(options.compile_opts.build_config.single_requested_kind()?)
-    } else {
-        None
-    };
-
     let compilation = ops::compile(ws, &options.compile_opts)?;
 
-    if let Some(kind) = open_kind {
-        let name = match names.first() {
-            Some(s) => s.to_string(),
-            None => return Ok(()),
-        };
+    if options.open_result {
+        let name = &compilation.root_crate_names[0];
+        let kind = options.compile_opts.build_config.single_requested_kind()?;
         let path = compilation.root_output[&kind]
             .with_file_name("doc")
             .join(&name)


### PR DESCRIPTION
This removes the separate collision detection pass (in cargo_doc.rs) and uses the global collision detection instead. This removes the separate pass for running the resolver (which resulted in running the resolver four times every time `cargo doc` was run).

The `--open` option needs to know which path to open, so this is passed in a roundabout way via `Compilation`. Since this method uses the root units, I added a sort on the roots so that the crate that is opened is consistent between runs. This results in some slight behavioral changes.

This also makes the collision check slightly more stringent. The test `doc_multiple_targets_same_name` now generates an error instead of a warning because the old code did not check for collisions between libs and bins across packages (which should be very rare).
