### PR TITLE
Enable some tests on windows.

### DIFF
--- a/crates/cargo-test-support/src/tools.rs
+++ b/crates/cargo-test-support/src/tools.rs
@@ -2,11 +2,12 @@
 
 use crate::{basic_manifest, paths, project, Project};
 use lazy_static::lazy_static;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
 lazy_static! {
     static ref ECHO_WRAPPER: Mutex<Option<PathBuf>> = Mutex::new(None);
+    static ref ECHO: Mutex<Option<PathBuf>> = Mutex::new(None);
 }
 
 /// Returns the path to an executable that works as a wrapper around rustc.
@@ -35,6 +36,45 @@ pub fn echo_wrapper() -> PathBuf {
         .build();
     p.cargo("build").run();
     let path = p.bin("rustc-echo-wrapper");
+    *lock = Some(path.clone());
+    path
+}
+
+/// Returns the path to an executable that prints its arguments.
+///
+/// Do not expect this to be anything fancy.
+pub fn echo() -> PathBuf {
+    let mut lock = ECHO.lock().unwrap();
+    if let Some(path) = &*lock {
+        return path.clone();
+    }
+    if let Ok(path) = cargo_util::paths::resolve_executable(Path::new("echo")) {
+        *lock = Some(path.clone());
+        return path;
+    }
+    // Often on Windows, `echo` is not available.
+    let p = project()
+        .at(paths::global_root().join("basic-echo"))
+        .file("Cargo.toml", &basic_manifest("basic-echo", "1.0.0"))
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    let mut s = String::new();
+                    let mut it = std::env::args().skip(1).peekable();
+                    while let Some(n) = it.next() {
+                        s.push_str(&n);
+                        if it.peek().is_some() {
+                            s.push(' ');
+                        }
+                    }
+                    println!("{}", s);
+                }
+            "#,
+        )
+        .build();
+    p.cargo("build").run();
+    let path = p.bin("basic-echo");
     *lock = Some(path.clone());
     path
 }


### PR DESCRIPTION
This enables some more tests on windows that were disabled because `echo` is not always available. It's pretty easy to make a custom `echo`, so that's what this does.  I'm generally not comfortable with disabling tests just because there is an inconvenience like this.
