### PR TITLE
Temporarily ignore 2021 edition fix.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1503,6 +1503,7 @@ fn rustfix_handles_multi_spans() {
 }
 
 #[cargo_test]
+#[ignore] // Broken, see https://github.com/rust-lang/rust/pull/86009
 fn fix_edition_2021() {
     // Can migrate 2021, even when lints are allowed.
     if !is_nightly() {


### PR DESCRIPTION
The latest nightly broke the interaction of `--force-warns` and `--cap-lints`.  Since this will likely take at least a few days to fix, I am temporarily disabling this test to get cargo's CI working again.