### PR TITLE
relates to issue #9922

### DIFF
--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1331,6 +1331,19 @@ fn error_if_parent_cargo_toml_is_invalid() {
 }
 
 #[cargo_test]
+fn no_error_if_parent_cargo_toml_is_valid_toml_but_invalid_manifest() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("{{no_a_valid_workspace_project}}", "0.1.0"))
+        .file("valid/Cargo.toml", &basic_manifest("valid", "0.1.0"))
+        .file("valid/src/main.rs", "fn main() {}");
+    let p = p.build();
+
+    p.cargo("build")
+        .cwd("valid")
+        .run();
+}
+
+#[cargo_test]
 fn relative_path_for_member_works() {
     let p = project()
         .file(


### PR DESCRIPTION
see issue #9922

this PR describes the test case where a parent directory is not a valid workspace, hence the crate in the sub folder `valid` is a valid standalone crate and should build correctly.