### PR TITLE
docs: Fix sentence & update link for GitLab CI docs

### DIFF
--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -47,7 +47,7 @@ rust-nightly:
 
 This will test on the stable channel and nightly channel, but any
 breakage in nightly will not fail your overall build. Please see the
-[GitLab CI](https://docs.gitlab.com/ce/ci/yaml/README.html) for more
+[GitLab CI documentation](https://docs.gitlab.com/ce/ci/yaml/index.html) for more
 information.
 
 ### builds.sr.ht


### PR DESCRIPTION
This just adds a missing word in the sentence and updates the link for gitlab's ci docs.