### PR TITLE
Retry git fetch operations when `net.git_fetch_with_cli = true` is set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ memchr = "2.1.3"
 num_cpus = "1.0"
 opener = "0.5"
 percent-encoding = "2.0"
+regex = "1.0"
 rustfix = "0.6.0"
 semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -4,6 +4,8 @@ use crate::core::{TargetKind, Workspace};
 use crate::ops::CompileOptions;
 use anyhow::Error;
 use cargo_util::ProcessError;
+use itertools::Itertools;
+use lazy_static::lazy_static;
 use std::fmt;
 use std::path::PathBuf;
 
@@ -297,6 +299,140 @@ impl From<clap::Error> for CliError {
     fn from(err: clap::Error) -> CliError {
         let code = if err.use_stderr() { 1 } else { 0 };
         CliError::new(err.into(), code)
+    }
+}
+
+/// Error that comes from running `git` CLI. This wrapper exists to detect
+/// this kind of errors in [`crate::util::network::with_retry`] and properly
+/// retry them.
+pub struct GitCliError {
+    inner: anyhow::Error,
+}
+
+impl GitCliError {
+    /// Creates an insteance of [`GitCliError`].
+    ///
+    /// # Invariants
+    ///
+    /// The inner error must by constructed from [`ProcessError`] that
+    /// was returned as a result of running `git` CLI operation.
+    /// If it isn't true, the code won't panic, but [`Self::is_retryable()`]
+    /// will always return `false`.
+    pub fn new(inner: anyhow::Error) -> Self {
+        Self { inner }
+    }
+
+    /// Returns `true` if the git CLI error is transient and may be retried.
+    ///
+    /// The code here is inspired by `chromium` git retries code:
+    /// <https://chromium.googlesource.com/infra/infra/+/b9f6e35d2aa1ce9fcb385e414866e0b1635a6c77/go/src/infra/tools/git/retry_regexp.go#17>
+    pub fn is_retryable(&self) -> bool {
+        const GIT_TRANSIENT_ERRORS: &[&str] = &[
+            // Error patterns are taken from chromium.
+            // Please, keep them 1-to-1 exactly the same as in their source code
+            //
+            // If you are updating them, please keep the commit ref in the doc comment
+            // of this method up-to-date.
+            r#"!.*\[remote rejected\].*\(error in hook\)"#,
+            r#"!.*\[remote rejected\].*\(failed to lock\)"#,
+            r#"!.*\[remote rejected\].*\(error in Gerrit backend\)"#,
+            r#"remote error: Internal Server Error"#,
+            r#"fatal: Couldn't find remote ref "#,
+            r#"git fetch_pack: expected ACK/NAK, got"#,
+            r#"protocol error: bad pack header"#,
+            r#"The remote end hung up unexpectedly"#,
+            r#"The remote end hung up upon initial contact"#,
+            r#"TLS packet with unexpected length was received"#,
+            r#"RPC failed; result=\d+, HTTP code = \d+"#,
+            r#"Connection timed out"#,
+            r#"repository cannot accept new pushes; contact support"#,
+            r#"Service Temporarily Unavailable"#,
+            r#"The service is currently unavailable"#,
+            r#"Connection refused"#,
+            r#"The requested URL returned error: 5\d+"#,
+            r#"Operation too slow"#,
+            r#"Connection reset by peer"#,
+            r#"Unable to look up"#,
+            r#"Couldn't resolve host"#,
+            r#"Unknown SSL protocol error"#,
+            r#"Revision .* of patch set \d+ does not match refs/changes"#,
+            r#"Git repository not found"#,
+            r#"Couldn't connect to server"#,
+            r#"transfer closed with outstanding read data remaining"#,
+            r#"Access denied to"#,
+            r#"The requested URL returned error: 429"#,
+            r#"RESOURCE_EXHAUSTED"#,
+            r#"Resource has been exhausted"#,
+            r#"check quota"#,
+            r#"fetch-pack: protocol error: bad band #\d+"#,
+            r#"The requested URL returned error: 400"#,
+            r#"fetch-pack: fetch failed"#,
+            r#"fetch-pack: unable to spawn http-fetch"#,
+            r#"fetch-pack: expected keep then TAB at start of http-fetch output"#,
+            r#"fetch-pack: expected hash then LF at end of http-fetch output"#,
+            r#"fetch-pack: unable to finish http-fetch"#,
+            r#"fetch-pack: pack downloaded from .* does not match expected hash .*"#,
+            // Regexes that are not included in chromium source code
+            // This one was reported in https://github.com/rust-lang/cargo/issues/9820
+            r#"Failed to connect .* Timed out"#,
+        ];
+
+        /// Merge all of the regex into a single regex OR-ed together
+        fn merge_regex(regexps: &[&str]) -> regex::Regex {
+            let source = regexps
+                .iter()
+                .format_with("|", |regex, f| f(&format_args!("(?:{})", regex)));
+
+            let source = &format!("(?i){}", source);
+
+            regex::Regex::new(source).expect("BUG: invalid git transient error regex")
+        }
+
+        lazy_static! {
+            static ref GIT_TRANSIENT_ERRORS_RE: regex::Regex = merge_regex(GIT_TRANSIENT_ERRORS);
+        }
+
+        let err = match self.inner.downcast_ref::<ProcessError>() {
+            Some(err) => err,
+            None => {
+                log::warn!(
+                    "BUG: `GitCliError` was constructed from non-`ProcessError`, \
+                    can't determine if it's retryable, assuming it's not... Error: {:?}",
+                    self,
+                );
+                return false;
+            }
+        };
+
+        err.stderr
+            .as_deref()
+            .map(|stderr| GIT_TRANSIENT_ERRORS_RE.is_match(&String::from_utf8_lossy(stderr)))
+            .unwrap_or_else(|| {
+                log::warn!(
+                    "BUG: git CLI stderr wasn't captured, \
+                    can't determine if it's retryable, assuming it's not... Error: {:?}",
+                    err
+                );
+                false
+            })
+    }
+}
+
+impl std::error::Error for GitCliError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl fmt::Debug for GitCliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl fmt::Display for GitCliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
     }
 }
 


### PR DESCRIPTION
Closes #9820 

This requires reading the `stderr` output of git matching it's output with a list of regular expressions.
Unfortunately, this is heuristic, but the best we can do. The implementation is heavily inspired by [chromium git-retry script](https://chromium.googlesource.com/infra/infra/+/b9f6e35d2aa1ce9fcb385e414866e0b1635a6c77/go/src/infra/tools/git/retry_regexp.go#17)
Stackoverflow mostly references python implementation (also in chromium codebase), however, comments in python code say [it's deprecated](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/a3d1aaf112499b19d1e2aafe5c33dad3266a6226/git_common.py#77) and reference Go implementation, which this PR is based on.

Some rough edges in this PR:
- The ProcessBuilder used to spawn `git` process provides methods with `anyhow::Error` API which isn't very convenient for local error handling and leaves some margin for bugs. It uses `ProcessError` under the hood, having access to it would be handy, but I didn't want to break the error type tendency in the API of this struct
-  According to our experience with cargo failing on git CLI errors, not all patterns are covered by `chromium` impl (see the tests for examples), so I had to extend that list
- Had to add `regex` crate as a dependency, however, it already is a transitive dependency of `cargo`, it's included via `env_logger`, `globset`, and `ignore` crates, so this doesn't increase the dependency tree.