### PR TITLE
Adjust the edition2021 resolver diff report.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1431,8 +1431,9 @@ fn edition_v2_resolver_report() {
     }
     Package::new("common", "1.0.0")
         .feature("f1", &[])
-        .file("src/lib.rs", "")
+        .add_dep(Dependency::new("opt_dep", "1.0").optional(true))
         .publish();
+    Package::new("opt_dep", "1.0.0").publish();
 
     Package::new("bar", "1.0.0")
         .add_dep(
@@ -1454,6 +1455,9 @@ fn edition_v2_resolver_report() {
                 [dependencies]
                 common = "1.0"
                 bar = "1.0"
+
+                [build-dependencies]
+                common = { version = "1.0", features = ["opt_dep"] }
             "#,
         )
         .file("src/lib.rs", "")
@@ -1466,13 +1470,16 @@ fn edition_v2_resolver_report() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 [..]
 [DOWNLOADED] bar v1.0.0 [..]
+[DOWNLOADED] opt_dep v1.0.0 [..]
 note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
-This may cause dependencies to resolve with a different set of features.
-More information about the resolver changes may be found at https://doc.rust-lang.org/cargo/reference/features.html#feature-resolver-version-2
-The following differences were detected with the current configuration:
+This may cause some dependencies to be built with fewer features enabled than previously.
+More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
+When building the following dependencies, the given features will no longer be used:
 
-  common v1.0.0 removed features `f1`
+  common v1.0.0: f1, opt_dep
+  common v1.0.0 (as host dependency): f1
 
+[CHECKING] opt_dep v1.0.0
 [CHECKING] common v1.0.0
 [CHECKING] bar v1.0.0
 [CHECKING] foo v0.1.0 [..]


### PR DESCRIPTION
This makes some adjustments to the report given on `cargo fix --edition` when there are differences in the feature resolver.

- Tweak the wording to be clearer.
- Removed the "activated dependencies" differences. This doesn't actually work (dependencies aren't ever completely removed), and isn't all that interesting (since it would be duplicating the same information from the feature differences).