### PR TITLE
Pull in semver 1.0.3 'x' fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ num_cpus = "1.0"
 opener = "0.4"
 percent-encoding = "2.0"
 rustfix = "0.5.0"
-semver = { version = "1.0", features = ["serde"] }
+semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }


### PR DESCRIPTION
As requested in https://github.com/rust-lang/rust/pull/85983#issuecomment-854682640 -- a Cargo.toml update to ensure Cargo-the-library users always get https://github.com/dtolnay/semver/pull/247. Fixes https://github.com/rust-lang/cargo/issues/9543.