### PR TITLE
Prioritize matching build metadata for '=' requirements

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -336,7 +336,7 @@ fn check_metadata(pkg: &Package, config: &Config) -> CargoResult<()> {
 // Checks that the package dependencies are safe to deploy.
 fn verify_dependencies(pkg: &Package) -> CargoResult<()> {
     for dep in pkg.dependencies() {
-        if dep.source_id().is_path() && !dep.specified_req() && dep.is_transitive() {
+        if dep.source_id().is_path() && dep.specified_req().is_none() && dep.is_transitive() {
             anyhow::bail!(
                 "all path dependencies must have a version specified \
                  when packaging.\ndependency `{}` does not specify \

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -139,7 +139,7 @@ fn verify_dependencies(
 ) -> CargoResult<()> {
     for dep in pkg.dependencies().iter() {
         if dep.source_id().is_path() || dep.source_id().is_git() {
-            if !dep.specified_req() {
+            if dep.specified_req().is_none() {
                 if !dep.is_transitive() {
                     // dev-dependencies will be stripped in TomlManifest::prepare_for_publish
                     continue;
@@ -202,7 +202,7 @@ fn transmit(
         .iter()
         .filter(|dep| {
             // Skip dev-dependency without version.
-            dep.is_transitive() || dep.specified_req()
+            dep.is_transitive() || dep.specified_req().is_some()
         })
         .map(|dep| {
             // If the dependency is from a different registry, then include the

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1718,7 +1718,11 @@ impl<P: ResolveToPath> DetailedTomlDependency<P> {
         }
 
         if let Some(version) = &self.version {
-            if version.contains('+') {
+            // Build metadata in the req is irrelevant except in the case of an
+            // exact req like `=1.0.0+metadata`.
+            if version.contains('+')
+                && !(version.trim_start().starts_with('=') && !version.contains(','))
+            {
                 cx.warnings.push(format!(
                     "version requirement `{}` for dependency `{}` \
                      includes semver metadata which will be ignored, removing the \

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -36,3 +36,38 @@ fn minimal_version_cli() {
 
     assert!(!lock.contains("1.1.0"));
 }
+
+#[cargo_test]
+fn same_version_different_metadata() {
+    Package::new("dep", "1.0.0+build1").publish();
+    Package::new("dep", "1.0.0+build2").publish();
+
+    for req in &["1.0.0", "1.0.0+irrelevant", "1.0.0+build2", "=1.0.0+build2"] {
+        let p = project()
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                        [package]
+                        name = "foo"
+                        version = "0.0.0"
+
+                        [dependencies]
+                        dep = "{}"
+                    "#,
+                    req,
+                ),
+            )
+            .file("src/main.rs", "fn main() {}")
+            .build();
+
+        p.cargo("generate-lockfile -Zminimal-versions")
+            .masquerade_as_nightly_cargo()
+            .run();
+
+        let lock = p.read_lockfile();
+
+        assert!(lock.contains("1.0.0+build1"));
+        assert!(!lock.contains("1.0.0+build2"));
+    }
+}

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -42,7 +42,17 @@ fn same_version_different_metadata() {
     Package::new("dep", "1.0.0+build1").publish();
     Package::new("dep", "1.0.0+build2").publish();
 
-    for req in &["1.0.0", "1.0.0+irrelevant", "1.0.0+build2", "=1.0.0+build2"] {
+    enum Dep {
+        Build1,
+        Build2,
+    }
+
+    for (req, expected_resolve) in &[
+        ("1.0.0", Dep::Build1),
+        ("1.0.0+irrelevant", Dep::Build1),
+        ("1.0.0+build2", Dep::Build1),
+        ("=1.0.0+build2", Dep::Build2),
+    ] {
         let p = project()
             .file(
                 "Cargo.toml",
@@ -67,7 +77,15 @@ fn same_version_different_metadata() {
 
         let lock = p.read_lockfile();
 
-        assert!(lock.contains("1.0.0+build1"));
-        assert!(!lock.contains("1.0.0+build2"));
+        match expected_resolve {
+            Dep::Build1 => {
+                assert!(lock.contains("1.0.0+build1"));
+                assert!(!lock.contains("1.0.0+build2"));
+            }
+            Dep::Build2 => {
+                assert!(!lock.contains("1.0.0+build1"));
+                assert!(lock.contains("1.0.0+build2"));
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR makes `lz4-sys = "=1.0.1+1.7.3"` resolve to https://crates.io/crates/lz4-sys/1.0.1+1.7.3 while `lz4-sys = "=1.0.1+1.7.5"` resolves to https://crates.io/crates/lz4-sys/1.0.1+1.7.5. Previously, build metadata in a requirement was irrelevant.

This is not in opposition to the semver ranges proto-spec, which has this to say:

> Implementations MAY reject Ranges with SemVer strings that include build metadata, but if they do not, then they MUST ignore any build metadata when evaluating versions for inclusion.

Build metadata continues to be ignored when evaluation versions for inclusion (i.e. whether a version is considered matching the version requirement). Build metadata only comes into play once there is a set of multiple matching versions that Cargo needs to choose among, which is not a behavior that is governed by the spec. Versions with a different build metadata **are still considered matching**, and one may use `cargo update --precise` to update among them.

### Examples:

<pre>
$ <b>tail Cargo.toml</b>
[dependencies]
lz4-sys = "=1.0.1+1.7.3"

$ <b>cargo generate-lockfile</b>   <kbd>resolves to 1.0.1+1.7.3</kbd>

$ <b>cargo update -p lz4-sys --precise 1.0.1+1.7.5</b>   <kbd>okay</kbd>
</pre>

<pre>
$ <b>tail Cargo.toml</b>
[dependencies]
lz4-sys = "=1.0.1+1.7.5"

$ <b>cargo generate-lockfile</b>   <kbd>resolves to 1.0.1+1.7.5</kbd>

$ <b>cargo update -p lz4-sys --precise 1.0.1+1.7.3</b>   <kbd>okay (also a match)</kbd>
</pre>

<pre>
$ <b>tail Cargo.toml</b>
[dependencies]
lz4-sys = "=1.0.1+asdf"

$ <b>cargo generate-lockfile</b>   <kbd>resolves to 1.0.1+1.7.5</kbd>

$ <b>cargo generate-lockfile -Z minimal-versions</b>   <kbd>resolves to 1.0.1+1.7.3</kbd>
</pre>