### PR TITLE
Change diesel compatibility messages

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -1248,21 +1248,8 @@ impl<'cfg> DrainState<'cfg> {
     }
 
     fn back_compat_notice(&self, cx: &Context<'_, '_>, unit: &Unit) -> CargoResult<()> {
-        fn is_broken_diesel(version: &Version) -> bool {
-            use semver::{Comparator, Op, Prerelease};
-
-            Comparator {
-                op: Op::Less,
-                major: 1,
-                minor: Some(4),
-                patch: Some(8),
-                pre: Prerelease::EMPTY,
-            }
-            .matches(version)
-        }
-
         if unit.pkg.name() != "diesel"
-            || !is_broken_diesel(unit.pkg.version())
+            || unit.pkg.version() >= &Version::new(1, 4, 8)
             || cx.bcx.ws.resolve_behavior() == ResolveBehavior::V1
             || !unit.pkg.package_id().source_id().is_registry()
             || !unit.features.is_empty()

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -50,11 +50,12 @@ use cargo_util::{exit_status_to_string, is_simple_exit_code, paths, ProcessBuild
 use log::{debug, trace, warn};
 use rustfix::diagnostics::Diagnostic;
 use rustfix::{self, CodeFix};
+use semver::{Comparator, Op, Prerelease};
 
 use crate::core::compiler::{CompileKind, RustcTargetData, TargetInfo};
 use crate::core::resolver::features::{DiffMap, FeatureOpts, FeatureResolver};
 use crate::core::resolver::{HasDevUnits, Resolve, ResolveBehavior};
-use crate::core::{Edition, MaybePackage, Workspace};
+use crate::core::{Edition, MaybePackage, PackageId, Workspace};
 use crate::ops::resolve::WorkspaceResolve;
 use crate::ops::{self, CompileOptions};
 use crate::util::diagnostic_server::{Message, RustfixDiagnosticServer};
@@ -321,17 +322,31 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
 }
 
 fn report_maybe_diesel(config: &Config, resolve: &Resolve) -> CargoResult<()> {
-    if resolve
-        .iter()
-        .any(|pid| pid.name() == "diesel" && pid.version().major == 1)
-        && resolve.iter().any(|pid| pid.name() == "diesel_migrations")
-    {
+    fn is_broken_diesel(pid: PackageId) -> bool {
+        if pid.name() != "diesel" {
+            return false;
+        }
+        Comparator {
+            op: Op::Less,
+            major: 1,
+            minor: Some(4),
+            patch: Some(8),
+            pre: Prerelease::EMPTY,
+        }
+        .matches(pid.version())
+    }
+
+    fn is_broken_diesel_migration(pid: PackageId) -> bool {
+        pid.name() == "diesel_migrations" && pid.version().major <= 1
+    }
+
+    if resolve.iter().any(is_broken_diesel) && resolve.iter().any(is_broken_diesel_migration) {
         config.shell().note(
             "\
 This project appears to use both diesel and diesel_migrations. These packages have
 a known issue where the build may fail due to the version 2 resolver preventing
-feature unification between those two packages. See
-<https://github.com/rust-lang/cargo/issues/9450> for some potential workarounds.
+feature unification between those two packages. Please update to at least diesel 1.4.8
+to prevent this issue from happening.
 ",
         )?;
     }

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -50,7 +50,7 @@ use cargo_util::{exit_status_to_string, is_simple_exit_code, paths, ProcessBuild
 use log::{debug, trace, warn};
 use rustfix::diagnostics::Diagnostic;
 use rustfix::{self, CodeFix};
-use semver::{Comparator, Op, Prerelease};
+use semver::Version;
 
 use crate::core::compiler::{CompileKind, RustcTargetData, TargetInfo};
 use crate::core::resolver::features::{DiffMap, FeatureOpts, FeatureResolver};
@@ -323,17 +323,7 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
 
 fn report_maybe_diesel(config: &Config, resolve: &Resolve) -> CargoResult<()> {
     fn is_broken_diesel(pid: PackageId) -> bool {
-        if pid.name() != "diesel" {
-            return false;
-        }
-        Comparator {
-            op: Op::Less,
-            major: 1,
-            minor: Some(4),
-            patch: Some(8),
-            pre: Prerelease::EMPTY,
-        }
-        .matches(pid.version())
+        pid.name() == "diesel" && pid.version() < &Version::new(1, 4, 8)
     }
 
     fn is_broken_diesel_migration(pid: PackageId) -> bool {


### PR DESCRIPTION
Diesel 1.4.8 fixes the critical behaviour. This commit changes the
corresponding messages for `cargo fix` and normal builds to prompt the
user to just update the diesel version to fix the corresponding
compilation errors.

As discussed in https://github.com/rust-lang/rust/issues/88903#issuecomment-923061946

Fixes https://github.com/rust-lang/rust/issues/88903
Fixes #9450 