### PR TITLE
Temporarily revert curl-sys update.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
 curl = { version = "0.4.38", features = ["http2"] }
-curl-sys = "0.4.47"
+curl-sys = "0.4.45"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"


### PR DESCRIPTION
This reverts curl-sys to the previously working version, with the intent to get nightly working again until 7.79.1 is published next week.

Fixes #9919