### PR TITLE
Give a hard error if `-Zrustdoc-scrape-examples` is missing a flag

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -874,7 +874,15 @@ impl CliUnstable {
             "namespaced-features" => self.namespaced_features = parse_empty(k, v)?,
             "weak-dep-features" => self.weak_dep_features = parse_empty(k, v)?,
             "credential-process" => self.credential_process = parse_empty(k, v)?,
-            "rustdoc-scrape-examples" => self.rustdoc_scrape_examples = v.map(|s| s.to_string()),
+            "rustdoc-scrape-examples" => {
+                if let Some(s) = v {
+                    self.rustdoc_scrape_examples = Some(s.to_string())
+                } else {
+                    bail!(
+                        r#"-Z rustdoc-scrape-examples must take "all" or "examples" as an argument"#
+                    )
+                }
+            }
             "skip-rustdoc-fingerprint" => self.skip_rustdoc_fingerprint = parse_empty(k, v)?,
             "compile-progress" => stabilized_warn(k, "1.30", STABILIZED_COMPILE_PROGRESS),
             "offline" => stabilized_err(k, "1.36", STABILIZED_OFFLINE)?,

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2326,3 +2326,28 @@ fn scrape_examples_crate_with_dash() {
     let doc_html = p.read_file("target/doc/da_sh/fn.foo.html");
     assert!(doc_html.contains("Examples found in repository"));
 }
+
+#[cargo_test]
+fn scrape_examples_missing_flag() {
+    if !is_nightly() {
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.2.4"
+            authors = []
+        "#,
+        )
+        .file("src/lib.rs", "//! These are the docs!")
+        .build();
+    p.cargo("doc -Zrustdoc-scrape-examples")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr("error: -Z rustdoc-scrape-examples must take [..] an argument")
+        .run();
+}


### PR DESCRIPTION
It's the same as if the option wasn't passed, and it makes it difficult to
figure out why rustdoc isn't generating examples.

Fixes https://github.com/rust-lang/cargo/issues/10042 (cc @willcrichton)