### PR TITLE
Fix --scrape-examples-target-crate using package name (with dashes) instead of crate name (with underscores)

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -21,6 +21,7 @@ mod unit;
 pub mod unit_dependencies;
 pub mod unit_graph;
 
+use std::collections::HashSet;
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
@@ -666,9 +667,14 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
 
         // Only scrape example for items from crates in the workspace, to reduce generated file size
         for pkg in cx.bcx.ws.members() {
-            rustdoc
-                .arg("--scrape-examples-target-crate")
-                .arg(pkg.name());
+            let names = pkg
+                .targets()
+                .iter()
+                .map(|target| target.crate_name())
+                .collect::<HashSet<_>>();
+            for name in names {
+                rustdoc.arg("--scrape-examples-target-crate").arg(name);
+            }
         }
     } else if cx.bcx.scrape_units.len() > 0 && cx.bcx.ws.is_member(&unit.pkg) {
         // We only pass scraped examples to packages in the workspace

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2297,3 +2297,32 @@ fn scrape_examples_complex_reverse_dependencies() {
         .masquerade_as_nightly_cargo()
         .run();
 }
+
+#[cargo_test]
+fn scrape_examples_crate_with_dash() {
+    if !is_nightly() {
+        // -Z rustdoc-scrape-examples is unstable
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "da-sh"
+                version = "0.0.1"
+                authors = []
+            "#,
+        )
+        .file("src/lib.rs", "pub fn foo() {}")
+        .file("examples/a.rs", "fn main() { da_sh::foo(); }")
+        .build();
+
+    p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
+        .masquerade_as_nightly_cargo()
+        .run();
+
+    let doc_html = p.read_file("target/doc/da_sh/fn.foo.html");
+    assert!(doc_html.contains("Examples found in repository"));
+}


### PR DESCRIPTION
This PR fixes #10035.