### PR TITLE
Add fetch smoke test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,8 @@ jobs:
       if: matrix.os == 'macos-latest'
     - run: cargo build --manifest-path crates/credential/cargo-credential-wincred/Cargo.toml
       if: matrix.os == 'windows-latest'
+    - name: Fetch smoke test
+      run: ci/fetch-smoke-test.sh
 
   resolver:
     runs-on: ubuntu-latest

--- a/ci/fetch-smoke-test.sh
+++ b/ci/fetch-smoke-test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This script builds with static curl, and verifies that fetching works.
+
+set -ex
+
+if [[ -z "$RUNNER_TEMP" ]]
+then
+    echo "RUNNER_TEMP must be set"
+    exit 1
+fi
+
+if [ ! -f Cargo.toml ]; then
+    echo "Must be run from root of project."
+    exit 1
+fi
+
+
+# Building openssl on Windows is a pain.
+if [[ $(rustc -Vv | grep host:) != *windows* ]]; then
+    FEATURES='vendored-openssl,curl-sys/static-curl,curl-sys/force-system-lib-on-osx'
+    export LIBZ_SYS_STATIC=1
+fi
+
+cargo build --features "$FEATURES"
+export CARGO_HOME=$RUNNER_TEMP/chome
+target/debug/cargo fetch
+rm -rf $CARGO_HOME


### PR DESCRIPTION
This adds a test with a statically built curl to check if running `cargo fetch` works.  This adds a few minutes to CI time, but I think it is worthwhile to try to catch some regressions.

Note that macOS uses system curl to match the rust-lang/rust build mode.
