### PR TITLE
Unify cargo and rustc's error reporting

### DIFF
--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -51,6 +51,7 @@ pub struct FutureBreakageItem {
 #[derive(Serialize, Deserialize)]
 pub struct Diagnostic {
     pub rendered: String,
+    pub level: String,
 }
 
 /// The filename in the top-level `target` directory where we store

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -89,13 +89,7 @@ pub fn exit_with_error(err: CliError, shell: &mut Shell) -> ! {
 /// Displays an error, and all its causes, to stderr.
 pub fn display_error(err: &Error, shell: &mut Shell) {
     debug!("display_error; err={:?}", err);
-    let has_verbose = _display_error(err, shell, true);
-    if has_verbose {
-        drop(writeln!(
-            shell.err(),
-            "\nTo learn more, run the command again with --verbose."
-        ));
-    }
+    _display_error(err, shell, true);
     if err
         .chain()
         .any(|e| e.downcast_ref::<InternalError>().is_some())

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -588,12 +588,7 @@ fn cargo_compile_with_invalid_code() {
 
     p.cargo("build")
         .with_status(101)
-        .with_stderr_contains(
-            "\
-[ERROR] could not compile `foo`
-
-To learn more, run the command again with --verbose.\n",
-        )
+        .with_stderr_contains("[ERROR] could not compile `foo` due to previous error\n")
         .run();
     assert!(p.root().join("Cargo.lock").is_file());
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1458,7 +1458,7 @@ fn build_deps_not_for_normal() {
         .with_stderr_contains("[..]can't find crate for `aaaaa`[..]")
         .with_stderr_contains(
             "\
-[ERROR] could not compile `foo`
+[ERROR] could not compile `foo` due to previous error
 
 Caused by:
   process didn't exit successfully: [..]

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -803,8 +803,7 @@ fn short_message_format() {
         .with_stderr_contains(
             "\
 src/lib.rs:1:27: error[E0308]: mismatched types
-error: aborting due to previous error
-error: could not compile `foo`
+error: could not compile `foo` due to previous error
 ",
         )
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -28,7 +28,7 @@ fn do_not_fix_broken_builds() {
     p.cargo("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_status(101)
-        .with_stderr_contains("[ERROR] could not compile `foo`")
+        .with_stderr_contains("[ERROR] could not compile `foo` due to previous error")
         .run();
     assert!(p.read_file("src/lib.rs").contains("let mut x = 3;"));
 }
@@ -833,8 +833,6 @@ fn prepare_for_unstable() {
 [ERROR] cannot migrate src/lib.rs to edition {next}
 Edition {next} is unstable and not allowed in this release, consider trying the nightly release channel.
 error: could not compile `foo`
-
-To learn more, run the command again with --verbose.
 ", next=next))
         .run();
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -742,9 +742,7 @@ fn compile_failure() {
     found at `[..]target`
 
 Caused by:
-  could not compile `foo`
-
-To learn more, run the command again with --verbose.
+  could not compile `foo` due to previous error
 ",
         )
         .run();


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust/issues/86854.

 ## Don't print "run the command again with --verbose"

Here is a typical error seen by users of Cargo:

```
error[E0601]: `main` function not found in crate `wrong`
  |
  = note: consider adding a `main` function to `src/main.rs`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0601`.
error: could not compile `wrong`

To learn more, run the command again with --verbose.
```

The `--verbose` output is not particularly helpful in this case. The
error is unrelated to what cargo is doing, and passing `--verbose` will
not give useful information about how to proceed. Additionally, it's
unclear that `--verbose` is referring to the cargo command and not
rustc; this is especially true when cargo is wrapped by another build
system (such as Meson, x.py, or Make).

This omits the "run the command again with --verbose" output. --verbose
is still shown in `cargo build --help`, but it's not singled out above
all the other options.

 ##  Combine rustc and cargo's diagnostic summaries

This works by introspecting rustc's error output, using the JSON format
to determine whether it's a warning or error, then skipping it
altogether if it's a summary of the diagnostics printed.

Before:

```
$ cargo check --message-format short
src/main.rs:1:10: warning: trait objects without an explicit `dyn` are deprecated
src/main.rs:1:1: error[E0601]: `main` function not found in crate `wrong`
src/main.rs:1:9: error[E0038]: the trait `Clone` cannot be made into an object
error: aborting due to 2 previous errors; 1 warning emitted
error: could not compile `wrong`
```

After:

```
$ cargo check --message-format short
src/main.rs:1:10: warning: trait objects without an explicit `dyn` are deprecated
src/main.rs:1:1: error[E0601]: `main` function not found in crate `wrong`
src/main.rs:1:9: error[E0038]: the trait `Clone` cannot be made into an object
error: could not compile `wrong` due to 2 previous errors; 1 warning emitted
```