### PR TITLE
Fix typo in gitignore docs.

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -416,7 +416,7 @@ The patterns should be [gitignore]-style patterns. Briefly:
   `foo`.
 - `/**/` matches zero or more directories. For example, `a/**/b` matches
   `a/b`, `a/x/b`, `a/x/y/b`, and so on.
-- `!` prefix negates a pattern. For example, a pattern of `src/**.rs` and
+- `!` prefix negates a pattern. For example, a pattern of `src/*.rs` and
   `!foo.rs` would match all files with the `.rs` extension inside the `src`
   directory, except for any file named `foo.rs`.
 


### PR DESCRIPTION
`**.ext` is collapsed to `*.ext` by git.
