### PR TITLE
Bump Cargo's curl requirement to 7.79.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
 curl = { version = "0.4.38", features = ["http2"] }
-curl-sys = "0.4.45"
+curl-sys = "0.4.46"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"


### PR DESCRIPTION
Brings in the latest release of `curl`