### PR TITLE
Add format option to `cargo tree` to print the lib_name

### DIFF
--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -102,17 +102,14 @@ impl<'a> fmt::Display for Display<'a> {
                             write!(fmt, "{}", features.join(","))?;
                         }
                         Chunk::Name => {
-                            write!(
-                                fmt,
-                                "{}",
-                                package
-                                    .manifest()
-                                    .targets()
-                                    .iter()
-                                    .find(|target| target.is_lib() || target.is_dylib())
-                                    .map(|lib_target| lib_target.name())
-                                    .unwrap_or(&package.name())
-                            )?;
+                            if let Some(target) = package
+                                .manifest()
+                                .targets()
+                                .iter()
+                                .find(|target| target.is_lib())
+                            {
+                                write!(fmt, "{}", target.name())?;
+                            }
                         }
                     }
                 }

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -13,7 +13,7 @@ enum Chunk {
     License,
     Repository,
     Features,
-    Name,
+    LibName,
 }
 
 pub struct Pattern(Vec<Chunk>);
@@ -29,7 +29,7 @@ impl Pattern {
                 RawChunk::Argument("l") => Chunk::License,
                 RawChunk::Argument("r") => Chunk::Repository,
                 RawChunk::Argument("f") => Chunk::Features,
-                RawChunk::Argument("lib") => Chunk::Name,
+                RawChunk::Argument("lib") => Chunk::LibName,
                 RawChunk::Argument(a) => {
                     bail!("unsupported pattern `{}`", a);
                 }
@@ -101,7 +101,7 @@ impl<'a> fmt::Display for Display<'a> {
                         Chunk::Features => {
                             write!(fmt, "{}", features.join(","))?;
                         }
-                        Chunk::Name => {
+                        Chunk::LibName => {
                             if let Some(target) = package
                                 .manifest()
                                 .targets()

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -11,6 +11,7 @@ enum Chunk {
     License,
     Repository,
     Features,
+    Name,
 }
 
 pub struct Pattern(Vec<Chunk>);
@@ -26,6 +27,7 @@ impl Pattern {
                 RawChunk::Argument("l") => Chunk::License,
                 RawChunk::Argument("r") => Chunk::Repository,
                 RawChunk::Argument("f") => Chunk::Features,
+                RawChunk::Argument("n") => Chunk::Name,
                 RawChunk::Argument(a) => {
                     bail!("unsupported pattern `{}`", a);
                 }
@@ -96,6 +98,22 @@ impl<'a> fmt::Display for Display<'a> {
                         }
                         Chunk::Features => {
                             write!(fmt, "{}", features.join(","))?;
+                        }
+                        Chunk::Name => {
+                            let pname = package.name().as_str();
+                            write!(
+                                fmt,
+                                "{}",
+                                package
+                                    .manifest()
+                                    .targets()
+                                    .iter()
+                                    .filter(|t| t.is_dylib() || t.is_lib())
+                                    .map(|l| l.name())
+                                    .collect::<Vec<_>>()
+                                    .get(0)
+                                    .unwrap_or(&pname)
+                            )?;
                         }
                     }
                 }

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -29,7 +29,7 @@ impl Pattern {
                 RawChunk::Argument("l") => Chunk::License,
                 RawChunk::Argument("r") => Chunk::Repository,
                 RawChunk::Argument("f") => Chunk::Features,
-                RawChunk::Argument("n") => Chunk::Name,
+                RawChunk::Argument("lib") => Chunk::Name,
                 RawChunk::Argument(a) => {
                     bail!("unsupported pattern `{}`", a);
                 }

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -108,7 +108,7 @@ impl<'a> fmt::Display for Display<'a> {
                                 .iter()
                                 .find(|target| target.is_lib())
                             {
-                                write!(fmt, "{}", target.name())?;
+                                write!(fmt, "{}", target.crate_name())?;
                             }
                         }
                     }

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -1,7 +1,9 @@
+use std::fmt;
+
+use anyhow::{bail, Error};
+
 use self::parse::{Parser, RawChunk};
 use super::{Graph, Node};
-use anyhow::{bail, Error};
-use std::fmt;
 
 mod parse;
 

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -109,7 +109,7 @@ impl<'a> fmt::Display for Display<'a> {
                                     .manifest()
                                     .targets()
                                     .iter()
-                                    .find(|target| target.is_dylib() || target.is_lib())
+                                    .find(|target| target.is_lib() || target.is_dylib())
                                     .map(|lib_target| lib_target.name())
                                     .unwrap_or(&package.name())
                             )?;

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -102,7 +102,6 @@ impl<'a> fmt::Display for Display<'a> {
                             write!(fmt, "{}", features.join(","))?;
                         }
                         Chunk::Name => {
-                            let pname = package.name().as_str();
                             write!(
                                 fmt,
                                 "{}",
@@ -110,11 +109,9 @@ impl<'a> fmt::Display for Display<'a> {
                                     .manifest()
                                     .targets()
                                     .iter()
-                                    .filter(|t| t.is_dylib() || t.is_lib())
-                                    .map(|l| l.name())
-                                    .collect::<Vec<_>>()
-                                    .get(0)
-                                    .unwrap_or(&pname)
+                                    .find(|target| target.is_dylib() || target.is_lib())
+                                    .map(|lib_target| lib_target.name())
+                                    .unwrap_or(&package.name())
                             )?;
                         }
                     }

--- a/src/cargo/ops/tree/format/parse.rs
+++ b/src/cargo/ops/tree/format/parse.rs
@@ -1,6 +1,7 @@
 //! Parser for the `--format` string for `cargo tree`.
 
-use std::{iter, str};
+use std::iter;
+use std::str;
 
 pub enum RawChunk<'a> {
     /// Raw text to include in the output.

--- a/src/cargo/ops/tree/format/parse.rs
+++ b/src/cargo/ops/tree/format/parse.rs
@@ -1,7 +1,6 @@
 //! Parser for the `--format` string for `cargo tree`.
 
-use std::iter;
-use std::str;
+use std::{iter, str};
 
 pub enum RawChunk<'a> {
     /// Raw text to include in the output.

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -145,6 +145,7 @@ strings will be replaced with the corresponding value:
 - `{l}` — The package license.
 - `{r}` — The package repository URL.
 - `{f}` — Comma-separated list of package features that are enabled.
+- `{lib}` — The name of the package's library.
 {{/option}}
 
 {{#option "`--prefix` _prefix_" }}

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -145,7 +145,7 @@ strings will be replaced with the corresponding value:
 - `{l}` — The package license.
 - `{r}` — The package repository URL.
 - `{f}` — Comma-separated list of package features that are enabled.
-- `{lib}` — The name of the package's library.
+- `{lib}` — The name, as used in a `use` statement, of the package's library.
 {{/option}}
 
 {{#option "`--prefix` _prefix_" }}

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -138,6 +138,8 @@ OPTIONS
            o  {f} — Comma-separated list of package features that are
               enabled.
 
+           o  {lib} — The name of the package's library.
+
        --prefix prefix
            Sets how each line is displayed. The prefix value can be one of:
 

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -138,7 +138,8 @@ OPTIONS
            o  {f} — Comma-separated list of package features that are
               enabled.
 
-           o  {lib} — The name of the package's library.
+           o  {lib} — The name, as used in a use statement, of the package's
+              library.
 
        --prefix prefix
            Sets how each line is displayed. The prefix value can be one of:

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -145,7 +145,7 @@ strings will be replaced with the corresponding value:</p>
 <li><code>{l}</code> — The package license.</li>
 <li><code>{r}</code> — The package repository URL.</li>
 <li><code>{f}</code> — Comma-separated list of package features that are enabled.</li>
-<li><code>{lib}</code> — The name of the package's library.</li>
+<li><code>{lib}</code> — The name, as used in a <code>use</code> statement, of the package's library.</li>
 </ul></dd>
 
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -145,6 +145,7 @@ strings will be replaced with the corresponding value:</p>
 <li><code>{l}</code> — The package license.</li>
 <li><code>{r}</code> — The package repository URL.</li>
 <li><code>{f}</code> — Comma-separated list of package features that are enabled.</li>
+<li><code>{lib}</code> — The name of the package's library.</li>
 </ul></dd>
 
 

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -188,7 +188,7 @@ strings will be replaced with the corresponding value:
 .RE
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fB{lib}\fR \[em] The name of the package's library.
+\h'-04'\(bu\h'+02'\fB{lib}\fR \[em] The name, as used in a \fBuse\fR statement, of the package's library.
 .RE
 .RE
 .sp

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -186,6 +186,10 @@ strings will be replaced with the corresponding value:
 .RS 4
 \h'-04'\(bu\h'+02'\fB{f}\fR \[em] Comma\-separated list of package features that are enabled.
 .RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fB{lib}\fR \[em] The name of the package's library.
+.RE
 .RE
 .sp
 \fB\-\-prefix\fR \fIprefix\fR

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1009,6 +1009,7 @@ foo v0.1.0 ([..]/foo)
 #[cargo_test]
 fn format() {
     Package::new("dep", "1.0.0").publish();
+    Package::new("other-dep", "1.0.0").publish();
 
     Package::new("dep_that_is_awesome", "1.0.0")
         .file(
@@ -1037,7 +1038,9 @@ fn format() {
 
             [dependencies]
             dep = {version="1.0", optional=true}
+            other-dep = {version="1.0", optional=true}
             dep_that_is_awesome = {version="1.0", optional=true}
+
 
             [features]
             default = ["foo"]
@@ -1045,7 +1048,7 @@ fn format() {
             bar = []
             "#,
         )
-        .file("src/lib.rs", "")
+        .file("src/main.rs", "")
         .build();
 
     p.cargo("tree --format <<<{p}>>>")
@@ -1082,20 +1085,21 @@ Caused by:
         .arg("{p} [{f}]")
         .with_stdout(
             "\
-foo v0.1.0 ([..]/foo) [bar,default,dep,dep_that_is_awesome,foo]
+foo v0.1.0 ([..]/foo) [bar,default,dep,dep_that_is_awesome,foo,other-dep]
 ├── dep v1.0.0 []
-└── dep_that_is_awesome v1.0.0 []
+├── dep_that_is_awesome v1.0.0 []
+└── other-dep v1.0.0 []
 ",
         )
         .run();
 
     p.cargo("tree")
-        .arg("--features=dep_that_is_awesome")
+        .arg("--features=other-dep,dep_that_is_awesome")
         .arg("--format={lib}")
         .with_stdout(
-            "\
-foo
-└── awesome_dep
+            "
+├── awesome_dep
+└── other_dep
 ",
         )
         .run();

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1009,6 +1009,7 @@ foo v0.1.0 ([..]/foo)
 #[cargo_test]
 fn format() {
     Package::new("dep", "1.0.0").publish();
+
     Package::new("dep_that_is_awesome", "1.0.0")
         .file(
             "Cargo.toml",
@@ -1036,7 +1037,7 @@ fn format() {
 
             [dependencies]
             dep = {version="1.0", optional=true}
-            dep_that_is_awesome = {version="1.0"}
+            dep_that_is_awesome = {version="1.0", optional=true}
 
             [features]
             default = ["foo"]
@@ -1048,9 +1049,7 @@ fn format() {
         .build();
 
     p.cargo("tree --format <<<{p}>>>")
-        .with_stdout("\
-<<<foo v0.1.0 ([..]/foo)>>>
-└── <<<dep_that_is_awesome v1.0.0>>>")
+        .with_stdout("<<<foo v0.1.0 ([..]/foo)>>>")
         .run();
 
     p.cargo("tree --format {}")
@@ -1066,42 +1065,40 @@ Caused by:
         .run();
 
     p.cargo("tree --format {p}-{{hello}}")
-        .with_stdout("\
-foo v0.1.0 ([..]/foo)-{hello}
-└── dep_that_is_awesome v1.0.0-{hello}")
+        .with_stdout("foo v0.1.0 ([..]/foo)-{hello}")
         .run();
 
     p.cargo("tree --format")
         .arg("{p} {l} {r}")
-        .with_stdout("\
-foo v0.1.0 ([..]/foo) MIT https://github.com/rust-lang/cargo
-└── dep_that_is_awesome v1.0.0  ")
+        .with_stdout("foo v0.1.0 ([..]/foo) MIT https://github.com/rust-lang/cargo")
         .run();
 
     p.cargo("tree --format")
         .arg("{p} {f}")
-        .with_stdout("\
-foo v0.1.0 ([..]/foo) bar,default,foo
-└── dep_that_is_awesome v1.0.0 ")
+        .with_stdout("foo v0.1.0 ([..]/foo) bar,default,foo")
         .run();
 
     p.cargo("tree --all-features --format")
         .arg("{p} [{f}]")
         .with_stdout(
             "\
-foo v0.1.0 ([..]/foo) [bar,default,dep,foo]
+foo v0.1.0 ([..]/foo) [bar,default,dep,dep_that_is_awesome,foo]
 ├── dep v1.0.0 []
 └── dep_that_is_awesome v1.0.0 []
 ",
         )
         .run();
 
-    p.cargo("tree --format {n}")
-        .with_stdout("\
+    p.cargo("tree")
+        .arg("--features=dep_that_is_awesome")
+        .arg("--format={lib}")
+        .with_stdout(
+            "\
 foo
-└── awesome_dep")
+└── awesome_dep
+",
+        )
         .run();
-
 }
 
 #[cargo_test]


### PR DESCRIPTION
Adds a way to have `cargo tree` display the name of the library inside a package dependency, which can differ from the name of the package. Updates the `tree::format` test to test for its proper behavior.

Closes #9659 