### PR TITLE
Adds backoff mechanism for retry

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2103,7 +2103,6 @@ pub struct SslVersionConfigRange {
 pub struct CargoNetConfig {
     pub retry: Option<u32>,
     pub retry_max_time: Option<DurationString>,
-    pub retry_delay: Option<DurationString>,
     pub offline: Option<bool>,
     pub git_fetch_with_cli: Option<bool>,
 }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2102,6 +2102,8 @@ pub struct SslVersionConfigRange {
 #[serde(rename_all = "kebab-case")]
 pub struct CargoNetConfig {
     pub retry: Option<u32>,
+    pub retry_max_time: Option<u64>,
+    pub retry_delay: Option<u64>,
     pub offline: Option<bool>,
     pub git_fetch_with_cli: Option<bool>,
 }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1542,7 +1542,7 @@ impl Config {
         assert!(
             self.package_cache_lock.borrow().is_some(),
             "package cache lock is not currently held, Cargo forgot to call \
-            `acquire_package_cache_lock` before we got to this stack frame",
+             `acquire_package_cache_lock` before we got to this stack frame",
         );
         assert!(ret.starts_with(self.home_path.as_path_unlocked()));
         ret
@@ -2315,7 +2315,7 @@ impl<'de> Deserialize<'de> for DurationString {
             Some(offset) => offset,
             None => {
                 return Err(serde::de::Error::custom(format!(
-                    "No unit is found on value: `{}`",
+                    "no unit is found on value: `{}`, expected an `s` or `ms` suffix",
                     s
                 )));
             }
@@ -2325,7 +2325,7 @@ impl<'de> Deserialize<'de> for DurationString {
             val
         } else {
             return Err(serde::de::Error::custom(format!(
-                "Invalid value format: `{}`, expecting a positive number followed by unit",
+                "invalid value format: `{}`, expecting a non-negative number followed by unit suffix",
                 s
             )));
         };

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -13,7 +13,6 @@ pub struct Retry<'a> {
     retries: u32,
     max_retry: u32,
     retry_max_time: Duration,
-    retry_delay: Option<Duration>,
 }
 
 impl<'a> Retry<'a> {
@@ -26,7 +25,6 @@ impl<'a> Retry<'a> {
                 .net_config()?
                 .retry_max_time
                 .map_or(Duration::from_secs(32), |e| e.inner()),
-            retry_delay: config.net_config()?.retry_delay.map(|e| e.inner()),
         })
     }
 
@@ -48,12 +46,7 @@ impl<'a> Retry<'a> {
     }
 
     fn backoff(&self) {
-        let backoff_time = if let Some(delay) = self.retry_delay {
-            delay
-        } else {
-            min(Duration::from_secs(1 << self.retries), self.retry_max_time)
-        };
-
+        let backoff_time = min(Duration::from_secs(1 << self.retries), self.retry_max_time);
         debug!("backing off for {} ms", backoff_time.as_millis());
         sleep(backoff_time);
     }

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -3,6 +3,8 @@ use std::cmp::min;
 use std::thread::sleep;
 use std::time::Duration;
 
+use log::debug;
+
 use crate::util::errors::{CargoResult, HttpNot200};
 use crate::util::Config;
 
@@ -52,6 +54,7 @@ impl<'a> Retry<'a> {
             min(Duration::from_secs(1 << self.retries), self.retry_max_time)
         };
 
+        debug!("backing off for {} ms", backoff_time.as_millis());
         sleep(backoff_time);
     }
 }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -108,8 +108,8 @@ root = "/some/path"         # `cargo install` destination directory
 
 [net]
 retry = 2                   # maximum number of network retries
-retry-max-time = 10s        # maximum time between each exponential backoff retries
-retry-delay = 10ms          # if present, override backoff time with a constant
+retry-max-time = "10s"      # maximum time between each exponential backoff retries
+retry-delay = "10ms"        # if present, override backoff time with a constant
 git-fetch-with-cli = true   # use the `git` executable for git operations
 offline = true              # do not access the network
 
@@ -634,13 +634,21 @@ The `[net]` table controls networking configuration.
 Number of times to retry possibly spurious network errors.
 
 #### `net.retry-max-time`
-* Type: string (*duration)
+* Type: string (duration)
 * Default: 32s
 * Environment: `CARGO_NET_RETRY_MAX_TIME`
 
-Upper bound for time between exponential backoff retries
+Maximum time for exponential backoff between network retries.
 
-Valid format: "{INT_VALUE}{s|ms}"
+By default, Cargo adds a delay between each network retry attempt. Exponential backoff refers to
+exponentially increasing delay times for each attempt. `net.retry-max-time` ensures that the
+delay duration will not exceed this value. This is useful if longer backoff is required in some
+cases.
+
+See `net.retry-delay` to disable exponential backoff.
+
+Valid format is a string starting with non-negative integer followed by `s` for seconds or
+`ms` for milliseconds.
 
 ### `net.retry-delay`
 * Type: string (duration)
@@ -648,9 +656,12 @@ Valid format: "{INT_VALUE}{s|ms}"
 * Environment: `CARGO_NET_RETRY_DELAY`
 
 Use constant time in between network retries instead of exponential increments. If present,
