### PR TITLE
Print executable name on `cargo test --no-run`.

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -144,6 +144,7 @@ fn substitute_macros(input: &str) -> String {
         ("[YANK]", "        Yank"),
         ("[OWNER]", "       Owner"),
         ("[MIGRATING]", "   Migrating"),
+        ("[EXECUTABLE]", "  Executable"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -1,11 +1,12 @@
-use crate::core::compiler::{Compilation, CompileKind, Doctest, UnitOutput};
+use crate::core::compiler::{Compilation, CompileKind, Doctest, Metadata, Unit, UnitOutput};
 use crate::core::shell::Verbosity;
 use crate::core::{TargetKind, Workspace};
 use crate::ops;
 use crate::util::errors::CargoResult;
 use crate::util::{add_path_args, CargoTestError, Config, Test};
-use cargo_util::ProcessError;
+use cargo_util::{ProcessBuilder, ProcessError};
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
 pub struct TestOptions {
     pub compile_opts: ops::CompileOptions,
@@ -21,6 +22,30 @@ pub fn run_tests(
     let compilation = compile_tests(ws, options)?;
 
     if options.no_run {
+        let config = ws.config();
+        let cwd = config.cwd();
+        for UnitOutput {
+            unit,
+            path,
+            script_meta,
+        } in compilation.tests.iter()
+        {
+            let (exe_display, cmd) = cmd_builds(
+                config,
+                cwd,
+                unit,
+                path,
+                script_meta,
+                test_args,
+                &compilation,
+            )?;
+            config
+                .shell()
+                .concise(|shell| shell.status("Executable", &exe_display))?;
+            config
+                .shell()
+                .verbose(|shell| shell.status("Executable", &cmd))?;
+        }
         return Ok(None);
     }
     let (test, mut errors) = run_unit_tests(ws.config(), options, test_args, &compilation)?;
@@ -48,6 +73,23 @@ pub fn run_benches(
     let compilation = compile_tests(ws, options)?;
 
     if options.no_run {
+        let config = ws.config();
+        let cwd = config.cwd();
+        for UnitOutput {
+            unit,
+            path,
+            script_meta,
+        } in compilation.tests.iter()
+        {
+            let (exe_display, cmd) =
+                cmd_builds(config, cwd, unit, path, script_meta, args, &compilation)?;
+            config
+                .shell()
+                .concise(|shell| shell.status("Executable", &exe_display))?;
+            config
+                .shell()
+                .verbose(|shell| shell.status("Executable", &cmd))?;
+        }
         return Ok(None);
     }
 
@@ -86,28 +128,8 @@ fn run_unit_tests(
     {
         let test = unit.target.name().to_string();
 
-        let test_path = unit.target.src_path().path().unwrap();
-        let exe_display = if let TargetKind::Test = unit.target.kind() {
-            format!(
-                "{} ({})",
-                test_path
-                    .strip_prefix(unit.pkg.root())
-                    .unwrap_or(test_path)
-                    .display(),
-                path.strip_prefix(cwd).unwrap_or(path).display()
-            )
-        } else {
-            format!(
-                "unittests ({})",
-                path.strip_prefix(cwd).unwrap_or(path).display()
-            )
-        };
-
-        let mut cmd = compilation.target_process(path, unit.kind, &unit.pkg, *script_meta)?;
-        cmd.args(test_args);
-        if unit.target.harness() && config.shell().verbosity() == Verbosity::Quiet {
-            cmd.arg("--quiet");
-        }
+        let (exe_display, cmd) =
+            cmd_builds(config, cwd, unit, path, script_meta, test_args, compilation)?;
         config
             .shell()
             .concise(|shell| shell.status("Running", &exe_display))?;
@@ -150,6 +172,41 @@ fn run_unit_tests(
             errors.into_iter().map(|(_, _, _, e)| e).collect(),
         ))
     }
+}
+
+fn cmd_builds(
+    config: &Config,
+    cwd: &Path,
+    unit: &Unit,
+    path: &PathBuf,
+    script_meta: &Option<Metadata>,
+    test_args: &[&str],
+    compilation: &Compilation<'_>,
+) -> CargoResult<(String, ProcessBuilder)> {
+    let test_path = unit.target.src_path().path().unwrap();
+    let exe_display = if let TargetKind::Test = unit.target.kind() {
+        format!(
+            "{} ({})",
+            test_path
+                .strip_prefix(unit.pkg.root())
+                .unwrap_or(test_path)
+                .display(),
+            path.strip_prefix(cwd).unwrap_or(path).display()
+        )
+    } else {
+        format!(
+            "unittests ({})",
+            path.strip_prefix(cwd).unwrap_or(path).display()
+        )
+    };
+
+    let mut cmd = compilation.target_process(path, unit.kind, &unit.pkg, *script_meta)?;
+    cmd.args(test_args);
+    if unit.target.harness() && config.shell().verbosity() == Verbosity::Quiet {
+        cmd.arg("--quiet");
+    }
+
+    Ok((exe_display, cmd))
 }
 
 fn run_doc_tests(

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1209,6 +1209,8 @@ fn test_bench_no_run() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] bench [optimized] target(s) in [..]
+[EXECUTABLE] [..] (target/release/deps/foo-[..][EXE])
+[EXECUTABLE] [..] (target/release/deps/bbaz-[..][EXE])
 ",
         )
         .run();

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2074,6 +2074,7 @@ fn minimal_download() {
 [COMPILING] dev_dep v1.0.0
 [COMPILING] foo v0.1.0 [..]
 [FINISHED] [..]
+[EXECUTABLE] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
         .run();

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -596,6 +596,8 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] [..] (target/debug/deps/foo-[..][EXE])
+[EXECUTABLE] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
         .run();
@@ -1125,6 +1127,7 @@ fn reuse_workspace_lib() {
 [COMPILING] baz v0.1.1 ([..])
 [RUNNING] `rustc[..] --test [..]`
 [FINISHED] [..]
+[EXECUTABLE] `[..]/target/debug/deps/baz-[..][EXE]`
 ",
         )
         .run();
@@ -1376,6 +1379,7 @@ fn reuse_panic_build_dep_test() {
 [RUNNING] [..]build-script-build`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--test[..]
 [FINISHED] [..]
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 ",
         )
         .run();

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -849,6 +849,7 @@ fn fresh_swapping_commands() {
 [FRESH] bar v1.0.0
 [FRESH] foo [..]
 [FINISHED] [..]
+[EXECUTABLE] `[..]/target/release/deps/foo-[..][EXE]`
 ",
         )
         .run();

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -63,6 +63,7 @@ fn deduplicate_messages_basic() {
 warning: `foo` (lib) generated 1 warning
 warning: `foo` (lib test) generated 1 warning (1 duplicate)
 [FINISHED] [..]
+[EXECUTABLE] [..] (target/debug/deps/foo-[..][EXE])
 ",
         rustc_message
     );
@@ -106,6 +107,7 @@ warning: `foo` (lib) generated 1 warning
 {}\
 warning: `foo` (lib test) generated 2 warnings (1 duplicate)
 [FINISHED] [..]
+[EXECUTABLE] [..] (target/debug/deps/foo-[..][EXE])
 ",
         lib_output, lib_test_output
     );

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -490,6 +490,7 @@ fn test_with_dev_profile() {
 [COMPILING] foo v0.1.0 [..]
 [RUNNING] `rustc --crate-name foo [..]-C debuginfo=2[..]
 [FINISHED] [..]
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 ",
         )
         .run();

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -406,6 +406,9 @@ fn panic_unwind_does_not_build_twice() {
 [RUNNING] `rustc --crate-name foo src/main.rs [..] --test [..]
 [RUNNING] `rustc --crate-name t1 tests/t1.rs [..]
 [FINISHED] [..]
+[EXECUTABLE] `[..]/target/debug/deps/t1-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 ",
         )
         .run();

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1099,6 +1099,9 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/a-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/c-[..][EXE]`
 ",
         )
         .run();
@@ -1111,6 +1114,8 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] bench [optimized] target(s) in [..]
+[EXECUTABLE] `[..]/target/release/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/release/deps/a-[..][EXE]`
 ",
         )
         .run();
@@ -1181,6 +1186,9 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/a-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/c-[..][EXE]`
 ",
         )
         .run();
@@ -1193,6 +1201,8 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [FINISHED] bench [optimized] target(s) in [..]
+[EXECUTABLE] `[..]/target/release/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/release/deps/a-[..][EXE]`
 ",
         )
         .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1346,6 +1346,7 @@ fn test_no_run() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
         .run();
@@ -1963,6 +1964,7 @@ fn example_bin_same_name() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 ",
         )
         .run();
@@ -2498,6 +2500,9 @@ fn bin_does_not_rebuild_tests() {
 [RUNNING] `rustc [..] src/main.rs [..]`
 [RUNNING] `rustc [..] src/main.rs [..]`
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
+[EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 ",
         )
         .run();
@@ -2556,6 +2561,7 @@ fn selective_test_optional_dep() {
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[EXECUTABLE] `[..]/target/debug/deps/a-[..][EXE]`
 ",
         )
         .run();


### PR DESCRIPTION
Closes #9957