### PR TITLE
Show feature resolver differences for dev-dependencies.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1428,6 +1428,7 @@ fn edition_v2_resolver_report() {
     }
     Package::new("common", "1.0.0")
         .feature("f1", &[])
+        .feature("dev-feat", &[])
         .add_dep(Dependency::new("opt_dep", "1.0").optional(true))
         .publish();
     Package::new("opt_dep", "1.0.0").publish();
@@ -1455,6 +1456,9 @@ fn edition_v2_resolver_report() {
 
                 [build-dependencies]
                 common = { version = "1.0", features = ["opt_dep"] }
+
+                [dev-dependencies]
+                common = { version="1.0", features=["dev-feat"] }
             "#,
         )
         .file("src/lib.rs", "")
@@ -1473,8 +1477,12 @@ This may cause some dependencies to be built with fewer features enabled than pr
 More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
 When building the following dependencies, the given features will no longer be used:
 
-  common v1.0.0: f1, opt_dep
-  common v1.0.0 (as host dependency): f1
+  common v1.0.0 removed features: dev-feat, f1, opt_dep
+  common v1.0.0 (as host dependency) removed features: dev-feat, f1
+
+The following differences only apply when building with dev-dependencies:
+
+  common v1.0.0 removed features: f1, opt_dep
 
 [CHECKING] opt_dep v1.0.0
 [CHECKING] common v1.0.0


### PR DESCRIPTION
During the crater run for 2021, there was a package that failed to update in a confusing way. The issue is that a feature was removed in the new resolver, but only for a dev-dependency. The report displayed with `cargo fix --edition` did not say anything about that, so it took me a bit to figure it out.  This changes it so that the report also includes changes to features of dev-dependencies.  I honestly don't remember my thought process behind the original code.

For example, the offending package now says:

```
When building the following dependencies, the given features will no longer be used:

  log v0.4.8 removed features: std
  syn v0.15.44 (as host dependency) removed features: extra-traits, visit

The following differences only apply when building with dev-dependencies:

  phf_shared v0.7.24 (as host dependency) removed features: unicase
```

And the error that happens after updating to 2021 is:

```
error[E0277]: the trait bound `UniCase<&str>: phf_shared::PhfHash` is not satisfied
  --> /Users/eric/.cargo/registry/src/github.com-1ecc6299db9ec823/mime_guess-1.8.7/build.rs:37:21
   |
37 |         forward_map.entry(UniCase(key), &format!("{:?}", val));
   |                     ^^^^^ the trait `phf_shared::PhfHash` is not implemented for `UniCase<&str>`
```

Hopefully developers will be able to see the note about the feature `unicase` being removed from `phf_shared`, and the error message about `UniCase` not implementing `PhfHash`, and connect the two together.  Previously, the upgrade report didn't mention anything about `phf_shared`, and thus no clues on what went wrong.
