### PR TITLE
Allow crate download by checksum

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -189,6 +189,7 @@ const CRATE_TEMPLATE: &str = "{crate}";
 const VERSION_TEMPLATE: &str = "{version}";
 const PREFIX_TEMPLATE: &str = "{prefix}";
 const LOWER_PREFIX_TEMPLATE: &str = "{lowerprefix}";
+const CHECKSUM_TEMPLATE: &str = "{sha256-checksum}";
 
 /// A "source" for a local (see `local::LocalRegistry`) or remote (see
 /// `remote::RemoteRegistry`) registry.
@@ -236,7 +237,8 @@ pub struct RegistryConfig {
     /// respectively.  The substring `{prefix}` will be replaced with the
     /// crate's prefix directory name, and the substring `{lowerprefix}` will
     /// be replaced with the crate's prefix directory name converted to
-    /// lowercase.
+    /// lowercase. The substring `{sha256-checksum}` will be replaced with the
+    /// crate's sha256 checksum.
     ///
     /// For backwards compatibility, if the string does not contain any
     /// markers (`{crate}`, `{version}`, `{prefix}`, or ``{lowerprefix}`), it

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -2,8 +2,8 @@ use crate::core::{GitReference, PackageId, SourceId};
 use crate::sources::git;
 use crate::sources::registry::MaybeLock;
 use crate::sources::registry::{
-    RegistryConfig, RegistryData, CRATE_TEMPLATE, LOWER_PREFIX_TEMPLATE, PREFIX_TEMPLATE,
-    VERSION_TEMPLATE,
+    RegistryConfig, RegistryData, CHECKSUM_TEMPLATE, CRATE_TEMPLATE, LOWER_PREFIX_TEMPLATE,
+    PREFIX_TEMPLATE, VERSION_TEMPLATE,
 };
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
@@ -243,7 +243,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         Ok(())
     }
 
-    fn download(&mut self, pkg: PackageId, _checksum: &str) -> CargoResult<MaybeLock> {
+    fn download(&mut self, pkg: PackageId, checksum: &str) -> CargoResult<MaybeLock> {
         let filename = self.filename(pkg);
 
         // Attempt to open an read-only copy first to avoid an exclusive write
@@ -267,6 +267,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
             && !url.contains(VERSION_TEMPLATE)
             && !url.contains(PREFIX_TEMPLATE)
             && !url.contains(LOWER_PREFIX_TEMPLATE)
+            && !url.contains(CHECKSUM_TEMPLATE)
         {
             write!(url, "/{}/{}/download", CRATE_TEMPLATE, VERSION_TEMPLATE).unwrap();
         }
@@ -275,7 +276,8 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
             .replace(CRATE_TEMPLATE, &*pkg.name())
             .replace(VERSION_TEMPLATE, &pkg.version().to_string())
             .replace(PREFIX_TEMPLATE, &prefix)
-            .replace(LOWER_PREFIX_TEMPLATE, &prefix.to_lowercase());
+            .replace(LOWER_PREFIX_TEMPLATE, &prefix.to_lowercase())
+            .replace(CHECKSUM_TEMPLATE, checksum);
 
         Ok(MaybeLock::Download {
             url,

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -135,6 +135,7 @@ The keys are:
   - `{prefix}`: A directory prefix computed from the crate name. For example,
     a crate named `cargo` has a prefix of `ca/rg`. See below for details.
   - `{lowerprefix}`: Lowercase variant of `{prefix}`.
+  - `{sha256-checksum}`: The crate's sha256 checksum.
 
   If none of the markers are present, then the value
   `/{crate}/{version}/download` is appended to the end.


### PR DESCRIPTION
The `dl` key in `config.json` currently allows the following substitutions: {crate}, {version}, {prefix}, {lowerprefix}.

This change adds a {checksum} placeholder for the crate's sha256 checksum. Does not change any existing behavior.

Allowing downloads by checksum makes it possible for crate files to be placed in a content addressable store. 