### PR TITLE
When a dependency does not have a version, git or path, fails directly

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1707,14 +1707,11 @@ impl<P: ResolveToPath> DetailedTomlDependency<P> {
         kind: Option<DepKind>,
     ) -> CargoResult<Dependency> {
         if self.version.is_none() && self.path.is_none() && self.git.is_none() {
-            let msg = format!(
+            bail!(
                 "dependency ({}) specified without \
-                 providing a local path, Git repository, or \
-                 version to use. This will be considered an \
-                 error in future versions",
+                 providing a local path, Git repository, or version to use.",
                 name_in_toml
             );
-            cx.warnings.push(msg);
         }
 
         if let Some(version) = &self.version {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -796,10 +796,14 @@ fn empty_dependencies() {
     Package::new("bar", "0.0.1").publish();
 
     p.cargo("build")
-        .with_stderr_contains(
+        .with_status(101)
+        .with_stderr(
             "\
-warning: dependency (bar) specified without providing a local path, Git repository, or version \
-to use. This will be considered an error in future versions
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  dependency (bar) specified without providing a local path, Git repository, or version \
+to use.
 ",
         )
         .run();


### PR DESCRIPTION
Make this warning be an error.

ref: https://github.com/rust-lang/cargo/issues/9682#issuecomment-879108193