### PR TITLE
[beta] Backport cargo-util version fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/cargo/lib.rs"
 atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.1" }
-cargo-util = { path = "crates/cargo-util", version = "0.1.0" }
+cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
 curl = { version = "0.4.23", features = ["http2"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Cargo Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Backport of #9745 to fix the version for cargo-util.  This should help if someone does `cargo update -p cargo` to ensure they get the correct version of cargo-util. 
