### PR TITLE
Display registry name instead of registry URL when possible

### DIFF
--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::hash;
 use url::Url;
 
+const DOCS_RS_URL: &'static str = "https://docs.rs/";
+
 /// Mode used for `std`.
 #[derive(Debug, Hash)]
 pub enum RustdocExternMode {
@@ -63,7 +65,7 @@ pub struct RustdocExternMap {
 impl Default for RustdocExternMap {
     fn default() -> Self {
         let mut registries = HashMap::new();
-        registries.insert("crates-io".into(), "https://docs.rs/".into());
+        registries.insert(CRATES_IO_REGISTRY.into(), DOCS_RS_URL.into());
         Self {
             registries,
             std: None,
@@ -76,8 +78,8 @@ fn default_crates_io_to_docs_rs<'de, D: serde::Deserializer<'de>>(
 ) -> Result<HashMap<String, String>, D::Error> {
     use serde::Deserialize;
     let mut registries = HashMap::deserialize(de)?;
-    if !registries.contains_key("crates-io") {
-        registries.insert("crates-io".into(), "https://docs.rs/".into());
+    if !registries.contains_key(CRATES_IO_REGISTRY) {
+        registries.insert(CRATES_IO_REGISTRY.into(), DOCS_RS_URL.into());
     }
     Ok(registries)
 }

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -252,7 +252,7 @@ mod tests {
         let loc = CRATES_IO_INDEX.into_url().unwrap();
         let pkg_id = PackageId::new("foo", "1.0.0", SourceId::for_registry(&loc).unwrap()).unwrap();
         assert_eq!(
-            r#"PackageId { name: "foo", version: "1.0.0", source: "registry `https://github.com/rust-lang/crates.io-index`" }"#,
+            r#"PackageId { name: "foo", version: "1.0.0", source: "registry `crates-io`" }"#,
             format!("{:?}", pkg_id)
         );
 
@@ -260,7 +260,7 @@ mod tests {
 PackageId {
     name: "foo",
     version: "1.0.0",
-    source: "registry `https://github.com/rust-lang/crates.io-index`",
+    source: "registry `crates-io`",
 }
 "#
         .trim();
@@ -271,7 +271,7 @@ PackageId {
 PackageId {
     name: "foo",
     version: "1.0.0",
-    source: "registry `https://github.com/rust-lang/crates.io-index`"
+    source: "registry `crates-io`"
 }
 "#
         .trim();

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -1,6 +1,6 @@
 use crate::core::PackageId;
-use crate::sources::DirectorySource;
-use crate::sources::{GitSource, PathSource, RegistrySource, CRATES_IO_INDEX};
+use crate::sources::{DirectorySource, CRATES_IO_DOMAIN, CRATES_IO_INDEX};
+use crate::sources::{GitSource, PathSource, RegistrySource};
 use crate::util::{CanonicalUrl, CargoResult, Config, IntoUrl};
 use log::trace;
 use serde::de;
@@ -224,7 +224,7 @@ impl SourceId {
 
     pub fn display_registry_name(self) -> String {
         if self.is_default_registry() {
-            "crates.io".to_string()
+            CRATES_IO_DOMAIN.to_string()
         } else if let Some(name) = &self.inner.name {
             name.clone()
         } else {

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -216,9 +216,9 @@ impl SourceId {
 
     pub fn display_index(self) -> String {
         if self.is_default_registry() {
-            "crates.io index".to_string()
+            format!("{} index", CRATES_IO_DOMAIN)
         } else {
-            format!("`{}` index", url_display(self.url()))
+            format!("`{}` index", self.display_registry_name())
         }
     }
 
@@ -463,7 +463,7 @@ impl fmt::Display for SourceId {
                 Ok(())
             }
             SourceKind::Path => write!(f, "{}", url_display(&self.inner.url)),
-            SourceKind::Registry => write!(f, "registry `{}`", url_display(&self.inner.url)),
+            SourceKind::Registry => write!(f, "registry `{}`", self.display_registry_name()),
             SourceKind::LocalRegistry => write!(f, "registry `{}`", url_display(&self.inner.url)),
             SourceKind::Directory => write!(f, "dir {}", url_display(&self.inner.url)),
         }

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -234,7 +234,7 @@ impl SourceId {
 
     pub fn display_registry_name(self) -> String {
         if self.is_default_registry() {
-            CRATES_IO_DOMAIN.to_string()
+            CRATES_IO_REGISTRY.to_string()
         } else if let Some(name) = &self.inner.name {
             name.clone()
         } else if self.precise().is_some() {

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -1,3 +1,5 @@
+use crate::sources::CRATES_IO_DOMAIN;
+
 pub use self::cargo_clean::{clean, CleanOptions};
 pub use self::cargo_compile::{
     compile, compile_with_exec, compile_ws, create_bcx, print, resolve_all_features, CompileOptions,
@@ -66,7 +68,7 @@ fn check_dep_has_version(dep: &crate::core::Dependency, publish: bool) -> crate:
 
     if !dep.specified_req() && dep.is_transitive() {
         let dep_version_source = dep.registry_id().map_or_else(
-            || "crates.io".to_string(),
+            || CRATES_IO_DOMAIN.to_string(),
             |registry_id| registry_id.display_registry_name(),
         );
         anyhow::bail!(

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -20,7 +20,7 @@ use crate::core::resolver::CliFeatures;
 use crate::core::source::Source;
 use crate::core::{Package, SourceId, Workspace};
 use crate::ops;
-use crate::sources::{RegistrySource, SourceConfigMap, CRATES_IO_REGISTRY};
+use crate::sources::{RegistrySource, SourceConfigMap, CRATES_IO_DOMAIN, CRATES_IO_REGISTRY};
 use crate::util::config::{self, Config, SslVersionConfig, SslVersionConfigRange};
 use crate::util::errors::CargoResult;
 use crate::util::important_paths::find_root_manifest_for_wd;
@@ -730,7 +730,7 @@ pub fn registry_login(
         "Login",
         format!(
             "token for `{}` saved",
-            reg.as_ref().map_or("crates.io", String::as_str)
+            reg.as_ref().map_or(CRATES_IO_DOMAIN, String::as_str)
         ),
     )?;
     Ok(())
@@ -738,7 +738,7 @@ pub fn registry_login(
 
 pub fn registry_logout(config: &Config, reg: Option<String>) -> CargoResult<()> {
     let (registry, reg_cfg, _) = registry(config, None, None, reg.clone(), false, false)?;
-    let reg_name = reg.as_deref().unwrap_or("crates.io");
+    let reg_name = reg.as_deref().unwrap_or(CRATES_IO_DOMAIN);
     if reg_cfg.credential_process.is_none() && reg_cfg.token.is_none() {
         config.shell().status(
             "Logout",

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -2,6 +2,7 @@ use crate::core::shell::Verbosity;
 use crate::core::{GitReference, Workspace};
 use crate::ops;
 use crate::sources::path::PathSource;
+use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::{CargoResult, Config};
 use anyhow::{bail, Context as _};
 use cargo_util::{paths, Sha256};
@@ -248,7 +249,7 @@ fn sync(
     // replace original sources with vendor
     for source_id in sources {
         let name = if source_id.is_default_registry() {
-            "crates-io".to_string()
+            CRATES_IO_REGISTRY.to_string()
         } else {
             source_id.url().to_string()
         };

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -207,7 +207,7 @@ restore the source replacement configuration to continue the build
         let mut srcs = Vec::new();
         if let Some(registry) = def.registry {
             let url = url(&registry, &format!("source.{}.registry", name))?;
-            srcs.push(SourceId::for_registry(&url)?);
+            srcs.push(SourceId::for_alt_registry(&url, &name)?);
         }
         if let Some(local_registry) = def.local_registry {
             let path = local_registry.resolve_path(self.config);

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -247,7 +247,7 @@ restore the source replacement configuration to continue the build
             check_not_set("tag", def.tag)?;
             check_not_set("rev", def.rev)?;
         }
-        if name == "crates-io" && srcs.is_empty() {
+        if name == CRATES_IO_REGISTRY && srcs.is_empty() {
             srcs.push(SourceId::crates_io(self.config)?);
         }
 

--- a/src/cargo/sources/mod.rs
+++ b/src/cargo/sources/mod.rs
@@ -2,7 +2,7 @@ pub use self::config::SourceConfigMap;
 pub use self::directory::DirectorySource;
 pub use self::git::GitSource;
 pub use self::path::PathSource;
-pub use self::registry::{RegistrySource, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
+pub use self::registry::{RegistrySource, CRATES_IO_DOMAIN, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
 pub use self::replaced::ReplacedSource;
 
 pub mod config;

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -184,6 +184,7 @@ use crate::util::{restricted_names, CargoResult, Config, Filesystem, OptVersionR
 const PACKAGE_SOURCE_LOCK: &str = ".cargo-ok";
 pub const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
 pub const CRATES_IO_REGISTRY: &str = "crates-io";
+pub const CRATES_IO_DOMAIN: &str = "crates.io";
 const CRATE_TEMPLATE: &str = "{crate}";
 const VERSION_TEMPLATE: &str = "{version}";
 const PREFIX_TEMPLATE: &str = "{prefix}";

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -29,17 +29,16 @@ fn depend_on_alt_registry() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `alternative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 
     p.cargo("clean").run();
@@ -48,7 +47,7 @@ fn depend_on_alt_registry() {
     p.cargo("build")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
@@ -83,19 +82,18 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .publish();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `alternative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `alternative`)
+[DOWNLOADED] [..] v0.0.1 (registry `alternative`)
+[COMPILING] baz v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }
 
@@ -126,19 +124,18 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .publish();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `alternative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] baz v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `alternative`)
+[DOWNLOADED] [..] v0.0.1 (registry `alternative`)
+[COMPILING] baz v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }
 
@@ -169,21 +166,19 @@ fn depend_on_alt_registry_depends_on_crates_io() {
         .publish();
 
     p.cargo("build")
-        .with_stderr_unordered(&format!(
+        .with_stderr_unordered(
             "\
-[UPDATING] `{alt_reg}` index
-[UPDATING] `{reg}` index
+[UPDATING] `alternative` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] baz v0.0.1
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            alt_reg = registry::alt_registry_path().to_str().unwrap(),
-            reg = registry::registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }
 
@@ -403,20 +398,19 @@ fn alt_registry_and_crates_io_deps() {
         .publish();
 
     p.cargo("build")
-        .with_stderr_contains(format!(
-            "[UPDATING] `{}` index",
-            registry::alt_registry_path().to_str().unwrap()
-        ))
-        .with_stderr_contains(&format!(
-            "[UPDATING] `{}` index",
-            registry::registry_path().to_str().unwrap()
-        ))
-        .with_stderr_contains("[DOWNLOADED] crates_io_dep v0.0.1 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[DOWNLOADED] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[COMPILING] alt_reg_dep v0.1.0 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[COMPILING] crates_io_dep v0.0.1")
-        .with_stderr_contains("[COMPILING] foo v0.0.1 ([CWD])")
-        .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `alternative` index
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] crates_io_dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] alt_reg_dep v0.1.0 (registry `alternative`)
+[COMPILING] alt_reg_dep v0.1.0 (registry `alternative`)
+[COMPILING] crates_io_dep v0.0.1
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
         .run();
 }
 
@@ -607,7 +601,7 @@ fn patch_alt_reg() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `alternative` index
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -697,24 +691,20 @@ fn no_api() {
         .build();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `alternative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 
     // Check all of the API commands.
-    let err = format!(
-        "[ERROR] registry `{}` does not support API commands",
-        registry::alt_registry_path().display()
-    );
+    let err = "[ERROR] registry `alternative` does not support API commands";
 
     p.cargo("login --registry alternative TOKEN")
         .with_status(101)
@@ -1244,17 +1234,16 @@ fn registries_index_relative_url() {
     Package::new("bar", "0.0.1").alternative(true).publish();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `relative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
-[COMPILING] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `relative`)
+[COMPILING] bar v0.0.1 (registry `relative`)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry::alt_registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -912,7 +912,7 @@ Caused by:
   failed to load source for dependency `bar`
 
 Caused by:
-  Unable to update registry `https://[..]`
+  Unable to update registry `crates-io`
 
 Caused by:
   could not find a configured source with the name `bar` \
@@ -958,7 +958,7 @@ Caused by:
   failed to load source for dependency `bar`
 
 Caused by:
-  Unable to update registry `https://[..]`
+  Unable to update registry `crates-io`
 
 Caused by:
   detected a cycle of `replace-with` sources, [..]
@@ -1006,7 +1006,7 @@ Caused by:
   failed to load source for dependency `bar`
 
 Caused by:
-  Unable to update registry `https://[..]`
+  Unable to update registry `crates-io`
 
 Caused by:
   detected a cycle of `replace-with` sources, the source `crates-io` is \
@@ -1445,7 +1445,7 @@ fn redefined_sources() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] source `foo` defines source registry `https://github.com/rust-lang/crates.io-index`, \
+[ERROR] source `foo` defines source registry `crates-io`, \
     but that source is already defined by `crates-io`
 note: Sources are not allowed to be defined multiple times.
 ",

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4777,7 +4777,7 @@ fn avoid_dev_deps() {
             "\
 [UPDATING] [..]
 [ERROR] no matching package named `baz` found
-location searched: registry `https://github.com/rust-lang/crates.io-index`
+location searched: registry `crates-io`
 required by package `bar v0.1.0 ([..]/foo)`
 ",
         )

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -105,7 +105,7 @@ fn feature_required_dependency() {
 [UPDATING] [..]
 [DOWNLOADING] [..]
 [DOWNLOADED] bar v1.0.0 [..]
-error: failed to download replaced source registry `https://github.com/rust-lang/crates.io-index`
+error: failed to download replaced source registry `crates-io`
 
 Caused by:
   failed to parse manifest at `[..]/bar-1.0.0/Cargo.toml`
@@ -136,7 +136,7 @@ Caused by:
   unable to get packages from source
 
 Caused by:
-  failed to download replaced source registry `https://github.com/rust-lang/crates.io-index`
+  failed to download replaced source registry `crates-io`
 
 Caused by:
   failed to parse manifest at `[..]/bar-1.0.0/Cargo.toml`

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -9,7 +9,6 @@ fn simple_cross_package() {
     if cross_compile::disabled() {
         return;
     }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -42,10 +41,11 @@ fn simple_cross_package() {
     p.cargo("package --target")
         .arg(&target)
         .with_stderr(
-            "   Packaging foo v0.0.0 ([CWD])
-   Verifying foo v0.0.0 ([CWD])
-   Compiling foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
-    Finished dev [unoptimized + debuginfo] target(s) in [..]
+            "\
+[PACKAGING] foo v0.0.0 ([CWD])
+[VERIFYING] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -100,15 +100,15 @@ fn publish_with_target() {
     p.cargo("publish --token sekrit")
         .arg("--target")
         .arg(&target)
-        .with_stderr(&format!(
-            "    Updating `{registry}` index
-   Packaging foo v0.0.0 ([CWD])
-   Verifying foo v0.0.0 ([CWD])
-   Compiling foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
-    Finished dev [unoptimized + debuginfo] target(s) in [..]
-   Uploading foo v0.0.0 ([CWD])
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[PACKAGING] foo v0.0.0 ([CWD])
+[VERIFYING] foo v0.0.0 ([CWD])
+[COMPILING] foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[UPLOADING] foo v0.0.0 ([CWD])
 ",
-            registry = registry::registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -194,7 +194,7 @@ Caused by:
   no matching package found
   searched package name: `baz`
   perhaps you meant:      bar or foo
-  location searched: registry `https://github.com/rust-lang/crates.io-index`
+  location searched: registry `crates-io`
   required by package `bar v0.1.0`
 ",
         )

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -70,7 +70,7 @@ fn dependency_gate_ignored() {
             "\
 [UPDATING] [..]
 [ERROR] no matching package named `bar` found
-location searched: registry `https://github.com/rust-lang/crates.io-index`
+location searched: registry `crates-io`
 required by package `foo v0.1.0 ([..]/foo)`
 ",
         )

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -94,14 +94,14 @@ fn multiple_pkgs() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] foo v0.0.1 (registry `[CWD]/registry`)
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.2 (registry `[CWD]/registry`)
+[DOWNLOADED] bar v0.0.2 (registry `dummy-registry`)
 [INSTALLING] bar v0.0.2
 [COMPILING] bar v0.0.2
 [FINISHED] release [optimized] target(s) in [..]
@@ -154,14 +154,14 @@ fn multiple_pkgs_path_set() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] foo v0.0.1 (registry `[CWD]/registry`)
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.2 (registry `[CWD]/registry`)
+[DOWNLOADED] bar v0.0.2 (registry `dummy-registry`)
 [INSTALLING] bar v0.0.2
 [COMPILING] bar v0.0.2
 [FINISHED] release [optimized] target(s) in [..]
@@ -1695,8 +1695,9 @@ fn install_yanked_cargo_package() {
     cargo_process("install baz --version 0.0.1")
         .with_status(101)
         .with_stderr_contains(
-            "error: cannot install package `baz`, it has been yanked from registry \
-         `https://github.com/rust-lang/crates.io-index`",
+            "\
+[ERROR] cannot install package `baz`, it has been yanked from registry `crates-io`
+",
         )
         .run();
 }
@@ -1791,24 +1792,24 @@ fn install_semver_metadata() {
     cargo_process("install foo --registry alternative --version 1.0.0+abc").run();
     cargo_process("install foo --registry alternative")
         .with_stderr("\
-[UPDATING] `[ROOT]/alternative-registry` index
-[IGNORED] package `foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)` is already installed, use --force to override
+[UPDATING] `alternative` index
+[IGNORED] package `foo v1.0.0+abc (registry `alternative`)` is already installed, use --force to override
 [WARNING] be sure to add [..]
 ")
         .run();
     // "Updating" is not displayed here due to the --version fast-path.
     cargo_process("install foo --registry alternative --version 1.0.0+abc")
         .with_stderr("\
-[IGNORED] package `foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)` is already installed, use --force to override
+[IGNORED] package `foo v1.0.0+abc (registry `alternative`)` is already installed, use --force to override
 [WARNING] be sure to add [..]
 ")
         .run();
     cargo_process("install foo --registry alternative --version 1.0.0 --force")
         .with_stderr(
             "\
-[UPDATING] `[ROOT]/alternative-registry` index
-[INSTALLING] foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)
-[COMPILING] foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)
+[UPDATING] `alternative` index
+[INSTALLING] foo v1.0.0+abc (registry `alternative`)
+[COMPILING] foo v1.0.0+abc (registry `alternative`)
 [FINISHED] [..]
 [REPLACING] [ROOT]/home/.cargo/bin/foo[EXE]
 [REPLACED] package [..]
@@ -1820,16 +1821,18 @@ fn install_semver_metadata() {
     paths::home().join(".cargo/registry").rm_rf();
     paths::home().join(".cargo/bin").rm_rf();
     cargo_process("install foo --registry alternative --version 1.0.0")
-        .with_stderr("\
-[UPDATING] `[ROOT]/alternative-registry` index
+        .with_stderr(
+            "\
+[UPDATING] `alternative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)
-[INSTALLING] foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)
-[COMPILING] foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)
+[DOWNLOADED] foo v1.0.0+abc (registry `alternative`)
+[INSTALLING] foo v1.0.0+abc (registry `alternative`)
+[COMPILING] foo v1.0.0+abc (registry `alternative`)
 [FINISHED] [..]
 [INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
-[INSTALLED] package `foo v1.0.0+abc (registry `[ROOT]/alternative-registry`)` (executable `foo[EXE]`)
+[INSTALLED] package `foo v1.0.0+abc (registry `alternative`)` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
-")
+",
+        )
         .run();
 }

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -803,8 +803,9 @@ fn already_installed_updates_yank_status_on_upgrade() {
     cargo_process("install foo --version=1.0.1")
         .with_status(101)
         .with_stderr_contains(
-            "error: cannot install package `foo`, it has been yanked from registry \
-            `https://github.com/rust-lang/crates.io-index`",
+            "\
+[ERROR] cannot install package `foo`, it has been yanked from registry `crates-io`
+",
         )
         .run();
 

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -365,10 +365,10 @@ Caused by:
   failed to load source for dependency `bar`
 
 Caused by:
-  Unable to update registry `https://[..]`
+  Unable to update registry `crates-io`
 
 Caused by:
-  failed to update replaced source registry `https://[..]`
+  failed to update replaced source registry `crates-io`
 
 Caused by:
   local registry path is not a directory: [..]path[..]to[..]nowhere

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -164,7 +164,7 @@ fn cargo_compile_offline_not_try_update() {
 
     let msg = "\
 [ERROR] no matching package named `not_cached_dep` found
-location searched: registry `https://github.com/rust-lang/crates.io-index`
+location searched: registry `crates-io`
 required by package `bar v0.1.0 ([..]/bar)`
 As a reminder, you're using offline mode (--offline) which can sometimes cause \
 surprising resolution failures, if this error is too confusing you may wish to \
@@ -532,16 +532,18 @@ fn offline_resolve_optional_fail() {
 
     p.cargo("build --offline")
         .with_status(101)
-        .with_stderr("\
+        .with_stderr(
+            "\
 [ERROR] failed to select a version for the requirement `dep = \"^2.0\"`
 candidate versions found which didn't match: 1.0.0
-location searched: `[..]` index (which is replacing registry `https://github.com/rust-lang/crates.io-index`)
+location searched: `[..]` index (which is replacing registry `crates-io`)
 required by package `foo v0.1.0 ([..]/foo)`
 perhaps a crate was updated and forgotten to be re-vendored?
 As a reminder, you're using offline mode (--offline) which can sometimes cause \
 surprising resolution failures, if this error is too confusing you may wish to \
 retry without the offline flag.
-")
+",
+        )
         .run();
 }
 

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -52,7 +52,7 @@ fn replace() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([CWD]/bar)
@@ -99,7 +99,7 @@ fn from_config_without_z() {
         .with_stderr(
             "\
 [WARNING] `[patch]` in cargo config was ignored, the -Zpatch-in-config command-line flag is required
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
@@ -143,7 +143,7 @@ fn from_config() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -185,7 +185,7 @@ fn from_config_relative() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -230,7 +230,7 @@ fn from_config_precedence() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -270,7 +270,7 @@ fn nonexistent() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -365,7 +365,7 @@ fn patch_to_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -403,7 +403,7 @@ fn unused() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [WARNING] Patch `bar v0.2.0 ([CWD]/bar)` was not used in the crate graph.
 [..]
 [..]
@@ -469,7 +469,7 @@ fn prefer_patch_version() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -523,7 +523,7 @@ fn unused_from_config() {
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [WARNING] Patch `bar v0.2.0 ([CWD]/bar)` was not used in the crate graph.
 [..]
 [..]
@@ -597,7 +597,7 @@ fn unused_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [WARNING] Patch `bar v0.2.0 ([..])` was not used in the crate graph.
 [..]
 [..]
@@ -650,7 +650,7 @@ fn add_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
@@ -714,7 +714,7 @@ fn add_patch_from_config() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
@@ -774,7 +774,7 @@ fn add_ignored_patch() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
 [COMPILING] bar v0.1.0
@@ -866,7 +866,7 @@ fn add_patch_with_features() {
             "\
 [WARNING] patch for `bar` uses the features mechanism. \
 default-features and features will not take effect because the patch dependency does not support this mechanism
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -914,7 +914,7 @@ fn add_patch_with_setting_default_features() {
             "\
 [WARNING] patch for `bar` uses the features mechanism. \
 default-features and features will not take effect because the patch dependency does not support this mechanism
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1004,7 +1004,7 @@ fn new_minor() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.1 [..]
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1054,7 +1054,7 @@ fn transitive_new_minor() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] baz v0.1.1 [..]
 [COMPILING] bar v0.1.0 [..]
 [COMPILING] foo v0.0.1 ([CWD])
@@ -1092,7 +1092,7 @@ fn new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.2.0 [..]
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
@@ -1121,7 +1121,7 @@ fn new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.2.0 [..]
 [COMPILING] bar v0.2.0
@@ -1173,7 +1173,7 @@ fn transitive_new_major() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] baz v0.2.0 [..]
 [COMPILING] bar v0.1.0 [..]
 [COMPILING] foo v0.0.1 ([CWD])
@@ -1230,7 +1230,7 @@ fn shared_by_transitive() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [COMPILING] baz v0.1.2 [..]
 [COMPILING] bar v0.1.0 [..]
 [COMPILING] foo v0.1.0 ([CWD])
@@ -1952,7 +1952,7 @@ fn update_unused_new_version() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [COMPILING] bar v0.1.6 ([..]/bar)
 [COMPILING] foo v0.0.1 ([..]/foo)
 [FINISHED] [..]
@@ -1970,7 +1970,7 @@ fn update_unused_new_version() {
     p.cargo("update -p bar")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [ADDING] bar v0.1.6 ([..]/bar)
 [REMOVING] bar v0.1.5
 ",
@@ -1982,7 +1982,7 @@ fn update_unused_new_version() {
     p.cargo("update")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [ADDING] bar v0.1.6 ([..]/bar)
 [REMOVING] bar v0.1.5
 ",
@@ -2021,14 +2021,14 @@ fn too_many_matches() {
         .with_status(101)
         .with_stderr(
             "\
-[UPDATING] `[..]/alternative-registry` index
+[UPDATING] `alternative` index
 [ERROR] failed to resolve patches for `https://github.com/rust-lang/crates.io-index`
 
 Caused by:
   patch for `bar` in `https://github.com/rust-lang/crates.io-index` failed to resolve
 
 Caused by:
-  patch for `bar` in `registry `[..]/alternative-registry`` resolved to more than one candidate
+  patch for `bar` in `registry `alternative`` resolved to more than one candidate
   Found versions: 0.1.0, 0.1.1
   Update the patch definition to select only one package.
   For example, add an `=` version requirement to the patch definition, such as `version = \"=0.1.1\"`.
@@ -2146,7 +2146,7 @@ fn patch_walks_backwards() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2160,7 +2160,7 @@ fn patch_walks_backwards() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2198,7 +2198,7 @@ fn patch_walks_backwards_restricted() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2268,7 +2268,7 @@ fn patched_dep_new_version() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 [..]
 [CHECKING] baz v0.1.0
@@ -2301,9 +2301,9 @@ fn patched_dep_new_version() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] baz v0.1.1 (registry `[..]/registry`)
+[DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
 [CHECKING] baz v0.1.1
 [CHECKING] bar v0.1.0 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
@@ -2345,11 +2345,11 @@ fn patch_update_doesnt_update_other_sources() {
     p.cargo("check")
         .with_stderr_unordered(
             "\
-[UPDATING] `[..]/registry` index
-[UPDATING] `[..]/alternative-registry` index
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.1.0 (registry `[..]/alternative-registry`)
-[CHECKING] bar v0.1.0 (registry `[..]/alternative-registry`)
+[DOWNLOADED] bar v0.1.0 (registry `alternative`)
+[CHECKING] bar v0.1.0 (registry `alternative`)
 [CHECKING] bar v0.1.0 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2371,7 +2371,7 @@ fn patch_update_doesnt_update_other_sources() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/registry` index
+[UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2409,11 +2409,11 @@ fn can_update_with_alt_reg() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/alternative-registry` index
-[UPDATING] `[..]/registry` index
+[UPDATING] `alternative` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.1.1 (registry `[..]/alternative-registry`)
-[CHECKING] bar v0.1.1 (registry `[..]/alternative-registry`)
+[DOWNLOADED] bar v0.1.1 (registry `alternative`)
+[CHECKING] bar v0.1.1 (registry `alternative`)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
 ",
@@ -2429,8 +2429,8 @@ fn can_update_with_alt_reg() {
     p.cargo("update -p bar")
         .with_stderr(
             "\
-[UPDATING] `[..]/alternative-registry` index
-[UPDATING] `[..]/registry` index
+[UPDATING] `alternative` index
+[UPDATING] `dummy-registry` index
 ",
         )
         .run();
@@ -2454,11 +2454,11 @@ fn can_update_with_alt_reg() {
     p.cargo("check")
         .with_stderr(
             "\
-[UPDATING] `[..]/alternative-registry` index
-[UPDATING] `[..]/registry` index
+[UPDATING] `alternative` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.1.2 (registry `[..]/alternative-registry`)
-[CHECKING] bar v0.1.2 (registry `[..]/alternative-registry`)
+[DOWNLOADED] bar v0.1.2 (registry `alternative`)
+[CHECKING] bar v0.1.2 (registry `alternative`)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
 ",

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -90,16 +90,15 @@ fn simple() {
         .build();
 
     p.cargo("publish --no-verify --token sekrit")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `dummy-registry` index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [UPLOADING] foo v0.0.1 ([CWD])
 ",
-            reg = registry::registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 
     validate_upload_foo();
@@ -141,9 +140,9 @@ fn old_token_location() {
     fs::write(&credentials, r#"token = "api-token""#).unwrap();
 
     p.cargo("publish --no-verify")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `dummy-registry` index
 [WARNING] using `registry.token` config value with source replacement is deprecated
 This may become a hard error in the future[..]
 Use the --token command-line flag to remove this warning.
@@ -152,8 +151,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [UPLOADING] foo v0.0.1 ([CWD])
 ",
-            reg = registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 
     validate_upload_foo();

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -333,7 +333,7 @@ fn warn_package_with_yanked() {
 [PACKAGING] foo v0.0.1 ([..])
 [UPDATING] `[..]` index
 [WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry \
-    `crates.io`, consider updating to a version that is not yanked
+    `crates-io`, consider updating to a version that is not yanked
 ",
         )
         .run();
@@ -372,7 +372,7 @@ dependencies = [
 [DOWNLOADED] foo v0.1.0 (registry `[..]`)
 [INSTALLING] foo v0.1.0
 [WARNING] package `bar v0.1.0` in Cargo.lock is yanked in registry \
-    `crates.io`, consider running without --locked
+    `crates-io`, consider running without --locked
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `[..]`)
 [COMPILING] bar v0.1.0

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -31,17 +31,16 @@ fn simple() {
     Package::new("bar", "0.0.1").publish();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 
     p.cargo("clean").run();
@@ -80,19 +79,18 @@ fn deps() {
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
     p.cargo("build")
-        .with_stderr(&format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }
 
@@ -279,10 +277,10 @@ fn bad_cksum() {
 [UPDATING] [..] index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum [..]
-[ERROR] failed to download replaced source registry `https://[..]`
+[ERROR] failed to download replaced source registry `crates-io`
 
 Caused by:
-  failed to verify the checksum of `bad-cksum v0.0.1 (registry `[ROOT][..]`)`
+  failed to verify the checksum of `bad-cksum v0.0.1 (registry `dummy-registry`)`
 ",
         )
         .run();
@@ -322,17 +320,16 @@ required by package `foo v0.0.1 ([..])`
     Package::new("notyet", "0.0.1").publish();
 
     p.cargo("build")
-        .with_stderr(format!(
+        .with_stderr(
             "\
-[UPDATING] `{reg}` index
+[UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] notyet v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
-            reg = registry_path().to_str().unwrap()
-        ))
+        )
         .run();
 }
 
@@ -372,7 +369,7 @@ fn package_with_path_deps() {
 
 Caused by:
   no matching package named `notyet` found
-  location searched: registry `https://github.com/rust-lang/crates.io-index`
+  location searched: registry `crates-io`
   required by package `foo v0.0.1 [..]`
 ",
         )
@@ -387,7 +384,7 @@ Caused by:
 [UPDATING] `[..]` index
 [VERIFYING] foo v0.0.1 ([CWD])
 [DOWNLOADING] crates ...
-[DOWNLOADED] notyet v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ([CWD][..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -421,7 +418,7 @@ fn lockfile_locks() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -461,8 +458,8 @@ fn lockfile_locks_transitively() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
@@ -509,8 +506,8 @@ fn yanks_are_not_used() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [COMPILING] baz v0.0.1
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
@@ -722,7 +719,7 @@ fn update_with_lockfile_if_packages_missing() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -769,7 +766,7 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.2 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.2 (registry `dummy-registry`)
 [COMPILING] bar v0.0.2
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -792,7 +789,7 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.3 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.3 (registry `dummy-registry`)
 [COMPILING] bar v0.0.3
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -852,7 +849,7 @@ fn dev_dependency_not_used() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..] v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -948,7 +945,7 @@ fn updating_a_dep() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [COMPILING] bar v0.0.1
 [COMPILING] a v0.0.1 ([CWD]/a)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -977,7 +974,7 @@ fn updating_a_dep() {
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.1.0 (registry `[ROOT][..]`)
+[DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 [COMPILING] bar v0.1.0
 [COMPILING] a v0.0.1 ([CWD]/a)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -1035,7 +1032,7 @@ fn git_and_registry_dep() {
 [UPDATING] [..]
 [UPDATING] [..]
 [DOWNLOADING] crates ...
-[DOWNLOADED] a v0.0.1 (registry `[ROOT][..]`)
+[DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
 [COMPILING] a v0.0.1
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
@@ -1112,7 +1109,7 @@ fn update_publish_then_update() {
             "\
 [UPDATING] [..]
 [DOWNLOADING] crates ...
-[DOWNLOADED] a v0.1.1 (registry `[ROOT][..]`)
+[DOWNLOADED] a v0.1.1 (registry `dummy-registry`)
 [COMPILING] a v0.1.1
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
@@ -1190,7 +1187,7 @@ fn update_transitive_dependency() {
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
-[DOWNLOADED] b v0.1.1 (registry `[ROOT][..]`)
+[DOWNLOADED] b v0.1.1 (registry `dummy-registry`)
 [COMPILING] b v0.1.1
 [COMPILING] a v0.1.0
 [COMPILING] foo v0.5.0 ([..])
@@ -1299,9 +1296,9 @@ fn update_multiple_packages() {
         .run();
 
     p.cargo("build")
-        .with_stderr_contains("[DOWNLOADED] a v0.1.1 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[DOWNLOADED] b v0.1.1 (registry `[ROOT][..]`)")
-        .with_stderr_contains("[DOWNLOADED] c v0.1.1 (registry `[ROOT][..]`)")
+        .with_stderr_contains("[DOWNLOADED] a v0.1.1 (registry `dummy-registry`)")
+        .with_stderr_contains("[DOWNLOADED] b v0.1.1 (registry `dummy-registry`)")
+        .with_stderr_contains("[DOWNLOADED] c v0.1.1 (registry `dummy-registry`)")
         .with_stderr_contains("[COMPILING] a v0.1.1")
         .with_stderr_contains("[COMPILING] b v0.1.1")
         .with_stderr_contains("[COMPILING] c v0.1.1")

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -42,7 +42,7 @@ fn override_simple() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 ([CWD])
@@ -195,7 +195,7 @@ fn transitive() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.2.0 (registry [..])
@@ -247,7 +247,7 @@ fn persists_across_rebuilds() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [UPDATING] git repository `file://[..]`
 [COMPILING] bar v0.1.0 (file://[..])
 [COMPILING] foo v0.0.1 ([CWD])
@@ -294,8 +294,8 @@ fn replace_registry_with_path() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
-[COMPILING] bar v0.1.0 ([ROOT][..])
+[UPDATING] `dummy-registry` index
+[COMPILING] bar v0.1.0 ([ROOT][..]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -359,7 +359,7 @@ fn use_a_spec_to_select() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
@@ -420,7 +420,7 @@ fn override_adds_some_deps() {
     p.cargo("build")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry [..])
@@ -440,14 +440,14 @@ fn override_adds_some_deps() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 ",
         )
         .run();
     p.cargo("update -p https://github.com/rust-lang/crates.io-index#bar")
         .with_stderr(
             "\
-[UPDATING] `[ROOT][..]` index
+[UPDATING] `dummy-registry` index
 ",
         )
         .run();

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -87,7 +87,7 @@ fn dependency_gate_ignored() {
             "\
 [UPDATING] [..]
 [ERROR] no matching package named `bar` found
-location searched: registry `https://github.com/rust-lang/crates.io-index`
+location searched: registry `crates-io`
 required by package `foo v0.1.0 ([..]/foo)`
 ",
         )


### PR DESCRIPTION
Fixes #6691

This PR can be divided into several parts:

- c5be3de: Try to display registry names instead of URLs for `impl Dipslay for SourceId`. This benefits almost all kinds of messages using`SourceId` directly or indrectly.
- 9394d48: This fixes `Updating <name> index` part of `[source]` replacement, which previously didn't preserve the registry name information.
- 4c2f9b5: This makes its best effort to show registry names for deps from `Cargo.lock`. Since current lockfile format does not serialize any registry name. We here try the best effort to restore registry name from either `[registries]` table or `[source]` replacement table. This is done by manually implementing `Hash` and `PartialEq` for `SourceIdInner`, of which two traits previously are simply derived. 
    To make `SourceIdInner` generate the same hash no matter it contains `name` field or not, here we remove `name` field from hashing and only concern about `kind`, `precise` and `canonical_url`.
    
Feel free to ask me for adding more tests, though I am not sure what tests should be added 😅