### PR TITLE
WIP: Click to go to toml file

### DIFF
--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -212,7 +212,7 @@ impl fmt::Display for PackageId {
         write!(f, "{} v{}", self.inner.name, self.inner.version)?;
 
         if !self.inner.source_id.is_default_registry() {
-            write!(f, " ({})", self.inner.source_id)?;
+            write!(f, " ({}/Cargo.toml)", self.inner.source_id)?;
         }
 
         Ok(())

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -772,7 +772,7 @@ impl<'cfg> Workspace<'cfg> {
         };
         for (path, name) in candidates {
             self.find_path_deps(&path, root_manifest, true)
-                .with_context(|| format!("failed to load manifest for dependency `{}`", name))
+                .with_context(|| format!("failed to load manifest for dependency `{}`\n({})", name, path.to_string_lossy()))
                 .map_err(|err| ManifestError::new(err, manifest_path.clone()))?;
         }
         Ok(())


### PR DESCRIPTION
When we have lots of rust we have lots of crates; getting to the right cargo toml file can be tricky.
If the full path to the Cargo.toml is in the output then IDEs like vscode can just click through to go to the file in question.

This is a prelude to what I really want: I want to be able to click on an error and go to a specific line number.
At least this way we can quickly get to the specific file if not the exact line that a dependency was defined at.