### PR TITLE
[beta] Move `tmp` test directory.

### DIFF
--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -172,7 +172,7 @@ impl Layout {
             fingerprint: dest.join(".fingerprint"),
             examples: dest.join("examples"),
             doc: root.join("doc"),
-            tmp: dest.join("tmp"),
+            tmp: root.join("tmp"),
             root,
             dest,
             _lock: lock,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -627,6 +627,7 @@ impl TomlProfile {
                 | "rust"
                 | "rustc"
                 | "rustdoc"
+                | "tmp"
                 | "uninstall"
         ) || lower_name.starts_with("cargo")
         {

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -233,7 +233,6 @@ corresponding environment variable is set to the empty string, `""`.
   where integration tests or benchmarks are free to put any data needed by
   the tests/benches. Cargo initially creates this directory but doesn't
   manage its content in any way, this is the responsibility of the test code.
-  There are separate directories for `debug` and `release` profiles.
 
 [integration test]: cargo-targets.md#integration-tests
 [`env` macro]: ../../std/macro.env.html

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1377,7 +1377,10 @@ fn crate_env_vars() {
                     let tmpdir: PathBuf = tmp.unwrap().into();
 
                     let exe: PathBuf = env::current_exe().unwrap().into();
-                    let mut expected: PathBuf = exe.parent().unwrap().parent().unwrap().into();
+                    let mut expected: PathBuf = exe.parent().unwrap()
+                        .parent().unwrap()
+                        .parent().unwrap()
+                        .into();
                     expected.push("tmp");
                     assert_eq!(tmpdir, expected);
 

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -60,6 +60,8 @@ fn simple() {
 }
 
 #[cargo_test]
+// Broken, temporarily disable until https://github.com/rust-lang/rust/pull/82776 is resolved.
+#[ignore]
 fn std_docs() {
     // Mapping std docs somewhere else.
     if !is_nightly() {


### PR DESCRIPTION
This is a beta backport of #9814.

Includes #9824 to make CI pass.
