### PR TITLE
Bump curl.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
-curl = { version = "0.4.23", features = ["http2"] }
-curl-sys = "0.4.22"
+curl = { version = "0.4.38", features = ["http2"] }
+curl-sys = "0.4.45"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"


### PR DESCRIPTION
This updates to the latest version of curl (7.78).  7.77 which is used in rust-lang/rust had an issue where it was failing in Windows 8.  I have confirmed that 7.78 works correctly.

Fixes #9788 
