### PR TITLE
Spot the crate typo easily

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -284,9 +284,15 @@ pub(super) fn activation_error(
                 .filter(|&(d, _)| d < 4)
                 .collect();
             candidates.sort_by_key(|o| o.0);
-            let mut msg = format!(
-                "no matching package found\nsearched package name: `{}`\n", dep.package_name());
-            if !candidates.is_empty() {
+            let mut msg: String;
+            if candidates.is_empty() {
+                msg = format!("no matching package named `{}` found\n", dep.package_name());
+            } else {
+                msg = format!(
+                    "no matching package found\nsearched package name: `{}`\n",
+                    dep.package_name()
+                );
+
                 // If dependency package name is equal to the name of the candidate here
                 // it may be a prerelease package which hasn't been specified correctly
                 if dep.package_name() == candidates[0].1.name()

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -285,11 +285,7 @@ pub(super) fn activation_error(
                 .collect();
             candidates.sort_by_key(|o| o.0);
             let mut msg = format!(
-                "no matching package named `{}` found\n\
-                 location searched: {}\n",
-                dep.package_name(),
-                dep.source_id()
-            );
+                "no matching package named `{}` found\n", dep.package_name());
             if !candidates.is_empty() {
                 // If dependency package name is equal to the name of the candidate here
                 // it may be a prerelease package which hasn't been specified correctly
@@ -312,8 +308,9 @@ pub(super) fn activation_error(
                     if candidates.len() > 3 {
                         names.push("...");
                     }
-
-                    msg.push_str("perhaps you meant: ");
+                    // Vertically align first suggestion with missing crate name
+                    // so the silly typo you probably made jumps out at you.
+                    msg.push_str("perhaps you meant:                ");
                     msg.push_str(&names.iter().enumerate().fold(
                         String::default(),
                         |acc, (i, el)| match i {
@@ -323,9 +320,9 @@ pub(super) fn activation_error(
                         },
                     ));
                 }
-
                 msg.push('\n');
             }
+            msg.push_str(&format!("location searched: {}\n", dep.source_id()));
             msg.push_str("required by ");
             msg.push_str(&describe_path(
                 &cx.parents.path_to_bottom(&parent.package_id()),

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -285,7 +285,7 @@ pub(super) fn activation_error(
                 .collect();
             candidates.sort_by_key(|o| o.0);
             let mut msg = format!(
-                "no matching package named `{}` found\n", dep.package_name());
+                "no matching package found\nsearched package name: `{}`\n", dep.package_name());
             if !candidates.is_empty() {
                 // If dependency package name is equal to the name of the candidate here
                 // it may be a prerelease package which hasn't been specified correctly
@@ -309,8 +309,8 @@ pub(super) fn activation_error(
                         names.push("...");
                     }
                     // Vertically align first suggestion with missing crate name
-                    // so the silly typo you probably made jumps out at you.
-                    msg.push_str("perhaps you meant:                ");
+                    // so a typo jumps out at you.
+                    msg.push_str("perhaps you meant:      ");
                     msg.push_str(&names.iter().enumerate().fold(
                         String::default(),
                         |acc, (i, el)| match i {

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -191,9 +191,10 @@ fn simple_install_fail() {
 error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`
 
 Caused by:
-  no matching package named `baz` found
+  no matching package found
+  searched package name: `baz`
+  perhaps you meant:      bar or foo
   location searched: registry `https://github.com/rust-lang/crates.io-index`
-  perhaps you meant: bar or foo
   required by package `bar v0.1.0`
 ",
         )

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -964,9 +964,10 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
         .with_status(101)
         .with_stderr(
             "\
-error: no matching package named `bar` found
+error: no matching package found
+searched package name: `bar`
+perhaps you meant:      foo
 location searched: [..]
-perhaps you meant: foo
 required by package `foo v0.5.0 ([..])`
 ",
         )

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -155,9 +155,10 @@ fn wrong_case() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-error: no matching package named `Init` found
+error: no matching package found
+searched package name: `Init`
+perhaps you meant:      init
 location searched: registry [..]
-perhaps you meant: init
 required by package `foo v0.0.1 ([..])`
 ",
         )
@@ -190,9 +191,10 @@ fn mis_hyphenated() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-error: no matching package named `mis_hyphenated` found
+error: no matching package found
+searched package name: `mis_hyphenated`
+perhaps you meant:      mis-hyphenated
 location searched: registry [..]
-perhaps you meant: mis-hyphenated
 required by package `foo v0.0.1 ([..])`
 ",
         )
@@ -1439,9 +1441,9 @@ fn use_semver_package_incorrectly() {
         .with_stderr(
             "\
 error: no matching package named `a` found
-location searched: [..]
 prerelease package needs to be specified explicitly
 a = { version = \"0.1.1-alpha.0\" }
+location searched: [..]
 required by package `b v0.1.0 ([..])`
 ",
         )

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1440,7 +1440,8 @@ fn use_semver_package_incorrectly() {
         .with_status(101)
         .with_stderr(
             "\
-error: no matching package named `a` found
+error: no matching package found
+searched package name: `a`
 prerelease package needs to be specified explicitly
 a = { version = \"0.1.1-alpha.0\" }
 location searched: [..]


### PR DESCRIPTION
ego tweak to make it easy to spot typos:

Before:
```
error: no matching package named `sc-consensus-primitivies` found
location searched: /Users/bit/p/substrate1/client/primitives/consensus/common
perhaps you meant: sc-consensus-primitives
required by package `sc-network v0.9.0 (/Users/bit/p/substrate1/client/network)`
```
After:
```
error: no matching package named `sc-consensus-primitivies` found
perhaps you meant:                sc-consensus-primitives
location searched: /Users/bit/p/substrate1/client/primitives/consensus/common
required by package `sc-network v0.9.0 (/Users/bit/p/substrate1/client/network)`
```