### PR TITLE
Fix `cargo fix --edition` on stable.

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -857,8 +857,7 @@ impl FixArgs {
             if edition.supports_compat_lint() {
                 if env::var_os(SUPPORTS_FORCE_WARN).is_some() {
                     cmd.arg("--force-warn")
-                        .arg(format!("rust-{}-compatibility", edition))
-                        .arg("-Zunstable-options");
+                        .arg(format!("rust-{}-compatibility", edition));
                 } else {
                     cmd.arg("-W").arg(format!("rust-{}-compatibility", edition));
                 }


### PR DESCRIPTION
I accidentally missed the removal of a `-Zunstable-options` flag in #9800.  This prevented `cargo fix --edition` from working on stable/beta.
