### PR TITLE
Fix version string.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -137,8 +137,7 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'",
 
 pub fn get_version_string(is_verbose: bool) -> String {
     let version = cargo::version();
-    let mut version_string = version.to_string();
-    version_string.push('\n');
+    let mut version_string = format!("cargo {}\n", version);
     if is_verbose {
         version_string.push_str(&format!(
             "release: {}.{}.{}\n",

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -7,11 +7,11 @@ fn simple() {
     let p = project().build();
 
     p.cargo("version")
-        .with_stdout(&format!("{}\n", cargo::version()))
+        .with_stdout(&format!("cargo {}\n", cargo::version()))
         .run();
 
     p.cargo("--version")
-        .with_stdout(&format!("{}\n", cargo::version()))
+        .with_stdout(&format!("cargo {}\n", cargo::version()))
         .run();
 }
 


### PR DESCRIPTION
The version string for `cargo version` was inadvertently changed in #9657 so that it does not include the leading `cargo` as in `cargo 1.53.0 (4369396ce 2021-04-27)`.

