### PR TITLE
Fix errors in `cargo fetch` usage guide

### DIFF
--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -32,8 +32,8 @@ you plan to use Cargo without a network with the `--offline` flag.
 
 <dl>
 <dt class="option-term" id="option-cargo-fetch---target"><a class="option-anchor" href="#option-cargo-fetch---target"></a><code>--target</code> <em>triple</em></dt>
-<dd class="option-desc">Fetch for the given architecture. The default is the host
-architecture. The general format of the triple is
+<dd class="option-desc">Fetch for the given architecture. The default is to fetch dependencies
+for all targets. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
 list of supported targets.</p>
 <p>This may also be specified with the <code>build.target</code>

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -13,8 +13,9 @@ cargo-fetch - Fetch dependencies of a package from the network
 
 If a `Cargo.lock` file is available, this command will ensure that all of the
 git dependencies and/or registry dependencies are downloaded and locally
-available. Subsequent Cargo commands never touch the network after a `cargo
-fetch` unless the lock file changes.
+available. Subsequent Cargo commands run with `--locked`, `--frozen`, or
+`--offline` will not touch the network after a `cargo fetch` unless the lock
+file changes.
 
 If the lock file is not available, then this command will generate the lock
 file before fetching the dependencies.


### PR DESCRIPTION
While working on distro packaging guidelines for Rust software in Arch Linux with another team member (hey @grawlinson) we ran into a disagreement about when and how `cargo fetch` should be used. After a little bit of clamor it became apparent that one of us was working from fiddling around and testing and the other by reading the documentation. It's unfortunate but in this case the docs seem to be wrong.

See commit messages for further details.
