### PR TITLE
Add `d` as an alias for `doc`

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -319,7 +319,7 @@ Some common cargo commands are (see all commands with --list):
     build, b    Compile the current package
     check, c    Analyze the current package and report errors, but don't build object files
     clean       Remove the target directory
-    doc         Build this package's and its dependencies' documentation
+    doc, d      Build this package's and its dependencies' documentation
     new         Create a new cargo package
     init        Create a new cargo package in an existing directory
     run, r      Run a binary or example of the local package

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -4,6 +4,8 @@ use cargo::ops::{self, DocOptions};
 
 pub fn cli() -> App {
     subcommand("doc")
+        // subcommand aliases are handled in aliased_command()
+        // .alias("d")
         .about("Build a package's documentation")
         .arg(opt("quiet", "No output printed to stdout").short("q"))
         .arg(opt(

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -48,9 +48,10 @@ fn main() {
 
 /// Table for defining the aliases which come builtin in `Cargo`.
 /// The contents are structured as: `(alias, aliased_command, description)`.
-const BUILTIN_ALIASES: [(&str, &str, &str); 4] = [
+const BUILTIN_ALIASES: [(&str, &str, &str); 5] = [
     ("b", "build", "alias: build"),
     ("c", "check", "alias: check"),
+    ("d", "doc", "alias: doc"),
     ("r", "run", "alias: run"),
     ("t", "test", "alias: test"),
 ];

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -252,6 +252,7 @@ subcommand and arguments. The following aliases are built-in to Cargo:
 [alias]
 b = "build"
 c = "check"
+d = "doc"
 t = "test"
 r = "run"
 ```


### PR DESCRIPTION
I expected that this alias would already exist. `doc` feels to me like the other commands that currently have aliases. `build`, `check`, `run`, and `test` are all modes of using the existing repository, and are all things one might run at least somewhat frequently during development. There is no other built in cargo subcommand that starts with `d`, so this also has the virtue of being pretty unambiguous.