### PR TITLE
Fix warnings from better precision of `dead_code` lint

### DIFF
--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -656,6 +656,7 @@ Caused by:
     );
 
     #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
     struct S {
         f1: i64,
         f2: String,
@@ -1155,6 +1156,7 @@ fn table_merge_failure() {
     );
 
     #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
     struct Table {
         key: StringList,
     }


### PR DESCRIPTION
The lint now ignores derived `Clone` and `Debug` implementations, as of
PR rust-lang/rust#85200, which landed a couple of days ago.

I sprinkled `#[allow(dead_code)]` in a few places; the fields are not
expected to be read since they are just part of a very specific test.
