### PR TITLE
Emit warning for migrating to unstable edition in stable channel

### DIFF
--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -54,7 +54,7 @@ pub enum Message {
         message: String,
     },
     EditionAlreadyEnabled {
-        file: String,
+        message: String,
         edition: Edition,
     },
 }
@@ -177,18 +177,13 @@ impl<'a> DiagnosticPrinter<'a> {
                 )?;
                 Ok(())
             }
-            Message::EditionAlreadyEnabled { file, edition } => {
+            Message::EditionAlreadyEnabled { message, edition } => {
                 if !self.dedupe.insert(msg.clone()) {
                     return Ok(());
                 }
-                let warning = format!(
-                    "`{}` is already on the latest edition ({}), \
-                     unable to migrate further",
-                    file, edition
-                );
                 // Don't give a really verbose warning if it has already been issued.
                 if self.dedupe.insert(Message::EditionAlreadyEnabled {
-                    file: "".to_string(), // Dummy, so that this only long-warns once.
+                    message: "".to_string(), // Dummy, so that this only long-warns once.
                     edition: *edition,
                 }) {
                     self.config.shell().warn(&format!("\
@@ -205,10 +200,10 @@ process requires following these steps:
 More details may be found at
 https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
 ",
-                        warning, this_edition=edition, prev_edition=edition.previous().unwrap()
+                        message, this_edition=edition, prev_edition=edition.previous().unwrap()
                     ))
                 } else {
-                    self.config.shell().warn(warning)
+                    self.config.shell().warn(message)
                 }
             }
         }


### PR DESCRIPTION
Resolves #9782 

Also alter the original error message slightly.

