### PR TITLE
Add a compatibility notice for diesel and the new resolver.

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -1207,7 +1207,6 @@ feature resolver. Some workarounds you may want to consider:
 - Try using the previous resolver by setting `resolver = \"1\"` in `Cargo.toml`
   (see <https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions>
   for more information).
-- Check for the 2.0 release of diesel which does not have this problem.
 ",
             unit.pkg.version(),
             features_suggestion


### PR DESCRIPTION
This adds a notice about a compatibility issue with diesel and the new feature resolver. This will display a notice if it detects the scenario where diesel causes a build error.  It also prints a not when using `cargo fix --edition` when it detects a setup that may fail.
