### PR TITLE
Allow `cargo update --precise` with metadata.

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -1,8 +1,3 @@
-use std::collections::{BTreeMap, HashSet};
-
-use log::debug;
-use termcolor::Color::{self, Cyan, Green, Red};
-
 use crate::core::registry::PackageRegistry;
 use crate::core::resolver::features::{CliFeatures, HasDevUnits};
 use crate::core::{PackageId, PackageIdSpec};
@@ -10,6 +5,10 @@ use crate::core::{Resolve, SourceId, Workspace};
 use crate::ops;
 use crate::util::config::Config;
 use crate::util::CargoResult;
+use anyhow::Context;
+use log::debug;
+use std::collections::{BTreeMap, HashSet};
+use termcolor::Color::{self, Cyan, Green, Red};
 
 pub struct UpdateOptions<'a> {
     pub config: &'a Config,
@@ -95,6 +94,9 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                         //       seems like a pretty hokey reason to single out
                         //       the registry as well.
                         let precise = if dep.source_id().is_registry() {
+                            semver::Version::parse(precise).with_context(|| {
+                                format!("invalid version format for precise version `{}`", precise)
+                            })?;
                             format!("{}={}->{}", dep.name(), dep.version(), precise)
                         } else {
                             precise.to_string()


### PR DESCRIPTION
`cargo update --precise` would require that the version matches *exactly*, including build metadata.  Usually the build metadata is ignored (like in dependency declarations), but in this circumstance it isn't.  This can be awkward in some cases where it can be more convenient to type just the version number without the build metadata.

This changes it so that if the metadata isn't provided, then it will be ignored when matching.  Otherwise, it will be honored. This is slightly different from a version requirement like `=1.2.3+foo` which ignores the metadata completely.

This also adds a slightly better error message if you don't type in valid syntax for a version number (previously it would just emit the `no matching package` error).
