### PR TITLE
Drop the im-rc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ walkdir = "2.2"
 clap = "2.31.2"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
-im-rc = "15.0.0"
 itertools = "0.10.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -4,7 +4,7 @@ use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::Config;
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::ops::Range;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
@@ -91,7 +91,7 @@ impl ResolverProgress {
 /// This is sorted so that it impls Hash, and owns its contents,
 /// needed so it can be part of the key for caching in the `DepsCache`.
 /// It is also cloned often as part of `Context`, hence the `RC`.
-/// `im-rs::OrdSet` was slower of small sets like this,
+/// `im_rc::OrdSet` was slower of small sets like this,
 /// but this can change with improvements to std, im, or llvm.
 /// Using a consistent type for this allows us to use the highly
 /// optimized comparison operators like `is_subset` at the interfaces.
@@ -200,41 +200,37 @@ impl Ord for DepsFrame {
     fn cmp(&self, other: &DepsFrame) -> Ordering {
         self.just_for_error_messages
             .cmp(&other.just_for_error_messages)
-            .reverse()
-            .then_with(|| self.min_candidates().cmp(&other.min_candidates()))
+            .then_with(||
+            // the frame with the sibling that has the least number of candidates
+            // needs to get bubbled up to the top of the heap we use below, so
+            // reverse comparison here.
+            self.min_candidates().cmp(&other.min_candidates()).reverse())
     }
 }
 
-/// Note that an `OrdSet` is used for the remaining dependencies that need
-/// activation. This set is sorted by how many candidates each dependency has.
+/// Note that a `BinaryHeap` is used for the remaining dependencies that need
+/// activation. This heap is sorted such that the "largest value" is the most
+/// constrained dependency, or the one with the least candidates.
 ///
 /// This helps us get through super constrained portions of the dependency
 /// graph quickly and hopefully lock down what later larger dependencies can
 /// use (those with more candidates).
 #[derive(Clone)]
 pub struct RemainingDeps {
-    /// a monotonic counter, increased for each new insertion.
-    time: u32,
-    /// the data is augmented by the insertion time.
-    /// This insures that no two items will cmp eq.
-    /// Forcing the OrdSet into a multi set.
-    data: im_rc::OrdSet<(DepsFrame, u32)>,
+    deps: BinaryHeap<DepsFrame>,
 }
 
 impl RemainingDeps {
     pub fn new() -> RemainingDeps {
         RemainingDeps {
-            time: 0,
-            data: im_rc::OrdSet::new(),
+            deps: BinaryHeap::new(),
         }
     }
     pub fn push(&mut self, x: DepsFrame) {
-        let insertion_time = self.time;
-        self.data.insert((x, insertion_time));
-        self.time += 1;
+        self.deps.push(x);
     }
     pub fn pop_most_constrained(&mut self) -> Option<(bool, (Summary, DepInfo))> {
-        while let Some((mut deps_frame, insertion_time)) = self.data.remove_min() {
+        while let Some(mut deps_frame) = self.deps.pop() {
             let just_here_for_the_error_messages = deps_frame.just_for_error_messages;
 
             // Figure out what our next dependency to activate is, and if nothing is
@@ -242,14 +238,14 @@ impl RemainingDeps {
             // move on to the next frame.
             if let Some(sibling) = deps_frame.remaining_siblings.next() {
                 let parent = Summary::clone(&deps_frame.parent);
-                self.data.insert((deps_frame, insertion_time));
+                self.deps.push(deps_frame);
                 return Some((just_here_for_the_error_messages, (parent, sibling)));
             }
         }
         None
     }
     pub fn iter(&mut self) -> impl Iterator<Item = (PackageId, Dependency)> + '_ {
-        self.data.iter().flat_map(|(other, _)| other.flatten())
+        self.deps.iter().flat_map(|other| other.flatten())
     }
 }
 

--- a/src/cargo/util/graph.rs
+++ b/src/cargo/util/graph.rs
@@ -1,26 +1,26 @@
 use std::borrow::Borrow;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 pub struct Graph<N: Clone, E: Clone> {
-    nodes: im_rc::OrdMap<N, im_rc::OrdMap<N, E>>,
+    nodes: BTreeMap<N, BTreeMap<N, E>>,
 }
 
 impl<N: Eq + Ord + Clone, E: Default + Clone> Graph<N, E> {
     pub fn new() -> Graph<N, E> {
         Graph {
-            nodes: im_rc::OrdMap::new(),
+            nodes: BTreeMap::new(),
         }
     }
 
     pub fn add(&mut self, node: N) {
-        self.nodes.entry(node).or_insert_with(im_rc::OrdMap::new);
+        self.nodes.entry(node).or_insert_with(BTreeMap::new);
     }
 
     pub fn link(&mut self, node: N, child: N) -> &mut E {
         self.nodes
             .entry(node)
-            .or_insert_with(im_rc::OrdMap::new)
+            .or_insert_with(BTreeMap::new)
             .entry(child)
             .or_insert_with(Default::default)
     }


### PR DESCRIPTION
*[View all comments](https://triagebot.infra.rust-lang.org/gh-comments/rust-lang/cargo/pull/9878)*

This PR drops cargo's dependency on im-rc. The `im-rc` and `im` crates seem to be [unmaintained](https://github.com/bodil/im-rs/issues/185), with no code changes, releases, or issue / PR triage in over a year. The linked issue also lists some logic / panic bugs that are still present in the latest im/im-rc releases, which have gone unfixed for at least a year, as well.

A [RUSTSEC advisory](https://github.com/rustsec/advisory-db/pull/891) to mark `im` and `im-rc` as unmaintained has been proposed, but the crate's author has apparently responded ~somewhere~ (I cannot even confirm that, since that conversation has not been linked in the issue) that the crates are still "maintained", but the GitHub project - both code and issues / PRs - has remained untouched since.

The `im-rc` crate has now been gathering bug reports for over a year, while also having increasingly outdated crate dependencies (`bitmaps` 2 vs .3, `rand_core` 0.5 vs 0.6, `rand_xoshiro` 0.4 vs 0.6, `arbitrary` 0.4 vs. 1, `proptest` 0.9 vs. 1, `quickcheck` 0.9 vs .1, and dev-dependencies `pretty_assertions` 0.6 vs. 0.7, `proptest_derive` 0.1 vs. 0.3, `rand` 0.7 vs. 0.8).

I'm not sure whether the original reason to use immutable data structures in cargo is still valid. In the [PR where this dependency was introduced](https://github.com/rust-lang/cargo/pull/6336), the reasoning is that cloning some data structures is expensive, but [benchmarks](https://github.com/bodil/im-rs/issues/26) for comparing data structures from `std` and those from `im-rc` yielded mixed results. Some of the [performance issues](https://github.com/rust-lang/cargo/issues/5130) that the introduction of `im-rc` was supposed to work around have since been resolved [in simpler ways](https://github.com/rust-lang/cargo/pull/5132).

---

This PR removes the dependency on `im-rc` and makes the following changes:

- replace `im_rc::HashMap` with `std::collections::HashMap`
- replace `im_rc::HashSet` with `std::collections::HashSet`
- replace `im_rc::OrdMap` with `std::collections::BTreeMap`
- replace `im_rc::OrdSet` with `std::collections::BTreeSet`
- replace `im_rc::hashmap::Entry` with `std::collections::hash_map::Entry`

Additionally, data from a BTreeSet is temporarily moved into a `VecDeque` in `RemainingDeps::pop_most_constrained` to make sure `pop_front` and `push_back` operations are not too slow (the `BTreeSet::pop_first` method is still nightly-only under the experimental `map_first_last` feature flag). The original code before the introduction of `im-rc` used a reversed `std::collections::BinaryHeap` max-heap for this purpose, which should work instead of temporarily moving data around, as well (though I have not ever used a BinaryHeap in this way before).

---

I have run some simple benchmarks against my change to make sure performance does not regress. Since there's no official "bench"es in the cargo project, I just ran `cargo test` in both debug and release mode in `hyperfine` before and after applying the changes from this PR, with the `CFG_DISABLE_CROSS_TESTS=1` environment variable set, against the current nightly Rust toolchain (`rustc 1.57.0-nightly (e30b68353 2021-09-05)`).

Before this PR:

- `cargo test` (debug)

<pre>  Time (<font color="#26A269"><b>mean</b></font> ± <font color="#26A269">σ</font>):     <font color="#26A269"><b>75.710 s</b></font> ± <font color="#26A269"> 3.423 s</font>    [User: <font color="#12488B">620.908 s</font>, System: <font color="#12488B">246.731 s</font>]
  Range (<font color="#2AA1B3">min</font> … <font color="#A347BA">max</font>):   <font color="#2AA1B3">69.566 s</font> … <font color="#A347BA">81.616 s</font>    10 runs
</pre>

- `cargo test --release`

<pre>  Time (<font color="#26A269"><b>mean</b></font> ± <font color="#26A269">σ</font>):     <font color="#26A269"><b>66.515 s</b></font> ± <font color="#26A269"> 2.600 s</font>    [User: <font color="#12488B">567.307 s</font>, System: <font color="#12488B">238.467 s</font>]
  Range (<font color="#2AA1B3">min</font> … <font color="#A347BA">max</font>):   <font color="#2AA1B3">62.159 s</font> … <font color="#A347BA">70.810 s</font>    10 runs
</pre>

After this PR:

- `cargo test` (debug)

<pre>  Time (<font color="#26A269"><b>mean</b></font> ± <font color="#26A269">σ</font>):     <font color="#26A269"><b>76.524 s</b></font> ± <font color="#26A269"> 5.503 s</font>    [User: <font color="#12488B">620.339 s</font>, System: <font color="#12488B">253.578 s</font>]
  Range (<font color="#2AA1B3">min</font> … <font color="#A347BA">max</font>):   <font color="#2AA1B3">67.246 s</font> … <font color="#A347BA">87.058 s</font>    10 runs
</pre>

- `cargo test --release`

<pre>  Time (<font color="#26A269"><b>mean</b></font> ± <font color="#26A269">σ</font>):     <font color="#26A269"><b>66.460 s</b></font> ± <font color="#26A269"> 4.264 s</font>    [User: <font color="#12488B">562.187 s</font>, System: <font color="#12488B">238.884 s</font>]
  Range (<font color="#2AA1B3">min</font> … <font color="#A347BA">max</font>):   <font color="#2AA1B3">62.246 s</font> … <font color="#A347BA">77.469 s</font>    10 runs
</pre>

Assuming the unit and integration tests cover the changed code at all, the performance impact of dropping `im-rc` in favor of using collections from the standard library is either very very small (within the margin of error of the benchmark results), and if anything, ever so slightly in favor of the `std` collections in `release` mode.

As a nice side effect, the compiled `cargo` binary is also slightly smaller with this change, probably not only because `im-rc` is dropped, but also due to removal / de-duplication of old versions of crates from `im-rc`'s dependency tree.

- debug: 223.9 MB vs. 209.1 MB
- release: 19.2 MB vs. 19.0 MB

(compared on x86_64 linux target, with same rust toolchain)

---

Alternatively, there is now a fork of the `im` project ([imbl](https://crates.io/crates/imbl)), where a brave soul has started to triage all logic bugs and panic! issues that have not been triaged in the old project.