### PR TITLE
Change --scrape-examples flag to -Z rustdoc-scrape-examples

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -654,6 +654,9 @@ unstable_cli_options!(
     timings: Option<Vec<String>>  = ("Display concurrency information"),
     unstable_options: bool = ("Allow the usage of unstable options"),
     weak_dep_features: bool = ("Allow `dep_name?/feature` feature syntax"),
+    // TODO(wcrichto): move scrape example configuration into Cargo.toml before stabilization
+    // See: https://github.com/rust-lang/cargo/pull/9525#discussion_r728470927
+    rustdoc_scrape_examples: Option<String> = ("Allow rustdoc to scrape examples from reverse-dependencies for documentation"),
     skip_rustdoc_fingerprint: bool = (HIDDEN),
 );
 
@@ -871,6 +874,7 @@ impl CliUnstable {
             "namespaced-features" => self.namespaced_features = parse_empty(k, v)?,
             "weak-dep-features" => self.weak_dep_features = parse_empty(k, v)?,
             "credential-process" => self.credential_process = parse_empty(k, v)?,
+            "rustdoc-scrape-examples" => self.rustdoc_scrape_examples = v.map(|s| s.to_string()),
             "skip-rustdoc-fingerprint" => self.skip_rustdoc_fingerprint = parse_empty(k, v)?,
             "compile-progress" => stabilized_warn(k, "1.30", STABILIZED_COMPILE_PROGRESS),
             "offline" => stabilized_err(k, "1.36", STABILIZED_OFFLINE)?,

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -765,7 +765,6 @@ fn run_verify(
             target_rustc_args: rustc_args,
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
-            rustdoc_scrape_examples: None,
             honor_rust_version: true,
         },
         &exec,

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -544,7 +544,6 @@ pub trait ArgMatchesExt {
             target_rustc_args: None,
             local_rustdoc_args: None,
             rustdoc_document_private_items: false,
-            rustdoc_scrape_examples: None,
             honor_rust_version: !self._is_present("ignore-rust-version"),
         };
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1390,11 +1390,11 @@ Custom named profiles have been stabilized in the 1.57 release. See the
 * RFC: [#3123](https://github.com/rust-lang/rfcs/pull/3123)
 * Tracking Issue: [#9910](https://github.com/rust-lang/cargo/issues/9910)
 
-The `--scrape-examples` argument to the `doc` command tells Rustdoc to search
-crates in the current workspace for calls to functions. Those call-sites are then
-included as documentation. The flag can take an argument of `all` or `examples`
-which configures which crate in the workspace to analyze for examples. For instance:
+The `-Z rustdoc-scrape-examples` argument tells Rustdoc to search crates in the current workspace
+for calls to functions. Those call-sites are then included as documentation. The flag can take an
+argument of `all` or `examples` which configures which crate in the workspace to analyze for examples.
+For instance:
 
 ```
-cargo doc -Z unstable-options --scrape-examples examples
+cargo doc -Z unstable-options -Z rustdoc-scrape-examples=examples
 ```

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2152,7 +2152,7 @@ fn doc_fingerprint_unusual_behavior() {
 #[cargo_test]
 fn scrape_examples_basic() {
     if !is_nightly() {
-        // --scrape-examples is unstable
+        // -Z rustdoc-scrape-examples is unstable
         return;
     }
 
@@ -2170,7 +2170,7 @@ fn scrape_examples_basic() {
         .file("src/lib.rs", "pub fn foo() {}\npub fn bar() { foo(); }")
         .build();
 
-    p.cargo("doc -Zunstable-options --scrape-examples all")
+    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
@@ -2192,7 +2192,7 @@ fn scrape_examples_basic() {
 #[cargo_test]
 fn scrape_examples_avoid_build_script_cycle() {
     if !is_nightly() {
-        // --scrape-examples is unstable
+        // -Z rustdoc-scrape-examples is unstable
         return;
     }
 
@@ -2231,7 +2231,7 @@ fn scrape_examples_avoid_build_script_cycle() {
         .file("bar/build.rs", "fn main(){}")
         .build();
 
-    p.cargo("doc --all -Zunstable-options --scrape-examples all")
+    p.cargo("doc --all -Zunstable-options -Z rustdoc-scrape-examples=all")
         .masquerade_as_nightly_cargo()
         .run();
 }
@@ -2239,7 +2239,7 @@ fn scrape_examples_avoid_build_script_cycle() {
 #[cargo_test]
 fn scrape_examples_complex_reverse_dependencies() {
     if !is_nightly() {
-        // --scrape-examples is unstable
+        // -Z rustdoc-scrape-examples is unstable
         return;
     }
 
@@ -2293,7 +2293,7 @@ fn scrape_examples_complex_reverse_dependencies() {
         .file("b/src/lib.rs", "")
         .build();
 
-    p.cargo("doc -Zunstable-options --scrape-examples all")
+    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
         .masquerade_as_nightly_cargo()
         .run();
 }


### PR DESCRIPTION
I'm working on getting the scrape examples feature working on docs.rs. However, docs.rs uses `cargo rustdoc` instead of `cargo doc`, and right now the `--scrape-examples` flag is only allowed for `cargo doc`. So this PR changes it to a `-Z` flag that can be passed to either command.