### PR TITLE
Chore: prefer `HashMap::from` rather than collecting `Vec` of tuples

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -15,10 +15,10 @@ lazy_static::lazy_static! {
     // Maps from commonly known external commands (not builtin to cargo) to their
     // description, for the help page. Reserved for external subcommands that are
     // core within the rust ecosystem (esp ones that might become internal in the future).
-    static ref KNOWN_EXTERNAL_COMMAND_DESCRIPTIONS: HashMap<&'static str, &'static str> = vec![
+    static ref KNOWN_EXTERNAL_COMMAND_DESCRIPTIONS: HashMap<&'static str, &'static str> = HashMap::from([
         ("clippy", "Checks a package to catch common mistakes and improve your Rust code."),
         ("fmt", "Formats all bin and lib files of the current crate using rustfmt."),
-    ].into_iter().collect();
+    ]);
 }
 
 pub fn main(config: &mut Config) -> CliResult {


### PR DESCRIPTION
Hello there! Since Cargo upgraded to the 2021 Edition recently (which implies a `rust-version` of `1.56` or greater), I figured now may be a good time to use the new [`HashMap::from` shortcut](https://doc.rust-lang.org/stable/std/collections/struct.HashMap.html#impl-From%3C%5B(K%2C%20V)%3B%20N%5D%3E) of rust-lang/rust#84111. There should be no change in behavior here, but it does make the code a little bit neater! 🎉