### PR TITLE
Update Windows env uppercase key check.

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -232,14 +232,11 @@ impl Config {
             })
             .collect();
 
-        let upper_case_env = if cfg!(windows) {
-            HashMap::new()
-        } else {
-            env.clone()
-                .into_iter()
-                .map(|(k, _)| (k.to_uppercase().replace("-", "_"), k))
-                .collect()
-        };
+        let upper_case_env = env
+            .clone()
+            .into_iter()
+            .map(|(k, _)| (k.to_uppercase().replace("-", "_"), k))
+            .collect();
 
         let cache_rustc_info = match env.get("CARGO_CACHE_RUSTC_INFO") {
             Some(cache) => cache != "0",
@@ -696,12 +693,6 @@ impl Config {
     }
 
     fn check_environment_key_case_mismatch(&self, key: &ConfigKey) {
-        if cfg!(windows) {
-            // In the case of windows the check for case mismatch in keys can be skipped
-            // as windows already converts its environment keys into the desired format.
-            return;
-        }
-
         if let Some(env_key) = self.upper_case_env.get(key.as_env_key()) {
             let _ = self.shell().warn(format!(
                 "Environment variables are expected to use uppercase letters and underscores, \

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -341,9 +341,12 @@ fn custom_linker_env() {
 }
 
 #[cargo_test]
-// Temporarily disabled until https://github.com/rust-lang/rust/pull/85270 is in nightly.
-#[cfg_attr(target_os = "windows", ignore)]
 fn target_in_environment_contains_lower_case() {
+    if cfg!(windows) && !cargo_test_support::is_nightly() {
+        // Remove this check when 1.55 is stabilized.
+        // https://github.com/rust-lang/rust/pull/85270
+        return;
+    }
     let p = project().file("src/main.rs", "fn main() {}").build();
 
     let target = rustc_host();


### PR DESCRIPTION
This is the followup for #9646. Rust now correctly spawns processes with preserved casing on nightly on Windows, so the exceptions here are no longer needed.