### PR TITLE
Show information about abnormal `fix` errors.

### DIFF
--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -48,6 +48,7 @@ pub enum Message {
         files: Vec<String>,
         krate: Option<String>,
         errors: Vec<String>,
+        abnormal_exit: Option<String>,
     },
     ReplaceFailed {
         file: String,
@@ -135,6 +136,7 @@ impl<'a> DiagnosticPrinter<'a> {
                 files,
                 krate,
                 errors,
+                abnormal_exit,
             } => {
                 if let Some(ref krate) = *krate {
                     self.config.shell().warn(&format!(
@@ -170,6 +172,13 @@ impl<'a> DiagnosticPrinter<'a> {
                             writeln!(self.config.shell().err())?;
                         }
                     }
+                }
+                if let Some(exit) = abnormal_exit {
+                    writeln!(
+                        self.config.shell().err(),
+                        "rustc exited abnormally: {}",
+                        exit
+                    )?;
                 }
                 writeln!(
                     self.config.shell().err(),


### PR DESCRIPTION
During a recent crater run, we ran into a few circumstances where `cargo fix` failed unexpectedly, and we can't reproduce the errors locally.  The sequence was:

1. Cargo ran `rustc` and collected the diagnostics to apply, and modified the files.
2. Cargo ran `rustc` again to verify the fixes. This step failed, but only emitted warnings.
3. Cargo ran `rustc` again to show the original diagnostics, and this exited normally with warnings.

We don't know why the second step failed.  This change makes it so that cargo will collect any non-diagnostic messages (like ICEs), and will also display the exit code if it is abnormal.
