### PR TITLE
Update cargo-platform to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/cargo/lib.rs"
 [dependencies]
 atty = "0.2"
 bytesize = "1.0"
-cargo-platform = { path = "crates/cargo-platform", version = "0.1.1" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-platform"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Cargo Project Developers"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/doc/src/reference/pkgid-spec.md
+++ b/src/doc/src/reference/pkgid-spec.md
@@ -49,7 +49,7 @@ The following are some examples of specs for several different git dependencies:
 | Spec                                                      | Name             | Version  |
 |:----------------------------------------------------------|:----------------:|:--------:|
 | `https://github.com/rust-lang/cargo#0.52.0`               | `cargo`          | `0.52.0` |
-| `https://github.com/rust-lang/cargo#cargo-platform:0.1.1` | <nobr>`cargo-platform`</nobr> | `0.1.1`  |
+| `https://github.com/rust-lang/cargo#cargo-platform:0.1.2` | <nobr>`cargo-platform`</nobr> | `0.1.2`  |
 | `ssh://git@github.com/rust-lang/regex.git#regex:1.4.3`    | `regex`          | `1.4.3`  |
 
 Local packages on the filesystem can use `file://` URLs to reference them:


### PR DESCRIPTION
This preps cargo-platform for a release. The only substantial change is that this should include the license files into the archive that is uploaded to crates.io.

Closes #9758