### PR TITLE
Stabilize the rustc-link-arg option

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -315,7 +315,6 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     paths::create_dir_all(&script_dir)?;
     paths::create_dir_all(&script_out_dir)?;
 
-    let extra_link_arg = cx.bcx.config.cli_unstable().extra_link_arg;
     let nightly_features_allowed = cx.bcx.config.nightly_features_allowed;
     let targets: Vec<Target> = unit.pkg.targets().to_vec();
     // Need a separate copy for the fresh closure.
@@ -427,7 +426,6 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
             &pkg_descr,
             &script_out_dir,
             &script_out_dir,
-            extra_link_arg,
             nightly_features_allowed,
             &targets,
         )?;
@@ -455,7 +453,6 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
                 &pkg_descr,
                 &prev_script_out_dir,
                 &script_out_dir,
-                extra_link_arg,
                 nightly_features_allowed,
                 &targets_fresh,
             )?,
@@ -508,7 +505,6 @@ impl BuildOutput {
         pkg_descr: &str,
         script_out_dir_when_generated: &Path,
         script_out_dir: &Path,
-        extra_link_arg: bool,
         nightly_features_allowed: bool,
         targets: &[Target],
     ) -> CargoResult<BuildOutput> {
@@ -519,7 +515,6 @@ impl BuildOutput {
             pkg_descr,
             script_out_dir_when_generated,
             script_out_dir,
-            extra_link_arg,
             nightly_features_allowed,
             targets,
         )
@@ -535,7 +530,6 @@ impl BuildOutput {
         pkg_descr: &str,
         script_out_dir_when_generated: &Path,
         script_out_dir: &Path,
-        extra_link_arg: bool,
         nightly_features_allowed: bool,
         targets: &[Target],
     ) -> CargoResult<BuildOutput> {
@@ -606,59 +600,47 @@ impl BuildOutput {
                     linker_args.push((LinkType::Cdylib, value))
                 }
                 "rustc-link-arg-bins" => {
-                    if extra_link_arg {
-                        if !targets.iter().any(|target| target.is_bin()) {
-                            bail!(
-                                "invalid instruction `cargo:{}` from {}\n\
-                                 The package {} does not have a bin target.",
-                                key,
-                                whence,
-                                pkg_descr
-                            );
-                        }
-                        linker_args.push((LinkType::Bin, value));
-                    } else {
-                        warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
+                    if !targets.iter().any(|target| target.is_bin()) {
+                        bail!(
+                            "invalid instruction `cargo:{}` from {}\n\
+                                The package {} does not have a bin target.",
+                            key,
+                            whence,
+                            pkg_descr
+                        );
                     }
+                    linker_args.push((LinkType::Bin, value));
                 }
                 "rustc-link-arg-bin" => {
-                    if extra_link_arg {
-                        let mut parts = value.splitn(2, '=');
-                        let bin_name = parts.next().unwrap().to_string();
-                        let arg = parts.next().ok_or_else(|| {
-                            anyhow::format_err!(
-                                "invalid instruction `cargo:{}={}` from {}\n\
-                                 The instruction should have the form cargo:{}=BIN=ARG",
-                                key,
-                                value,
-                                whence,
-                                key
-                            )
-                        })?;
-                        if !targets
-                            .iter()
-                            .any(|target| target.is_bin() && target.name() == bin_name)
-                        {
-                            bail!(
-                                "invalid instruction `cargo:{}` from {}\n\
-                                 The package {} does not have a bin target with the name `{}`.",
-                                key,
-                                whence,
-                                pkg_descr,
-                                bin_name
-                            );
-                        }
-                        linker_args.push((LinkType::SingleBin(bin_name), arg.to_string()));
-                    } else {
-                        warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
+                    let mut parts = value.splitn(2, '=');
+                    let bin_name = parts.next().unwrap().to_string();
+                    let arg = parts.next().ok_or_else(|| {
+                        anyhow::format_err!(
+                            "invalid instruction `cargo:{}={}` from {}\n\
+                                The instruction should have the form cargo:{}=BIN=ARG",
+                            key,
+                            value,
+                            whence,
+                            key
+                        )
+                    })?;
+                    if !targets
+                        .iter()
+                        .any(|target| target.is_bin() && target.name() == bin_name)
+                    {
+                        bail!(
+                            "invalid instruction `cargo:{}` from {}\n\
+                                The package {} does not have a bin target with the name `{}`.",
+                            key,
+                            whence,
+                            pkg_descr,
+                            bin_name
+                        );
                     }
+                    linker_args.push((LinkType::SingleBin(bin_name), arg.to_string()));
                 }
                 "rustc-link-arg" => {
-                    if extra_link_arg {
-                        linker_args.push((LinkType::All, value));
-                    } else {
-                        warnings.push(format!("cargo:{} requires -Zextra-link-arg flag", key));
-                    }
+                    linker_args.push((LinkType::All, value));
                 }
                 "rustc-cfg" => cfgs.push(value.to_string()),
                 "rustc-env" => {
@@ -953,8 +935,6 @@ fn prev_build_output(cx: &mut Context<'_, '_>, unit: &Unit) -> (Option<BuildOutp
         .and_then(|bytes| paths::bytes2path(&bytes))
         .unwrap_or_else(|_| script_out_dir.clone());
 
-    let extra_link_arg = cx.bcx.config.cli_unstable().extra_link_arg;
-
     (
         BuildOutput::parse_file(
             &output_file,
@@ -962,7 +942,6 @@ fn prev_build_output(cx: &mut Context<'_, '_>, unit: &Unit) -> (Option<BuildOutp
             &unit.pkg.to_string(),
             &prev_script_out_dir,
             &script_out_dir,
-            extra_link_arg,
             cx.bcx.config.nightly_features_allowed,
             unit.pkg.targets(),
         )

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -633,7 +633,6 @@ unstable_cli_options!(
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
     future_incompat_report: bool = ("Enable creation of a future-incompat report for all dependencies"),
-    extra_link_arg: bool = ("Allow `cargo:rustc-link-arg` in build scripts"),
     features: Option<Vec<String>>  = (HIDDEN),
     jobserver_per_rustc: bool = (HIDDEN),
     minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
@@ -688,6 +687,9 @@ const STABILIZED_FEATURES: &str = "The new feature resolver is now available \
     by specifying `resolver = \"2\"` in Cargo.toml.\n\
     See https://doc.rust-lang.org/nightly/cargo/reference/features.html#feature-resolver-version-2 \
     for more information.";
+
+const STABILIZED_EXTRA_LINK_ARG: &str = "Additional linker arguments are now \
+    supported without passing this flag.";
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
@@ -859,7 +861,6 @@ impl CliUnstable {
             "terminal-width" => self.terminal_width = Some(parse_usize_opt(v)?),
             "namespaced-features" => self.namespaced_features = parse_empty(k, v)?,
             "weak-dep-features" => self.weak_dep_features = parse_empty(k, v)?,
-            "extra-link-arg" => self.extra_link_arg = parse_empty(k, v)?,
             "credential-process" => self.credential_process = parse_empty(k, v)?,
             "skip-rustdoc-fingerprint" => self.skip_rustdoc_fingerprint = parse_empty(k, v)?,
             "compile-progress" => stabilized_warn(k, "1.30", STABILIZED_COMPILE_PROGRESS),
@@ -869,6 +870,7 @@ impl CliUnstable {
             "config-profile" => stabilized_warn(k, "1.43", STABILIZED_CONFIG_PROFILE),
             "crate-versions" => stabilized_warn(k, "1.47", STABILIZED_CRATE_VERSIONS),
             "package-features" => stabilized_warn(k, "1.51", STABILIZED_PACKAGE_FEATURES),
+            "extra-link-arg" => stabilized_warn(k, "1.56", STABILIZED_EXTRA_LINK_ARG),
             "future-incompat-report" => self.future_incompat_report = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -121,7 +121,7 @@ fn load_config_table(config: &Config, prefix: &str) -> CargoResult<TargetConfig>
     // Links do not support environment variables.
     let target_key = ConfigKey::from_str(prefix);
     let links_overrides = match config.get_table(&target_key)? {
-        Some(links) => parse_links_overrides(&target_key, links.val, config)?,
+        Some(links) => parse_links_overrides(&target_key, links.val)?,
         None => BTreeMap::new(),
     };
     Ok(TargetConfig {
@@ -135,10 +135,7 @@ fn load_config_table(config: &Config, prefix: &str) -> CargoResult<TargetConfig>
 fn parse_links_overrides(
     target_key: &ConfigKey,
     links: HashMap<String, CV>,
-    config: &Config,
 ) -> CargoResult<BTreeMap<String, BuildOutput>> {
-    let extra_link_arg = config.cli_unstable().extra_link_arg;
-
     let mut links_overrides = BTreeMap::new();
     for (lib_name, value) in links {
         // Skip these keys, it shares the namespace with `TargetConfig`.
@@ -182,28 +179,14 @@ fn parse_links_overrides(
                     output.linker_args.extend(args);
                 }
                 "rustc-link-arg-bins" => {
-                    if extra_link_arg {
-                        let args = value.list(key)?;
-                        let args = args.iter().map(|v| (LinkType::Bin, v.0.clone()));
-                        output.linker_args.extend(args);
-                    } else {
-                        config.shell().warn(format!(
-                            "target config `{}.{}` requires -Zextra-link-arg flag",
-                            target_key, key
-                        ))?;
-                    }
+                    let args = value.list(key)?;
+                    let args = args.iter().map(|v| (LinkType::Bin, v.0.clone()));
+                    output.linker_args.extend(args);
                 }
                 "rustc-link-arg" => {
-                    if extra_link_arg {
-                        let args = value.list(key)?;
-                        let args = args.iter().map(|v| (LinkType::All, v.0.clone()));
-                        output.linker_args.extend(args);
-                    } else {
-                        config.shell().warn(format!(
-                            "target config `{}.{}` requires -Zextra-link-arg flag",
-                            target_key, key
-                        ))?;
-                    }
+                    let args = value.list(key)?;
+                    let args = args.iter().map(|v| (LinkType::All, v.0.clone()));
+                    output.linker_args.extend(args);
                 }
                 "rustc-cfg" => {
                     let list = value.list(key)?;

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -94,6 +94,12 @@ one detailed below.
   re-run the script.
 * [`cargo:rerun-if-env-changed=VAR`](#rerun-if-env-changed) — Tells Cargo when
   to re-run the script.
+* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) – Passes custom flags to a
+  linker for benchmarks, binaries, `cdylib` crates, examples, and tests.
+* [`cargo:rustc-link-arg-bin=BIN=FLAG`](#rustc-link-arg-bin) – Passes custom
+  flags to a linker for the binary `BIN`.
+* [`cargo:rustc-link-arg-bins=FLAG`](#rustc-link-arg-bins) – Passes custom
+  flags to a linker for binaries.
 * [`cargo:rustc-link-lib=[KIND=]NAME`](#rustc-link-lib) — Adds a library to
   link.
 * [`cargo:rustc-link-search=[KIND=]PATH`](#rustc-link-search) — Adds to the
@@ -109,6 +115,38 @@ one detailed below.
   terminal.
 * [`cargo:KEY=VALUE`](#the-links-manifest-key) — Metadata, used by `links`
   scripts.
+
+
+<a id="rustc-link-arg"></a>
+#### `cargo:rustc-link-arg=FLAG`
+
+The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
+option][link-arg] to the compiler, but only when building supported targets
+(benchmarks, binaries, `cdylib` crates, examples, and tests). Its usage is
+highly platform specific. It is useful to set the shared library version or
+linker script.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-link-arg-bin"></a>
+#### `cargo:rustc-link-arg-bin=BIN=FLAG`
+
+The `rustc-link-arg-bin` instruction tells Cargo to pass the [`-C
+link-arg=FLAG` option][link-arg] to the compiler, but only when building
+the binary target with name `BIN`. Its usage is highly platform specific. It is useful
+to set a linker script or other linker options.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
+
+<a id="rustc-link-arg-bins"></a>
+#### `cargo:rustc-link-arg-bins=FLAG`
+
+The `rustc-link-arg-bins` instruction tells Cargo to pass the [`-C
+link-arg=FLAG` option][link-arg] to the compiler, but only when building a
+binary target. Its usage is highly platform specific. It is useful
+to set a linker script or other linker options.
+
+[link-arg]: ../../rustc/codegen-options/index.md#link-arg
 
 <a id="rustc-link-lib"></a>
 #### `cargo:rustc-link-lib=[KIND=]NAME`

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -63,7 +63,6 @@ Each new feature described below should explain how to use it.
 * Unstable-specific features
     * [-Z allow-features](#allow-features) — Provides a way to restrict which unstable features are used.
 * Build scripts and linking
-    * [extra-link-arg](#extra-link-arg) — Allows build scripts to pass extra link arguments in more cases.
     * [Metabuild](#metabuild) — Provides declarative build scripts.
 * Resolver and features
     * [no-index-update](#no-index-update) — Prevents cargo from updating the index cache.
@@ -132,51 +131,6 @@ The list of features passed to cargo's `-Zallow-features` is also passed
 to any Rust tools that cargo ends up calling (like `rustc` or
 `rustdoc`). Thus, if you run `cargo -Zallow-features=`, no unstable
 Cargo _or_ Rust features can be used.
-
-### extra-link-arg
-* Tracking Issue: [#9426](https://github.com/rust-lang/cargo/issues/9426)
-* Original Pull Request: [#7811](https://github.com/rust-lang/cargo/pull/7811)
-
-The `-Z extra-link-arg` flag makes the following instructions available
-in build scripts:
-
-* [`cargo:rustc-link-arg-bins=FLAG`](#rustc-link-arg-bins) – Passes custom
-  flags to a linker for binaries.
-* [`cargo:rustc-link-arg-bin=BIN=FLAG`](#rustc-link-arg-bin) – Passes custom
-  flags to a linker for the binary `BIN`.
-* [`cargo:rustc-link-arg=FLAG`](#rustc-link-arg) – Passes custom flags to a
-  linker for benchmarks, binaries, `cdylib` crates, examples, and tests.
-
-<a id="rustc-link-arg-bins"></a>
-#### `cargo:rustc-link-arg-bins=FLAG`
-
-The `rustc-link-arg-bins` instruction tells Cargo to pass the [`-C
-link-arg=FLAG` option][link-arg] to the compiler, but only when building a
-binary target. Its usage is highly platform specific. It is useful
-to set a linker script or other linker options.
-
-[link-arg]: ../../rustc/codegen-options/index.md#link-arg
-
-<a id="rustc-link-arg-bin"></a>
-#### `cargo:rustc-link-arg-bin=BIN=FLAG`
-
-The `rustc-link-arg-bin` instruction tells Cargo to pass the [`-C
-link-arg=FLAG` option][link-arg] to the compiler, but only when building
-the binary target with name `BIN`. Its usage is highly platform specific. It is useful
-to set a linker script or other linker options.
-
-[link-arg]: ../../rustc/codegen-options/index.md#link-arg
-
-<a id="rustc-link-arg"></a>
-#### `cargo:rustc-link-arg=FLAG`
-
-The `rustc-link-arg` instruction tells Cargo to pass the [`-C link-arg=FLAG`
-option][link-arg] to the compiler, but only when building supported targets
-(benchmarks, binaries, `cdylib` crates, examples, and tests). Its usage is
-highly platform specific. It is useful to set the shared library version or
-linker script.
-
-[link-arg]: ../../rustc/codegen-options/index.md#link-arg
 
 ### no-index-update
 * Original Issue: [#3479](https://github.com/rust-lang/cargo/issues/3479)
@@ -1479,3 +1433,10 @@ for more information on using the features CLI options.
 The `resolver` feature in `Cargo.toml` has been stabilized in the 1.51 release.
 See the [resolver versions](resolver.md#resolver-versions) for more
 information about specifying resolvers.
+
+### extra-link-arg
+
+The `extra-link-arg` feature to specify additional linker arguments in build
+scripts has been stabilized in the 1.56 release. See the [build script
+documentation](build-scripts.md#outputs-of-the-build-script) for more
+information on specifying extra linker arguments.

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -1,4 +1,4 @@
-//! Tests for -Zextra-link-arg.
+//! Tests for additional link arguments.
 
 // NOTE: Many of these tests use `without_status()` when passing bogus flags
 // because MSVC link.exe just gives a warning on unknown flags (how helpful!),
@@ -22,7 +22,7 @@ fn build_script_extra_link_arg_bin() {
         )
         .build();
 
-    p.cargo("build -Zextra-link-arg -v")
+    p.cargo("build -v")
         .masquerade_as_nightly_cargo()
         .without_status()
         .with_stderr_contains(
@@ -62,7 +62,7 @@ fn build_script_extra_link_arg_bin_single() {
         )
         .build();
 
-    p.cargo("build -Zextra-link-arg -v")
+    p.cargo("build -v")
         .masquerade_as_nightly_cargo()
         .without_status()
         .with_stderr_contains(
@@ -89,33 +89,12 @@ fn build_script_extra_link_arg() {
         )
         .build();
 
-    p.cargo("build -Zextra-link-arg -v")
+    p.cargo("build -v")
         .masquerade_as_nightly_cargo()
         .without_status()
         .with_stderr_contains(
             "[RUNNING] `rustc --crate-name foo [..]-C link-arg=--this-is-a-bogus-flag[..]",
         )
-        .run();
-}
-
-#[cargo_test]
-fn build_script_extra_link_arg_warn_without_flag() {
-    let p = project()
-        .file("Cargo.toml", &basic_bin_manifest("foo"))
-        .file("src/main.rs", "fn main() {}")
-        .file(
-            "build.rs",
-            r#"
-                fn main() {
-                    println!("cargo:rustc-link-arg=--this-is-a-bogus-flag");
-                }
-            "#,
-        )
-        .build();
-
-    p.cargo("build -v")
-        .with_status(0)
-        .with_stderr_contains("warning: cargo:rustc-link-arg requires -Zextra-link-arg flag")
         .run();
 }
 
@@ -146,7 +125,7 @@ fn link_arg_missing_target() {
         r#"fn main() { println!("cargo:rustc-link-arg-bins=--bogus"); }"#,
     );
 
-    p.cargo("check -Zextra-link-arg")
+    p.cargo("check")
         .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr("\
@@ -161,7 +140,7 @@ The package foo v0.0.1 ([ROOT]/foo) does not have a bin target.
         r#"fn main() { println!("cargo:rustc-link-arg-bin=abc=--bogus"); }"#,
     );
 
-    p.cargo("check -Zextra-link-arg")
+    p.cargo("check")
         .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr(
@@ -178,7 +157,7 @@ The package foo v0.0.1 ([ROOT]/foo) does not have a bin target with the name `ab
         r#"fn main() { println!("cargo:rustc-link-arg-bin=abc"); }"#,
     );
 
-    p.cargo("check -Zextra-link-arg")
+    p.cargo("check")
         .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr(
@@ -281,7 +260,7 @@ fn link_arg_transitive_not_allowed() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v -Zextra-link-arg")
+    p.cargo("build -v")
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\


### PR DESCRIPTION
This change removes the unstable option (tracked by #9426) and unconditionally accepts additional linker arguments (as implemented in #7811 and #8441). Documentation is moved from unstable to what appeared to be the correct location.

I am not aware of any significant concerns with the option and it appears consistent with some other existing stable linker options.

Please let me know if this is not the appropriate process or if there is anything that I am missing from the PR.