### PR TITLE
Unignore fix_edition_2021.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1510,7 +1510,6 @@ fn rustfix_handles_multi_spans() {
 }
 
 #[cargo_test]
-#[ignore] // Broken, see https://github.com/rust-lang/rust/pull/86009
 fn fix_edition_2021() {
     // Can migrate 2021, even when lints are allowed.
     if !is_nightly() {


### PR DESCRIPTION
The issue has been fixed by https://github.com/rust-lang/rust/pull/86572.
