### PR TITLE
Rustdoc nocapture

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -233,7 +233,15 @@ fn run_doc_tests(
         }
 
         for arg in test_args {
-            p.arg("--test-args").arg(arg);
+            // We special-case "--nocapture" because rustdoc needs to handle it directly.
+            if *arg == "--nocapture" {
+                // FIXME(GuillaumeGomez): remove the `unstable-options` once rustdoc stabilizes the
+                // `--nocapture` option.
+                p.arg("-Z").arg("unstable-options");
+                p.arg(arg);
+            } else {
+                p.arg("--test-args").arg(arg);
+            }
         }
 
         p.args(args);

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4388,3 +4388,42 @@ fn test_workspaces_cwd() {
         .with_stdout_contains("test test_integration_deep_cwd ... ok")
         .run();
 }
+
+#[cargo_test]
+fn doctest_nocapture() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                [features]
+                bar = []
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                /// ```rust
+                /// println!("hello cake!");
+                /// ```
+                pub fn hello() {}
+            "#,
+        )
+        .build();
+
+    p.cargo("test -- --nocapture")
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] [..] (target/debug/deps/foo[..][EXE])
+[DOCTEST] foo",
+        )
+        .with_stdout_contains("running 0 tests")
+        .with_stdout_contains("test [..] ... ok")
+        .with_stdout_contains("hello cake!")
+        .run();
+}


### PR DESCRIPTION
Following https://github.com/rust-lang/rust/pull/86230.

It might need to wait for rustdoc latest nightly to be published first to pass CI though (so tomorrow).

Also: the `--nocapture` option is unstable for now in rustdoc, is there something particular to be done until it's stable on cargo side? For now I simply add `-Zunstable-options` but not sure if it's the way to go?