### PR TITLE
Fix test: hash value depends on endianness and bitness.

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -618,10 +618,9 @@ impl Ord for SourceKind {
 // Otherwise please just leave a comment in your PR as to why the hash value is
 // changing and why the old value can't be easily preserved.
 //
-// The hash value differs depending on endianess and bit-width since Rust 1.45
-// (see https://github.com/rust-lang/rust/issues/74215). We run this test only
-// on 64-bit little-endian platforms which are most commonly used for
-// development and tested in CI.
+// The hash value depends on endianness and bit-width, so we only run this test on 
+// little-endian 64-bit CPUs (such as x86-64 and ARM64) where it matches the 
+// well-known value.
 #[test]
 #[cfg(all(target_endian = "little", target_pointer_width = "64"))]
 fn test_cratesio_hash() {

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -618,8 +618,8 @@ impl Ord for SourceKind {
 // Otherwise please just leave a comment in your PR as to why the hash value is
 // changing and why the old value can't be easily preserved.
 //
-// The hash value depends on endianness and bit-width, so we only run this test on 
-// little-endian 64-bit CPUs (such as x86-64 and ARM64) where it matches the 
+// The hash value depends on endianness and bit-width, so we only run this test on
+// little-endian 64-bit CPUs (such as x86-64 and ARM64) where it matches the
 // well-known value.
 #[test]
 #[cfg(all(target_endian = "little", target_pointer_width = "64"))]

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -617,7 +617,13 @@ impl Ord for SourceKind {
 // you're able to restore the hash to its original value, please do so!
 // Otherwise please just leave a comment in your PR as to why the hash value is
 // changing and why the old value can't be easily preserved.
+//
+// The hash value differs depending on endianess and bit-width since Rust 1.45
+// (see https://github.com/rust-lang/rust/issues/74215). We run this test only
+// on 64-bit little-endian platforms which are most commonly used for
+// development and tested in CI.
 #[test]
+#[cfg(all(target_endian = "little", target_pointer_width = "64"))]
 fn test_cratesio_hash() {
     let config = Config::default().unwrap();
     let crates_io = SourceId::crates_io(&config).unwrap();


### PR DESCRIPTION
The test fails on 32-bit systems and on big-endian systems since Rust 1.44.

Fixes #10004.