### PR TITLE
Move `tmp` test directory.

### DIFF
--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -172,7 +172,7 @@ impl Layout {
             fingerprint: dest.join(".fingerprint"),
             examples: dest.join("examples"),
             doc: root.join("doc"),
-            tmp: dest.join("tmp"),
+            tmp: root.join("tmp"),
             root,
             dest,
             _lock: lock,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -642,6 +642,7 @@ impl TomlProfile {
                 | "rust"
                 | "rustc"
                 | "rustdoc"
+                | "tmp"
                 | "uninstall"
         ) || lower_name.starts_with("cargo")
         {

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -233,7 +233,6 @@ corresponding environment variable is set to the empty string, `""`.
   where integration tests or benchmarks are free to put any data needed by
   the tests/benches. Cargo initially creates this directory but doesn't
   manage its content in any way, this is the responsibility of the test code.
-  There are separate directories for `debug` and `release` profiles.
 
 [integration test]: cargo-targets.md#integration-tests
 [`env` macro]: ../../std/macro.env.html

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1377,7 +1377,10 @@ fn crate_env_vars() {
                     let tmpdir: PathBuf = tmp.unwrap().into();
 
                     let exe: PathBuf = env::current_exe().unwrap().into();
-                    let mut expected: PathBuf = exe.parent().unwrap().parent().unwrap().into();
+                    let mut expected: PathBuf = exe.parent().unwrap()
+                        .parent().unwrap()
+                        .parent().unwrap()
+                        .into();
                     expected.push("tmp");
                     assert_eq!(tmpdir, expected);
 


### PR DESCRIPTION
The `tmp` directory added in #9375 was placed within the profile directory (such as `target/debug/tmp` or `target/release/tmp`).  This causes problems for any cargo target (binary, test, etc.) with the name `tmp` as there is a name collision.  This PR attempts to address that by moving the `tmp` directory to the root of the target directory (`target/tmp`), and reserving the profile name "tmp".

Fixes #9783