### PR TITLE
Update should_use_metadata function

### DIFF
--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -493,8 +493,8 @@ fn changing_bin_features_caches_targets() {
     /* Targets should be cached from the first build */
 
     let mut e = p.cargo("build");
-    // MSVC/apple does not include hash in binary filename, so it gets recompiled.
-    if cfg!(any(target_env = "msvc", target_vendor = "apple")) {
+    // MSVC does not include hash in binary filename, so it gets recompiled.
+    if cfg!(target_env = "msvc") {
         e.with_stderr("[COMPILING] foo[..]\n[FINISHED] dev[..]");
     } else {
         e.with_stderr("[FINISHED] dev[..]");
@@ -503,7 +503,7 @@ fn changing_bin_features_caches_targets() {
     p.rename_run("foo", "off2").with_stdout("feature off").run();
 
     let mut e = p.cargo("build --features foo");
-    if cfg!(any(target_env = "msvc", target_vendor = "apple")) {
+    if cfg!(target_env = "msvc") {
         e.with_stderr("[COMPILING] foo[..]\n[FINISHED] dev[..]");
     } else {
         e.with_stderr("[FINISHED] dev[..]");


### PR DESCRIPTION
* Correct the reason for not renaming dylibs
* Add todo for -install-name/-soname usage
* Limit wasm32 executable metadata omission to emscripten. Wasm file don't contain any filename themself.
* Don't omit metadata for executables on macOS. backtrace-rs is now able to load debuginfo for renamed .dSYM files: https://github.com/rust-lang/backtrace-rs/blob/ed3689c2f2b9a31546d75fae389a32a572957dbd/src/symbolize/gimli/macho.rs#L51-L65
* Mention another reason to include the metadata hash for libstd.