### PR TITLE
Unify weak and namespaced features.

### DIFF
--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -405,12 +405,12 @@ impl Requirements<'_> {
         &mut self,
         package: InternedString,
         feat: InternedString,
-        dep_prefix: bool,
+        weak: bool,
     ) -> Result<(), RequirementError> {
         // If `package` is indeed an optional dependency then we activate the
         // feature named `package`, but otherwise if `package` is a required
         // dependency then there's no feature associated with it.
-        if !dep_prefix
+        if !weak
             && self
                 .summary
                 .dependencies()
@@ -456,12 +456,11 @@ impl Requirements<'_> {
             FeatureValue::DepFeature {
                 dep_name,
                 dep_feature,
-                dep_prefix,
                 // Weak features are always activated in the dependency
                 // resolver. They will be narrowed inside the new feature
                 // resolver.
-                weak: _,
-            } => self.require_dep_feature(*dep_name, *dep_feature, *dep_prefix)?,
+                weak,
+            } => self.require_dep_feature(*dep_name, *dep_feature, *weak)?,
         };
         Ok(())
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1163,14 +1163,10 @@ impl<'cfg> Workspace<'cfg> {
                     }
                 }
                 // This should be enforced by CliFeatures.
-                FeatureValue::Dep { .. }
-                | FeatureValue::DepFeature {
-                    dep_prefix: true, ..
-                } => panic!("unexpected dep: syntax {}", feature),
+                FeatureValue::Dep { .. } => panic!("unexpected dep: syntax {}", feature),
                 FeatureValue::DepFeature {
                     dep_name,
                     dep_feature,
-                    dep_prefix: _,
                     weak: _,
                 } => {
                     if dependencies.contains_key(dep_name) {
@@ -1283,14 +1279,10 @@ impl<'cfg> Workspace<'cfg> {
                         .map(|s| s.to_string())
                         .collect::<Vec<_>>()
                 }
-                FeatureValue::Dep { .. }
-                | FeatureValue::DepFeature {
-                    dep_prefix: true, ..
-                } => panic!("unexpected dep: syntax {}", feature),
+                FeatureValue::Dep { .. } => panic!("unexpected dep: syntax {}", feature),
                 FeatureValue::DepFeature {
                     dep_name,
                     dep_feature,
-                    dep_prefix: _,
                     weak: _,
                 } => {
                     // Finds set of `pkg/feat` that are very similar to current `pkg/feat`.
@@ -1446,14 +1438,10 @@ impl<'cfg> Workspace<'cfg> {
                     cwd_features.insert(feature.clone());
                 }
                 // This should be enforced by CliFeatures.
-                FeatureValue::Dep { .. }
-                | FeatureValue::DepFeature {
-                    dep_prefix: true, ..
-                } => panic!("unexpected dep: syntax {}", feature),
+                FeatureValue::Dep { .. } => panic!("unexpected dep: syntax {}", feature),
                 FeatureValue::DepFeature {
                     dep_name,
                     dep_feature,
-                    dep_prefix: _,
                     weak: _,
                 } => {
                     // I think weak can be ignored here.

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -1225,10 +1225,7 @@ fn validate_required_features(
                     ))?;
                 }
             }
-            FeatureValue::Dep { .. }
-            | FeatureValue::DepFeature {
-                dep_prefix: true, ..
-            } => {
+            FeatureValue::Dep { .. } => {
                 anyhow::bail!(
                     "invalid feature `{}` in required-features of target `{}`: \
                     `dep:` prefixed feature values are not allowed in required-features",
@@ -1248,7 +1245,6 @@ fn validate_required_features(
             FeatureValue::DepFeature {
                 dep_name,
                 dep_feature,
-                dep_prefix: false,
                 weak: false,
             } => {
                 match resolve

--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -488,7 +488,6 @@ fn add_cli_features(
             FeatureValue::DepFeature {
                 dep_name,
                 dep_feature,
-                dep_prefix: _,
                 weak,
             } => {
                 let dep_connections = match graph.dep_name_map[&package_index].get(&dep_name) {
@@ -596,12 +595,12 @@ fn add_feature_rec(
             FeatureValue::DepFeature {
                 dep_name,
                 dep_feature,
-                dep_prefix,
-                // `weak` is ignored, because it will be skipped if the
-                // corresponding dependency is not found in the map, which
-                // means it wasn't activated. Skipping is handled by
-                // `is_dep_activated` when the graph was built.
-                weak: _,
+                // Note: `weak` is mostly handled when the graph is built in
+                // `is_dep_activated` which is responsible for skipping
+                // unactivated weak dependencies. Here it is only used to
+                // determine if the feature of the dependency name is
+                // activated on self.
+                weak,
             } => {
                 let dep_indexes = match graph.dep_name_map[&package_index].get(dep_name) {
                     Some(indexes) => indexes.clone(),
@@ -619,7 +618,7 @@ fn add_feature_rec(
                 };
                 for (dep_index, is_optional) in dep_indexes {
                     let dep_pkg_id = graph.package_id_for_index(dep_index);
-                    if is_optional && !dep_prefix {
+                    if is_optional && !weak {
                         // Activate the optional dep on self.
                         add_feature(
                             graph,

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -517,61 +517,6 @@ syntax in the features table, so it does not have an implicit feature with that 
 }
 
 #[cargo_test]
-fn crate_feature_explicit() {
-    // dep:name/feature syntax shouldn't set implicit feature.
-    Package::new("bar", "1.0.0")
-        .file(
-            "src/lib.rs",
-            r#"
-                #[cfg(not(feature="feat"))]
-                compile_error!{"feat missing"}
-            "#,
-        )
-        .feature("feat", &[])
-        .publish();
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-
-                [dependencies]
-                bar = {version = "1.0", optional=true}
-
-                [features]
-                f1 = ["dep:bar/feat"]
-            "#,
-        )
-        .file(
-            "src/lib.rs",
-            r#"
-                #[cfg(not(feature="f1"))]
-                compile_error!{"f1 missing"}
-
-                #[cfg(feature="bar")]
-                compile_error!{"bar should not be set"}
-            "#,
-        )
-        .build();
-
-    p.cargo("check -Z namespaced-features --features f1")
-        .masquerade_as_nightly_cargo()
-        .with_stderr(
-            "\
-[UPDATING] [..]
-[DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.0.0 [..]
-[CHECKING] bar v1.0.0
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
-        .run();
-}
-
-#[cargo_test]
 fn crate_syntax_bad_name() {
     // "dep:bar" = []
     Package::new("bar", "1.0.0").publish();
@@ -904,7 +849,6 @@ fn tree() {
 
                 [features]
                 a = ["bar/feat2"]
-                b = ["dep:bar/feat2"]
                 bar = ["dep:bar"]
             "#,
         )
@@ -946,38 +890,6 @@ bar v1.0.0
 │   └── foo v0.1.0 ([ROOT]/foo) (*)
 └── bar feature \"feat2\"
     └── foo feature \"a\" (command-line)
-",
-        )
-        .run();
-
-    p.cargo("tree -e features --features b -Z namespaced-features")
-        .masquerade_as_nightly_cargo()
-        .with_stdout(
-            "\
-foo v0.1.0 ([ROOT]/foo)
-├── bar feature \"default\"
-│   └── bar v1.0.0
-│       └── baz feature \"default\"
-│           └── baz v1.0.0
-└── bar feature \"feat1\"
-    └── bar v1.0.0 (*)
-",
-        )
-        .run();
-
-    p.cargo("tree -e features --features b -i bar -Z namespaced-features")
-        .masquerade_as_nightly_cargo()
-        .with_stdout(
-            "\
-bar v1.0.0
-├── bar feature \"default\"
-│   └── foo v0.1.0 ([ROOT]/foo)
-│       ├── foo feature \"b\" (command-line)
-│       └── foo feature \"default\" (command-line)
-├── bar feature \"feat1\"
-│   └── foo v0.1.0 ([ROOT]/foo) (*)
-└── bar feature \"feat2\"
-    └── foo feature \"b\" (command-line)
 ",
         )
         .run();


### PR DESCRIPTION
This unifies weak and namespaced features in order to simplify the syntax and semantics.  Previously there were four different ways to specify the feature of a dependency:

* `package-name/feature-name` — Enables feature `package-name` on self and enables `feature-name` on the dependency. (Today's behavior.)
* `package-name?/feature-name` — Only enables `feature-name` on the given package if it that package is enabled and will also activates a feature named `package-name` (which must be defined implicitly or explicitly).
* `dep:package-name/feature-name` — Enables dependency `package-name`, and enables `feature-name` on that dependency. This does NOT enable a feature named "package-name".
* `dep:package-name?/feature-name` — Only enables `feature-name` on the given package if it that package is enabled.  This does NOT enable a feature named "package-name".

This changes it so there are only two:

* `package-name/feature-name` — Today's behavior.
* `package-name?/feature-name` — Only enables `feature-name` on the given package if it that package is enabled.  This does NOT enable a feature named "package-name" (the same behavior as `dep:package-name?/feature-name` above).

This is a fairly subtle change, and in most cases probably won't be noticed.  However, it simplifies things which helps with writing documentation and explaining how it works.
