### PR TITLE
Support path_in_vcs as part of cargo_vcs_metadata

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -66,6 +66,8 @@ enum GeneratedFile {
 #[derive(Serialize)]
 struct VcsInfo {
     git: GitVcsInfo,
+    /// Path to the package within repo (empty string if root). / not \
+    path_in_vcs: String,
 }
 
 #[derive(Serialize)]
@@ -408,8 +410,14 @@ fn check_repo_state(
                         "found (git) Cargo.toml at {:?} in workdir {:?}",
                         path, workdir
                     );
+                    let path_in_vcs = path
+                        .parent()
+                        .and_then(|p| p.to_str())
+                        .unwrap_or("")
+                        .replace("\\", "/");
                     return Ok(Some(VcsInfo {
                         git: git(p, src_files, &repo)?,
+                        path_in_vcs,
                     }));
                 }
             }

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -43,6 +43,22 @@ fields in the manifest.
 See [the reference](../reference/publishing.html) for more details about
 packaging and publishing.
 
+### .cargo_vcs_info.json format
+
+Will generate a `.cargo_vcs_info.json` in the following format
+
+```javascript
+{
+ "git": {
+   "sha1": "aac20b6e7e543e6dd4118b246c77225e3a3a1302"
+ },
+ "path_in_vcs": ""
+}
+```
+
+`path_in_vcs` will be set to a repo-relative path for packages
+in subdirectories of the version control repository.
+
 ## OPTIONS
 
 ### Package Options

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -45,6 +45,19 @@ DESCRIPTION
        <https://doc.rust-lang.org/cargo/reference/publishing.html> for more
        details about packaging and publishing.
 
+   .cargo_vcs_info.json format
+       Will generate a .cargo_vcs_info.json in the following format
+
+           {
+            "git": {
+              "sha1": "aac20b6e7e543e6dd4118b246c77225e3a3a1302"
+            },
+            "path_in_vcs": ""
+           }
+
+       path_in_vcs will be set to a repo-relative path for packages in
+       subdirectories of the version control repository.
+
 OPTIONS
    Package Options
        -l, --list

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -43,6 +43,22 @@ fields in the manifest.
 See [the reference](../reference/publishing.html) for more details about
 packaging and publishing.
 
+### .cargo_vcs_info.json format
+
+Will generate a `.cargo_vcs_info.json` in the following format
+
+```javascript
+{
+ "git": {
+   "sha1": "aac20b6e7e543e6dd4118b246c77225e3a3a1302"
+ },
+ "path_in_vcs": ""
+}
+```
+
+`path_in_vcs` will be set to a repo-relative path for packages
+in subdirectories of the version control repository.
+
 ## OPTIONS
 
 ### Package Options

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -67,6 +67,22 @@ fields in the manifest.
 .sp
 See \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/publishing.html> for more details about
 packaging and publishing.
+.SS ".cargo_vcs_info.json format"
+Will generate a \fB\&.cargo_vcs_info.json\fR in the following format
+.sp
+.RS 4
+.nf
+{
+ "git": {
+   "sha1": "aac20b6e7e543e6dd4118b246c77225e3a3a1302"
+ },
+ "path_in_vcs": ""
+}
+.fi
+.RE
+.sp
+\fBpath_in_vcs\fR will be set to a repo\-relative path for packages
+in subdirectories of the version control repository.
 .SH "OPTIONS"
 .SS "Package Options"
 .sp


### PR DESCRIPTION
Depends on #9865 - this PR will look simpler once that one lands. I can't target my PR to the base branch of #9865 as an external contributor (since it's in my fork). For now just review the latest commit of this one.

This is a backward compatible change that is an alternative to #9837