### PR TITLE
Fix `BorrowMutError` when calling `cargo doc --open`

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -2,7 +2,6 @@ use crate::core::{Shell, Workspace};
 use crate::ops;
 use crate::util::config::PathAndArgs;
 use crate::util::CargoResult;
-use serde::Deserialize;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -14,13 +13,6 @@ pub struct DocOptions {
     pub open_result: bool,
     /// Options to pass through to the compiler
     pub compile_opts: ops::CompileOptions,
-}
-
-#[derive(Deserialize)]
-struct CargoDocConfig {
-    /// Browser to use to open docs. If this is unset, the value of the environment variable
-    /// `BROWSER` will be used.
-    browser: Option<PathAndArgs>,
 }
 
 /// Main method for `cargo doc`.
@@ -36,10 +28,8 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
             .join("index.html");
         if path.exists() {
             let config_browser = {
-                let cfg = ws.config().get::<CargoDocConfig>("doc")?;
-
-                cfg.browser
-                    .map(|path_args| (path_args.path.resolve_program(ws.config()), path_args.args))
+                let cfg: Option<PathAndArgs> = ws.config().get("doc.browser")?;
+                cfg.map(|path_args| (path_args.path.resolve_program(ws.config()), path_args.args))
             };
 
             let mut shell = ws.config().shell();

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -35,15 +35,16 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
             .join(&name)
             .join("index.html");
         if path.exists() {
+            let config_browser = {
+                let cfg = ws.config().get::<CargoDocConfig>("doc")?;
+
+                cfg.browser
+                    .map(|path_args| (path_args.path.resolve_program(ws.config()), path_args.args))
+            };
+
             let mut shell = ws.config().shell();
             shell.status("Opening", path.display())?;
-            let cfg = ws.config().get::<CargoDocConfig>("doc")?;
-            open_docs(
-                &path,
-                &mut shell,
-                cfg.browser
-                    .map(|path_args| (path_args.path.resolve_program(ws.config()), path_args.args)),
-            )?;
+            open_docs(&path, &mut shell, config_browser)?;
         }
     }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1170,6 +1170,40 @@ fn doc_workspace_open_help_message() {
 
 #[cargo_test]
 #[cfg(not(windows))] // `echo` may not be available
+fn doc_extern_map_local() {
+    assert!(is_nightly());
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+        [doc.extern-map]
+        std = "local"
+    "#,
+    );
+
+
+    p.cargo("doc -Zrustdoc-map --open")
+        .env("BROWSER", "echo")
+        .masquerade_as_nightly_cargo()
+        .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
+        .with_stderr_does_not_contain("warning: unused config key `doc.extern-map` [..]")
+        .run();
+}
+
+#[cargo_test]
+#[cfg(not(windows))] // `echo` may not be available
 fn doc_workspace_open_different_library_and_package_names() {
     let p = project()
         .file(

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1171,7 +1171,10 @@ fn doc_workspace_open_help_message() {
 #[cargo_test]
 #[cfg(not(windows))] // `echo` may not be available
 fn doc_extern_map_local() {
-    assert!(is_nightly());
+    if !is_nightly() {
+        // -Zextern-html-root-url is unstable
+        return;
+    }
 
     let p = project()
         .file(
@@ -1183,21 +1186,20 @@ fn doc_extern_map_local() {
             "#,
         )
         .file("src/lib.rs", "")
+        .file(".cargo/config.toml", "doc.extern-map.std = 'local'")
         .build();
-
-    p.change_file(
-        ".cargo/config.toml",
-        r#"
-[doc.extern-map]
-std = "local"
-    "#,
-    );
 
     p.cargo("doc -v --no-deps -Zrustdoc-map --open")
         .env("BROWSER", "echo")
         .masquerade_as_nightly_cargo()
-        .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
-        .with_stderr_does_not_contain("warning: unused config key `doc.extern-map` [..]")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.1.0 [..]
+[RUNNING] `rustdoc --crate-type lib --crate-name foo src/lib.rs [..]--crate-version 0.1.0`
+[FINISHED] [..]
+     Opening [CWD]/target/doc/foo/index.html
+",
+        )
         .run();
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1188,13 +1188,12 @@ fn doc_extern_map_local() {
     p.change_file(
         ".cargo/config.toml",
         r#"
-        [doc.extern-map]
-        std = "local"
+[doc.extern-map]
+std = "local"
     "#,
     );
 
-
-    p.cargo("doc -Zrustdoc-map --open")
+    p.cargo("doc -v --no-deps -Zrustdoc-map --open")
         .env("BROWSER", "echo")
         .masquerade_as_nightly_cargo()
         .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")


### PR DESCRIPTION
~~I'm not sure why the existing test suite didn't catch this, it definitely calls `cargo doc --open`.~~

I had 

```toml
[doc.extern-map]
std = "local"
```

in my `.cargo/config.toml`. Will write a test case that sets that and then tries to run `cargo doc --open`.

Closes #9530 