### PR TITLE
Don't allow config env to modify vars set by cargo

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -348,7 +348,12 @@ impl<'cfg> Compilation<'cfg> {
         if self.config.cli_unstable().configurable_env {
             // Apply any environment variables from the config
             for (key, value) in self.config.env_config()?.iter() {
-                if value.is_force() || cmd.get_env(key).is_none() {
+                // never override a value that has already been set by cargo
+                if cmd.get_envs().contains_key(key) {
+                    continue;
+                }
+
+                if value.is_force() || env::var_os(key).is_none() {
                     cmd.env(key, value.resolve(self.config));
                 }
             }

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -131,3 +131,31 @@ fn env_relative() {
         .masquerade_as_nightly_cargo()
         .run();
 }
+
+#[cargo_test]
+fn env_no_override() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("unchanged"))
+        .file(
+            "src/main.rs",
+            r#"
+        use std::env;
+        fn main() {
+            println!( "CARGO_PKG_NAME:{}", env!("CARGO_PKG_NAME") );
+        }
+        "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+                [env]
+                CARGO_PKG_NAME = { value = "from-config", force = true }
+            "#,
+        )
+        .build();
+
+    p.cargo("run -Zconfigurable-env")
+        .masquerade_as_nightly_cargo()
+        .with_stdout_contains("CARGO_PKG_NAME:unchanged")
+        .run();
+}


### PR DESCRIPTION
This changes how the `[env]` variables are applied. They will no longer replace any variables that are being set by cargo itself, whether or not the `force` flag is set. The `force` flag still determines whether existing variables from the environment can be overridden or not.

Addresses unresolved issue in #9539