### PR TITLE
Add requirements to cargo_test.

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -21,7 +21,7 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut ignore = false;
     let mut requires_reason = false;
     let mut found_reason = false;
-    let is_not_nightly = || !version().1;
+    let is_not_nightly = !version().1;
     for rule in split_rules(attr) {
         match rule.as_str() {
             "build_std_real" => {
@@ -29,19 +29,19 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // explicit opt-in (these generally only work on linux, and
                 // have some extra requirements, and are slow, and can pollute
                 // the environment since it downloads dependencies).
-                ignore |= is_not_nightly();
+                ignore |= is_not_nightly;
                 ignore |= option_env!("CARGO_RUN_BUILD_STD_TESTS").is_none();
             }
             "build_std_mock" => {
                 // Only run the "mock" build-std tests on nightly and disable
                 // for windows-gnu which is missing object files (see
                 // https://github.com/rust-lang/wg-cargo-std-aware/issues/46).
-                ignore |= is_not_nightly();
+                ignore |= is_not_nightly;
                 ignore |= cfg!(all(target_os = "windows", target_env = "gnu"));
             }
             "nightly" => {
                 requires_reason = true;
-                ignore |= is_not_nightly();
+                ignore |= is_not_nightly;
             }
             s if s.starts_with("requires_") => {
                 let command = &s[9..];

--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -1,19 +1,87 @@
 extern crate proc_macro;
 
 use proc_macro::*;
+use std::process::Command;
+use std::sync::Once;
 
 #[proc_macro_attribute]
 pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Ideally these options would be embedded in the test itself. However, I
+    // find it very helpful to have the test clearly state whether or not it
+    // is ignored. It would be nice to have some kind of runtime ignore
+    // support (such as
+    // https://internals.rust-lang.org/t/pre-rfc-skippable-tests/14611).
+    //
+    // Unfortunately a big drawback here is that if the environment changes
+    // (such as the existence of the `git` CLI), this will not trigger a
+    // rebuild and the test will still be ignored. In theory, something like
+    // `tracked_env` or `tracked_path`
+    // (https://github.com/rust-lang/rust/issues/99515) could help with this,
+    // but they don't really handle the absence of files well.
+    let mut ignore = false;
+    let mut requires_reason = false;
+    let mut found_reason = false;
+    let is_not_nightly = || !version().1;
+    for rule in split_rules(attr) {
+        match rule.as_str() {
+            "build_std_real" => {
+                // Only run the "real" build-std tests on nightly and with an
+                // explicit opt-in (these generally only work on linux, and
+                // have some extra requirements, and are slow, and can pollute
+                // the environment since it downloads dependencies).
+                ignore |= is_not_nightly();
+                ignore |= option_env!("CARGO_RUN_BUILD_STD_TESTS").is_none();
+            }
+            "build_std_mock" => {
+                // Only run the "mock" build-std tests on nightly and disable
+                // for windows-gnu which is missing object files (see
+                // https://github.com/rust-lang/wg-cargo-std-aware/issues/46).
+                ignore |= is_not_nightly();
+                ignore |= cfg!(all(target_os = "windows", target_env = "gnu"));
+            }
+            "nightly" => {
+                requires_reason = true;
+                ignore |= is_not_nightly();
+            }
+            "disable_git_cli" => {
+                ignore |= disable_git_cli();
+            }
+            s if s.starts_with("requires_") => {
+                let command = &s[9..];
+                ignore |= !has_command(command);
+            }
+            s if s.starts_with(">=1.") => {
+                requires_reason = true;
+                let min_minor = s[4..].parse().unwrap();
+                ignore |= version().0 < min_minor;
+            }
+            s if s.starts_with("reason=") => {
+                found_reason = true;
+            }
+            _ => panic!("unknown rule {:?}", rule),
+        }
+    }
+    if requires_reason && !found_reason {
+        panic!(
+            "#[cargo_test] with a rule also requires a reason, \
+            such as #[cargo_test(nightly, reason = \"needs -Z unstable-thing\")]"
+        );
+    }
+
     let span = Span::call_site();
     let mut ret = TokenStream::new();
-    ret.extend(Some(TokenTree::from(Punct::new('#', Spacing::Alone))));
-    let test = TokenTree::from(Ident::new("test", span));
-    ret.extend(Some(TokenTree::from(Group::new(
-        Delimiter::Bracket,
-        test.into(),
-    ))));
-
-    let build_std = contains_ident(&attr, "build_std");
+    let add_attr = |ret: &mut TokenStream, attr_name| {
+        ret.extend(Some(TokenTree::from(Punct::new('#', Spacing::Alone))));
+        let attr = TokenTree::from(Ident::new(attr_name, span));
+        ret.extend(Some(TokenTree::from(Group::new(
+            Delimiter::Bracket,
+            attr.into(),
+        ))));
+    };
+    add_attr(&mut ret, "test");
+    if ignore {
+        add_attr(&mut ret, "ignore");
+    }
 
     for token in item {
         let group = match token {
@@ -38,17 +106,6 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             };"#,
         );
 
-        // If this is a `build_std` test (aka `tests/build-std/*.rs`) then they
-        // only run on nightly and they only run when specifically instructed to
-        // on CI.
-        if build_std {
-            let ts = to_token_stream("if !cargo_test_support::is_nightly() { return }");
-            new_body.extend(ts);
-            let ts = to_token_stream(
-                "if std::env::var(\"CARGO_RUN_BUILD_STD_TESTS\").is_err() { return }",
-            );
-            new_body.extend(ts);
-        }
         new_body.extend(group.stream());
         ret.extend(Some(TokenTree::from(Group::new(
             group.delimiter(),
@@ -59,13 +116,86 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
     ret
 }
 
-fn contains_ident(t: &TokenStream, ident: &str) -> bool {
-    t.clone().into_iter().any(|t| match t {
-        TokenTree::Ident(i) => i.to_string() == ident,
+fn split_rules(t: TokenStream) -> Vec<String> {
+    let tts: Vec<_> = t.into_iter().collect();
+    tts.split(|tt| match tt {
+        TokenTree::Punct(p) => p.as_char() == ',',
         _ => false,
     })
+    .filter(|parts| !parts.is_empty())
+    .map(|parts| {
+        parts
+            .into_iter()
+            .map(|part| part.to_string())
+            .collect::<String>()
+    })
+    .collect()
 }
 
 fn to_token_stream(code: &str) -> TokenStream {
     code.parse().unwrap()
+}
+
+static mut VERSION: (u32, bool) = (0, false);
+
+fn version() -> &'static (u32, bool) {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let output = Command::new("rustc")
+            .arg("-V")
+            .output()
+            .expect("rustc should run");
+        let stdout = std::str::from_utf8(&output.stdout).expect("utf8");
+        let vers = stdout.split_whitespace().skip(1).next().unwrap();
+        let is_nightly = option_env!("CARGO_TEST_DISABLE_NIGHTLY").is_none()
+            && (vers.contains("-nightly") || vers.contains("-dev"));
+        let minor = vers.split('.').skip(1).next().unwrap().parse().unwrap();
+        unsafe { VERSION = (minor, is_nightly) }
+    });
+    unsafe { &VERSION }
+}
+
+fn disable_git_cli() -> bool {
+    // mingw git on Windows does not support Windows-style file URIs.
+    // Appveyor in the rust repo has that git up front in the PATH instead
+    // of Git-for-Windows, which causes this to fail.
+    matches!(option_env!("CARGO_TEST_DISABLE_GIT_CLI"), Some("1"))
+}
+
+fn has_command(command: &str) -> bool {
+    let output = match Command::new(command).arg("--version").output() {
+        Ok(output) => output,
+        Err(e) => {
+            // hg is not installed on GitHub macos.
+            // Consider installing it if Cargo gains more hg support, but
+            // otherwise it isn't critical.
+            if is_ci() && !(cfg!(target_os = "macos") && command == "hg") {
+                panic!(
+                    "expected command `{}` to be somewhere in PATH: {}",
+                    command, e
+                );
+            }
+            return false;
+        }
+    };
+    if !output.status.success() {
+        panic!(
+            "expected command `{}` to be runnable, got error {}:\n\
+            stderr:{}\n\
+            stdout:{}\n",
+            command,
+            output.status,
+            String::from_utf8_lossy(&output.stderr),
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+    true
+}
+
+/// Whether or not this running in a Continuous Integration environment.
+fn is_ci() -> bool {
+    // Consider using `tracked_env` instead of option_env! when it is stabilized.
+    // `tracked_env` will handle changes, but not require rebuilding the macro
+    // itself like option_env does.
+    option_env!("CI").is_some() || option_env!("TF_BUILD").is_some()
 }

--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -43,9 +43,6 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
                 requires_reason = true;
                 ignore |= is_not_nightly();
             }
-            "disable_git_cli" => {
-                ignore |= disable_git_cli();
-            }
             s if s.starts_with("requires_") => {
                 let command = &s[9..];
                 ignore |= !has_command(command);
@@ -153,13 +150,6 @@ fn version() -> &'static (u32, bool) {
         unsafe { VERSION = (minor, is_nightly) }
     });
     unsafe { &VERSION }
-}
-
-fn disable_git_cli() -> bool {
-    // mingw git on Windows does not support Windows-style file URIs.
-    // Appveyor in the rust repo has that git up front in the PATH instead
-    // of Git-for-Windows, which causes this to fail.
-    matches!(option_env!("CARGO_TEST_DISABLE_GIT_CLI"), Some("1"))
 }
 
 fn has_command(command: &str) -> bool {

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1128,6 +1128,10 @@ pub fn rustc_host_env() -> String {
 
 pub fn is_nightly() -> bool {
     let vv = &RUSTC_INFO.verbose_version;
+    // CARGO_TEST_DISABLE_NIGHTLY is set in rust-lang/rust's CI so that all
+    // nightly-only tests are disabled there. Otherwise, it could make it
+    // difficult to land changes which would need to be made simultaneously in
+    // rust-lang/cargo and rust-lan/rust, which isn't possible.
     env::var("CARGO_TEST_DISABLE_NIGHTLY").is_err()
         && (vv.contains("-nightly") || vv.contains("-dev"))
 }
@@ -1348,16 +1352,6 @@ pub fn slow_cpu_multiplier(main: u64) -> Duration {
             env::var("CARGO_TEST_SLOW_CPU_MULTIPLIER").ok().and_then(|m| m.parse().ok()).unwrap_or(1);
     }
     Duration::from_secs(*SLOW_CPU_MULTIPLIER * main)
-}
-
-pub fn command_is_available(cmd: &str) -> bool {
-    if let Err(e) = process(cmd).arg("-V").exec_with_output() {
-        eprintln!("{} not available, skipping tests", cmd);
-        eprintln!("{:?}", e);
-        false
-    } else {
-        true
-    }
 }
 
 #[cfg(windows)]

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -92,8 +92,6 @@ The options it supports are:
 * `>=1.64` — This indicates that the test will only run with the given version of `rustc` or newer.
   This can be used when a new `rustc` feature has been stabilized that the test depends on.
   If this is specified, a `reason` is required to explain why it is being checked.
-* `disable_git_cli` — This is needed for `git-fetch-with-cli` tests.
-  This disables the test in rust-lang/rust's CI due to a compatibility issue.
 
 #### Testing Nightly Features
 

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -68,7 +68,7 @@ The `#[cargo_test]` attribute injects code which does some setup before starting
 It will create a filesystem "sandbox" under the "cargo integration test" directory for each test, such as `/path/to/cargo/target/tmp/cit/t123/`.
 The sandbox will contain a `home` directory that will be used instead of your normal home directory.
 
-The `#[cargo_test`] attribute takes several options that will affect how the test is generated.
+The `#[cargo_test]` attribute takes several options that will affect how the test is generated.
 They are listed in parentheses separated with commas, such as:
 
 ```rust,ignore
@@ -86,7 +86,7 @@ The options it supports are:
 * `build_std_mock` — This is a "mock" `-Zbuild-std` test (which uses a mock standard library).
   This only runs on nightly, and is disabled for windows-gnu.
 * `requires_` — This indicates a command that is required to be installed to be run.
-  For example, `requires_rustmft` means the test will only run if the executable `rustfmt` is installed.
+  For example, `requires_rustfmt` means the test will only run if the executable `rustfmt` is installed.
   These tests are *always* run on CI.
   This is mainly used to avoid requiring contributors from having every dependency installed.
 * `>=1.64` — This indicates that the test will only run with the given version of `rustc` or newer.

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -13,7 +13,7 @@
 //! not catching any regressions that `tests/testsuite/standard_lib.rs` isn't
 //! already catching.
 //!
-//! All tests here should use `#[cargo_test(build_std)]` to indicate that
+//! All tests here should use `#[cargo_test(build_std_real)]` to indicate that
 //! boilerplate should be generated to require the nightly toolchain and the
 //! `CARGO_RUN_BUILD_STD_TESTS` env var to be set to actually run these tests.
 //! Otherwise the tests are skipped.
@@ -59,7 +59,7 @@ impl BuildStd for Execs {
     }
 }
 
-#[cargo_test(build_std)]
+#[cargo_test(build_std_real)]
 fn basic() {
     let p = project()
         .file(
@@ -127,7 +127,7 @@ fn basic() {
     assert_eq!(p.glob(deps_dir.join("*.dylib")).count(), 0);
 }
 
-#[cargo_test(build_std)]
+#[cargo_test(build_std_real)]
 fn cross_custom() {
     let p = project()
         .file(
@@ -170,7 +170,7 @@ fn cross_custom() {
         .run();
 }
 
-#[cargo_test(build_std)]
+#[cargo_test(build_std_real)]
 fn custom_test_framework() {
     let p = project()
         .file(

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1,15 +1,10 @@
 //! Tests for the `cargo bench` command.
 
-use cargo_test_support::is_nightly;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn cargo_bench_simple() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
@@ -51,12 +46,8 @@ fn cargo_bench_simple() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_bench_implicit() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "src/main.rs",
@@ -99,12 +90,8 @@ fn bench_bench_implicit() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_bin_implicit() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "src/main.rs",
@@ -146,12 +133,8 @@ fn bench_bin_implicit() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_tarname() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "benches/bin1.rs",
@@ -183,12 +166,8 @@ fn bench_tarname() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_multiple_targets() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "benches/bin1.rs",
@@ -223,12 +202,8 @@ fn bench_multiple_targets() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn cargo_bench_verbose() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
@@ -255,12 +230,8 @@ fn cargo_bench_verbose() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn many_similar_names() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "src/lib.rs",
@@ -302,12 +273,8 @@ fn many_similar_names() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn cargo_bench_failing_test() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
@@ -356,12 +323,8 @@ fn cargo_bench_failing_test() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_with_lib_dep() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -424,12 +387,8 @@ fn bench_with_lib_dep() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_with_deep_lib_dep() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .at("bar")
         .file(
@@ -487,12 +446,8 @@ fn bench_with_deep_lib_dep() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn external_bench_explicit() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -546,12 +501,8 @@ fn external_bench_explicit() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn external_bench_implicit() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "src/lib.rs",
@@ -593,12 +544,8 @@ fn external_bench_implicit() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_autodiscover_2015() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -670,12 +617,8 @@ https://github.com/rust-lang/cargo/issues/5330
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn dont_run_examples() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -686,12 +629,8 @@ fn dont_run_examples() {
     p.cargo("bench").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn pass_through_command_line() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "src/lib.rs",
@@ -727,12 +666,8 @@ fn pass_through_command_line() {
 
 // Regression test for running cargo-bench twice with
 // tests in an rlib
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn cargo_bench_twice() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file(
@@ -754,12 +689,8 @@ fn cargo_bench_twice() {
     }
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn lib_bin_same_name() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -811,12 +742,8 @@ fn lib_bin_same_name() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn lib_with_standard_name() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("syntax", "0.0.1"))
         .file(
@@ -861,12 +788,8 @@ fn lib_with_standard_name() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn lib_with_standard_name2() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -911,12 +834,8 @@ fn lib_with_standard_name2() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_dylib() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1005,12 +924,8 @@ fn bench_dylib() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_twice_with_build_cmd() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1054,12 +969,8 @@ fn bench_twice_with_build_cmd() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_with_examples() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1141,12 +1052,8 @@ fn bench_with_examples() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn test_a_bench() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1181,12 +1088,8 @@ fn test_a_bench() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn test_bench_no_run() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -1216,12 +1119,8 @@ fn test_bench_no_run() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn test_bench_no_run_emit_json() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -1249,12 +1148,8 @@ fn test_bench_no_run_emit_json() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn test_bench_no_fail_fast() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file(
@@ -1294,12 +1189,8 @@ fn test_bench_no_fail_fast() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn test_bench_multiple_packages() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1387,12 +1278,8 @@ fn test_bench_multiple_packages() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_all_workspace() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1444,12 +1331,8 @@ fn bench_all_workspace() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_all_exclude() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1493,12 +1376,8 @@ test bar ... bench:           [..] ns/iter (+/- [..])",
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_all_exclude_glob() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1542,12 +1421,8 @@ test bar ... bench:           [..] ns/iter (+/- [..])",
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_all_virtual_manifest() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1595,12 +1470,8 @@ fn bench_all_virtual_manifest() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_virtual_manifest_glob() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1649,12 +1520,8 @@ fn bench_virtual_manifest_glob() {
 }
 
 // https://github.com/rust-lang/cargo/issues/4287
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn legacy_bench_name() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1691,12 +1558,8 @@ please set bench.path in Cargo.toml",
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_virtual_manifest_all_implied() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1741,12 +1604,8 @@ fn bench_virtual_manifest_all_implied() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn json_artifact_includes_executable_for_benchmark() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "benches/benchmark.rs",

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6104,12 +6104,8 @@ fn target_directory_backup_exclusion() {
     assert!(!&cachedir_tag.is_file());
 }
 
-#[cargo_test]
+#[cargo_test(>=1.64, reason = "--diagnostic-width is stabilized in 1.64")]
 fn simple_terminal_width() {
-    if !is_nightly() {
-        // --diagnostic-width is stabilized in 1.64
-        return;
-    }
     let p = project()
         .file(
             "src/lib.rs",

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -1,7 +1,7 @@
 //! Tests for `cargo-features` definitions.
 
 use cargo_test_support::registry::Package;
-use cargo_test_support::{is_nightly, project, registry};
+use cargo_test_support::{project, registry};
 
 #[cargo_test]
 fn feature_required() {
@@ -215,14 +215,8 @@ release and is no longer necessary to be listed in the manifest
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zallow-features is unstable")]
 fn allow_features() {
-    if !is_nightly() {
-        // -Zallow-features on rustc is nightly only
-        eprintln!("skipping test allow_features without nightly rustc");
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -286,14 +280,8 @@ Caused by:
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zallow-features is unstable")]
 fn allow_features_to_rustc() {
-    if !is_nightly() {
-        // -Zallow-features on rustc is nightly only
-        eprintln!("skipping test allow_features_to_rustc without nightly rustc");
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -329,14 +317,8 @@ fn allow_features_to_rustc() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zallow-features is unstable")]
 fn allow_features_in_cfg() {
-    if !is_nightly() {
-        // -Zallow-features on rustc is nightly only
-        eprintln!("skipping test allow_features_in_cfg without nightly rustc");
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -1,6 +1,6 @@
 //! Tests for -Zcheck-cfg.
 
-use cargo_test_support::{basic_manifest, is_nightly, project};
+use cargo_test_support::{basic_manifest, project};
 
 macro_rules! x {
     ($tool:tt => $what:tt $(of $who:tt)?) => {{
@@ -29,13 +29,8 @@ macro_rules! x {
     }};
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -58,13 +53,8 @@ fn features() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_with_deps() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -93,13 +83,8 @@ fn features_with_deps() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_with_opt_deps() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -129,13 +114,8 @@ fn features_with_opt_deps() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_with_namespaced_features() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -163,13 +143,8 @@ fn features_with_namespaced_features() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_names() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
@@ -181,13 +156,8 @@ fn well_known_names() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_values() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
@@ -199,13 +169,8 @@ fn well_known_values() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn cli_all_options() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -230,13 +195,8 @@ fn cli_all_options() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_with_cargo_check() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -259,13 +219,8 @@ fn features_with_cargo_check() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_names_with_check() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
@@ -277,13 +232,8 @@ fn well_known_names_with_check() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_values_with_check() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
@@ -295,13 +245,8 @@ fn well_known_values_with_check() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_test() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -324,13 +269,8 @@ fn features_test() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_doctest() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc and rustdoc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -355,13 +295,8 @@ fn features_doctest() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_names_test() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
@@ -373,13 +308,8 @@ fn well_known_names_test() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_values_test() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/main.rs", "fn main() {}")
@@ -391,13 +321,8 @@ fn well_known_values_test() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_names_doctest() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc and rustdoc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/lib.rs", "#[allow(dead_code)] fn foo() {}")
@@ -410,13 +335,8 @@ fn well_known_names_doctest() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn well_known_values_doctest() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc and rustdoc command line
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("src/lib.rs", "#[allow(dead_code)] fn foo() {}")
@@ -429,13 +349,8 @@ fn well_known_values_doctest() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn features_doc() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustdoc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -459,13 +374,8 @@ fn features_doc() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn build_script_feedback() {
-    if !is_nightly() {
-        // rustc-check-cfg: is only availaible on nightly
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -490,13 +400,8 @@ fn build_script_feedback() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn build_script_doc() {
-    if !is_nightly() {
-        // rustc-check-cfg: is only availaible on nightly
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -530,12 +435,8 @@ fn build_script_doc() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn build_script_override() {
-    if !is_nightly() {
-        // rustc-check-cfg: is only availaible on nightly
-        return;
-    }
     let target = cargo_test_support::rustc_host();
 
     let p = project()
@@ -570,13 +471,8 @@ fn build_script_override() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn build_script_test() {
-    if !is_nightly() {
-        // rustc-check-cfg: is only availaible on nightly
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -630,13 +526,8 @@ fn build_script_test() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn config_valid() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -668,13 +559,8 @@ fn config_valid() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--check-cfg is unstable")]
 fn config_invalid() {
-    if !is_nightly() {
-        // --check-cfg is a nightly only rustc command line
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -2,8 +2,8 @@
 //!
 //! See `cargo_test_support::cross_compile` for more detail.
 
+use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_bin_manifest, basic_manifest, cross_compile, project};
-use cargo_test_support::{is_nightly, rustc_host};
 
 #[cargo_test]
 fn simple_cross() {
@@ -411,13 +411,9 @@ fn linker() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "plugins are unstable")]
 fn plugin_with_extra_dylib_dep() {
     if cross_compile::disabled() {
-        return;
-    }
-    if !is_nightly() {
-        // plugins are unstable
         return;
     }
 
@@ -1298,13 +1294,9 @@ fn cross_test_dylib() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
 fn doctest_xcompile_linker() {
     if cross_compile::disabled() {
-        return;
-    }
-    if !is_nightly() {
-        // -Zdoctest-xcompile is unstable
         return;
     }
 

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -1,6 +1,5 @@
 //! Tests for custom json target specifications.
 
-use cargo_test_support::is_nightly;
 use cargo_test_support::{basic_manifest, project};
 use std::fs;
 
@@ -34,12 +33,8 @@ const SIMPLE_SPEC: &str = r#"
 }
 "#;
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires features no_core, lang_items")]
 fn custom_target_minimal() {
-    if !is_nightly() {
-        // Requires features no_core, lang_items
-        return;
-    }
     let p = project()
         .file(
             "src/lib.rs",
@@ -66,12 +61,8 @@ fn custom_target_minimal() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires features no_core, lang_items, auto_traits")]
 fn custom_target_dependency() {
-    if !is_nightly() {
-        // Requires features no_core, lang_items, auto_traits
-        return;
-    }
     let p = project()
         .file(
             "Cargo.toml",
@@ -122,12 +113,8 @@ fn custom_target_dependency() {
     p.cargo("build --lib --target custom-target.json -v").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires features no_core, lang_items")]
 fn custom_bin_target() {
-    if !is_nightly() {
-        // Requires features no_core, lang_items
-        return;
-    }
     let p = project()
         .file(
             "src/main.rs",
@@ -143,13 +130,9 @@ fn custom_bin_target() {
     p.cargo("build --target custom-bin-target.json -v").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires features no_core, lang_items")]
 fn changing_spec_rebuilds() {
     // Changing the .json file will trigger a rebuild.
-    if !is_nightly() {
-        // Requires features no_core, lang_items
-        return;
-    }
     let p = project()
         .file(
             "src/lib.rs",
@@ -190,13 +173,9 @@ fn changing_spec_rebuilds() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires features no_core, lang_items")]
 fn changing_spec_relearns_crate_types() {
     // Changing the .json file will invalidate the cache of crate types.
-    if !is_nightly() {
-        // Requires features no_core, lang_items
-        return;
-    }
     let p = project()
         .file(
             "Cargo.toml",
@@ -235,13 +214,9 @@ fn changing_spec_relearns_crate_types() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires features no_core, lang_items")]
 fn custom_target_ignores_filepath() {
     // Changing the path of the .json file will not trigger a rebuild.
-    if !is_nightly() {
-        // Requires features no_core, lang_items
-        return;
-    }
     let p = project()
         .file(
             "src/lib.rs",

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -5,7 +5,7 @@ use cargo_test_support::compare::assert_match_exact;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::Package;
 use cargo_test_support::{
-    basic_bin_manifest, basic_manifest, is_nightly, main_file, project, rustc_host, Project,
+    basic_bin_manifest, basic_manifest, main_file, project, rustc_host, Project,
 };
 use filetime::FileTime;
 use std::fs;
@@ -228,13 +228,8 @@ fn no_rewrite_if_no_change() {
     );
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Z binary-dep-depinfo is unstable")]
 fn relative_depinfo_paths_ws() {
-    if !is_nightly() {
-        // -Z binary-dep-depinfo is unstable (https://github.com/rust-lang/rust/issues/63012)
-        return;
-    }
-
     // Test relative dep-info paths in a workspace with --target with
     // proc-macros and other dependency kinds.
     Package::new("regdep", "0.1.0")
@@ -366,13 +361,8 @@ fn relative_depinfo_paths_ws() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Z binary-dep-depinfo is unstable")]
 fn relative_depinfo_paths_no_ws() {
-    if !is_nightly() {
-        // -Z binary-dep-depinfo is unstable (https://github.com/rust-lang/rust/issues/63012)
-        return;
-    }
-
     // Test relative dep-info paths without a workspace with proc-macros and
     // other dependency kinds.
     Package::new("regdep", "0.1.0")
@@ -533,12 +523,8 @@ fn reg_dep_source_not_tracked() {
     );
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Z binary-dep-depinfo is unstable")]
 fn canonical_path() {
-    if !is_nightly() {
-        // -Z binary-dep-depinfo is unstable (https://github.com/rust-lang/rust/issues/63012)
-        return;
-    }
     if !cargo_test_support::symlink_supported() {
         return;
     }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -4,7 +4,7 @@ use cargo::core::compiler::RustDocFingerprint;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, project};
-use cargo_test_support::{is_nightly, rustc_host, symlink_supported, tools};
+use cargo_test_support::{rustc_host, symlink_supported, tools};
 use std::fs;
 use std::str;
 
@@ -748,12 +748,8 @@ fn doc_same_name() {
     p.cargo("doc").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "no_core, lang_items requires nightly")]
 fn doc_target() {
-    if !is_nightly() {
-        // no_core, lang_items requires nightly.
-        return;
-    }
     const TARGET: &str = "arm-unknown-linux-gnueabihf";
 
     let p = project()
@@ -1310,13 +1306,8 @@ fn doc_workspace_open_help_message() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zextern-html-root-url is unstable")]
 fn doc_extern_map_local() {
-    if !is_nightly() {
-        // -Zextern-html-root-url is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2050,13 +2041,8 @@ fn crate_versions_flag_is_overridden() {
     asserts(output_documentation());
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zdoctest-in-workspace is unstable")]
 fn doc_test_in_workspace() {
-    if !is_nightly() {
-        // -Zdoctest-in-workspace is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2357,13 +2343,8 @@ fn doc_fingerprint_unusual_behavior() {
     assert!(real_doc.join("somefile").exists());
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_basic() {
-    if !is_nightly() {
-        // -Z rustdoc-scrape-examples is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2397,13 +2378,8 @@ fn scrape_examples_basic() {
     assert!(p.build_dir().join("doc/src/ex/ex.rs.html").exists());
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_avoid_build_script_cycle() {
-    if !is_nightly() {
-        // -Z rustdoc-scrape-examples is unstable
-        return;
-    }
-
     let p = project()
         // package with build dependency
         .file(
@@ -2444,13 +2420,8 @@ fn scrape_examples_avoid_build_script_cycle() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_complex_reverse_dependencies() {
-    if !is_nightly() {
-        // -Z rustdoc-scrape-examples is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2506,13 +2477,8 @@ fn scrape_examples_complex_reverse_dependencies() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_crate_with_dash() {
-    if !is_nightly() {
-        // -Z rustdoc-scrape-examples is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2535,12 +2501,8 @@ fn scrape_examples_crate_with_dash() {
     assert!(doc_html.contains("Examples found in repository"));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_missing_flag() {
-    if !is_nightly() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2560,13 +2522,8 @@ fn scrape_examples_missing_flag() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_configure_profile() {
-    if !is_nightly() {
-        // -Z rustdoc-scrape-examples is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -2593,13 +2550,8 @@ fn scrape_examples_configure_profile() {
     assert!(doc_html.contains("More examples"));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
 fn scrape_examples_issue_10545() {
-    if !is_nightly() {
-        // -Z rustdoc-scrape-examples is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -1,7 +1,7 @@
 //! Tests for edition setting.
 
 use cargo::core::Edition;
-use cargo_test_support::{basic_lib_manifest, is_nightly, project};
+use cargo_test_support::{basic_lib_manifest, project};
 
 #[cargo_test]
 fn edition_works_for_build_script() {
@@ -82,15 +82,11 @@ Caused by:
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "fundamentally always nightly")]
 fn edition_unstable() {
     // During the period where a new edition is coming up, but not yet stable,
     // this test will verify that it can be used with `cargo-features`. If
     // there is no next edition, it does nothing.
-    if !is_nightly() {
-        // This test is fundamentally always nightly.
-        return;
-    }
     let next = match Edition::LATEST_UNSTABLE {
         Some(next) => next,
         None => {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -907,15 +907,11 @@ fn prepare_for_latest_stable() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "fundamentally always nightly")]
 fn prepare_for_already_on_latest_unstable() {
     // During the period where a new edition is coming up, but not yet stable,
     // this test will check what happens if you are already on the latest. If
     // there is no next edition, it does nothing.
-    if !is_nightly() {
-        // This test is fundamentally always nightly.
-        return;
-    }
     let next_edition = match Edition::LATEST_UNSTABLE {
         Some(next) => next,
         None => {

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -9,7 +9,7 @@
 
 use super::config::write_config_toml;
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_manifest, is_nightly, project, Project};
+use cargo_test_support::{basic_manifest, project, Project};
 
 // An arbitrary lint (unused_variables) that triggers a lint.
 // We use a special flag to force it to generate a report.
@@ -24,12 +24,11 @@ fn simple_project() -> Project {
         .build()
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn output_on_stable() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
     let p = simple_project();
 
     p.cargo("check")
@@ -54,13 +53,11 @@ fn no_gate_future_incompat_report() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn test_zero_future_incompat() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
-
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("src/main.rs", "fn main() {}")
@@ -88,13 +85,11 @@ note: 0 dependencies had future-incompatible warnings
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn test_single_crate() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
-
     let p = simple_project();
 
     for command in &["build", "check", "rustc", "test"] {
@@ -144,13 +139,11 @@ frequency = 'never'
     }
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn test_multi_crate() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
-
     Package::new("first-dep", "0.0.1")
         .file("src/lib.rs", FUTURE_EXAMPLE)
         .publish();
@@ -267,13 +260,11 @@ fn test_multi_crate() {
     assert_eq!(lines.next(), None);
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn color() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
-
     let p = simple_project();
 
     p.cargo("check")
@@ -291,13 +282,11 @@ fn color() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn bad_ids() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
-
     let p = simple_project();
 
     p.cargo("report future-incompatibilities --id 1")
@@ -326,13 +315,11 @@ Available IDs are: 1
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(
+    nightly,
+    reason = "-Zfuture-incompat-test requires nightly (permanently)"
+)]
 fn suggestions_for_updates() {
-    if !is_nightly() {
-        // -Zfuture-incompat-test requires nightly (permanently)
-        return;
-    }
-
     Package::new("with_updates", "1.0.0")
         .file("src/lib.rs", FUTURE_EXAMPLE)
         .publish();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2642,7 +2642,7 @@ fn failed_submodule_checkout() {
     t.join().unwrap();
 }
 
-#[cargo_test(disable_git_cli)]
+#[cargo_test]
 fn use_the_cli() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -2743,7 +2743,7 @@ fn templatedir_doesnt_cause_problems() {
     p.cargo("build").run();
 }
 
-#[cargo_test(disable_git_cli)]
+#[cargo_test]
 fn git_with_cli_force() {
     // Supports a force-pushed repo.
     let git_project = git::new("dep1", |project| {
@@ -2800,7 +2800,7 @@ fn git_with_cli_force() {
     p.rename_run("foo", "foo2").with_stdout("two").run();
 }
 
-#[cargo_test(disable_git_cli)]
+#[cargo_test]
 fn git_fetch_cli_env_clean() {
     // This tests that git-fetch-with-cli works when GIT_DIR environment
     // variable is set (for whatever reason).
@@ -3500,7 +3500,7 @@ fn corrupted_checkout() {
     _corrupted_checkout(false);
 }
 
-#[cargo_test(disable_git_cli)]
+#[cargo_test]
 fn corrupted_checkout_with_cli() {
     // Test what happens if the checkout is corrupted somehow with git cli.
     _corrupted_checkout(true);

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1,6 +1,5 @@
 //! Tests for git support.
 
-use std::env;
 use std::fs;
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};
@@ -13,13 +12,6 @@ use std::thread;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, main_file, path2url, project};
 use cargo_test_support::{sleep_ms, t, Project};
-
-fn disable_git_cli() -> bool {
-    // mingw git on Windows does not support Windows-style file URIs.
-    // Appveyor in the rust repo has that git up front in the PATH instead
-    // of Git-for-Windows, which causes this to fail.
-    env::var("CARGO_TEST_DISABLE_GIT_CLI") == Ok("1".to_string())
-}
 
 #[cargo_test]
 fn cargo_compile_simple_git_dep() {
@@ -2650,11 +2642,8 @@ fn failed_submodule_checkout() {
     t.join().unwrap();
 }
 
-#[cargo_test]
+#[cargo_test(disable_git_cli)]
 fn use_the_cli() {
-    if disable_git_cli() {
-        return;
-    }
     let project = project();
     let git_project = git::new("dep1", |project| {
         project
@@ -2754,11 +2743,8 @@ fn templatedir_doesnt_cause_problems() {
     p.cargo("build").run();
 }
 
-#[cargo_test]
+#[cargo_test(disable_git_cli)]
 fn git_with_cli_force() {
-    if disable_git_cli() {
-        return;
-    }
     // Supports a force-pushed repo.
     let git_project = git::new("dep1", |project| {
         project
@@ -2814,11 +2800,8 @@ fn git_with_cli_force() {
     p.rename_run("foo", "foo2").with_stdout("two").run();
 }
 
-#[cargo_test]
+#[cargo_test(disable_git_cli)]
 fn git_fetch_cli_env_clean() {
-    if disable_git_cli() {
-        return;
-    }
     // This tests that git-fetch-with-cli works when GIT_DIR environment
     // variable is set (for whatever reason).
     let git_dep = git::new("dep1", |project| {
@@ -3517,12 +3500,9 @@ fn corrupted_checkout() {
     _corrupted_checkout(false);
 }
 
-#[cargo_test]
+#[cargo_test(disable_git_cli)]
 fn corrupted_checkout_with_cli() {
     // Test what happens if the checkout is corrupted somehow with git cli.
-    if disable_git_cli() {
-        return;
-    }
     _corrupted_checkout(true);
 }
 

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2642,7 +2642,7 @@ fn failed_submodule_checkout() {
     t.join().unwrap();
 }
 
-#[cargo_test]
+#[cargo_test(requires_git)]
 fn use_the_cli() {
     let project = project();
     let git_project = git::new("dep1", |project| {
@@ -2743,7 +2743,7 @@ fn templatedir_doesnt_cause_problems() {
     p.cargo("build").run();
 }
 
-#[cargo_test]
+#[cargo_test(requires_git)]
 fn git_with_cli_force() {
     // Supports a force-pushed repo.
     let git_project = git::new("dep1", |project| {
@@ -2800,7 +2800,7 @@ fn git_with_cli_force() {
     p.rename_run("foo", "foo2").with_stdout("two").run();
 }
 
-#[cargo_test]
+#[cargo_test(requires_git)]
 fn git_fetch_cli_env_clean() {
     // This tests that git-fetch-with-cli works when GIT_DIR environment
     // variable is set (for whatever reason).

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -3,7 +3,6 @@
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
-use std::process::Command;
 
 use cargo_test_support::git;
 use cargo_test_support::paths;
@@ -90,11 +89,8 @@ fn run_test(path_env: Option<&OsStr>) {
     );
 }
 
-#[cargo_test]
+#[cargo_test(requires_git)]
 fn use_git_gc() {
-    if Command::new("git").arg("--version").output().is_err() {
-        return;
-    }
     run_test(None);
 }
 

--- a/tests/testsuite/init/formats_source/mod.rs
+++ b/tests/testsuite/init/formats_source/mod.rs
@@ -1,15 +1,11 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
-use cargo_test_support::{command_is_available, Project};
+use cargo_test_support::Project;
 
 use cargo_test_support::curr_dir;
 
-#[cargo_test]
+#[cargo_test(requires_rustfmt)]
 fn formats_source() {
-    if !command_is_available("rustfmt") {
-        return;
-    }
-
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/mod.rs
+++ b/tests/testsuite/init/mod.rs
@@ -1,5 +1,4 @@
 //! Tests for the `cargo init` command.
-use std::process::Command;
 
 mod auto_git;
 mod bin_already_exists_explicit;
@@ -39,15 +38,3 @@ mod simple_hg_ignore_exists;
 mod simple_lib;
 mod unknown_flags;
 mod with_argument;
-
-pub fn mercurial_available() -> bool {
-    let result = Command::new("hg")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if !result {
-        println!("`hg` not available, skipping test");
-    }
-    result
-}

--- a/tests/testsuite/init/simple_hg/mod.rs
+++ b/tests/testsuite/init/simple_hg/mod.rs
@@ -2,15 +2,10 @@ use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
-use crate::init::mercurial_available;
 use cargo_test_support::curr_dir;
 
-#[cargo_test]
+#[cargo_test(requires_hg)]
 fn simple_hg() {
-    if !mercurial_available() {
-        return;
-    }
-
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -1,8 +1,6 @@
 //! Tests for the jobserver protocol.
 
-use cargo_util::is_ci;
 use std::net::TcpListener;
-use std::process::Command;
 use std::thread;
 
 use cargo_test_support::{cargo_exe, project};
@@ -58,17 +56,8 @@ fn jobserver_exists() {
     p.cargo("build -j2").run();
 }
 
-#[cargo_test]
+#[cargo_test(requires_make)]
 fn makes_jobserver_used() {
-    let make = if cfg!(windows) {
-        "mingw32-make"
-    } else {
-        "make"
-    };
-    if !is_ci() && Command::new(make).arg("--version").output().is_err() {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -162,7 +151,7 @@ all:
         drop((a2, a3));
     });
 
-    p.process(make)
+    p.process("make")
         .env("CARGO", cargo_exe())
         .env("ADDR", addr.to_string())
         .arg("-j2")
@@ -172,15 +161,6 @@ all:
 
 #[cargo_test]
 fn jobserver_and_j() {
-    let make = if cfg!(windows) {
-        "mingw32-make"
-    } else {
-        "make"
-    };
-    if !is_ci() && Command::new(make).arg("--version").output().is_err() {
-        return;
-    }
-
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -192,7 +172,7 @@ all:
         )
         .build();
 
-    p.process(make)
+    p.process("make")
         .env("CARGO", cargo_exe())
         .arg("-j2")
         .with_stderr(

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -1,5 +1,6 @@
 //! Tests for the jobserver protocol.
 
+use cargo_util::is_ci;
 use std::net::TcpListener;
 use std::process::Command;
 use std::thread;
@@ -64,7 +65,7 @@ fn makes_jobserver_used() {
     } else {
         "make"
     };
-    if Command::new(make).arg("--version").output().is_err() {
+    if !is_ci() && Command::new(make).arg("--version").output().is_err() {
         return;
     }
 
@@ -176,7 +177,7 @@ fn jobserver_and_j() {
     } else {
         "make"
     };
-    if Command::new(make).arg("--version").output().is_err() {
+    if !is_ci() && Command::new(make).arg("--version").output().is_err() {
         return;
     }
 

--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -1,15 +1,10 @@
 //! Tests for rustc plugins.
 
+use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_manifest, project};
-use cargo_test_support::{is_nightly, rustc_host};
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "plugins are unstable")]
 fn plugin_to_the_max() {
-    if !is_nightly() {
-        // plugins are unstable
-        return;
-    }
-
     let foo = project()
         .file(
             "Cargo.toml",
@@ -103,13 +98,8 @@ fn plugin_to_the_max() {
     foo.cargo("doc").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "plugins are unstable")]
 fn plugin_with_dynamic_native_dependency() {
-    if !is_nightly() {
-        // plugins are unstable
-        return;
-    }
-
     let build = project()
         .at("builder")
         .file(
@@ -335,13 +325,8 @@ fn native_plugin_dependency_with_custom_linker() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires rustc_private")]
 fn panic_abort_plugins() {
-    if !is_nightly() {
-        // requires rustc_private
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -383,13 +368,8 @@ fn panic_abort_plugins() {
     p.cargo("build").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "requires rustc_private")]
 fn shared_panic_abort_plugins() {
-    if !is_nightly() {
-        // requires rustc_private
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -1,6 +1,5 @@
 //! Tests for proc-macros.
 
-use cargo_test_support::is_nightly;
 use cargo_test_support::project;
 
 #[cargo_test]
@@ -203,13 +202,8 @@ fn impl_and_derive() {
     p.cargo("run").with_stdout("X { success: true }").run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "plugins are unstable")]
 fn plugin_and_proc_macro() {
-    if !is_nightly() {
-        // plugins are unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -1,9 +1,8 @@
 //! Tests for profiles.
 
-use std::env;
-
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
+use std::env;
 
 #[cargo_test]
 fn profile_overrides() {

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -1,14 +1,10 @@
 //! Tests for public/private dependencies.
 
+use cargo_test_support::project;
 use cargo_test_support::registry::Package;
-use cargo_test_support::{is_nightly, project};
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
 fn exported_priv_warning() {
-    if !is_nightly() {
-        // exported_private_dependencies lint is unstable
-        return;
-    }
     Package::new("priv_dep", "0.1.0")
         .file("src/lib.rs", "pub struct FromPriv;")
         .publish();
@@ -46,12 +42,8 @@ src/lib.rs:3:13: warning: type `[..]FromPriv` from private dependency 'priv_dep'
         .run()
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
 fn exported_pub_dep() {
-    if !is_nightly() {
-        // exported_private_dependencies lint is unstable
-        return;
-    }
     Package::new("pub_dep", "0.1.0")
         .file("src/lib.rs", "pub struct FromPub;")
         .publish();

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -414,13 +414,8 @@ fn test_multiple_required_features() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_default_features() {
-    if !is_nightly() {
-        // #[bench] is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -487,13 +482,8 @@ Consider enabling them by passing, e.g., `--features=\"a\"`
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_arg_features() {
-    if !is_nightly() {
-        // #[bench] is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -535,13 +525,8 @@ fn bench_arg_features() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "bench")]
 fn bench_multiple_required_features() {
-    if !is_nightly() {
-        // #[bench] is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -1,7 +1,7 @@
 //! Tests for the -Zrustdoc-map feature.
 
 use cargo_test_support::registry::{self, Package};
-use cargo_test_support::{is_nightly, paths, project, Project};
+use cargo_test_support::{paths, project, Project};
 
 fn basic_project() -> Project {
     Package::new("bar", "1.0.0")
@@ -41,13 +41,9 @@ fn ignores_on_stable() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn simple() {
     // Basic test that it works with crates.io.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     let p = basic_project();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])
@@ -59,15 +55,12 @@ fn simple() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/bar/struct.Straw.html""#));
 }
 
-#[cargo_test]
 // Broken, temporarily disable until https://github.com/rust-lang/rust/pull/82776 is resolved.
 #[ignore]
+#[cargo_test]
+// #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn std_docs() {
     // Mapping std docs somewhere else.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     // For local developers, skip this test if docs aren't installed.
     let docs = std::path::Path::new(&paths::sysroot()).join("share/doc/rust/html");
     if !docs.exists() {
@@ -114,13 +107,9 @@ fn std_docs() {
     assert!(myfun.contains(r#"href="https://example.com/rust/core/option/enum.Option.html""#));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn renamed_dep() {
     // Handles renamed dependencies.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     Package::new("bar", "1.0.0")
         .file("src/lib.rs", "pub struct Straw;")
         .publish();
@@ -157,13 +146,9 @@ fn renamed_dep() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/bar/struct.Straw.html""#));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn lib_name() {
     // Handles lib name != package name.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     Package::new("bar", "1.0.0")
         .file(
             "Cargo.toml",
@@ -210,13 +195,9 @@ fn lib_name() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/rumpelstiltskin/struct.Straw.html""#));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn alt_registry() {
     // Supports other registry names.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     registry::alt_init();
     Package::new("bar", "1.0.0")
         .alternative(true)
@@ -290,15 +271,11 @@ fn alt_registry() {
     assert!(gold.contains(r#"href="https://docs.rs/grimm/1.0.0/grimm/struct.Gold.html""#));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn multiple_versions() {
     // What happens when there are multiple versions.
     // NOTE: This is currently broken behavior. Rustdoc does not provide a way
     // to match renamed dependencies.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     Package::new("bar", "1.0.0")
         .file("src/lib.rs", "pub struct Spin;")
         .publish();
@@ -342,13 +319,9 @@ fn multiple_versions() {
     assert!(fn2.contains(r#"href="https://docs.rs/bar/2.0.0/bar/struct.Straw.html""#));
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn rebuilds_when_changing() {
     // Make sure it rebuilds if the map changes.
-    if !is_nightly() {
-        // --extern-html-root-url is unstable
-        return;
-    }
     let p = basic_project();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
         .masquerade_as_nightly_cargo(&["rustdoc-map"])

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5,7 +5,7 @@ use cargo_test_support::registry::Package;
 use cargo_test_support::{
     basic_bin_manifest, basic_lib_manifest, basic_manifest, cargo_exe, project,
 };
-use cargo_test_support::{cross_compile, is_nightly, paths};
+use cargo_test_support::{cross_compile, paths};
 use cargo_test_support::{rustc_host, sleep_ms};
 use std::fs;
 
@@ -3983,12 +3983,8 @@ fn test_dep_with_dev() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
 fn cargo_test_doctest_xcompile_ignores() {
-    if !is_nightly() {
-        // -Zdoctest-xcompile is unstable
-        return;
-    }
     // -Zdoctest-xcompile also enables --enable-per-target-ignores which
     // allows the ignore-TARGET syntax.
     let p = project()
@@ -4038,13 +4034,9 @@ fn cargo_test_doctest_xcompile_ignores() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
 fn cargo_test_doctest_xcompile() {
     if !cross_compile::can_run_on_host() {
-        return;
-    }
-    if !is_nightly() {
-        // -Zdoctest-xcompile is unstable
         return;
     }
     let p = project()
@@ -4078,13 +4070,9 @@ fn cargo_test_doctest_xcompile() {
     .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
 fn cargo_test_doctest_xcompile_runner() {
     if !cross_compile::can_run_on_host() {
-        return;
-    }
-    if !is_nightly() {
-        // -Zdoctest-xcompile is unstable
         return;
     }
 
@@ -4159,13 +4147,9 @@ fn cargo_test_doctest_xcompile_runner() {
     .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zdoctest-xcompile is unstable")]
 fn cargo_test_doctest_xcompile_no_runner() {
     if !cross_compile::can_run_on_host() {
-        return;
-    }
-    if !is_nightly() {
-        // -Zdoctest-xcompile is unstable
         return;
     }
 
@@ -4202,13 +4186,8 @@ fn cargo_test_doctest_xcompile_no_runner() {
     .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zpanic-abort-tests in rustc is unstable")]
 fn panic_abort_tests() {
-    if !is_nightly() {
-        // -Zpanic-abort-tests in rustc is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -4247,13 +4226,8 @@ fn panic_abort_tests() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zpanic-abort-tests in rustc is unstable")]
 fn panic_abort_only_test() {
-    if !is_nightly() {
-        // -Zpanic-abort-tests in rustc is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -4288,13 +4262,8 @@ fn panic_abort_only_test() {
         .run();
 }
 
-#[cargo_test]
+#[cargo_test(nightly, reason = "-Zpanic-abort-tests in rustc is unstable")]
 fn panic_abort_test_profile_inherits() {
-    if !is_nightly() {
-        // -Zpanic-abort-tests in rustc is unstable
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",


### PR DESCRIPTION
This extends the `#[cargo_test]` attribute to support some additional requirements to control whether or not a test can run. The motivation for this is:

* Can more clearly see when a test is disabled when it prints "ignored"
* Can more easily scan for disabled tests when I do version bumps to see which ones should be enabled on stable (to pass on CI).

The form is a comma separated list of requirements, and if they don't pass the test is ignored.  The requirements can be:

* `nightly` — The test only runs on nightly.
* `>=1.55` — The test only runs on rustc with the given version or newer.
* `requires_git` — Requires the given command to be installed.  Can be things like `requires_rustfmt` or `requires_hg`, etc.

This also enforces that the author must write a reason why it is ignored (for some of the requirements) so that when I look for tests to update, I know why it is disabled.

This also removes the `CARGO_TEST_DISABLE_GIT_CLI` option, which appears to no longer be necessary since we have migrated to GitHub Actions.
