### PR TITLE
Improve error message when unable to initialize git index repo

### DIFF
--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -88,8 +88,9 @@ impl<'cfg> RemoteRegistry<'cfg> {
                     // things that we don't want.
                     let mut opts = git2::RepositoryInitOptions::new();
                     opts.external_template(false);
-                    Ok(git2::Repository::init_opts(&path, &opts)
-                        .with_context(|| "failed to initialize index git repository")?)
+                    Ok(git2::Repository::init_opts(&path, &opts).with_context(|| {
+                        format!("failed to initialize index git repository (in {:?})", path)
+                    })?)
                 }
             }
         })


### PR DESCRIPTION
With this - it'll be more obvious which git repo
couldn't be initialized.

Looks like this
```
➜  cargo RUST_BACKTRACE=1 target/debug/cargo build
error: failed to get `anyhow` as a dependency of package `cargo v0.57.0 (/Users/nipunn/src/cargo)`

Caused by:
  failed to initialize index git repository (in "/Users/nipunn/.cargo/registry/index/github.com-1ecc6299db9ec823")

Caused by:
  failed to parse config file: invalid configuration key (in /Users/nipunn/.config/git/config:1); class=Config (7)
```

Does the best we can with #9854 - since I don't think it can actually be fixed.
Fixes #9854