### PR TITLE
Revert "When a dependency does not have a version, git or path, fails directly"

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1762,11 +1762,14 @@ impl<P: ResolveToPath> DetailedTomlDependency<P> {
         kind: Option<DepKind>,
     ) -> CargoResult<Dependency> {
         if self.version.is_none() && self.path.is_none() && self.git.is_none() {
-            bail!(
+            let msg = format!(
                 "dependency ({}) specified without \
-                 providing a local path, Git repository, or version to use.",
+                 providing a local path, Git repository, or \
+                 version to use. This will be considered an \
+                 error in future versions",
                 name_in_toml
             );
+            cx.warnings.push(msg);
         }
 
         if let Some(version) = &self.version {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -763,14 +763,10 @@ fn empty_dependencies() {
     Package::new("bar", "0.0.1").publish();
 
     p.cargo("build")
-        .with_status(101)
-        .with_stderr(
+        .with_stderr_contains(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  dependency (bar) specified without providing a local path, Git repository, or version \
-to use.
+warning: dependency (bar) specified without providing a local path, Git repository, or version \
+to use. This will be considered an error in future versions
 ",
         )
         .run();


### PR DESCRIPTION
Reverts rust-lang/cargo#9686

We discussed, and felt like this change wasn't all that important, and a few people have mentioned that it caused problems for them.

Closes #9885