### PR TITLE
Warn if an "all" target is specified, but we don't match anything

### DIFF
--- a/tests/testsuite/cargo_targets.rs
+++ b/tests/testsuite/cargo_targets.rs
@@ -3,6 +3,35 @@
 use cargo_test_support::project;
 
 #[cargo_test]
+fn warn_unmatched_target_filters() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        [package]
+        name = "foo"
+        version = "0.1.0"
+
+        [lib]
+        test = false
+        bench = false
+        "#,
+        )
+        .file("src/lib.rs", r#"fn main() {}"#)
+        .build();
+
+    p.cargo("check --tests --bins --examples --benches")
+        .with_stderr(
+            "\
+[WARNING] Target filters `bins`, `tests`, `examples`, `benches` specified, \
+but no targets matched. This is a no-op
+[FINISHED][..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn reserved_windows_target_name() {
     let p = project()
         .file(


### PR DESCRIPTION
If a combination of --bins, --benches, --examples, --tests flags have
been specified, but we didn't match on anything after resolving the unit-list,
we emit a warning to make it clear that cargo didn't do anything and that the
code is unchecked.

This is my first PR and there are a couple things that I'm unsure about
* The integration test covers only one case (ideally it should cover every combination of the above mentioned flags the user can pass). I figured since the warning function is so simple, it'd best not to clog the testsuite with unnecessary `p.cargo().runs()` and whatnot. If I should make the test more comprehensive I can do that, it's also very easy to write unit tests so i can do that as well if needed.
* I figure we don't actually have to check the `--all-targets`, but i'm doing so for consistency. I also didn't check for the `--lib` flag at all because (I'm assuming) if the user passes `--lib` and there are no libraries, we error. 
Edit: I notice (among other things) we sometimes silently skip certain units that have incompatible feature flags (see [here](https://github.com/rust-lang/cargo/blob/ed0c8c6d66e36fafbce4f78907a110838797ae39/src/cargo/ops/cargo_compile.rs#L1140)) so maybe we should be checking the `--lib` flag after all, in the event that a library was silently skipped and we no-opped :thinking:

And thanks to @ehuss for taking the time to answer my questions and helping me through the contribution process, much appreciated

Closes #9536