### PR TITLE
Don't recommend filing issues on rust-lang/cargo for Cargo.toml errors.

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -37,12 +37,11 @@ pub const MANIFEST_PREAMBLE: &str = "\
 # When uploading crates to the registry Cargo will automatically
 # \"normalize\" Cargo.toml files for maximal compatibility
 # with all versions of Cargo and also rewrite `path` dependencies
-# to registry (e.g., crates.io) dependencies
+# to registry (e.g., crates.io) dependencies.
 #
-# If you believe there's an error in this file please file an
-# issue against the rust-lang/cargo repository. If you're
-# editing this file be aware that the upstream Cargo.toml
-# will likely look very different (and much more reasonable)
+# If you are reading this file be aware that the original Cargo.toml
+# will likely look very different (and much more reasonable).
+# See Cargo.toml.orig for the original contents.
 ";
 
 /// Information about a package that is available somewhere in the file system.


### PR DESCRIPTION
I don't think this suggestion has ever led to something useful, and is just confusing.

cc #9610


