### PR TITLE
Disambiguate is_symlink.

### DIFF
--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -124,8 +124,6 @@ pub trait CargoPathExt {
     fn move_in_time<F>(&self, travel_amount: F)
     where
         F: Fn(i64, u32) -> (i64, u32);
-
-    fn is_symlink(&self) -> bool;
 }
 
 impl CargoPathExt for Path {
@@ -198,12 +196,14 @@ impl CargoPathExt for Path {
             });
         }
     }
+}
 
-    fn is_symlink(&self) -> bool {
-        fs::symlink_metadata(self)
-            .map(|m| m.file_type().is_symlink())
-            .unwrap_or(false)
-    }
+// Replace with std implementation when stabilized, see
+// https://github.com/rust-lang/rust/issues/85748
+pub fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 fn do_op<F>(path: &Path, desc: &str, mut f: F)

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4519,6 +4519,7 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
 #[cargo_test]
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn uplift_dsym_of_bin_on_mac() {
+    use cargo_test_support::paths::is_symlink;
     let p = project()
         .file("src/main.rs", "fn main() { panic!(); }")
         .file("src/bin/b.rs", "fn main() { panic!(); }")
@@ -4531,7 +4532,7 @@ fn uplift_dsym_of_bin_on_mac() {
         .run();
     assert!(p.target_debug_dir().join("foo.dSYM").is_dir());
     assert!(p.target_debug_dir().join("b.dSYM").is_dir());
-    assert!(p.target_debug_dir().join("b.dSYM").is_symlink());
+    assert!(is_symlink(&p.target_debug_dir().join("b.dSYM")));
     assert!(p.target_debug_dir().join("examples/c.dSYM").is_dir());
     assert!(!p.target_debug_dir().join("c.dSYM").exists());
     assert!(!p.target_debug_dir().join("d.dSYM").exists());
@@ -4540,6 +4541,7 @@ fn uplift_dsym_of_bin_on_mac() {
 #[cargo_test]
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn uplift_dsym_of_bin_on_mac_when_broken_link_exists() {
+    use cargo_test_support::paths::is_symlink;
     let p = project()
         .file("src/main.rs", "fn main() { panic!(); }")
         .build();
@@ -4558,7 +4560,7 @@ fn uplift_dsym_of_bin_on_mac_when_broken_link_exists() {
             .join("foo-baaaaaadbaaaaaad.dSYM"),
         &dsym,
     );
-    assert!(dsym.is_symlink());
+    assert!(is_symlink(&dsym));
     assert!(!dsym.exists());
 
     p.cargo("build").enable_mac_dsym().run();

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1,6 +1,6 @@
 //! Tests for the `cargo clean` command.
 
-use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::paths::is_symlink;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_bin_manifest, basic_manifest, git, main_file, project, rustc_host};
 use std::env;
@@ -438,7 +438,7 @@ fn assert_all_clean(build_dir: &Path) {
         {
             continue;
         }
-        if path.is_symlink() || path.is_file() {
+        if is_symlink(path) || path.is_file() {
             panic!("{:?} was not cleaned", path);
         }
     }


### PR DESCRIPTION
`Path::is_symlink` was added in https://github.com/rust-lang/rust/pull/85747 which triggers the `unstable_name_collisions` lint, breaking Cargo's CI.  This switches it to a free function to avoid the collision.
