### PR TITLE
Fix rustc --profile=dev unstable check.

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -363,7 +363,7 @@ pub trait ArgMatchesExt {
         // This is an early exit, since it allows combination with `--release`.
         match (specified_profile, profile_checking) {
             // `cargo rustc` has legacy handling of these names
-            (Some(name @ ("test" | "bench" | "check")), ProfileChecking::LegacyRustc) |
+            (Some(name @ ("dev" | "test" | "bench" | "check")), ProfileChecking::LegacyRustc) |
             // `cargo fix` and `cargo check` has legacy handling of this profile name
             (Some(name @ "test"), ProfileChecking::LegacyTestOnly) => return Ok(InternedString::new(name)),
             _ => {}

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -702,3 +702,32 @@ fn legacy_commands_support_custom() {
         p.build_dir().rm_rf();
     }
 }
+
+#[cargo_test]
+fn legacy_rustc() {
+    // `cargo rustc` historically has supported dev/test/bench/check
+    // other profiles are covered in check::rustc_check
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [profile.dev]
+                codegen-units = 3
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("rustc --profile dev -v")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.1.0 [..]
+[RUNNING] `rustc --crate-name foo [..]-C codegen-units=3[..]
+[FINISHED] [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
This fixes an oversight from #9685 where `cargo rustc --profile=dev` was accidentally changed to require `-Zunstable-options`.  1.54 and earlier supported that [here](https://github.com/rust-lang/cargo/blob/rust-1.54.0/src/bin/cargo/commands/rustc.rs#L490.

Fixes #9897