### PR TITLE
Allow cargo aliases to shadow existing commands with flags

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -201,6 +201,12 @@ fn expand_aliases(
                     .get_matches_from_safe(alias)?;
 
                 let (new_cmd, _) = new_args.subcommand();
+                if new_cmd == cmd {
+                    // Don't reexpand if the alias is a default-flags alias
+                    // eg. fmt = "fmt --verbose"
+                    return Ok((new_args, global_args));
+                }
+
                 already_expanded.push(cmd.to_string());
                 if already_expanded.contains(&new_cmd.to_string()) {
                     // Crash if the aliases are corecursive / unresolvable

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -289,6 +289,12 @@ r = "run"
 
 Aliases are not allowed to redefine existing built-in commands.
 
+Aliases are allowed to redefine non-built-in commands with default flags
+```toml
+[alias]
+fmt = "fmt --verbose"
+```
+
 #### `[build]`
 
 The `[build]` table controls build-time operations and compiler settings.

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -99,16 +99,12 @@ fn default_args_alias() {
 
     p.cargo("echo")
         .env("PATH", &path)
-        .with_status(101)
-        .with_stderr("error: alias echo has unresolvable recursive definition: echo -> echo")
+        .with_stdout("echo --flag1 --flag2")
         .run();
 
     p.cargo("test-1")
         .env("PATH", &path)
-        .with_status(101)
-        .with_stderr(
-            "error: alias test-1 has unresolvable recursive definition: test-1 -> echo -> echo",
-        )
+        .with_stdout("echo --flag1 --flag2")
         .run();
 
     // Builtins are not expanded by rule


### PR DESCRIPTION
Teaches cargo to accept default-args aliases of the form
[alias]
fmt = fmt --verbose

Teaches cargo to failfast (rather than stack overflow on corecursive
aliases)
[alias]
test-1 = test-2
test-2 = test-3
test-3 = test-1

Fixes #8360