### PR TITLE
Changes rustc argument from `--force-warns` to `--force-warn`

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -793,7 +793,7 @@ impl FixArgs {
         if let Some(edition) = self.prepare_for_edition {
             if edition.supports_compat_lint() {
                 if config.nightly_features_allowed {
-                    cmd.arg("--force-warns")
+                    cmd.arg("--force-warn")
                         .arg(format!("rust-{}-compatibility", edition))
                         .arg("-Zunstable-options");
                 } else {


### PR DESCRIPTION
The rustc argument was renamed in rust-lang/rust#87346 breaking `cargo fix` on the nightly toolchain.

I encountered this while attempting to test Edition 2021 migrations.


I ran `RUSTC=/path/to/nightly/rustc cargo test` and encountered a few failing tests, but none of them seemed at all related to the 1 line I changed, so if they crop up in CI as well, would love some help on identifying what's causing that.

Closes rust-lang/rust#87360