### PR TITLE
Temporarily disable extern-html-root-url test.

### DIFF
--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -60,6 +60,8 @@ fn simple() {
 }
 
 #[cargo_test]
+// Broken, temporarily disable until https://github.com/rust-lang/rust/pull/82776 is resolved.
+#[ignore]
 fn std_docs() {
     // Mapping std docs somewhere else.
     if !is_nightly() {


### PR DESCRIPTION
A change in https://github.com/rust-lang/rust/pull/82776 broke this test,
so disabling for now until it is figured out how things are going to work.