### PR TITLE
[beta] 1.56 backports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
 curl = { version = "0.4.38", features = ["http2"] }
-curl-sys = "0.4.45"
+curl-sys = "0.4.48"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -62,6 +62,7 @@ use cargo_util::ProcessBuilder;
 use crossbeam_utils::thread::Scope;
 use jobserver::{Acquired, Client, HelperThread};
 use log::{debug, info, trace};
+use semver::Version;
 
 use super::context::OutputFile;
 use super::job::{
@@ -74,9 +75,8 @@ use crate::core::compiler::future_incompat::{
     FutureBreakageItem, FutureIncompatReportPackage, OnDiskReports,
 };
 use crate::core::resolver::ResolveBehavior;
-use crate::core::{FeatureValue, PackageId, Shell, TargetKind};
+use crate::core::{PackageId, Shell, TargetKind};
 use crate::util::diagnostic_server::{self, DiagnosticPrinter};
-use crate::util::interning::InternedString;
 use crate::util::machine_message::{self, Message as _};
 use crate::util::CargoResult;
 use crate::util::{self, internal, profile};
@@ -1249,55 +1249,27 @@ impl<'cfg> DrainState<'cfg> {
 
     fn back_compat_notice(&self, cx: &Context<'_, '_>, unit: &Unit) -> CargoResult<()> {
         if unit.pkg.name() != "diesel"
-            || unit.pkg.version().major != 1
+            || unit.pkg.version() >= &Version::new(1, 4, 8)
             || cx.bcx.ws.resolve_behavior() == ResolveBehavior::V1
             || !unit.pkg.package_id().source_id().is_registry()
             || !unit.features.is_empty()
         {
             return Ok(());
         }
-        let other_diesel = match cx
+        if !cx
             .bcx
             .unit_graph
             .keys()
-            .find(|unit| unit.pkg.name() == "diesel" && !unit.features.is_empty())
+            .any(|unit| unit.pkg.name() == "diesel" && !unit.features.is_empty())
         {
-            Some(u) => u,
-            // Unlikely due to features.
-            None => return Ok(()),
-        };
-        let mut features_suggestion: BTreeSet<_> = other_diesel.features.iter().collect();
-        let fmap = other_diesel.pkg.summary().features();
-        // Remove any unnecessary features.
-        for feature in &other_diesel.features {
-            if let Some(feats) = fmap.get(feature) {
-                for feat in feats {
-                    if let FeatureValue::Feature(f) = feat {
-                        features_suggestion.remove(&f);
-                    }
-                }
-            }
+            return Ok(());
         }
-        features_suggestion.remove(&InternedString::new("default"));
-        let features_suggestion = toml::to_string(&features_suggestion).unwrap();
-
-        cx.bcx.config.shell().note(&format!(
+        cx.bcx.config.shell().note(
             "\
 This error may be due to an interaction between diesel and Cargo's new
-feature resolver. Some workarounds you may want to consider:
-- Add a build-dependency in Cargo.toml on diesel to force Cargo to add the appropriate
-  features. This may look something like this:
-
-    [build-dependencies]
-    diesel = {{ version = \"{}\", features = {} }}
-
-- Try using the previous resolver by setting `resolver = \"1\"` in `Cargo.toml`
-  (see <https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions>
-  for more information).
+feature resolver. Try updating to diesel 1.4.8 to fix this error.
 ",
-            unit.pkg.version(),
-            features_suggestion
-        ))?;
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION
Beta backports of:

- #9937 — Bump curl-sys to 0.4.48 with curl 7.79.1 which will hopefully fix the http2 errors
- #9927 — Change diesel compatibility messages