### PR TITLE
Fix test not to rely on `cargo` in PATH.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1719,7 +1719,7 @@ fn fix_with_run_cargo_in_proc_macros() {
     
                 #[proc_macro]
                 pub fn foo(_input: TokenStream) -> TokenStream {
-                    let output = std::process::Command::new("cargo")
+                    let output = std::process::Command::new(env!("CARGO"))
                         .args(&["metadata", "--format-version=1"])
                         .output()
                         .unwrap();


### PR DESCRIPTION
This fixes a test that was trying to execute `cargo` from PATH.  This test doesn't work on rust-lang/rust where the rustup installation is removed, and thus there is no `cargo` in PATH.
