### PR TITLE
Replace deprecated `[replace]` references with `[patch]`

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -480,7 +480,7 @@ never intended to support this feature, so for now this message is just a
 warning. In the future, however, this message will become a hard error.
 
 To change the dependency graph via an override it's recommended to use the
-`[replace]` feature of Cargo instead of the path override feature. This is
+`[patch]` feature of Cargo instead of the path override feature. This is
 documented online at the url below for more information.
 
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -183,7 +183,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
                      \n\
                      directory sources are not intended to be edited, if \
                      modifications are required then it is recommended \
-                     that [replace] is used with a forked copy of the \
+                     that `[patch]` is used with a forked copy of the \
                      source\
                      ",
                     file.display(),

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -472,7 +472,7 @@ expected: [..]
 actual:   [..]
 
 directory sources are not intended to be edited, if modifications are \
-required then it is recommended that [replace] is used with a forked copy of \
+required then it is recommended that `[patch]` is used with a forked copy of \
 the source
 ",
         )

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -65,7 +65,7 @@ never intended to support this feature, so for now this message is just a
 warning. In the future, however, this message will become a hard error.
 
 To change the dependency graph via an override it's recommended to use the
-`[replace]` feature of Cargo instead of the path override feature. This is
+`[patch]` feature of Cargo instead of the path override feature. This is
 documented online at the url below for more information.
 
 https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html


### PR DESCRIPTION
Cf. #7092.

Note: Untested, but given the changes I figure that if the testsuite passes it should be fairly safe.