### PR TITLE
Fix semver check for rust 1.54.0

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -943,7 +943,7 @@ pub fn foo<T, U>() {}
 use updated_crate::foo;
 
 fn main() {
-    foo::<u8>(); // Error: this function takes 2 type arguments but only 1 type argument was supplied
+    foo::<u8>(); // Error: this function takes 2 generic arguments but 1 generic argument was supplied
 }
 ```
 


### PR DESCRIPTION
This updates semver.md to use the new error message for reporting missing generic arguments.