### PR TITLE
Fix package_default_run test.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -737,7 +737,7 @@ impl Execs {
         }
     }
 
-    fn verify_checks_output(&self, output: &Output) {
+    fn verify_checks_output(&self, stdout: &[u8], stderr: &[u8]) {
         if self.expect_exit_code.unwrap_or(0) != 0
             && self.expect_stdout.is_none()
             && self.expect_stdin.is_none()
@@ -758,8 +758,8 @@ impl Execs {
                 "`with_status()` is used, but no output is checked.\n\
                  The test must check the output to ensure the correct error is triggered.\n\
                  --- stdout\n{}\n--- stderr\n{}",
-                String::from_utf8_lossy(&output.stdout),
-                String::from_utf8_lossy(&output.stderr),
+                String::from_utf8_lossy(stdout),
+                String::from_utf8_lossy(stderr),
             );
         }
     }
@@ -806,13 +806,13 @@ impl Execs {
     }
 
     fn match_output(&self, actual: &Output) -> Result<()> {
-        self.verify_checks_output(actual);
         self.match_status(actual.status.code(), &actual.stdout, &actual.stderr)
             .and(self.match_stdout(&actual.stdout, &actual.stderr))
             .and(self.match_stderr(&actual.stdout, &actual.stderr))
     }
 
     fn match_status(&self, code: Option<i32>, stdout: &[u8], stderr: &[u8]) -> Result<()> {
+        self.verify_checks_output(stdout, stderr);
         match self.expect_exit_code {
             None => Ok(()),
             Some(expected) if code == Some(expected) => Ok(()),

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -8,7 +8,6 @@
 
 use std::env;
 use std::ffi::OsStr;
-use std::fmt;
 use std::fs;
 use std::os;
 use std::path::{Path, PathBuf};
@@ -725,7 +724,7 @@ impl Execs {
         self.ran = true;
         let p = (&self.process_builder).clone().unwrap();
         if let Err(e) = self.match_process(&p) {
-            panic!("\nExpected: {:?}\n    but: {}", self, e)
+            panic!("\n{}", e)
         }
     }
 
@@ -733,7 +732,7 @@ impl Execs {
     pub fn run_output(&mut self, output: &Output) {
         self.ran = true;
         if let Err(e) = self.match_output(output) {
-            panic!("\nExpected: {:?}\n    but: {}", self, e)
+            panic!("\n{}", e)
         }
     }
 
@@ -1006,10 +1005,11 @@ impl Execs {
                     Ok(())
                 } else {
                     bail!(
-                        "differences:\n\
+                        "{} did not match:\n\
                          {}\n\n\
                          other output:\n\
                          `{}`",
+                        description,
                         diffs.join("\n"),
                         String::from_utf8_lossy(extra)
                     )
@@ -1401,12 +1401,6 @@ fn zip_all<T, I1: Iterator<Item = T>, I2: Iterator<Item = T>>(a: I1, b: I2) -> Z
     ZipAll {
         first: a,
         second: b,
-    }
-}
-
-impl fmt::Debug for Execs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "execs")
     }
 }
 

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -427,13 +427,10 @@ fn metabuild_metadata() {
     // The metabuild Target is filtered out of the `metadata` results.
     let p = basic_project();
 
-    let output = p
+    let meta = p
         .cargo("metadata --format-version=1")
         .masquerade_as_nightly_cargo()
-        .exec_with_output()
-        .expect("cargo metadata failed");
-    let stdout = str::from_utf8(&output.stdout).unwrap();
-    let meta: serde_json::Value = serde_json::from_str(stdout).expect("failed to parse json");
+        .run_json();
     let mb_info: Vec<&str> = meta["packages"]
         .as_array()
         .unwrap()

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4,6 +4,7 @@ use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, main_file, project, rustc_host};
+use serde_json::json;
 
 #[cargo_test]
 fn cargo_metadata_simple() {
@@ -1550,106 +1551,8 @@ fn package_default_run() {
             "#,
         )
         .build();
-    p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-                "packages": [
-                    {
-                        "authors": [
-                            "wycats@example.com"
-                        ],
-                        "categories": [],
-                        "default_run": "a",
-                        "dependencies": [],
-                        "description": null,
-                        "edition": "2018",
-                        "features": {},
-                        "id": "foo 0.1.0 (path+file:[..])",
-                        "keywords": [],
-                        "license": null,
-                        "license_file": null,
-                        "links": null,
-                        "manifest_path": "[..]Cargo.toml",
-                        "metadata": null,
-                        "publish": null,
-                        "name": "foo",
-                        "readme": null,
-                        "repository": null,
-                        "homepage": null,
-                        "documentation": null,
-                        "source": null,
-                        "targets": [
-                            {
-                                "crate_types": [
-                                    "lib"
-                                ],
-                                "doc": true,
-                                "doctest": true,
-                                "test": true,
-                                "edition": "2018",
-                                "kind": [
-                                    "lib"
-                                ],
-                                "name": "foo",
-                                "src_path": "[..]src/lib.rs"
-                            },
-                            {
-                                "crate_types": [
-                                    "bin"
-                                ],
-                                "doc": true,
-                                "doctest": false,
-                                "test": true,
-                                "edition": "2018",
-                                "kind": [
-                                    "bin"
-                                ],
-                                "name": "a",
-                                "src_path": "[..]src/bin/a.rs",
-                                "test": true
-                            },
-                            {
-                                "crate_types": [
-                                    "bin"
-                                ],
-                                "doc": true,
-                                "doctest": false,
-                                "test": true,
-                                "edition": "2018",
-                                "kind": [
-                                    "bin"
-                                ],
-                                "name": "b",
-                                "src_path": "[..]src/bin/b.rs",
-                                "test": true
-                            }
-                        ],
-                        "version": "0.1.0"
-                    }
-                ],
-                "resolve": {
-                    "nodes": [
-                        {
-                            "dependencies": [],
-                            "deps": [],
-                            "features": [],
-                            "id": "foo 0.1.0 (path+file:[..])"
-                        }
-                    ],
-                    "root": "foo 0.1.0 (path+file:[..])"
-                },
-                "target_directory": "[..]",
-                "version": 1,
-                "workspace_members": [
-                    "foo 0.1.0 (path+file:[..])"
-                ],
-                "workspace_root": "[..]",
-                "metadata": null
-            }
-            "#,
-        )
-        .run();
+    let json = p.cargo("metadata").run_json();
+    assert_eq!(json["packages"][0]["default_run"], json!("a"));
 }
 
 #[cargo_test]


### PR DESCRIPTION
The `package_default_run` test was checking the output of `cargo metadata`, which included the "targets" field. Unfortunately the order of the targets in this test depend on the filesystem order, so the test may randomly fail.

The fix here is to just check for the one field that this test was interested in.

An alternate solution would be to sort the targets.  Another alternate solution would be to use `"{...}"` for the targets to ignore them.  I kinda liked simplifying it to check just one field.

This includes a series of commits that are just general changes to the test infrastructure:

* Change cargo-test-support to use anyhow.
* Remove unused `ErrMsg`.
* Fix a bug with `verify_checks_output`.
* Remove the weird Debug impl for Execs.
* Added a helper function for getting the JSON output from cargo.  (I can imagine a lot of possible enhancements here.)

