### PR TITLE
Swap out some outdated repo urls in documentation

### DIFF
--- a/src/cargo/util/canonical_url.rs
+++ b/src/cargo/util/canonical_url.rs
@@ -19,7 +19,7 @@ impl CanonicalUrl {
     pub fn new(url: &Url) -> CargoResult<CanonicalUrl> {
         let mut url = url.clone();
 
-        // cannot-be-a-base-urls (e.g., `github.com:rust-lang-nursery/rustfmt.git`)
+        // cannot-be-a-base-urls (e.g., `github.com:rust-lang/rustfmt.git`)
         // are not supported.
         if url.cannot_be_a_base() {
             anyhow::bail!(

--- a/src/doc/src/guide/cargo-toml-vs-cargo-lock.md
+++ b/src/doc/src/guide/cargo-toml-vs-cargo-lock.md
@@ -29,17 +29,17 @@ name = "hello_world"
 version = "0.1.0"
 
 [dependencies]
-rand = { git = "https://github.com/rust-lang-nursery/rand.git" }
+regex = { git = "https://github.com/rust-lang/regex.git" }
 ```
 
-This package has a single dependency, on the `rand` library. We’ve stated in
+This package has a single dependency, on the `regex` library. We’ve stated in
 this case that we’re relying on a particular Git repository that lives on
 GitHub. Since we haven’t specified any other information, Cargo assumes that
 we intend to use the latest commit on the `master` branch to build our package.
 
 Sound good? Well, there’s one problem: If you build this package today, and
 then you send a copy to me, and I build this package tomorrow, something bad
-could happen. There could be more commits to `rand` in the meantime, and my
+could happen. There could be more commits to `regex` in the meantime, and my
 build would include new commits while yours would not. Therefore, we would
 get different builds. This would be bad because we want reproducible builds.
 
@@ -47,7 +47,7 @@ We could fix this problem by putting a `rev` line in our `Cargo.toml`:
 
 ```toml
 [dependencies]
-rand = { git = "https://github.com/rust-lang-nursery/rand.git", rev = "9f35b8e" }
+regex = { git = "https://github.com/rust-lang/regex.git", rev = "9f9f693" }
 ```
 
 Now our builds will be the same. But there’s a big drawback: now we have to
@@ -64,7 +64,7 @@ name = "hello_world"
 version = "0.1.0"
 
 [dependencies]
-rand = { git = "https://github.com/rust-lang-nursery/rand.git" }
+regex = { git = "https://github.com/rust-lang/regex.git" }
 ```
 
 Cargo will take the latest commit and write that information out into our
@@ -75,13 +75,13 @@ Cargo will take the latest commit and write that information out into our
 name = "hello_world"
 version = "0.1.0"
 dependencies = [
- "rand 0.1.0 (git+https://github.com/rust-lang-nursery/rand.git#9f35b8e439eeedd60b9414c58f389bdc6a3284f9)",
+ "regex 1.5.0 (git+https://github.com/rust-lang/regex.git#9f9f693768c584971a4d53bc3c586c33ed3a6831)",
 ]
 
 [[package]]
-name = "rand"
-version = "0.1.0"
-source = "git+https://github.com/rust-lang-nursery/rand.git#9f35b8e439eeedd60b9414c58f389bdc6a3284f9"
+name = "regex"
+version = "1.5.0"
+source = "git+https://github.com/rust-lang/regex.git#9f9f693768c584971a4d53bc3c586c33ed3a6831"
 ```
 
 You can see that there’s a lot more information here, including the exact
@@ -93,14 +93,14 @@ When we’re ready to opt in to a new version of the library, Cargo can
 re-calculate the dependencies and update things for us:
 
 ```console
-$ cargo update           # updates all dependencies
-$ cargo update -p rand   # updates just “rand”
+$ cargo update            # updates all dependencies
+$ cargo update -p regex   # updates just “regex”
 ```
 
 This will write out a new `Cargo.lock` with the new version information. Note
 that the argument to `cargo update` is actually a
-[Package ID Specification](../reference/pkgid-spec.md) and `rand` is just a short
-specification.
+[Package ID Specification](../reference/pkgid-spec.md) and `regex` is just a
+short specification.
 
 [def-manifest]:  ../appendix/glossary.md#manifest  '"manifest" (glossary entry)'
 [def-package]:   ../appendix/glossary.md#package   '"package" (glossary entry)'

--- a/src/doc/src/guide/tests.md
+++ b/src/doc/src/guide/tests.md
@@ -11,7 +11,7 @@ currently has no tests:
 
 ```console
 $ cargo test
-   Compiling rand v0.1.0 (https://github.com/rust-lang-nursery/rand.git#9f35b8e)
+   Compiling regex v1.5.0 (https://github.com/rust-lang/regex.git#9f9f693)
    Compiling hello_world v0.1.0 (file:///path/to/package/hello_world)
      Running target/test/hello_world-9c2b65bbb79eabce
 

--- a/src/doc/src/guide/working-on-an-existing-project.md
+++ b/src/doc/src/guide/working-on-an-existing-project.md
@@ -3,19 +3,19 @@
 If you download an existing [package][def-package] that uses Cargo, it’s
 really easy to get going.
 
-First, get the package from somewhere. In this example, we’ll use `rand`
+First, get the package from somewhere. In this example, we’ll use `regex`
 cloned from its repository on GitHub:
 
 ```console
-$ git clone https://github.com/rust-lang-nursery/rand.git
-$ cd rand
+$ git clone https://github.com/rust-lang/regex.git
+$ cd regex
 ```
 
 To build, use `cargo build`:
 
 ```console
 $ cargo build
-   Compiling rand v0.1.0 (file:///path/to/package/rand)
+   Compiling regex v1.5.0 (file:///path/to/package/regex)
 ```
 
 This will fetch all of the dependencies and then build them, along with the

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -128,7 +128,7 @@ you need to specify is the location of the repository with the `git` key:
 
 ```toml
 [dependencies]
-rand = { git = "https://github.com/rust-lang-nursery/rand" }
+regex = { git = "https://github.com/rust-lang/regex" }
 ```
 
 Cargo will fetch the `git` repository at this location then look for a
@@ -144,7 +144,7 @@ the latest commit on a branch named `next`:
 
 ```toml
 [dependencies]
-rand = { git = "https://github.com/rust-lang-nursery/rand", branch = "next" }
+regex = { git = "https://github.com/rust-lang/regex", branch = "next" }
 ```
 
 Once a `git` dependency has been added, Cargo will lock that dependency to the

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1265,10 +1265,12 @@ but cannot be used multiple times
 
 #[cargo_test]
 fn test_install_git_cannot_be_a_base_url() {
-    cargo_process("install --git github.com:rust-lang-nursery/rustfmt.git")
+    cargo_process("install --git github.com:rust-lang/rustfmt.git")
         .with_status(101)
-        .with_stderr("\
-[ERROR] invalid url `github.com:rust-lang-nursery/rustfmt.git`: cannot-be-a-base-URLs are not supported")
+        .with_stderr(
+            "\
+[ERROR] invalid url `github.com:rust-lang/rustfmt.git`: cannot-be-a-base-URLs are not supported",
+        )
         .run();
 }
 


### PR DESCRIPTION
I noticed that `rand` and `rustfmt` are no longer located in rust-lang-nursery.

Rather than updating `rand` to github.com/rust-random/rand, I've swapped it out for `regex` in this PR. Some considerations:

- Preference for github.com/rust-lang over github.com/rust-random to reduce the perception of unnecessarily endorsing a project that isn't already endorsed by being in Cargo's org.
- Ruled out `libc` because make-your-own-libcpocalypse is not a fun detour for anyone following along and experimenting with git dependencies.
- Ruled out everything with a -rs suffix (`git2-rs`, `flate2-rs`, `backtrace-rs`, `futures-rs`) out of personal distaste.
- Went for something that has comparable name recognition to rand, i.e. ruled out `hashbrown`.

We could alternatively use dummy URLs like github.com/user/example everywhere but I feel that maintaining this every several years is not a big deal and is worth it for the character of the documentation.