### PR TITLE
Change how the fix_deny_warnings_but_not_others test works

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -561,7 +561,10 @@ fn fix_deny_warnings_but_not_others() {
                     x
                 }
 
-                fn bar() {}
+                pub fn bar() {
+                    #[allow(unused_mut)]
+                    let mut _y = 4;
+                }
             ",
         )
         .build();
@@ -570,7 +573,7 @@ fn fix_deny_warnings_but_not_others() {
         .env("__CARGO_FIX_YOLO", "1")
         .run();
     assert!(!p.read_file("src/lib.rs").contains("let mut x = 3;"));
-    assert!(p.read_file("src/lib.rs").contains("fn bar() {}"));
+    assert!(p.read_file("src/lib.rs").contains("let mut _y = 4;"));
 }
 
 #[cargo_test]


### PR DESCRIPTION
This changes how the `fix_deny_warnings_but_not_others` test works to avoid breakage from a new compiler suggestion that affects rustfix. It should still test the same thing, but through a slightly different mechanism to avoid breaking when new compiler suggestion are added.

Relevant PR for rust-lang/rust: https://github.com/rust-lang/rust/pull/83004

Full explanation in this comment: https://github.com/rust-lang/rust/pull/83004#issuecomment-859155118

Please let me know if you have a better suggestion for this fix. I believe [we're trying to land this ASAP because the beta is being cut tomorrow](https://github.com/rust-lang/rust/pull/83004#issuecomment-858481702), so I will try to get back to any feedback as soon as possible.

cc @pnkfelix 