### PR TITLE
Exclude `target` from content-indexing on Windows

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -637,6 +637,7 @@ pub fn create_dir_all_excluded_from_backups_atomic(p: impl AsRef<Path>) -> Resul
     // point as the old one).
     let tempdir = TempFileBuilder::new().prefix(base).tempdir_in(parent)?;
     exclude_from_backups(tempdir.path());
+    exclude_from_content_indexing(tempdir.path());
     // Previously std::fs::create_dir_all() (through paths::create_dir_all()) was used
     // here to create the directory directly and fs::create_dir_all() explicitly treats
     // the directory being created concurrently by another thread or process as success,
@@ -668,6 +669,29 @@ fn exclude_from_backups(path: &Path) {
 ",
     );
     // Similarly to exclude_from_time_machine() we ignore errors here as it's an optional feature.
+}
+
+/// Marks the directory as excluded from content indexing.
+///
+/// This is recommended to prevent the content of derived/temporary files from being indexed.
+/// This is very important for Windows users, as the live content indexing significantly slows
+/// cargo's I/O operations.
+///
+/// This is currently a no-op on non-Windows platforms.
+fn exclude_from_content_indexing(path: &Path) {
+    if cfg!(windows) {
+        use std::iter::once;
+        use std::os::windows::prelude::OsStrExt;
+        use winapi::um::fileapi::{GetFileAttributesW, SetFileAttributesW};
+        use winapi::um::winnt::FILE_ATTRIBUTE_NOT_CONTENT_INDEXED;
+
+        let lp_path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
+        unsafe {
+            SetFileAttributesW(lp_path.as_ptr(), GetFileAttributesW(lp_path.as_ptr()) | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
+        }
+    } else {
+        let _ = path;
+    }
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
This has a noticeable performance improvement for most projects, especially when the storage device is a hard drive.

Closes #8694