### PR TITLE
Deduplicate compiler diagnostics.

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -129,7 +129,7 @@ pub fn prepare(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
 }
 
 fn emit_build_output(
-    state: &JobState<'_>,
+    state: &JobState<'_, '_>,
     output: &BuildOutput,
     out_dir: &Path,
     package_id: PackageId,

--- a/src/cargo/core/compiler/job.rs
+++ b/src/cargo/core/compiler/job.rs
@@ -12,13 +12,13 @@ pub struct Job {
 /// Each proc should send its description before starting.
 /// It should send either once or close immediately.
 pub struct Work {
-    inner: Box<dyn FnOnce(&JobState<'_>) -> CargoResult<()> + Send>,
+    inner: Box<dyn FnOnce(&JobState<'_, '_>) -> CargoResult<()> + Send>,
 }
 
 impl Work {
     pub fn new<F>(f: F) -> Work
     where
-        F: FnOnce(&JobState<'_>) -> CargoResult<()> + Send + 'static,
+        F: FnOnce(&JobState<'_, '_>) -> CargoResult<()> + Send + 'static,
     {
         Work { inner: Box::new(f) }
     }
@@ -27,7 +27,7 @@ impl Work {
         Work::new(|_| Ok(()))
     }
 
-    pub fn call(self, tx: &JobState<'_>) -> CargoResult<()> {
+    pub fn call(self, tx: &JobState<'_, '_>) -> CargoResult<()> {
         (self.inner)(tx)
     }
 
@@ -58,7 +58,7 @@ impl Job {
 
     /// Consumes this job by running it, returning the result of the
     /// computation.
-    pub fn run(self, state: &JobState<'_>) -> CargoResult<()> {
+    pub fn run(self, state: &JobState<'_, '_>) -> CargoResult<()> {
         self.work.call(state)
     }
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -925,7 +925,7 @@ impl Target {
             TargetKind::ExampleLib(..) | TargetKind::ExampleBin => {
                 format!("example \"{}\"", self.name())
             }
-            TargetKind::CustomBuild => "custom-build".to_string(),
+            TargetKind::CustomBuild => "build script".to_string(),
         }
     }
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -71,6 +71,7 @@ mod lto;
 mod member_discovery;
 mod member_errors;
 mod message_format;
+mod messages;
 mod metabuild;
 mod metadata;
 mod minimal_versions;

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -1,0 +1,114 @@
+//! General tests specifically about diagnostics and other messages.
+//!
+//! Tests for message caching can be found in `cache_messages`.
+
+use cargo_test_support::{process, project, Project};
+
+/// Captures the actual diagnostics displayed by rustc. This is done to avoid
+/// relying on the exact message formatting in rustc.
+pub fn raw_rustc_output(project: &Project, path: &str, extra: &[&str]) -> String {
+    let mut proc = process("rustc");
+    if cfg!(windows) {
+        // Sanitize in case the caller wants to do direct string comparison with Cargo's output.
+        proc.arg(path.replace('/', "\\"));
+    } else {
+        proc.arg(path);
+    }
+    let rustc_output = proc
+        .arg("--crate-type=lib")
+        .args(extra)
+        .cwd(project.root())
+        .exec_with_output()
+        .expect("rustc to run");
+    assert!(rustc_output.stdout.is_empty());
+    assert!(rustc_output.status.success());
+    // Do a little dance to remove rustc's "warnings emitted" message and the subsequent newline.
+    let stderr = std::str::from_utf8(&rustc_output.stderr).expect("utf8");
+    let mut lines = stderr.lines();
+    let mut result = String::new();
+    while let Some(line) = lines.next() {
+        if line.contains("warning emitted") || line.contains("warnings emitted") {
+            // Eat blank line.
+            match lines.next() {
+                None | Some("") => continue,
+                Some(s) => panic!("unexpected str {}", s),
+            }
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+    result
+}
+
+#[cargo_test]
+fn deduplicate_messages_basic() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+                pub fn foo() {
+                    let x = 1;
+                }
+            "#,
+        )
+        .build();
+    let rustc_message = raw_rustc_output(&p, "src/lib.rs", &[]);
+    let expected_output = format!(
+        "{}\
+warning: `foo` (lib) generated 1 warning
+warning: `foo` (lib test) generated 1 warning (1 duplicate)
+[FINISHED] [..]
+",
+        rustc_message
+    );
+    p.cargo("test --no-run -j1")
+        .with_stderr(&format!("[COMPILING] foo [..]\n{}", expected_output))
+        .run();
+    // Run again, to check for caching behavior.
+    p.cargo("test --no-run -j1")
+        .with_stderr(expected_output)
+        .run();
+}
+
+#[cargo_test]
+fn deduplicate_messages_mismatched_warnings() {
+    // One execution prints 1 warning, the other prints 2 where there is an overlap.
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+                pub fn foo() {
+                    let x = 1;
+                }
+
+                #[test]
+                fn t1() {
+                    let MY_VALUE = 1;
+                    assert_eq!(MY_VALUE, 1);
+                }
+            "#,
+        )
+        .build();
+    let lib_output = raw_rustc_output(&p, "src/lib.rs", &[]);
+    let mut lib_test_output = raw_rustc_output(&p, "src/lib.rs", &["--test"]);
+    // Remove the duplicate warning.
+    let start = lib_test_output.find(&lib_output).expect("same warning");
+    lib_test_output.replace_range(start..start + lib_output.len(), "");
+    let expected_output = format!(
+        "\
+{}\
+warning: `foo` (lib) generated 1 warning
+{}\
+warning: `foo` (lib test) generated 2 warnings (1 duplicate)
+[FINISHED] [..]
+",
+        lib_output, lib_test_output
+    );
+    p.cargo("test --no-run -j1")
+        .with_stderr(&format!("[COMPILING] foo v0.0.1 [..]\n{}", expected_output))
+        .run();
+    // Run again, to check for caching behavior.
+    p.cargo("test --no-run -j1")
+        .with_stderr(expected_output)
+        .run();
+}


### PR DESCRIPTION
This adds some logic to deduplicate diagnostics emitted across rustc invocations. There are some situations where different targets can emit the same message, and that has caused confusion particularly for new users. A prominent example is running `cargo test` which will build the library twice concurrently (once as a normal library, and once as a test).

As part of this, the "N warnings emitted" message sent by rustc is intercepted, and instead cargo generates its own summary. This is to prevent potentially confusing situations where that message is either deduplicated, or wrong. It also provides a little more context to explain exactly *what* issued the warnings.  Example:

```warning: `foo` (lib) generated 1 warning```

This only impacts human-readable output, it does not change JSON behavior.

Closes #9104