### PR TITLE
Add a mean to mutably access the members of a workspace

### DIFF
--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -10,7 +10,7 @@ pub use self::resolver::{Resolve, ResolveVersion};
 pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};
-pub use self::workspace::{MaybePackage, Members, Workspace, WorkspaceConfig, WorkspaceRootConfig};
+pub use self::workspace::{MaybePackage, Workspace, WorkspaceConfig, WorkspaceRootConfig};
 
 pub mod compiler;
 pub mod dependency;

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -473,12 +473,52 @@ impl<'cfg> Workspace<'cfg> {
         }
     }
 
+    /// Returns a mutable iterator over all packages in this workspace
+    pub fn members_mut(&mut self) -> impl Iterator<Item = &mut Package> {
+        let packages = &mut self.packages.packages;
+        let members: HashSet<_> = self
+            .members
+            .iter()
+            .map(|path| path.parent().unwrap().to_owned())
+            .collect();
+
+        packages.iter_mut().filter_map(move |(path, package)| {
+            if members.contains(path) {
+                if let MaybePackage::Package(ref mut p) = package {
+                    return Some(p);
+                }
+            }
+
+            None
+        })
+    }
+
     /// Returns an iterator over default packages in this workspace
     pub fn default_members<'a>(&'a self) -> Members<'a, 'cfg> {
         Members {
             ws: self,
             iter: self.default_members.iter(),
         }
+    }
+
+    /// Returns an iterator over default packages in this workspace
+    pub fn default_members_mut(&mut self) -> impl Iterator<Item = &mut Package> {
+        let packages = &mut self.packages.packages;
+        let members: HashSet<_> = self
+            .default_members
+            .iter()
+            .map(|path| path.parent().unwrap().to_owned())
+            .collect();
+
+        packages.iter_mut().filter_map(move |(path, package)| {
+            if members.contains(path) {
+                if let MaybePackage::Package(ref mut p) = package {
+                    return Some(p);
+                }
+            }
+
+            None
+        })
     }
 
     /// Returns true if the package is a member of the workspace.


### PR DESCRIPTION
It is used by cargo-c to patch all the lib crates in a workspace.