### PR TITLE
Improve "wrong output" error.

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -566,7 +566,11 @@ impl BuildOutput {
             let (key, value) = match (key, value) {
                 (Some(a), Some(b)) => (a, b.trim_end()),
                 // Line started with `cargo:` but didn't match `key=value`.
-                _ => bail!("Wrong output in {}: `{}`", whence, line),
+                _ => bail!("invalid output in {}: `{}`\n\
+                    Expected a line with `cargo:key=value` with an `=` character, \
+                    but none was found.\n\
+                    See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
+                    for more information about build script outputs.", whence, line),
             };
 
             // This will rewrite paths if the target directory has been moved.

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4942,3 +4942,31 @@ fn duplicate_script_with_extra_env() {
             .run();
     }
 }
+
+#[cargo_test]
+fn wrong_output() {
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo:example");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+[COMPILING] foo [..]
+error: invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo:example`
+Expected a line with `cargo:key=value` with an `=` character, but none was found.
+See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
+for more information about build script outputs.
+",
+        )
+        .run();
+}


### PR DESCRIPTION
The error message for an improperly formatted build script output was a bit abrupt and unhelpful.  This adds some more details to the error message.