### PR TITLE
Update rustfix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ memchr = "2.1.3"
 num_cpus = "1.0"
 opener = "0.4"
 percent-encoding = "2.0"
-rustfix = "0.5.0"
+rustfix = "0.6.0"
 semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_ignored = "0.1.0"

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1495,3 +1495,23 @@ The following differences were detected with the current configuration:
 ")
         .run();
 }
+
+#[cargo_test]
+fn rustfix_handles_multi_spans() {
+    // Checks that rustfix handles a single diagnostic with multiple
+    // suggestion spans (non_fmt_panic in this case).
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file(
+            "src/lib.rs",
+            r#"
+                pub fn foo() {
+                    panic!(format!("hey"));
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("fix --allow-no-vcs").run();
+    assert!(p.read_file("src/lib.rs").contains(r#"panic!("hey");"#));
+}


### PR DESCRIPTION
This updates rustfix to 0.6.0. There are a few changes since 0.5.0, the following are noticeable changes:

* https://github.com/rust-lang/rustfix/pull/185 — Fix some panics in edge cases.
* https://github.com/rust-lang/rustfix/pull/195 — Revert revert multiple suggestions fix

The important one is https://github.com/rust-lang/rustfix/pull/195 which is necessary to handle some 2021 edition migration support. I have added a test to check that it works correctly.
