### PR TITLE
Implement `[future-incompat-report]` config section

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1215,6 +1215,18 @@ the `--future-incompat-report` flag. The developer should then update their
 dependencies to a version where the issue is fixed, or work with the
 developers of the dependencies to help resolve the issue.
 
+This feature can be configured through a `[future-incompat-report]`
+section in `.cargo/config`. Currently, the supported options are:
+
+```
+[future-incompat-report]
+frequency = FREQUENCY
+```
+
+The supported values for `FREQUENCY` are 'always` and 'never', which control
+whether or not a message is printed out at the end of `cargo build` / `cargo check`.
+
+
 ### patch-in-config
 * Original Pull Request: [#9204](https://github.com/rust-lang/cargo/pull/9204)
 * Tracking Issue: [#9269](https://github.com/rust-lang/cargo/issues/9269)

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -148,7 +148,7 @@ pub fn write_config_at(path: impl AsRef<Path>, contents: &str) {
     fs::write(path, contents).unwrap();
 }
 
-fn write_config_toml(config: &str) {
+pub fn write_config_toml(config: &str) {
     write_config_at(paths::root().join(".cargo/config.toml"), config);
 }
 


### PR DESCRIPTION
Currently, I've just implemented the `always` and `never` frequencies
from the RFC, which don't require tracking any additional state.

cc @ehuss 