### PR TITLE
Enable strip test on macos.

### DIFF
--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -470,8 +470,6 @@ fn thin_lto_works() {
 }
 
 #[cargo_test]
-// Strip doesn't work on macos.
-#[cfg_attr(target_os = "macos", ignore)]
 fn strip_works() {
     if !is_nightly() {
         // -Zstrip is unstable


### PR DESCRIPTION
This enables the `strip_works` test for macos, which was fixed a while ago in https://github.com/rust-lang/rust/pull/82037.