### PR TITLE
Render build-std web links as hyperlinks

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -504,7 +504,7 @@ the [issue tracker](https://github.com/rust-lang/wg-cargo-std-aware/issues) of
 the tracking repository, and if it's not there please file a new issue!
 
 ### build-std-features
-* Tracking Repository: https://github.com/rust-lang/wg-cargo-std-aware
+* Tracking Repository: <https://github.com/rust-lang/wg-cargo-std-aware>
 
 This flag is a sibling to the `-Zbuild-std` feature flag. This will configure
 the features enabled for the standard library itself when building the standard

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -423,7 +423,7 @@ private_dep = "2.0.0" # Will be 'private' by default
 ```
 
 ### build-std
-* Tracking Repository: https://github.com/rust-lang/wg-cargo-std-aware
+* Tracking Repository: <https://github.com/rust-lang/wg-cargo-std-aware>
 
 The `build-std` feature enables Cargo to compile the standard library itself as
 part of a crate graph compilation. This feature has also historically been known
@@ -493,9 +493,9 @@ feature for Cargo has an extremely long history and is very large in scope, and
 this is just the beginning. If you'd like to report bugs please either report
 them to:
 
-* Cargo - https://github.com/rust-lang/cargo/issues/new - for implementation bugs
+* Cargo - <https://github.com/rust-lang/cargo/issues/new> - for implementation bugs
 * The tracking repository -
-  https://github.com/rust-lang/wg-cargo-std-aware/issues/new - for larger design
+  <https://github.com/rust-lang/wg-cargo-std-aware/issues/new> - for larger design
   questions.
 
 Also if you'd like to see a feature that's not yet implemented and/or if


### PR DESCRIPTION
Several hyperlinks in the unstable docs page are not rendered properly as links when the documentation is built. This PR addresses this.

<img width="622" alt="Screenshot 2021-08-16 201532" src="https://user-images.githubusercontent.com/10340167/129644467-2c8ec535-3d44-497e-8fba-d8364b794faf.png">
