### PR TITLE
Include the linker in the fingerprint.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1035,6 +1035,11 @@ pub fn rustc_host() -> &'static str {
     &RUSTC_INFO.host
 }
 
+/// The host triple suitable for use in a cargo environment variable (uppercased).
+pub fn rustc_host_env() -> String {
+    rustc_host().to_uppercase().replace('-', "_")
+}
+
 pub fn is_nightly() -> bool {
     let vv = &RUSTC_INFO.verbose_version;
     env::var("CARGO_TEST_DISABLE_NIGHTLY").is_err()

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -13,7 +13,9 @@ use std::time::SystemTime;
 use super::death;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_manifest, is_coarse_mtime, project, rustc_host, sleep_ms};
+use cargo_test_support::{
+    basic_manifest, is_coarse_mtime, project, rustc_host, rustc_host_env, sleep_ms,
+};
 
 #[cargo_test]
 fn modifying_and_moving() {
@@ -2405,10 +2407,7 @@ fn linking_interrupted() {
 
     // Make a change, start a build, then interrupt it.
     p.change_file("src/lib.rs", "// modified");
-    let linker_env = format!(
-        "CARGO_TARGET_{}_LINKER",
-        rustc_host().to_uppercase().replace('-', "_")
-    );
+    let linker_env = format!("CARGO_TARGET_{}_LINKER", rustc_host_env());
     // NOTE: This assumes that the paths to the linker or rustc are not in the
     // fingerprint. But maybe they should be?
     let mut cmd = p
@@ -2637,6 +2636,25 @@ fn cargo_env_changes() {
             "\
 [FRESH] foo [..]
 [FINISHED] [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn changing_linker() {
+    // Changing linker should rebuild.
+    let p = project().file("src/main.rs", "fn main() {}").build();
+    p.cargo("build").run();
+    let linker_env = format!("CARGO_TARGET_{}_LINKER", rustc_host_env());
+    p.cargo("build --verbose")
+        .env(&linker_env, "nonexistent-linker")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[COMPILING] foo v0.0.1 ([..])
+[RUNNING] `rustc [..] -C linker=nonexistent-linker [..]`
+[ERROR] [..]linker[..]
 ",
         )
         .run();

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -1,6 +1,8 @@
 //! Tests for configuration values that point to programs.
 
-use cargo_test_support::{basic_lib_manifest, no_such_file_err_msg, project, rustc_host};
+use cargo_test_support::{
+    basic_lib_manifest, no_such_file_err_msg, project, rustc_host, rustc_host_env,
+};
 
 #[cargo_test]
 fn pathless_tools() {
@@ -262,13 +264,9 @@ second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config
 
 #[cargo_test]
 fn custom_runner_env() {
-    let target = rustc_host();
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    let key = format!(
-        "CARGO_TARGET_{}_RUNNER",
-        target.to_uppercase().replace('-', "_")
-    );
+    let key = format!("CARGO_TARGET_{}_RUNNER", rustc_host_env());
 
     p.cargo("run")
         .env(&key, "nonexistent-runner --foo")
@@ -305,10 +303,7 @@ fn custom_runner_env_overrides_config() {
         )
         .build();
 
-    let key = format!(
-        "CARGO_TARGET_{}_RUNNER",
-        target.to_uppercase().replace('-', "_")
-    );
+    let key = format!("CARGO_TARGET_{}_RUNNER", rustc_host_env());
 
     p.cargo("run")
         .env(&key, "should-run --foo")
@@ -322,13 +317,9 @@ fn custom_runner_env_overrides_config() {
 fn custom_runner_env_true() {
     // Check for a bug where "true" was interpreted as a boolean instead of
     // the executable.
-    let target = rustc_host();
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    let key = format!(
-        "CARGO_TARGET_{}_RUNNER",
-        target.to_uppercase().replace('-', "_")
-    );
+    let key = format!("CARGO_TARGET_{}_RUNNER", rustc_host_env());
 
     p.cargo("run")
         .env(&key, "true")
@@ -338,13 +329,9 @@ fn custom_runner_env_true() {
 
 #[cargo_test]
 fn custom_linker_env() {
-    let target = rustc_host();
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    let key = format!(
-        "CARGO_TARGET_{}_LINKER",
-        target.to_uppercase().replace('-', "_")
-    );
+    let key = format!("CARGO_TARGET_{}_LINKER", rustc_host_env());
 
     p.cargo("build -v")
         .env(&key, "nonexistent-linker")


### PR DESCRIPTION
This adds the linker from the `[target]` config table to the fingerprint. Previously, changing the value would not trigger a rebuild.
