### PR TITLE
use 'unstable sort' for sorting primitives

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -60,7 +60,7 @@ pub fn run(
                 .into_iter()
                 .map(|(_pkg, target)| target.name())
                 .collect();
-            names.sort();
+            names.sort_unstable();
             anyhow::bail!(
                 "`cargo run` could not determine which binary to run. \
                  Use the `--bin` option to specify a binary, \

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -26,7 +26,7 @@ fn get_available_targets<'a>(
         .map(Target::name)
         .collect();
 
-    targets.sort();
+    targets.sort_unstable();
 
     Ok(targets)
 }


### PR DESCRIPTION
primitives can be safely sorted using `unstable_sort` for borderline homeopathic performance improvements