### PR TITLE
Some minor updates for package/publish package selection.

### DIFF
--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -28,7 +28,7 @@ pub fn cli() -> App {
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg_features()
-        .arg_package_spec(
+        .arg_package_spec_no_all(
             "Package(s) to assemble",
             "Assemble all packages in the workspace",
             "Don't assemble specified packages",

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -35,10 +35,8 @@ pub trait AppExt: Sized {
         all: &'static str,
         exclude: &'static str,
     ) -> Self {
-        self.arg_package_spec_simple(package)
+        self.arg_package_spec_no_all(package, all, exclude)
             ._arg(opt("all", "Alias for --workspace (deprecated)"))
-            ._arg(opt("workspace", all))
-            ._arg(multi_opt("exclude", "SPEC", exclude))
     }
 
     /// Variant of arg_package_spec that does not include the `--all` flag

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -27,6 +27,8 @@ pub type App = clap::App<'static, 'static>;
 pub trait AppExt: Sized {
     fn _arg(self, arg: Arg<'static, 'static>) -> Self;
 
+    /// Do not use this method, it is only for backwards compatibility.
+    /// Use `arg_package_spec_no_all` instead.
     fn arg_package_spec(
         self,
         package: &'static str,

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -1,5 +1,6 @@
 # cargo-package(1)
 {{*set actionverb="Package"}}
+{{*set noall=true}}
 
 ## NAME
 
@@ -66,6 +67,8 @@ Allow working directories with uncommitted VCS changes to be packaged.
 {{/option}}
 
 {{/options}}
+
+{{> section-package-selection }}
 
 ### Compilation Options
 

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -63,6 +63,8 @@ which defaults to `crates-io`.
 
 {{/options}}
 
+{{> section-options-package }}
+
 ### Compilation Options
 
 {{#options}}

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -61,6 +61,39 @@ OPTIONS
            Allow working directories with uncommitted VCS changes to be
            packaged.
 
+   Package Selection
+       By default, when no package selection options are given, the packages
+       selected depend on the selected manifest file (based on the current
+       working directory if --manifest-path is not given). If the manifest is
+       the root of a workspace then the workspaces default members are
+       selected, otherwise only the package defined by the manifest will be
+       selected.
+
+       The default members of a workspace can be set explicitly with the
+       workspace.default-members key in the root manifest. If this is not set,
+       a virtual workspace will include all workspace members (equivalent to
+       passing --workspace), and a non-virtual workspace will include only the
+       root crate itself.
+
+       -p spec..., --package spec...
+           Package only the specified packages. See cargo-pkgid(1) for the SPEC
+           format. This flag may be specified multiple times and supports
+           common Unix glob patterns like *, ? and []. However, to avoid your
+           shell accidentally expanding glob patterns before Cargo handles
+           them, you must use single quotes or double quotes around each
+           pattern.
+
+       --workspace
+           Package all members in the workspace.
+
+       --exclude SPEC...
+           Exclude the specified packages. Must be used in conjunction with the
+           --workspace flag. This flag may be specified multiple times and
+           supports common Unix glob patterns like *, ? and []. However, to
+           avoid your shell accidentally expanding glob patterns before Cargo
+           handles them, you must use single quotes or double quotes around
+           each pattern.
+
    Compilation Options
        --target triple
            Package for the given architecture. The default is the host

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -67,6 +67,13 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#registrydefault>
            config key which defaults to crates-io.
 
+   Package Selection
+       By default, the package in the current working directory is selected.
+       The -p flag can be used to choose a different package in a workspace.
+
+       -p spec, --package spec
+           The package to publish. See cargo-pkgid(1) for the SPEC format.
+
    Compilation Options
        --target triple
            Publish for the given architecture. The default is the host

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -1,6 +1,7 @@
 # cargo-package(1)
 
 
+
 ## NAME
 
 cargo-package - Assemble the local package into a distributable tarball
@@ -67,6 +68,47 @@ or the license).</dd>
 
 
 </dl>
+
+### Package Selection
+
+By default, when no package selection options are given, the packages selected
+depend on the selected manifest file (based on the current working directory if
+`--manifest-path` is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+
+The default members of a workspace can be set explicitly with the
+`workspace.default-members` key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+`--workspace`), and a non-virtual workspace will include only the root crate itself.
+
+<dl>
+
+<dt class="option-term" id="option-cargo-package--p"><a class="option-anchor" href="#option-cargo-package--p"></a><code>-p</code> <em>spec</em>...</dt>
+<dt class="option-term" id="option-cargo-package---package"><a class="option-anchor" href="#option-cargo-package---package"></a><code>--package</code> <em>spec</em>...</dt>
+<dd class="option-desc">Package only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.</dd>
+
+
+<dt class="option-term" id="option-cargo-package---workspace"><a class="option-anchor" href="#option-cargo-package---workspace"></a><code>--workspace</code></dt>
+<dd class="option-desc">Package all members in the workspace.</dd>
+
+
+
+
+<dt class="option-term" id="option-cargo-package---exclude"><a class="option-anchor" href="#option-cargo-package---exclude"></a><code>--exclude</code> <em>SPEC</em>...</dt>
+<dd class="option-desc">Exclude the specified packages. Must be used in conjunction with the
+<code>--workspace</code> flag. This flag may be specified multiple times and supports
+common Unix glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.</dd>
+
+
+</dl>
+
 
 ### Compilation Options
 

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -76,6 +76,22 @@ which defaults to <code>crates-io</code>.</dd>
 
 </dl>
 
+### Package Selection
+
+By default, the package in the current working directory is selected. The `-p`
+flag can be used to choose a different package in a workspace.
+
+<dl>
+
+<dt class="option-term" id="option-cargo-publish--p"><a class="option-anchor" href="#option-cargo-publish--p"></a><code>-p</code> <em>spec</em></dt>
+<dt class="option-term" id="option-cargo-publish---package"><a class="option-anchor" href="#option-cargo-publish---package"></a><code>--package</code> <em>spec</em></dt>
+<dd class="option-desc">The package to publish. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC
+format.</dd>
+
+
+</dl>
+
+
 ### Compilation Options
 
 <dl>

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -91,6 +91,41 @@ or the license).
 .RS 4
 Allow working directories with uncommitted VCS changes to be packaged.
 .RE
+.SS "Package Selection"
+By default, when no package selection options are given, the packages selected
+depend on the selected manifest file (based on the current working directory if
+\fB\-\-manifest\-path\fR is not given). If the manifest is the root of a workspace then
+the workspaces default members are selected, otherwise only the package defined
+by the manifest will be selected.
+.sp
+The default members of a workspace can be set explicitly with the
+\fBworkspace.default\-members\fR key in the root manifest. If this is not set, a
+virtual workspace will include all workspace members (equivalent to passing
+\fB\-\-workspace\fR), and a non\-virtual workspace will include only the root crate itself.
+.sp
+\fB\-p\fR \fIspec\fR\&..., 
+\fB\-\-package\fR \fIspec\fR\&...
+.RS 4
+Package only the specified packages. See \fBcargo\-pkgid\fR(1) for the
+SPEC format. This flag may be specified multiple times and supports common Unix
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+expanding glob patterns before Cargo handles them, you must use single quotes or
+double quotes around each pattern.
+.RE
+.sp
+\fB\-\-workspace\fR
+.RS 4
+Package all members in the workspace.
+.RE
+.sp
+\fB\-\-exclude\fR \fISPEC\fR\&...
+.RS 4
+Exclude the specified packages. Must be used in conjunction with the
+\fB\-\-workspace\fR flag. This flag may be specified multiple times and supports
+common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell
+accidentally expanding glob patterns before Cargo handles them, you must use
+single quotes or double quotes around each pattern.
+.RE
 .SS "Compilation Options"
 .sp
 \fB\-\-target\fR \fItriple\fR

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -82,6 +82,16 @@ Otherwise it will use the default registry, which is defined by the
 \fI\f(BIregistry.default\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#registrydefault> config key
 which defaults to \fBcrates\-io\fR\&.
 .RE
+.SS "Package Selection"
+By default, the package in the current working directory is selected. The \fB\-p\fR
+flag can be used to choose a different package in a workspace.
+.sp
+\fB\-p\fR \fIspec\fR, 
+\fB\-\-package\fR \fIspec\fR
+.RS 4
+The package to publish. See \fBcargo\-pkgid\fR(1) for the SPEC
+format.
+.RE
 .SS "Compilation Options"
 .sp
 \fB\-\-target\fR \fItriple\fR


### PR DESCRIPTION
This is just a few small things I missed in the review of #9559.

* Don't include the deprecated `--all` flag in `cargo package`.
* Update the man pages for the new flags.