### PR TITLE
Enable support for fix --edition for 2021.

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -208,15 +208,15 @@ impl Edition {
 
     /// Whether or not this edition supports the `rust_*_compatibility` lint.
     ///
-    /// Ideally this would not be necessary, but currently 2021 does not have
-    /// any lints, and thus `rustc` doesn't recognize it. Perhaps `rustc`
-    /// could create an empty group instead?
+    /// Ideally this would not be necessary, but editions may not have any
+    /// lints, and thus `rustc` doesn't recognize it. Perhaps `rustc` could
+    /// create an empty group instead?
     pub(crate) fn supports_compat_lint(&self) -> bool {
         use Edition::*;
         match self {
             Edition2015 => false,
             Edition2018 => true,
-            Edition2021 => false,
+            Edition2021 => true,
         }
     }
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1501,3 +1501,49 @@ fn rustfix_handles_multi_spans() {
     p.cargo("fix --allow-no-vcs").run();
     assert!(p.read_file("src/lib.rs").contains(r#"panic!("hey");"#));
 }
+
+#[cargo_test]
+fn fix_edition_2021() {
+    // Can migrate 2021, even when lints are allowed.
+    if !is_nightly() {
+        // 2021 is unstable
+        return;
+    }
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2018"
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                #![allow(ellipsis_inclusive_range_patterns)]
+
+                pub fn f() -> bool {
+                    let x = 123;
+                    match x {
+                        0...100 => true,
+                        _ => false,
+                    }
+                }
+            "#,
+        )
+        .build();
+    p.cargo("fix --edition --allow-no-vcs")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[CHECKING] foo v0.1.0 [..]
+[MIGRATING] src/lib.rs from 2018 edition to 2021
+[FIXED] src/lib.rs (1 fix)
+[FINISHED] [..]
+",
+        )
+        .run();
+    assert!(p.read_file("src/lib.rs").contains(r#"0..=100 => true,"#));
+}


### PR DESCRIPTION
This adds support for using `cargo fix --edition` to migrate to 2021.  

This also uses the new, currently unstable, `--force-warns` flag. This was added because there were a significant number of crates that were "allow"ing lints that are required for migrating the edition. This wasn't a problem for 2018, because its lints were new, and all "allow" to start.  For 2021, several older "warn" lints are becoming hard errors.  "allow"ing them would cause the migration to fail.

