### PR TITLE
Add target_dir for 3rd party subcommands

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -163,11 +163,7 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> Cli
         }
     };
 
-    let cargo_exe = config.cargo_exe()?;
-    let err = match ProcessBuilder::new(&command)
-        .env(cargo::CARGO_ENV, cargo_exe)
-        .args(args)
-        .exec_replace()
+    let err = match cargo::ops::execute_external_subcommand(&config, &command, args)
     {
         Ok(()) => return Ok(()),
         Err(e) => e,

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -85,3 +85,26 @@ fn check_dep_has_version(dep: &crate::core::Dependency, publish: bool) -> crate:
     }
     Ok(true)
 }
+
+// Temporary - should this be in a subcommand.rs file?
+use crate::Config;
+use crate::util::important_paths::find_root_manifest_for_wd;
+use crate::core::Workspace;
+use cargo_util::ProcessBuilder;
+use std::ffi::OsStr;
+
+pub fn execute_external_subcommand<T: AsRef<OsStr>>(config: &Config, command: T, args: &[&str])
+    -> crate::CargoResult<()>
+{
+    let cargo_exe = config.cargo_exe()?;
+    let manifest_path = find_root_manifest_for_wd(config.cwd())?;
+    let ws = Workspace::new(&manifest_path, config)?;
+
+    let cargo_target_dir = ws.target_dir().into_path_unlocked();
+
+    ProcessBuilder::new(&command)
+        .env(crate::CARGO_ENV, cargo_exe)
+        .env("CARGO_TARGET_DIR", &cargo_target_dir)
+        .args(args)
+        .exec_replace()
+}


### PR DESCRIPTION
This allows third party subcommands to see the target dir
environment variable as cargo has processed it from the workspace.
Due to moving the processing to ops, this also allows further
variables to be exposed to subcommands in the future.

Fixes https://github.com/rust-lang/cargo/issues/9804