### PR TITLE
[beta] Revert "When a dependency does not have a version, git or path…

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1762,11 +1762,14 @@ impl<P: ResolveToPath> DetailedTomlDependency<P> {
         kind: Option<DepKind>,
     ) -> CargoResult<Dependency> {
         if self.version.is_none() && self.path.is_none() && self.git.is_none() {
-            bail!(
+            let msg = format!(
                 "dependency ({}) specified without \
-                 providing a local path, Git repository, or version to use.",
+                 providing a local path, Git repository, or \
+                 version to use. This will be considered an \
+                 error in future versions",
                 name_in_toml
             );
+            cx.warnings.push(msg);
         }
 
         if let Some(version) = &self.version {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -763,14 +763,10 @@ fn empty_dependencies() {
     Package::new("bar", "0.0.1").publish();
 
     p.cargo("build")
-        .with_status(101)
-        .with_stderr(
+        .with_stderr_contains(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  dependency (bar) specified without providing a local path, Git repository, or version \
-to use.
+warning: dependency (bar) specified without providing a local path, Git repository, or version \
+to use. This will be considered an error in future versions
 ",
         )
         .run();

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -656,6 +656,7 @@ Caused by:
     );
 
     #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
     struct S {
         f1: i64,
         f2: String,
@@ -1155,6 +1156,7 @@ fn table_merge_failure() {
     );
 
     #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
     struct Table {
         key: StringList,
     }


### PR DESCRIPTION
…, fails directly"

This reverts commit 98d5d10268684d337d70caa2b0b95cc4c13b34f9, reversing
changes made to 3658906b0700ec70c727d95f5cdecc7c61a95a82.

Reverting #9686

Also including #9906 for CI.