### PR TITLE
 Make commands in dependencies available to run

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -20,7 +20,17 @@ pub fn run(
 
     // We compute the `bins` here *just for diagnosis*. The actual set of
     // packages to be run is determined by the `ops::compile` call below.
-    let packages = options.spec.get_packages(ws)?;
+    let (package_set, resolver) = ops::resolve_ws(ws)?;
+    let packages = if let ops::Packages::Packages(ref pkg_names) = options.spec {
+        let pkgids: Vec<_> = pkg_names
+            .iter()
+            .flat_map(|name| resolver.query(name))
+            .collect();
+        package_set.get_many(pkgids)?
+    } else {
+        options.spec.get_packages(ws)?
+    };
+
     let bins: Vec<_> = packages
         .into_iter()
         .flat_map(|pkg| {

--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -1,10 +1,13 @@
+use std::collections::HashSet;
 use std::ffi::OsString;
 use std::iter;
 use std::path::Path;
 
 use crate::core::compiler::UnitOutput;
-use crate::core::{TargetKind, Workspace};
-use crate::ops;
+use crate::core::dependency::DepKind;
+use crate::core::resolver::Resolve;
+use crate::core::{Package, PackageIdSpec, PackageSet, TargetKind, Workspace};
+use crate::ops::{self, Packages};
 use crate::util::CargoResult;
 
 pub fn run(
@@ -20,19 +23,10 @@ pub fn run(
 
     // We compute the `bins` here *just for diagnosis*. The actual set of
     // packages to be run is determined by the `ops::compile` call below.
-    let (package_set, resolver) = ops::resolve_ws(ws)?;
-    let packages = if let ops::Packages::Packages(ref pkg_names) = options.spec {
-        let pkgids: Vec<_> = pkg_names
-            .iter()
-            .flat_map(|name| resolver.query(name))
-            .collect();
-        package_set.get_many(pkgids)?
-    } else {
-        options.spec.get_packages(ws)?
-    };
+    let packages = packages_eligible_to_run(ws, &options.spec)?;
 
     let bins: Vec<_> = packages
-        .into_iter()
+        .iter()
         .flat_map(|pkg| {
             iter::repeat(pkg).zip(pkg.manifest().targets().iter().filter(|target| {
                 !target.is_lib()
@@ -101,11 +95,51 @@ pub fn run(
         Ok(path) => path.to_path_buf(),
         Err(_) => path.to_path_buf(),
     };
-    let pkg = bins[0].0;
+    let pkg = &bins[0].0;
     let mut process = compile.target_process(exe, unit.kind, pkg, *script_meta)?;
     process.args(args).cwd(config.cwd());
 
     config.shell().status("Running", process.to_string())?;
 
     process.exec_replace()
+}
+
+pub fn packages_eligible_to_run<'a>(
+    ws: &Workspace<'a>,
+    request: &Packages,
+) -> CargoResult<Vec<Package>> {
+    let matching_dependencies = if let ops::Packages::Packages(ref pkg_names) = request {
+        let specs: HashSet<_> = pkg_names
+            .into_iter()
+            .flat_map(|s| PackageIdSpec::parse(s))
+            .collect();
+
+        let (package_set, resolver): (PackageSet<'a>, Resolve) = ops::resolve_ws(ws)?;
+
+        // Restrict all direct dependencies only to build and development ones.
+        // Cargo wouldn't be able to run anything after installation, so
+        // normal dependencies are out.
+        let direct_dependencies: Vec<_> = ws
+            .members()
+            .flat_map(|pkg| resolver.deps(pkg.package_id()))
+            .filter(|(_, manifest_deps)| {
+                manifest_deps.into_iter().any(|dep| match dep.kind() {
+                    DepKind::Development | DepKind::Build => true,
+                    DepKind::Normal => false,
+                })
+            })
+            .collect();
+
+        specs.into_iter().filter_map(|pkgidspec|
+            // Either a workspace match…
+            ws.members().find(|pkg| pkgidspec.matches(pkg.package_id()))
+                .or_else(|| { // …or a direct dependency as fallback
+                    let maybe_dep = direct_dependencies.iter().find(|(dep_pkgid, _)| pkgidspec.matches(*dep_pkgid));
+                    maybe_dep.map(|(dep_pkgid, _)| package_set.get_one(*dep_pkgid).unwrap())
+                })).cloned().collect()
+    } else {
+        request.get_packages(ws)?.into_iter().cloned().collect()
+    };
+
+    Ok(matching_dependencies)
 }

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -16,7 +16,7 @@ pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadat
 pub use self::cargo_package::{package, package_one, PackageOpts};
 pub use self::cargo_pkgid::pkgid;
 pub use self::cargo_read_manifest::{read_package, read_packages};
-pub use self::cargo_run::run;
+pub use self::cargo_run::{packages_eligible_to_run, run};
 pub use self::cargo_test::{run_benches, run_tests, TestOptions};
 pub use self::cargo_uninstall::uninstall;
 pub use self::fix::{fix, fix_maybe_exec_rustc, FixOptions};


### PR DESCRIPTION
This approach teaches `cargo run` to handle also binary targets in dependencies. In turn, it allows using cargo as a shim
when needing to invoke a specific package version from the set of dependencies, without resorting to install a user-wide
version of a binary.
    
Users of e.g. `mdbook` should rejoice.

Note that this is my first contribution to `cargo`. I am not familiar yet on how is the best way to do things.
Also, I haven't adjusted any documentation yet, I wanted first to see if my idea is sound or not.

If approved, fixes #2267.