### PR TITLE
Add mising documentation regarding `cargo doc`

### DIFF
--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -32,7 +32,7 @@ Do not build documentation for dependencies.
 {{/option}}
 
 {{#option "`--document-private-items`" }}
-Include non-public items in the documentation.
+Include non-public items in the documentation. This will be enabled by default if documenting a binary target.
 {{/option}}
 
 {{/options}}

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -23,7 +23,8 @@ OPTIONS
            Do not build documentation for dependencies.
 
        --document-private-items
-           Include non-public items in the documentation.
+           Include non-public items in the documentation. This will be enabled
+           by default if documenting a binary target.
 
    Package Selection
        By default, when no package selection options are given, the packages

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -32,7 +32,7 @@ option.</dd>
 
 
 <dt class="option-term" id="option-cargo-doc---document-private-items"><a class="option-anchor" href="#option-cargo-doc---document-private-items"></a><code>--document-private-items</code></dt>
-<dd class="option-desc">Include non-public items in the documentation.</dd>
+<dd class="option-desc">Include non-public items in the documentation. This will be enabled by default if documenting a binary target.</dd>
 
 
 </dl>

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -28,7 +28,7 @@ Do not build documentation for dependencies.
 .sp
 \fB\-\-document\-private\-items\fR
 .RS 4
-Include non\-public items in the documentation.
+Include non\-public items in the documentation. This will be enabled by default if documenting a binary target.
 .RE
 .SS "Package Selection"
 By default, when no package selection options are given, the packages selected


### PR DESCRIPTION
It seems that the `--document-private-items` flag for `cargo doc` is automatically set when documenting a binary target. This change mentions that in the doc page.

The documentation did not mention this before, and it got me confused whilst I was trying to track down something going wrong.