### PR TITLE
install fails earlier when no binaries can be found

### DIFF
--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -79,6 +79,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     if let CompileFilter::Default { .. } = opts.filter {
         opts.filter = CompileFilter::Only {
             all_targets: true,
+            warn_unmatched: true,
             lib: LibRule::Default,
             bins: FilterRule::All,
             examples: FilterRule::All,

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 
 use cargo::core::{GitReference, SourceId};
-use cargo::ops;
+use cargo::ops::{self, CompileFilter, FilterRule, LibRule};
 use cargo::util::IntoUrl;
 
 pub fn cli() -> App {
@@ -136,6 +136,18 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
 
     compile_opts.build_config.requested_profile =
         args.get_profile_name(config, "release", ProfileChecking::Custom)?;
+
+    if !compile_opts.filter.is_specific() {
+        compile_opts.filter = CompileFilter::Only {
+            all_targets: false,
+            warn_unmatched: false,
+            lib: LibRule::False,
+            bins: FilterRule::All,
+            examples: FilterRule::none(),
+            benches: FilterRule::none(),
+            tests: FilterRule::none(),
+        }
+    }
 
     if args.is_present("list") {
         ops::install_list(root, config)?;

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 
 use cargo::core::{GitReference, SourceId};
-use cargo::ops::{self, CompileFilter, FilterRule, LibRule};
+use cargo::ops::{self, CompileFilter};
 use cargo::util::IntoUrl;
 
 pub fn cli() -> App {
@@ -138,15 +138,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
         args.get_profile_name(config, "release", ProfileChecking::Custom)?;
 
     if !compile_opts.filter.is_specific() {
-        compile_opts.filter = CompileFilter::Only {
-            all_targets: false,
-            warn_unmatched: false,
-            lib: LibRule::False,
-            bins: FilterRule::All,
-            examples: FilterRule::none(),
-            benches: FilterRule::none(),
-            tests: FilterRule::none(),
-        }
+        compile_opts.filter = CompileFilter::new_bare_install();
     }
 
     if args.is_present("list") {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -249,6 +249,7 @@ pub enum CompileFilter {
     },
     Only {
         all_targets: bool,
+        warn_unmatched: bool,
         lib: LibRule,
         bins: FilterRule,
         examples: FilterRule,
@@ -714,6 +715,7 @@ impl CompileFilter {
         {
             CompileFilter::Only {
                 all_targets: false,
+                warn_unmatched: true,
                 lib: rule_lib,
                 bins: rule_bins,
                 examples: rule_exms,
@@ -730,6 +732,7 @@ impl CompileFilter {
     pub fn new_all_targets() -> CompileFilter {
         CompileFilter::Only {
             all_targets: true,
+            warn_unmatched: true,
             lib: LibRule::Default,
             bins: FilterRule::All,
             examples: FilterRule::All,
@@ -1003,6 +1006,7 @@ fn generate_targets(
             ref examples,
             ref tests,
             ref benches,
+            ..
         } => {
             if *lib != LibRule::False {
                 let mut libs = Vec::new();
@@ -1158,14 +1162,15 @@ fn unmatched_target_filters(
 ) -> CargoResult<()> {
     if let CompileFilter::Only {
         all_targets,
-        lib: _,
+        warn_unmatched,
         ref bins,
         ref examples,
         ref tests,
         ref benches,
+        ..
     } = *filter
     {
-        if units.is_empty() {
+        if units.is_empty() && warn_unmatched {
             let mut filters = String::new();
             let mut miss_count = 0;
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -204,7 +204,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
         // For bare `cargo install` (no `--bin` or `--example`), check if there is
         // *something* to install. Explicit `--bin` or `--example` flags will be
         // checked at the start of `compile_ws`.
-        if !opts.filter.is_specific() && !pkg.targets().iter().any(|t| t.is_bin()) {
+        if opts.filter.is_bare_install() && !pkg.targets().iter().any(|t| t.is_bin()) {
             bail!(
                 "there is nothing to install in `{}`, because it has no binaries\n\
                  `cargo install` is only for installing programs, and can't be used with libraries.\n\

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -586,9 +586,9 @@ fn no_binaries() {
         .with_status(101)
         .with_stderr(
             "\
+[ERROR] there is nothing to install in `foo v0.0.1 ([..])`, because it has no binaries[..]
 [..]
-[..]
-[ERROR] no binaries are available for install using the selected features",
+[..]",
         )
         .run();
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -586,9 +586,9 @@ fn no_binaries() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] there is nothing to install in `foo v0.0.1 ([..])`, because it has no binaries[..]
 [..]
-[..]",
+[..]
+[ERROR] no binaries are available for install using the selected features",
         )
         .run();
 }


### PR DESCRIPTION
fixes #8970

this automatically filters out the lib targets in `cargo install` when no specific targets are provided by the user, so they won't get accidentally built.

now when you try to install a crate with no satisfied bin targets, cargo will skip the meat of the compile phase and give the same error message it currently gives when it finds no bin targets at all.

a new flag called `warn_unmatched` was also added to `CompileFilter::Only` that can suppress the warning about unmatched target filters.