### PR TITLE
Handle "jobs = 0" case in cargo config files

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -69,6 +69,9 @@ impl BuildConfig {
             )?;
         }
         let jobs = jobs.or(cfg.jobs).unwrap_or(::num_cpus::get() as u32);
+        if jobs == 0 {
+            anyhow::bail!("jobs may not be 0");
+        }
 
         Ok(BuildConfig {
             requested_kinds,

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4803,6 +4803,24 @@ fn good_cargo_config_jobs() {
 }
 
 #[cargo_test]
+fn invalid_cargo_config_jobs() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            r#"
+                [build]
+                jobs = 0
+            "#,
+        )
+        .build();
+    p.cargo("build -v")
+        .with_status(101)
+        .with_stderr_contains("error: jobs may not be 0")
+        .run();
+}
+
+#[cargo_test]
 fn invalid_jobs() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))


### PR DESCRIPTION
Cargo hangs without output if the jobs argument under build in a cargo/config file is set to 0. This PR handles this case by providing an appropriate error.

Closes #9219 