### PR TITLE
Fix warnings when documenting with `--document-private-items`

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -259,7 +259,7 @@ struct SerializedTarget<'a> {
     /// Serialized as a list of strings for historical reasons.
     kind: &'a TargetKind,
     /// Corresponds to `--crate-type` compiler attribute.
-    /// See https://doc.rust-lang.org/reference/linkage.html
+    /// See <https://doc.rust-lang.org/reference/linkage.html>
     crate_types: Vec<CrateType>,
     name: &'a str,
     src_path: Option<&'a PathBuf>,
@@ -267,7 +267,7 @@ struct SerializedTarget<'a> {
     #[serde(rename = "required-features", skip_serializing_if = "Option::is_none")]
     required_features: Option<Vec<&'a str>>,
     /// Whether docs should be built for the target via `cargo doc`
-    /// See https://doc.rust-lang.org/cargo/commands/cargo-doc.html#target-selection
+    /// See <https://doc.rust-lang.org/cargo/commands/cargo-doc.html#target-selection>
     doc: bool,
     doctest: bool,
     /// Whether tests should be run for the target (`test` field in `Cargo.toml`)

--- a/src/cargo/core/resolver/version_prefs.rs
+++ b/src/cargo/core/resolver/version_prefs.rs
@@ -9,8 +9,8 @@ use crate::util::interning::InternedString;
 
 /// A collection of preferences for particular package versions.
 ///
-/// This is built up with [`prefer_package_id`] and [`prefer_dep`], then used to sort the set of
-/// summaries for a package during resolution via [`sort_summaries`].
+/// This is built up with [`Self::prefer_package_id`] and [`Self::prefer_dependency`], then used to sort the set of
+/// summaries for a package during resolution via [`Self::sort_summaries`].
 ///
 /// As written, a version is either "preferred" or "not preferred".  Later extensions may
 /// introduce more granular preferences.

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -135,8 +135,8 @@ impl Rustc {
 /// for no-op builds, we cache it here, based on compiler's mtime and rustup's
 /// current toolchain.
 ///
-/// https://github.com/rust-lang/cargo/issues/5315
-/// https://github.com/rust-lang/rust/issues/49761
+/// <https://github.com/rust-lang/cargo/issues/5315>
+/// <https://github.com/rust-lang/rust/issues/49761>
 #[derive(Debug)]
 struct Cache {
     cache_location: Option<PathBuf>,


### PR DESCRIPTION
- Use hyperlinks for URLs
- Fix broken intra-doc links

This doesn't fix the following warning, since I wasn't sure what change
was appropriate:
```
warning: public documentation for `rustc_process` links to private item `self::core::compiler::Context::primary_packages`
   --> src/cargo/core/compiler/compilation.rs:164:22
    |
164 |     /// flag), see [`crate::core::compiler::Context::primary_packages`].
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this item is private
    |
    = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default
    = note: this link resolves only because you passed `--document-private-items`, but will break without
```

To avoid noise, this doesn't add an `allow` either.