### PR TITLE
Include aliases with other commands

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -112,6 +112,9 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'",
                         drop_println!(config, "    {}", name);
                     }
                 }
+                CommandInfo::Alias { name, target } => {
+                    drop_println!(config, "    {:<20} {}", name, target.iter().join(" "));
+                }
             }
         }
         return Ok(());

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -6,11 +6,12 @@ use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::interning::InternedString;
 use crate::util::restricted_names::is_glob_pattern;
+use crate::util::toml::{StringOrVec, TomlProfile};
+use crate::util::validate_package_name;
 use crate::util::{
     print_available_benches, print_available_binaries, print_available_examples,
     print_available_packages, print_available_tests,
 };
-use crate::util::{toml::TomlProfile, validate_package_name};
 use crate::CargoResult;
 use anyhow::bail;
 use cargo_util::paths;
@@ -715,10 +716,11 @@ pub fn values_os(args: &ArgMatches<'_>, name: &str) -> Vec<OsString> {
     args._values_of_os(name)
 }
 
-#[derive(PartialEq, PartialOrd, Eq, Ord)]
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub enum CommandInfo {
     BuiltIn { name: String, about: Option<String> },
     External { name: String, path: PathBuf },
+    Alias { name: String, target: StringOrVec },
 }
 
 impl CommandInfo {
@@ -726,6 +728,7 @@ impl CommandInfo {
         match self {
             CommandInfo::BuiltIn { name, .. } => name,
             CommandInfo::External { name, .. } => name,
+            CommandInfo::Alias { name, .. } => name,
         }
     }
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -760,7 +760,9 @@ impl TomlProfile {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Eq, PartialEq)]
+/// A StringOrVec can be parsed from either a TOML string or array,
+/// but is always stored as a vector.
+#[derive(Clone, Debug, Serialize, Eq, PartialEq, PartialOrd, Ord)]
 pub struct StringOrVec(Vec<String>);
 
 impl<'de> de::Deserialize<'de> for StringOrVec {
@@ -794,6 +796,12 @@ impl<'de> de::Deserialize<'de> for StringOrVec {
         }
 
         deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl StringOrVec {
+    pub fn iter<'a>(&'a self) -> std::slice::Iter<'a, String> {
+        self.0.iter()
     }
 }
 

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -10,7 +10,7 @@ use std::str;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths;
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_bin_manifest, basic_manifest, cargo_exe, project};
+use cargo_test_support::{basic_bin_manifest, basic_manifest, cargo_exe, project, project_in_home};
 
 fn path() -> Vec<PathBuf> {
     env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect()
@@ -32,13 +32,32 @@ fn list_commands_with_descriptions() {
 }
 
 #[cargo_test]
-fn list_aliases_with_descriptions() {
+fn list_builtin_aliases_with_descriptions() {
     let p = project().build();
     p.cargo("--list")
         .with_stdout_contains("    b                    alias: build")
         .with_stdout_contains("    c                    alias: check")
         .with_stdout_contains("    r                    alias: run")
         .with_stdout_contains("    t                    alias: test")
+        .run();
+}
+
+#[cargo_test]
+fn list_custom_aliases_with_descriptions() {
+    let p = project_in_home("proj")
+        .file(
+            &paths::home().join(".cargo").join("config"),
+            r#"
+            [alias]
+            myaliasstr = "foo --bar"
+            myaliasvec = ["foo", "--bar"]
+        "#,
+        )
+        .build();
+
+    p.cargo("--list")
+        .with_stdout_contains("    myaliasstr           foo --bar")
+        .with_stdout_contains("    myaliasvec           foo --bar")
         .run();
 }
 


### PR DESCRIPTION
The principal result is that they are now automatically included in the
`cargo --list` output.  Fixes #8486.