### PR TITLE
Allow binary-only dependencies in metadata

### DIFF
--- a/benches/benchsuite/benches/resolve.rs
+++ b/benches/benchsuite/benches/resolve.rs
@@ -2,7 +2,7 @@ use cargo::core::compiler::{CompileKind, RustcTargetData};
 use cargo::core::resolver::features::{CliFeatures, FeatureOpts, FeatureResolver, ForceAllTargets};
 use cargo::core::resolver::{HasDevUnits, ResolveBehavior};
 use cargo::core::{PackageIdSpec, Workspace};
-use cargo::ops::WorkspaceResolve;
+use cargo::ops::{BinaryOnlyDepsBehavior, WorkspaceResolve};
 use cargo::Config;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::fs;
@@ -198,6 +198,7 @@ fn do_resolve<'cfg>(config: &'cfg Config, ws_root: &Path) -> ResolveInfo<'cfg> {
         &specs,
         has_dev_units,
         force_all_targets,
+        BinaryOnlyDepsBehavior::Ignore,
     )
     .unwrap();
     ResolveInfo {
@@ -272,6 +273,7 @@ fn resolve_ws(c: &mut Criterion) {
                     specs,
                     *has_dev_units,
                     *force_all_targets,
+                    BinaryOnlyDepsBehavior::Ignore,
                 )
                 .unwrap();
             })

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -118,6 +118,7 @@ pub fn resolve_std<'cfg>(
         &specs,
         HasDevUnits::No,
         crate::core::resolver::features::ForceAllTargets::No,
