### PR TITLE
Fix typos “a”→“an”

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -36,7 +36,7 @@
 //!
 //! "NeedsToken" indicates that a rustc is interested in acquiring a token, but
 //! never that it would be impossible to make progress without one (i.e., it
-//! would be incorrect for rustc to not terminate due to a unfulfilled
+//! would be incorrect for rustc to not terminate due to an unfulfilled
 //! NeedsToken request); we do not usually fulfill all NeedsToken requests for a
 //! given rustc.
 //!

--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -85,7 +85,7 @@ impl ConflictStoreTrie {
         } else {
             // We are at the end of the set we are adding, there are three cases for what to do
             // next:
-            // 1. `self` is a empty dummy Node inserted by `or_insert_with`
+            // 1. `self` is an empty dummy Node inserted by `or_insert_with`
             //      in witch case we should replace it with `Leaf(con)`.
             // 2. `self` is a `Node` because we previously inserted a superset of
             //      the thing we are working on (I don't know if this happens in practice)

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -609,7 +609,7 @@ fn activate(
     cx.age += 1;
     if let Some((parent, dep)) = parent {
         let parent_pid = parent.package_id();
-        // add a edge from candidate to parent in the parents graph
+        // add an edge from candidate to parent in the parents graph
         cx.parents
             .link(candidate_pid, parent_pid)
             // and associate dep with that edge
@@ -700,7 +700,7 @@ struct BacktrackFrame {
 #[derive(Clone)]
 struct RemainingCandidates {
     remaining: RcVecIter<Summary>,
-    // This is a inlined peekable generator
+    // This is an inlined peekable generator
     has_another: Option<Summary>,
 }
 

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -205,7 +205,7 @@ impl Ord for DepsFrame {
     }
 }
 
-/// Note that a `OrdSet` is used for the remaining dependencies that need
+/// Note that an `OrdSet` is used for the remaining dependencies that need
 /// activation. This set is sorted by how many candidates each dependency has.
 ///
 /// This helps us get through super constrained portions of the dependency

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -164,7 +164,7 @@ impl SourceId {
     }
 
     /// Creates a SourceId from a remote registry URL when the registry name
-    /// cannot be determined, e.g. an user passes `--index` directly from CLI.
+    /// cannot be determined, e.g. a user passes `--index` directly from CLI.
     ///
     /// Use [`SourceId::for_alt_registry`] if a name can provided, which
     /// generates better messages for cargo.

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -207,7 +207,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         .iter()
         .map(|p| PackageIdSpec::parse(p))
         .map(|r| {
-            // Provide a error message if pkgid is not within the resolved
+            // Provide an error message if pkgid is not within the resolved
             // dependencies graph.
             r.and_then(|spec| spec.query(ws_resolve.targeted_resolve.iter()).and(Ok(spec)))
         })

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -54,7 +54,7 @@ pub struct GitDatabase {
 
 /// `GitCheckout` is a local checkout of a particular revision. Calling
 /// `clone_into` with a reference will resolve the reference into a revision,
-/// and return a `anyhow::Error` if no revision for that reference was found.
+/// and return an `anyhow::Error` if no revision for that reference was found.
 #[derive(Serialize)]
 pub struct GitCheckout<'a> {
     database: &'a GitDatabase,

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -685,7 +685,7 @@ impl Summaries {
 // * `2`: Added the "index format version" field so that if the index format
 //   changes, different versions of cargo won't get confused reading each
 //   other's caches.
-// * `3`: Bumped the version to work around a issue where multiple versions of
+// * `3`: Bumped the version to work around an issue where multiple versions of
 //   a package were published that differ only by semver metadata. For
 //   example, openssl-src 110.0.0 and 110.0.0+1.1.0f. Previously, the cache
 //   would be incorrectly populated with two entries, both 110.0.0. After

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -188,14 +188,14 @@ pub struct Config {
     /// This should be false if:
     /// - this is an artifact of the rustc distribution process for "stable" or for "beta"
     /// - this is an `#[test]` that does not opt in with `enable_nightly_features`
-    /// - this is a integration test that uses `ProcessBuilder`
+    /// - this is an integration test that uses `ProcessBuilder`
     ///      that does not opt in with `masquerade_as_nightly_cargo`
     /// This should be true if:
     /// - this is an artifact of the rustc distribution process for "nightly"
     /// - this is being used in the rustc distribution process internally
     /// - this is a cargo executable that was built from source
     /// - this is an `#[test]` that called `enable_nightly_features`
-    /// - this is a integration test that uses `ProcessBuilder`
+    /// - this is an integration test that uses `ProcessBuilder`
     ///       that called `masquerade_as_nightly_cargo`
     /// It's public to allow tests use nightly features.
     /// NOTE: this should be set before `configure()`. If calling this from an integration test,
@@ -836,7 +836,7 @@ impl Config {
         Ok(())
     }
 
-    /// Low-level method for getting a config value as a `OptValue<HashMap<String, CV>>`.
+    /// Low-level method for getting a config value as an `OptValue<HashMap<String, CV>>`.
     ///
     /// NOTE: This does not read from env. The caller is responsible for that.
     fn get_table(&self, key: &ConfigKey) -> CargoResult<OptValue<HashMap<String, CV>>> {

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -77,7 +77,7 @@ required by package `foo v0.1.0 ([..]/foo)`
         .run();
 
     // Publish a version without namespaced features, it should ignore 1.0.0
-    // an use this instead.
+    // and use this instead.
     Package::new("bar", "1.0.1")
         .add_dep(Dependency::new("baz", "1.0").optional(true))
         .feature("feat", &["baz"])

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -94,7 +94,7 @@ required by package `foo v0.1.0 ([..]/foo)`
         .run();
 
     // Publish a version without the ? feature, it should ignore 1.0.0
-    // an use this instead.
+    // and use this instead.
     Package::new("bar", "1.0.1")
         .add_dep(Dependency::new("baz", "1.0").optional(true))
         .feature("feat", &["baz"])


### PR DESCRIPTION
See rust-lang/rust#88230