-overrides `net.retry-max-time`.
+overrides `net.retry-max-time`. Setting this to 0 will disable any delay in between retry attempts.
 
-Valid format: "{INT_VALUE}{s|ms}"
+Setting this value can be helpful when there is a need to retry after a constant time.
+
+Valid format is a string starting with non-negative integer followed by `s` for seconds or
+`ms` for milliseconds.
 
 ##### `net.git-fetch-with-cli`
 * Type: boolean

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -109,7 +109,6 @@ root = "/some/path"         # `cargo install` destination directory
 [net]
 retry = 2                   # maximum number of network retries
 retry-max-time = "10s"      # maximum time between each exponential backoff retries
-retry-delay = "10ms"        # if present, override backoff time with a constant
 git-fetch-with-cli = true   # use the `git` executable for git operations
 offline = true              # do not access the network
 
@@ -644,21 +643,6 @@ By default, Cargo adds a delay between each network retry attempt. Exponential b
 exponentially increasing delay times for each attempt. `net.retry-max-time` ensures that the
 delay duration will not exceed this value. This is useful if longer backoff is required in some
 cases.
-
-See `net.retry-delay` to disable exponential backoff.
-
-Valid format is a string starting with non-negative integer followed by `s` for seconds or
-`ms` for milliseconds.
-
-### `net.retry-delay`
-* Type: string (duration)
-* Default: None
-* Environment: `CARGO_NET_RETRY_DELAY`
-
-Use constant time in between network retries instead of exponential increments. If present,
-overrides `net.retry-max-time`. Setting this to 0 will disable any delay in between retry attempts.
-
-Setting this value can be helpful when there is a need to retry after a constant time.
 
 Valid format is a string starting with non-negative integer followed by `s` for seconds or
 `ms` for milliseconds.

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -107,7 +107,9 @@ user-agent = "…"            # the user-agent header
 root = "/some/path"         # `cargo install` destination directory
 
 [net]
-retry = 2                   # network retries
+retry = 2                   # maximum number of network retries
+retry-max-time = 10s        # maximum time between each exponential backoff retries
+retry-delay = 10ms          # if present, override backoff time with a constant
 git-fetch-with-cli = true   # use the `git` executable for git operations
 offline = true              # do not access the network
 
@@ -630,6 +632,25 @@ The `[net]` table controls networking configuration.
 * Environment: `CARGO_NET_RETRY`
 
 Number of times to retry possibly spurious network errors.
+
+#### `net.retry-max-time`
+* Type: string (*duration)
+* Default: 32s
+* Environment: `CARGO_NET_RETRY_MAX_TIME`
+
+Upper bound for time between exponential backoff retries
+
+Valid format: "{INT_VALUE}{s|ms}"
+
+### `net.retry-delay`
+* Type: string (duration)
+* Default: None
+* Environment: `CARGO_NET_RETRY_DELAY`
+
+Use constant time in between network retries instead of exponential increments. If present,
+overrides `net.retry-max-time`.
+
+Valid format: "{INT_VALUE}{s|ms}"
 
 ##### `net.git-fetch-with-cli`
 * Type: boolean

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -156,6 +156,7 @@ supported environment variables are:
 [`http.user-agent`]: config.md#httpuser-agent
 [`install.root`]: config.md#installroot
 [`net.retry`]: config.md#netretry
+[`net.retry-max-time`]: config.md#netretry-max-time
 [`net.git-fetch-with-cli`]: config.md#netgit-fetch-with-cli
 [`net.offline`]: config.md#netoffline
 [`profile.<name>.build-override`]: config.md#profilenamebuild-override

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -95,7 +95,6 @@ supported environment variables are:
 * `CARGO_INSTALL_ROOT` — The default directory for [`cargo install`], see [`install.root`].
 * `CARGO_NET_RETRY` — Number of times to retry network errors, see [`net.retry`].
 * `CARGO_NET_RETRY_MAX_TIME` — Maximum time for exponential backoff between network retries, see [`net.retry-max-time`]
-* `CARGO_NET_RETRY_MAX_TIME` — Use constant time between network retries instead of exponential backoff, see [`net.retry-delay`]
 * `CARGO_NET_GIT_FETCH_WITH_CLI` — Enables the use of the `git` executable to fetch, see [`net.git-fetch-with-cli`].
 * `CARGO_NET_OFFLINE` — Offline mode, see [`net.offline`].
 * `CARGO_PROFILE_<name>_BUILD_OVERRIDE_<key>` — Override build script profile, see [`profile.<name>.build-override`].

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -94,6 +94,8 @@ supported environment variables are:
 * `CARGO_HTTP_USER_AGENT` — The HTTP user-agent header, see [`http.user-agent`].
 * `CARGO_INSTALL_ROOT` — The default directory for [`cargo install`], see [`install.root`].
 * `CARGO_NET_RETRY` — Number of times to retry network errors, see [`net.retry`].
