### PR TITLE
Add option to skip manifest guide in cargo-new

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -129,6 +129,7 @@ impl NewOptions {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "kebab-case")]
 struct CargoNewConfig {
     #[deprecated = "cargo-new no longer supports adding the authors field"]
     #[allow(dead_code)]
@@ -140,6 +141,8 @@ struct CargoNewConfig {
 
     #[serde(rename = "vcs")]
     version_control: Option<VersionControl>,
+
+    manifest_guide: Option<bool>,
 }
 
 fn get_name<'a>(path: &'a Path, opts: &'a NewOptions) -> CargoResult<&'a str> {
@@ -769,9 +772,7 @@ path = {}
 name = "{}"
 version = "0.1.0"
 edition = {}
-{}
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
+{}{}
 [dependencies]
 {}"#,
             name,
@@ -785,6 +786,11 @@ edition = {}
                     toml::Value::Array(vec!(toml::Value::String(registry.to_string())))
                 ),
                 None => "".to_string(),
+            },
+            if cfg.manifest_guide.unwrap_or(true) {
+                "\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n"
+            } else {
+                ""
             },
             cargotoml_path_specifier
         )

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -72,7 +72,8 @@ browser = "chromium"          # browser to use with `cargo doc --open`,
                               # overrides the `BROWSER` environment variable
 
 [cargo-new]
-vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
+vcs = "none"           # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
+manifest-guide = true  # whether to include a short guide in the new `Cargo.toml` file
 
 [http]
 debug = false               # HTTP debugging


### PR DESCRIPTION
Every `Cargo.toml` file generated with `cargo new` command includes the following line:

```toml
# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
```

I think it would be great if I can choose to remove this line.

This PR adds an option not to include the guide.