### PR TITLE
Adjust error message with offline and frozen.

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -46,10 +46,6 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &mut Resolve) -> CargoRes
     }
 
     if !ws.config().lock_update_allowed() {
-        if ws.config().offline() {
-            anyhow::bail!("can't update in the offline mode");
-        }
-
         let flag = if ws.config().network_allowed() {
             "--locked"
         } else {
@@ -58,8 +54,9 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &mut Resolve) -> CargoRes
         anyhow::bail!(
             "the lock file {} needs to be updated but {} was passed to prevent this\n\
              If you want to try to generate the lock file without accessing the network, \
-             use the --offline flag.",
+             remove the {} flag and use --offline instead.",
             ws.root().to_path_buf().join("Cargo.lock").display(),
+            flag,
             flag
         );
     }

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -511,7 +511,8 @@ fn locked_correct_error() {
             "\
 [UPDATING] `[..]` index
 error: the lock file [CWD]/Cargo.lock needs to be updated but --locked was passed to prevent this
-If you want to try to generate the lock file without accessing the network, use the --offline flag.
+If you want to try to generate the lock file without accessing the network, \
+remove the --locked flag and use --offline instead.
 ",
         )
         .run();

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -685,3 +685,16 @@ retry without the offline flag.
         )
         .run();
 }
+
+#[cargo_test]
+fn offline_and_frozen_and_no_lock() {
+    let p = project().file("src/lib.rs", "").build();
+    p.cargo("build --frozen --offline")
+        .with_status(101)
+        .with_stderr("\
+error: the lock file [ROOT]/foo/Cargo.lock needs to be updated but --frozen was passed to prevent this
+If you want to try to generate the lock file without accessing the network, \
+remove the --frozen flag and use --offline instead.
+")
+        .run();
+}


### PR DESCRIPTION
Using --offline with --frozen when the lock file needed to be updated gave a confusing error message. This updates it to make it slightly clearer.

Closes #9572
