### PR TITLE
Remove TOML incompatibility hacks

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -150,50 +150,10 @@ fn do_read_manifest(
 /// The purpose of this wrapper is to detect invalid TOML which was previously
 /// accepted and display a warning to the user in that case. The `file` and `config`
 /// parameters are only used by this fallback path.
-pub fn parse(toml: &str, file: &Path, config: &Config) -> CargoResult<toml::Value> {
-    let first_error = match toml.parse() {
-        Ok(ret) => return Ok(ret),
-        Err(e) => e,
-    };
-
-    let mut second_parser = toml::de::Deserializer::new(toml);
-    second_parser.set_require_newline_after_table(false);
-    if let Ok(ret) = toml::Value::deserialize(&mut second_parser) {
-        let msg = format!(
-            "\
-TOML file found which contains invalid syntax and will soon not parse
-at `{}`.
-
-The TOML spec requires newlines after table definitions (e.g., `[a] b = 1` is
-invalid), but this file has a table header which does not have a newline after
-it. A newline needs to be added and this warning will soon become a hard error
-in the future.",
-            file.display()
-        );
-        config.shell().warn(&msg)?;
-        return Ok(ret);
-    }
-
-    let mut third_parser = toml::de::Deserializer::new(toml);
-    third_parser.set_allow_duplicate_after_longer_table(true);
-    if let Ok(ret) = toml::Value::deserialize(&mut third_parser) {
-        let msg = format!(
-            "\
-TOML file found which contains invalid syntax and will soon not parse
-at `{}`.
-
-The TOML spec requires that each table header is defined at most once, but
-historical versions of Cargo have erroneously accepted this file. The table
-definitions will need to be merged together with one table header to proceed,
-and this will become a hard error in the future.",
-            file.display()
-        );
-        config.shell().warn(&msg)?;
-        return Ok(ret);
-    }
-
-    let first_error = anyhow::Error::from(first_error);
-    Err(first_error.context("could not parse input as TOML"))
+pub fn parse(toml: &str, _file: &Path, _config: &Config) -> CargoResult<toml::Value> {
+    // At the moment, no compatibility checks are needed.
+    toml.parse()
+        .map_err(|e| anyhow::Error::from(e).context("could not parse input as TOML"))
 }
 
 type TomlLibTarget = TomlTarget;

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -773,26 +773,15 @@ to use. This will be considered an error in future versions
 }
 
 #[cargo_test]
-fn invalid_toml_historically_allowed_is_warned() {
+fn invalid_toml_historically_allowed_fails() {
     let p = project()
         .file(".cargo/config", "[bar] baz = 2")
         .file("src/main.rs", "fn main() {}")
         .build();
 
     p.cargo("build")
-        .with_stderr(
-            "\
-warning: TOML file found which contains invalid syntax and will soon not parse
-at `[..]config`.
-
-The TOML spec requires newlines after table definitions (e.g., `[a] b = 1` is
-invalid), but this file has a table header which does not have a newline after
-it. A newline needs to be added and this warning will soon become a hard error
-in the future.
-[COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_status(101)
+        .with_stderr_contains("  expected newline, found an identifier at line 1 column 7")
         .run();
 }
 


### PR DESCRIPTION
- `set_require_newline_after_table` was added in #2680 back in 2016
- `set_allow_duplicate_after_longer_table` was added in #6761 in 2019

Several years later, this PR is turning these warnings into errors.

The function and documentation was kept so we can add additional hacks
in the future, like if we switch TOML parsers.