### PR TITLE
Fix plugin registrar change.

### DIFF
--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -463,15 +463,15 @@ fn plugin_with_extra_dylib_dep() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(plugin_registrar, rustc_private)]
+                #![feature(rustc_private)]
 
                 extern crate baz;
                 extern crate rustc_driver;
 
                 use rustc_driver::plugin::Registry;
 
-                #[plugin_registrar]
-                pub fn foo(reg: &mut Registry) {
+                #[no_mangle]
+                pub fn __rustc_plugin_registrar(reg: &mut Registry) {
                     println!("{}", baz::baz());
                 }
             "#,

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -67,15 +67,15 @@ fn plugin_to_the_max() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(plugin_registrar, rustc_private)]
+                #![feature(rustc_private)]
 
                 extern crate baz;
                 extern crate rustc_driver;
 
                 use rustc_driver::plugin::Registry;
 
-                #[plugin_registrar]
-                pub fn foo(_reg: &mut Registry) {
+                #[no_mangle]
+                pub fn __rustc_plugin_registrar(_reg: &mut Registry) {
                     println!("{}", baz::baz());
                 }
             "#,
@@ -191,7 +191,7 @@ fn plugin_with_dynamic_native_dependency() {
         .file(
             "bar/src/lib.rs",
             r#"
-                #![feature(plugin_registrar, rustc_private)]
+                #![feature(rustc_private)]
 
                 extern crate rustc_driver;
                 use rustc_driver::plugin::Registry;
@@ -200,8 +200,8 @@ fn plugin_with_dynamic_native_dependency() {
                 #[cfg_attr(target_env = "msvc", link(name = "builder.dll"))]
                 extern { fn foo(); }
 
-                #[plugin_registrar]
-                pub fn bar(_reg: &mut Registry) {
+                #[no_mangle]
+                pub fn __rustc_plugin_registrar(_reg: &mut Registry) {
                     unsafe { foo() }
                 }
             "#,

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -227,7 +227,7 @@ fn plugin_and_proc_macro() {
         .file(
             "src/lib.rs",
             r#"
-                #![feature(plugin_registrar, rustc_private)]
+                #![feature(rustc_private)]
                 #![feature(proc_macro, proc_macro_lib)]
 
                 extern crate rustc_driver;
@@ -236,8 +236,8 @@ fn plugin_and_proc_macro() {
                 extern crate proc_macro;
                 use proc_macro::TokenStream;
 
-                #[plugin_registrar]
-                pub fn plugin_registrar(reg: &mut Registry) {}
+                #[no_mangle]
+                pub fn __rustc_plugin_registrar(reg: &mut Registry) {}
 
                 #[proc_macro_derive(Questionable)]
                 pub fn questionable(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
The plugin tests were broken due to a change in https://github.com/rust-lang/rust/pull/85296 which removed the `plugin_registrar` attribute.