+* `CARGO_NET_RETRY_MAX_TIME` — Maximum time for exponential backoff between network retries, see [`net.retry-max-time`]
+* `CARGO_NET_RETRY_MAX_TIME` — Use constant time between network retries instead of exponential backoff, see [`net.retry-delay`]
 * `CARGO_NET_GIT_FETCH_WITH_CLI` — Enables the use of the `git` executable to fetch, see [`net.git-fetch-with-cli`].
 * `CARGO_NET_OFFLINE` — Offline mode, see [`net.offline`].
 * `CARGO_PROFILE_<name>_BUILD_OVERRIDE_<key>` — Override build script profile, see [`profile.<name>.build-override`].

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -109,3 +109,137 @@ fn net_retry_backoff_time() {
         .env("CARGO_LOG", "DEBUG")
         .run();
 }
+
+#[cargo_test]
+fn net_retry_config_bad_unit() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.bar]
+                git = "http://127.0.0.1:11/foo/bar"
+            "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+           [net]
+           retry-delay="10m"
+           [http]
+           timeout=1
+            "#,
+        )
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("build -v -j 1")
+        .with_status(101)
+        .with_stderr_contains("[..] unknown variant `m`, expected `s` or `ms`")
+        .run();
+}
+
+#[cargo_test]
+fn net_retry_config_bad_format() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.bar]
+                git = "http://127.0.0.1:11/foo/bar"
+            "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+           [net]
+           retry-delay="10m1"
+           [http]
+           timeout=1
+            "#,
+        )
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("build -v -j 1")
+        .with_status(101)
+        .with_stderr_contains("[..] unknown variant `m1`, expected `s` or `ms`")
+        .run();
+}
+
+#[cargo_test]
+fn net_retry_config_bad_format2() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.bar]
+                git = "http://127.0.0.1:11/foo/bar"
+            "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+           [net]
+           retry-delay="m10"
+           [http]
+           timeout=1
+            "#,
+        )
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("build -v -j 1")
+        .with_status(101)
+        .with_stderr_contains(
+            "[..] Invalid value format: `m10`, expecting a positive number followed by unit",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn net_retry_config_bad_format3() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies.bar]
+                git = "http://127.0.0.1:11/foo/bar"
+            "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+           [net]
+           retry-delay="10"
+           [http]
+           timeout=1
+            "#,
+        )
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("build -v -j 1")
+        .with_status(101)
+        .with_stderr_contains("[..] No unit is found on value: `10`")
+        .run();
+}

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -23,7 +23,7 @@ fn net_retry_loads_from_config() {
             r#"
            [net]
            retry=1
-           retry-delay="10ms"
+           retry-max-time="10ms"
            [http]
            timeout=1
             "#,
@@ -58,7 +58,7 @@ fn net_retry_git_outputs_warning() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay= "10ms"
+           retry-max-time= "10ms"
            [http]
            timeout=1
             "#,
@@ -95,7 +95,7 @@ fn net_retry_backoff_time() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay="10ms"
+           retry-max-time="10ms"
            [http]
            timeout=1
             "#,
@@ -129,7 +129,7 @@ fn net_retry_config_bad_unit() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay="10m"
+           retry-max-time="10m"
            [http]
            timeout=1
             "#,
@@ -162,7 +162,7 @@ fn net_retry_config_bad_format() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay="10m1"
+           retry-max-time="10m1"
            [http]
            timeout=1
             "#,
@@ -195,7 +195,7 @@ fn net_retry_config_bad_format2() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay="m10"
+           retry-max-time="m10"
            [http]
            timeout=1
             "#,
@@ -230,7 +230,7 @@ fn net_retry_config_bad_format3() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay="10"
+           retry-max-time="10"
            [http]
            timeout=1
             "#,

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -58,7 +58,7 @@ fn net_retry_git_outputs_warning() {
             ".cargo/config",
             r#"
            [net]
-           retry-delay="10ms"
+           retry-delay= "10ms"
            [http]
            timeout=1
             "#,
@@ -206,7 +206,7 @@ fn net_retry_config_bad_format2() {
     p.cargo("build -v -j 1")
         .with_status(101)
         .with_stderr_contains(
-            "[..] Invalid value format: `m10`, expecting a positive number followed by unit",
+            "[..] invalid value format: `m10`, expecting a non-negative number followed by unit suffix",
         )
         .run();
 }
@@ -240,6 +240,8 @@ fn net_retry_config_bad_format3() {
 
     p.cargo("build -v -j 1")
         .with_status(101)
-        .with_stderr_contains("[..] No unit is found on value: `10`")
+        .with_stderr_contains(
+            "[..] no unit is found on value: `10`, expected an `s` or `ms` suffix",
+        )
         .run();
 }


### PR DESCRIPTION
Addresses #9882 

Adds an exponential backoff mechanism for network retries.

Adds 2 additional `net` configuration:
- `retry-max-time`: Upper bound for exponential backoff time
- `retry-delay`: If present, override exponential backoff time with constant delay time (in second)

---

Would like to have some opinion on the PR first, before continuing.
Also, I'm not sure how to do time/duration-based testing in Rust, so I'm not sure how to devise a test for this.