### PR TITLE
Refactor so package publishing only determines git root in one place

### DIFF
--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -13,7 +13,7 @@ pub use self::cargo_generate_lockfile::UpdateOptions;
 pub use self::cargo_install::{install, install_list};
 pub use self::cargo_new::{init, new, NewOptions, VersionControl};
 pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
-pub use self::cargo_package::{package, package_one, PackageOpts};
+pub use self::cargo_package::{get_repo, package, package_one, PackageOpts};
 pub use self::cargo_pkgid::pkgid;
 pub use self::cargo_read_manifest::{read_package, read_packages};
 pub use self::cargo_run::run;


### PR DESCRIPTION
Refactor so package publishing only determines git root in one place

Depends on #9837