+        ops::BinaryOnlyDepsBehavior::Warn,
     )?;
     Ok((
         resolve.pkg_set,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -569,6 +569,7 @@ impl<'cfg> PackageSet<'cfg> {
         requested_kinds: &[CompileKind],
         target_data: &RustcTargetData<'_>,
         force_all_targets: ForceAllTargets,
+        treat_binary_only_as_lib: bool,
     ) -> BTreeMap<PackageId, Vec<&Package>> {
         root_ids
             .iter()
@@ -583,7 +584,11 @@ impl<'cfg> PackageSet<'cfg> {
                 )
                 .filter_map(|package_id| {
                     if let Ok(dep_pkg) = self.get_one(package_id) {
-                        if !dep_pkg.targets().iter().any(|t| t.is_lib()) {
+                        if !dep_pkg
+                            .targets()
+                            .iter()
+                            .any(|t| t.is_lib() || (treat_binary_only_as_lib && t.is_bin()))
+                        {
                             Some(dep_pkg)
                         } else {
                             None

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -377,6 +377,7 @@ pub fn create_bcx<'a, 'cfg>(
         &specs,
         has_dev_units,
         crate::core::resolver::features::ForceAllTargets::No,
+        ops::BinaryOnlyDepsBehavior::Warn,
     )?;
     let WorkspaceResolve {
         mut pkg_set,

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -252,6 +252,7 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
             &specs,
             has_dev_units,
             crate::core::resolver::features::ForceAllTargets::No,
+            ops::BinaryOnlyDepsBehavior::Warn,
         )?;
 
         let feature_opts = FeatureOpts::new_behavior(ResolveBehavior::V2, has_dev_units);

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -12,7 +12,9 @@ pub use self::cargo_generate_lockfile::update_lockfile;
 pub use self::cargo_generate_lockfile::UpdateOptions;
 pub use self::cargo_install::{install, install_list};
 pub use self::cargo_new::{init, new, NewOptions, VersionControl};
-pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
+pub use self::cargo_output_metadata::{
+    output_metadata, BinaryDepsMode, ExportInfo, OutputMetadataOptions,
+};
 pub use self::cargo_package::{package, package_one, PackageOpts};
 pub use self::cargo_pkgid::pkgid;
 pub use self::cargo_read_manifest::{read_package, read_packages};
@@ -28,7 +30,7 @@ pub use self::registry::{needs_custom_http_transport, registry_login, registry_l
 pub use self::registry::{publish, registry_configuration, RegistryConfig};
 pub use self::resolve::{
     add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws, resolve_ws_with_opts,
-    WorkspaceResolve,
+    BinaryOnlyDepsBehavior, WorkspaceResolve,
 };
 pub use self::vendor::{vendor, VendorOptions};
 

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -69,6 +69,12 @@ pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolv
     Ok((packages, resolve))
 }
 
+#[derive(Eq, PartialEq)]
+pub enum BinaryOnlyDepsBehavior {
+    Warn,
+    Ignore,
+}
+
 /// Resolves dependencies for some packages of the workspace,
 /// taking into account `paths` overrides and activated features.
 ///
@@ -87,6 +93,7 @@ pub fn resolve_ws_with_opts<'cfg>(
     specs: &[PackageIdSpec],
     has_dev_units: HasDevUnits,
     force_all_targets: ForceAllTargets,
+    binary_only_deps_behaviour: BinaryOnlyDepsBehavior,
 ) -> CargoResult<WorkspaceResolve<'cfg>> {
     let mut registry = PackageRegistry::new(ws.config())?;
     let mut add_patches = true;
@@ -178,6 +185,7 @@ pub fn resolve_ws_with_opts<'cfg>(
         requested_targets,
         target_data,
         force_all_targets,
+        binary_only_deps_behaviour == BinaryOnlyDepsBehavior::Ignore,
     );
     for (pkg_id, dep_pkgs) in no_lib_pkgs {
         for dep_pkg in dep_pkgs {

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -158,6 +158,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         &specs,
         has_dev,
         force_all,
+        ops::BinaryOnlyDepsBehavior::Warn,
     )?;
 
     let package_map: HashMap<PackageId, &Package> = ws_resolve

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -2136,6 +2136,153 @@ fn deps_with_bin_only() {
             "#,
         )
         .run();
+
+    p.cargo("metadata")
+        .arg("--binary-deps=include-if-no-library-dep")
+        .with_json(
+            r#"
+            {
+              "metadata": null,
+              "packages": [
+                {
+                  "authors": [
+                    "wycats@example.com"
+                  ],
+                  "categories": [],
+                  "default_run": null,
+                  "dependencies": [],
+                  "description": null,
+                  "documentation": null,
+                  "edition": "2015",
+                  "features": {},
+                  "homepage": null,
+                  "id": "bdep 0.5.0 ([..])",
+                  "keywords": [],
+                  "license": null,
+                  "license_file": null,
+                  "links": null,
+                  "manifest_path": "[..]/foo/bdep/Cargo.toml",
+                  "metadata": null,
+                  "name": "bdep",
+                  "publish": null,
+                  "readme": null,
+                  "repository": null,
+                  "rust_version": null,
+                  "source": null,
+                  "targets": [
+                    {
+                      "crate_types": [
+                        "bin"
+                      ],
+                      "doc": true,
+                      "doctest": false,
+                      "edition": "2015",
+                      "kind": [
+                        "bin"
+                      ],
+                      "name": "bdep",
+                      "src_path": "[..]/foo/bdep/src/main.rs",
+                      "test": true
+                    }
+                  ],
+                  "version": "0.5.0"
+                },
+                {
+                  "authors": [],
+                  "categories": [],
+                  "default_run": null,
+                  "dependencies": [
+                    {
+                      "features": [],
+                      "kind": null,
+                      "name": "bdep",
+                      "optional": false,
+                      "path": "[..]/foo/bdep",
+                      "registry": null,
+                      "rename": null,
+                      "req": "*",
+                      "source": null,
+                      "target": null,
+                      "uses_default_features": true
+                    }
+                  ],
+                  "description": null,
+                  "documentation": null,
+                  "edition": "2015",
+                  "features": {},
+                  "homepage": null,
+                  "id": "foo 0.1.0 (path+file:/[..]/foo)",
+                  "keywords": [],
+                  "license": null,
+                  "license_file": null,
+                  "links": null,
+                  "manifest_path": "[..]/foo/Cargo.toml",
+                  "metadata": null,
+                  "name": "foo",
+                  "publish": null,
+                  "readme": null,
+                  "repository": null,
+                  "rust_version": null,
+                  "source": null,
+                  "targets": [
+                    {
+                      "crate_types": [
+                        "lib"
+                      ],
+                      "doc": true,
+                      "doctest": true,
+                      "edition": "2015",
+                      "kind": [
+                        "lib"
+                      ],
+                      "name": "foo",
+                      "src_path": "[..]/foo/src/lib.rs",
+                      "test": true
+                    }
+                  ],
+                  "version": "0.1.0"
+                }
+              ],
+              "resolve": {
+                "nodes": [
+                  {
+                    "dependencies": [],
+                    "deps": [],
+                    "features": [],
+                    "id": "bdep 0.5.0 (path+file:/[..]/foo/bdep)"
+                  },
+                  {
+                    "dependencies": [
+                      "bdep 0.5.0 (path+file:/[..]/foo/bdep)"
+                    ],
+                    "deps": [
+                      {
+                        "dep_kinds": [
+                          {
+                            "kind": "binary",
+                            "target": null
+                          }
+                        ],
+                        "name": "bdep",
+                        "pkg": "bdep 0.5.0 (path+file:/[..]/foo/bdep)"
+                      }
+                    ],
+                    "features": [],
+                    "id": "foo 0.1.0 (path+file:/[..]/foo)"
+                  }
+                ],
+                "root": "foo 0.1.0 (path+file:/[..]/foo)"
+              },
+              "target_directory": "[..]/foo/target",
+              "version": 1,
+              "workspace_members": [
+                "foo 0.1.0 (path+file:/[..]/foo)"
+              ],
+              "workspace_root": "[..]/foo"
+            }
+            "#,
+        )
+        .run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
A number of projects, such as https://github.com/google/cargo-raze
consume the output of `cargo metadata` when generating input to other
build systems, such as Bazel and Buck. Typically, these projects use a
`Cargo.toml` file as the input to drive their work, and it can be useful
to express to these systems that a binary is required as part of the
build.

If such a dependency happens to have a lib target, sufficient dependency
information happens to be exposed via the resolve field to recreate the
dependency structure adequately.

However, for binary-only targets, that entire branch of the dependency
tree is cut off, making it hard to recreate this information.

This PR adds an option to `cargo metadata` to allow rendering these
subtrees, describing these deps as of kind "binary". This isn't really a
concept in cargo-proper, but may become one via
https://github.com/rust-lang/rfcs/pull/3168 and/or
https://github.com/rust-lang/rfcs/pull/3028 - this output format is
forwards-compatible with these proposals.

In an RFC 3028 world, binary deps would appear as `dep_kind` "binary",
and `cdylib` or `staticlib` deps would appear as new `DepKind` variants.
We'd probably add a new value of the flag, `declared`, and set that to
be the default. We may also want to deprecate the
`include-if-no-library-dep` value, and make these ignored binary deps a
hard error (replacing the existing warning log).

In an RFC 3168 world, there's an interesting metadata question to have -
there are (at least) three reasonable options in terms of handling
metadata:
1. Require a direct dependency on any package whose binary deps are
   being used from the crate which uses them - this gives a nicely
   restricted search space, and allows for nicely curated metadata
   output.
2. Allow any transitive package dependencies to be used as binary deps -
   this may significantly expand the output produced, but would model
   the implementation of the feature.
3. Require explicitly tagging binary deps as being used as binary deps -
   this looks a lot like RFC 3028, and would tend in that direction.