### PR TITLE
Registry functions return Poll to enable parallel fetching of index data

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -7,6 +7,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 use std::fmt::Write;
 use std::rc::Rc;
+use std::task::Poll;
 use std::time::Instant;
 
 use cargo::core::dependency::DepKind;
@@ -129,14 +130,14 @@ pub fn resolve_with_config_raw(
             dep: &Dependency,
             f: &mut dyn FnMut(Summary),
             fuzzy: bool,
-        ) -> CargoResult<()> {
+        ) -> Poll<CargoResult<()>> {
             for summary in self.list.iter() {
                 if fuzzy || dep.matches(summary) {
                     self.used.insert(summary.package_id());
                     f(summary.clone());
                 }
             }
-            Ok(())
+            Poll::Ready(Ok(()))
         }
 
         fn describe_source(&self, _src: SourceId) -> String {
@@ -145,6 +146,10 @@ pub fn resolve_with_config_raw(
 
         fn is_replaced(&self, _src: SourceId) -> bool {
             false
+        }
+
+        fn block_until_ready(&mut self) -> CargoResult<()> {
+            Ok(())
         }
     }
     impl<'a> Drop for MyRegistry<'a> {

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write as _;
 use std::io::{Read, Write};
+use std::task::Poll;
 
 pub const REPORT_PREAMBLE: &str = "\
 The following warnings were discovered during the build. These warnings are an
@@ -264,7 +265,7 @@ fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<
     let _lock = ws.config().acquire_package_cache_lock().ok()?;
     // Create a set of updated registry sources.
     let map = SourceConfigMap::new(ws.config()).ok()?;
-    let package_ids: BTreeSet<_> = package_ids
+    let mut package_ids: BTreeSet<_> = package_ids
         .iter()
         .filter(|pkg_id| pkg_id.source_id().is_registry())
         .collect();
@@ -279,15 +280,35 @@ fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<
             Some((sid, source))
         })
         .collect();
-    // Query the sources for new versions.
+
+    // Query the sources for available versions, mapping `package_ids` into `summaries`.
+    let mut summaries = Vec::new();
+    while !package_ids.is_empty() {
+        package_ids.retain(|&pkg_id| {
+            let source = match sources.get_mut(&pkg_id.source_id()) {
+                Some(s) => s,
+                None => return false,
+            };
+            let dep = match Dependency::parse(pkg_id.name(), None, pkg_id.source_id()) {
+                Ok(dep) => dep,
+                Err(_) => return false,
+            };
+            match source.query_vec(&dep) {
+                Poll::Ready(Ok(sum)) => {
+                    summaries.push((pkg_id, sum));
+                    false
+                }
+                Poll::Ready(Err(_)) => false,
+                Poll::Pending => true,
+            }
+        });
+        for (_, source) in sources.iter_mut() {
+            source.block_until_ready().ok()?;
+        }
+    }
+
     let mut updates = String::new();
-    for pkg_id in package_ids {
-        let source = match sources.get_mut(&pkg_id.source_id()) {
-            Some(s) => s,
-            None => continue,
-        };
-        let dep = Dependency::parse(pkg_id.name(), None, pkg_id.source_id()).ok()?;
-        let summaries = source.query_vec(&dep).ok()?;
+    for (pkg_id, summaries) in summaries {
         let mut updated_versions: Vec<_> = summaries
             .iter()
             .map(|summary| summary.version())

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -281,7 +281,7 @@ fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<
         })
         .collect();
 
-    // Query the sources for available versions, mapping `package_ids` into `summaries`.
+    // Query the sources for new versions, mapping `package_ids` into `summaries`.
     let mut summaries = Vec::new();
     while !package_ids.is_empty() {
         package_ids.retain(|&pkg_id| {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -678,7 +678,9 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
                     // the summaries it gives us though.
                     (Some(override_summary), Some(source)) => {
                         if !patches.is_empty() {
-                            return Poll::Ready(Err(anyhow::anyhow!("found patches and a path override")))
+                            return Poll::Ready(Err(anyhow::anyhow!(
+                                "found patches and a path override"
+                            )));
                         }
                         let mut n = 0;
                         let mut to_warn = None;
@@ -703,7 +705,9 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
         };
 
         if n > 1 {
-            return Poll::Ready(Err(anyhow::anyhow!("found an override with a non-locked list")))
+            return Poll::Ready(Err(anyhow::anyhow!(
+                "found an override with a non-locked list"
+            )));
         } else if let Some(summary) = to_warn {
             self.warn_bad_override(&override_summary, &summary)?;
         }
@@ -874,7 +878,7 @@ fn summary_for_patch(
             orig_patch.source_id(),
             versions.join(", "),
             versions.last().unwrap()
-        )))
+        )));
     }
     assert!(summaries.is_empty());
     // No summaries found, try to help the user figure out what is wrong.

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -24,6 +24,7 @@ use anyhow::Context as _;
 use log::debug;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
+use std::task::Poll;
 
 pub struct RegistryQueryer<'a> {
     pub registry: &'a mut (dyn Registry + 'a),
@@ -34,11 +35,11 @@ pub struct RegistryQueryer<'a> {
     /// specify minimum dependency versions to be used.
     minimal_versions: bool,
     /// a cache of `Candidate`s that fulfil a `Dependency`
-    registry_cache: HashMap<Dependency, Rc<Vec<Summary>>>,
+    registry_cache: HashMap<Dependency, Poll<Rc<Vec<Summary>>>>,
     /// a cache of `Dependency`s that are required for a `Summary`
     summary_cache: HashMap<
         (Option<PackageId>, Summary, ResolveOpts),
-        Rc<(HashSet<InternedString>, Rc<Vec<DepInfo>>)>,
+        (Rc<(HashSet<InternedString>, Rc<Vec<DepInfo>>)>, bool),
     >,
     /// all the cases we ended up using a supplied replacement
     used_replacements: HashMap<PackageId, Summary>,
@@ -62,6 +63,23 @@ impl<'a> RegistryQueryer<'a> {
         }
     }
 
+    pub fn reset_pending(&mut self) -> bool {
+        let mut all_ready = true;
+        self.registry_cache.retain(|_, r| {
+            if !r.is_ready() {
+                all_ready = false;
+            }
+            r.is_ready()
+        });
+        self.summary_cache.retain(|_, (_, r)| {
+            if !*r {
+                all_ready = false;
+            }
+            *r
+        });
+        all_ready
+    }
+
     pub fn used_replacement_for(&self, p: PackageId) -> Option<(PackageId, PackageId)> {
         self.used_replacements.get(&p).map(|r| (p, r.package_id()))
     }
@@ -76,19 +94,23 @@ impl<'a> RegistryQueryer<'a> {
     /// any candidates are returned which match an override then the override is
     /// applied by performing a second query for what the override should
     /// return.
-    pub fn query(&mut self, dep: &Dependency) -> CargoResult<Rc<Vec<Summary>>> {
+    pub fn query(&mut self, dep: &Dependency) -> Poll<CargoResult<Rc<Vec<Summary>>>> {
         if let Some(out) = self.registry_cache.get(dep).cloned() {
-            return Ok(out);
+            return out.map(Result::Ok);
         }
 
         let mut ret = Vec::new();
-        self.registry.query(
+        let ready = self.registry.query(
             dep,
             &mut |s| {
                 ret.push(s);
             },
             false,
         )?;
+        if ready.is_pending() {
+            self.registry_cache.insert(dep.clone(), Poll::Pending);
+            return Poll::Pending;
+        }
         for summary in ret.iter_mut() {
             let mut potential_matches = self
                 .replacements
@@ -105,7 +127,13 @@ impl<'a> RegistryQueryer<'a> {
                 dep.version_req()
             );
 
-            let mut summaries = self.registry.query_vec(dep, false)?.into_iter();
+            let mut summaries = match self.registry.query_vec(dep, false)? {
+                Poll::Ready(s) => s.into_iter(),
+                Poll::Pending => {
+                    self.registry_cache.insert(dep.clone(), Poll::Pending);
+                    return Poll::Pending;
+                }
+            };
             let s = summaries.next().ok_or_else(|| {
                 anyhow::format_err!(
                     "no matching package for override `{}` found\n\
@@ -122,13 +150,14 @@ impl<'a> RegistryQueryer<'a> {
                     .iter()
                     .map(|s| format!("  * {}", s.package_id()))
                     .collect::<Vec<_>>();
-                anyhow::bail!(
+                return Err(anyhow::anyhow!(
                     "the replacement specification `{}` matched \
                      multiple packages:\n  * {}\n{}",
                     spec,
                     s.package_id(),
                     bullets.join("\n")
-                );
+                ))
+                .into();
             }
 
             // The dependency should be hard-coded to have the same name and an
@@ -147,13 +176,14 @@ impl<'a> RegistryQueryer<'a> {
 
             // Make sure no duplicates
             if let Some(&(ref spec, _)) = potential_matches.next() {
-                anyhow::bail!(
+                return Err(anyhow::anyhow!(
                     "overlapping replacement specifications found:\n\n  \
                      * {}\n  * {}\n\nboth specifications match: {}",
                     matched_spec,
                     spec,
                     summary.package_id()
-                );
+                ))
+                .into();
             }
 
             for dep in summary.dependencies() {
@@ -175,11 +205,11 @@ impl<'a> RegistryQueryer<'a> {
             },
         );
 
-        let out = Rc::new(ret);
+        let out = Poll::Ready(Rc::new(ret));
 
         self.registry_cache.insert(dep.clone(), out.clone());
 
-        Ok(out)
+        out.map(Result::Ok)
     }
 
     /// Find out what dependencies will be added by activating `candidate`,
@@ -198,9 +228,8 @@ impl<'a> RegistryQueryer<'a> {
         if let Some(out) = self
             .summary_cache
             .get(&(parent, candidate.clone(), opts.clone()))
-            .cloned()
         {
-            return Ok(out);
+            return Ok(out.0.clone());
         }
         // First, figure out our set of dependencies based on the requested set
         // of features. This also calculates what features we're going to enable
@@ -209,17 +238,22 @@ impl<'a> RegistryQueryer<'a> {
 
         // Next, transform all dependencies into a list of possible candidates
         // which can satisfy that dependency.
+        let mut all_ready = true;
         let mut deps = deps
             .into_iter()
-            .map(|(dep, features)| {
-                let candidates = self.query(&dep).with_context(|| {
+            .filter_map(|(dep, features)| match self.query(&dep) {
+                Poll::Ready(Ok(candidates)) => Some(Ok((dep, candidates, features))),
+                Poll::Pending => {
+                    all_ready = false;
+                    None // we can ignore Pending deps, resolve will be repeatedly called until there are none to ignore
+                }
+                Poll::Ready(Err(e)) => Some(Err(e).with_context(|| {
                     format!(
                         "failed to get `{}` as a dependency of {}",
                         dep.package_name(),
                         describe_path_in_context(cx, &candidate.package_id()),
                     )
-                })?;
-                Ok((dep, candidates, features))
+                })),
             })
             .collect::<CargoResult<Vec<DepInfo>>>()?;
 
@@ -233,8 +267,10 @@ impl<'a> RegistryQueryer<'a> {
 
         // If we succeed we add the result to the cache so we can use it again next time.
         // We don't cache the failure cases as they don't impl Clone.
-        self.summary_cache
-            .insert((parent, candidate.clone(), opts.clone()), out.clone());
+        self.summary_cache.insert(
+            (parent, candidate.clone(), opts.clone()),
+            (out.clone(), all_ready),
+        );
 
         Ok(out)
     }

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -213,133 +213,140 @@ pub(super) fn activation_error(
     // give an error message that nothing was found.
     //
     // Maybe the user mistyped the ver_req? Like `dep="2"` when `dep="0.2"`
-    // was meant. So we re-query the registry with `deb="*"` so we can
+    // was meant. So we re-query the registry with `dep="*"` so we can
     // list a few versions that were actually found.
     let all_req = semver::VersionReq::parse("*").unwrap();
     let mut new_dep = dep.clone();
     new_dep.set_version_req(all_req);
 
-    let mut candidates = Vec::new();
-    // TODO: we can ignore the `Pending` case because we are just in an error reporting path,
-    // and we have probably already triggered the query anyway. But, if we start getting reports
-    // of confusing errors that go away when called again this is a place to look.
-    if let Poll::Ready(Err(e)) = registry.query(&new_dep, &mut |s| candidates.push(s), false) {
-        return to_resolve_err(e);
+    let mut candidates = loop {
+        match registry.query_vec(&new_dep, false) {
+            Poll::Ready(Ok(candidates)) => break candidates,
+            Poll::Ready(Err(e)) => return to_resolve_err(e),
+            Poll::Pending => match registry.block_until_ready() {
+                Ok(()) => continue,
+                Err(e) => return to_resolve_err(e),
+            },
+        }
     };
+
     candidates.sort_unstable_by(|a, b| b.version().cmp(a.version()));
 
-    let mut msg = if !candidates.is_empty() {
-        let versions = {
-            let mut versions = candidates
-                .iter()
-                .take(3)
-                .map(|cand| cand.version().to_string())
-                .collect::<Vec<_>>();
-
-            if candidates.len() > 3 {
-                versions.push("...".into());
-            }
-
-            versions.join(", ")
-        };
-
-        let mut msg = format!(
-            "failed to select a version for the requirement `{} = \"{}\"`\n\
-                 candidate versions found which didn't match: {}\n\
-                 location searched: {}\n",
-            dep.package_name(),
-            dep.version_req(),
-            versions,
-            registry.describe_source(dep.source_id()),
-        );
-        msg.push_str("required by ");
-        msg.push_str(&describe_path_in_context(cx, &parent.package_id()));
-
-        // If we have a path dependency with a locked version, then this may
-        // indicate that we updated a sub-package and forgot to run `cargo
-        // update`. In this case try to print a helpful error!
-        if dep.source_id().is_path() && dep.version_req().to_string().starts_with('=') {
-            msg.push_str(
-                "\nconsider running `cargo update` to update \
-                     a path dependency's locked version",
-            );
-        }
-
-        if registry.is_replaced(dep.source_id()) {
-            msg.push_str("\nperhaps a crate was updated and forgotten to be re-vendored?");
-        }
-
-        msg
-    } else {
-        // Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
-        // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
-        let mut candidates = Vec::new();
-        if let Poll::Ready(Err(e)) = registry.query(&new_dep, &mut |s| candidates.push(s), true) {
-            // TODO: we can ignore the `Pending` case because we are just in an error reporting path,
-            // and we have probably already triggered the query anyway. But, if we start getting reports
-            // of confusing errors that go away when called again this is a place to look.
-            return to_resolve_err(e);
-        };
-        candidates.sort_unstable_by_key(|a| a.name());
-        candidates.dedup_by(|a, b| a.name() == b.name());
-        let mut candidates: Vec<_> = candidates
-            .iter()
-            .map(|n| (lev_distance(&*new_dep.package_name(), &*n.name()), n))
-            .filter(|&(d, _)| d < 4)
-            .collect();
-        candidates.sort_by_key(|o| o.0);
-        let mut msg: String;
-        if candidates.is_empty() {
-            msg = format!("no matching package named `{}` found\n", dep.package_name());
-        } else {
-            msg = format!(
-                "no matching package found\nsearched package name: `{}`\n",
-                dep.package_name()
-            );
-
-            // If dependency package name is equal to the name of the candidate here
-            // it may be a prerelease package which hasn't been specified correctly
-            if dep.package_name() == candidates[0].1.name()
-                && candidates[0].1.package_id().version().is_prerelease()
-            {
-                msg.push_str("prerelease package needs to be specified explicitly\n");
-                msg.push_str(&format!(
-                    "{name} = {{ version = \"{version}\" }}",
-                    name = candidates[0].1.name(),
-                    version = candidates[0].1.package_id().version()
-                ));
-            } else {
-                let mut names = candidates
+    let mut msg =
+        if !candidates.is_empty() {
+            let versions = {
+                let mut versions = candidates
                     .iter()
                     .take(3)
-                    .map(|c| c.1.name().as_str())
+                    .map(|cand| cand.version().to_string())
                     .collect::<Vec<_>>();
 
                 if candidates.len() > 3 {
-                    names.push("...");
+                    versions.push("...".into());
                 }
-                // Vertically align first suggestion with missing crate name
-                // so a typo jumps out at you.
-                msg.push_str("perhaps you meant:      ");
+
+                versions.join(", ")
+            };
+
+            let mut msg = format!(
+                "failed to select a version for the requirement `{} = \"{}\"`\n\
+                 candidate versions found which didn't match: {}\n\
+                 location searched: {}\n",
+                dep.package_name(),
+                dep.version_req(),
+                versions,
+                registry.describe_source(dep.source_id()),
+            );
+            msg.push_str("required by ");
+            msg.push_str(&describe_path_in_context(cx, &parent.package_id()));
+
+            // If we have a path dependency with a locked version, then this may
+            // indicate that we updated a sub-package and forgot to run `cargo
+            // update`. In this case try to print a helpful error!
+            if dep.source_id().is_path() && dep.version_req().to_string().starts_with('=') {
                 msg.push_str(
-                    &names
+                    "\nconsider running `cargo update` to update \
+                     a path dependency's locked version",
+                );
+            }
+
+            if registry.is_replaced(dep.source_id()) {
+                msg.push_str("\nperhaps a crate was updated and forgotten to be re-vendored?");
+            }
+
+            msg
+        } else {
+            // Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
+            // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
+            let mut candidates = loop {
+                match registry.query_vec(&new_dep, true) {
+                    Poll::Ready(Ok(candidates)) => break candidates,
+                    Poll::Ready(Err(e)) => return to_resolve_err(e),
+                    Poll::Pending => match registry.block_until_ready() {
+                        Ok(()) => continue,
+                        Err(e) => return to_resolve_err(e),
+                    },
+                }
+            };
+
+            candidates.sort_unstable_by_key(|a| a.name());
+            candidates.dedup_by(|a, b| a.name() == b.name());
+            let mut candidates: Vec<_> = candidates
+                .iter()
+                .map(|n| (lev_distance(&*new_dep.package_name(), &*n.name()), n))
+                .filter(|&(d, _)| d < 4)
+                .collect();
+            candidates.sort_by_key(|o| o.0);
+            let mut msg: String;
+            if candidates.is_empty() {
+                msg = format!("no matching package named `{}` found\n", dep.package_name());
+            } else {
+                msg = format!(
+                    "no matching package found\nsearched package name: `{}`\n",
+                    dep.package_name()
+                );
+
+                // If dependency package name is equal to the name of the candidate here
+                // it may be a prerelease package which hasn't been specified correctly
+                if dep.package_name() == candidates[0].1.name()
+                    && candidates[0].1.package_id().version().is_prerelease()
+                {
+                    msg.push_str("prerelease package needs to be specified explicitly\n");
+                    msg.push_str(&format!(
+                        "{name} = {{ version = \"{version}\" }}",
+                        name = candidates[0].1.name(),
+                        version = candidates[0].1.package_id().version()
+                    ));
+                } else {
+                    let mut names = candidates
                         .iter()
-                        .enumerate()
-                        .fold(String::default(), |acc, (i, el)| match i {
+                        .take(3)
+                        .map(|c| c.1.name().as_str())
+                        .collect::<Vec<_>>();
+
+                    if candidates.len() > 3 {
+                        names.push("...");
+                    }
+                    // Vertically align first suggestion with missing crate name
+                    // so a typo jumps out at you.
+                    msg.push_str("perhaps you meant:      ");
+                    msg.push_str(&names.iter().enumerate().fold(
+                        String::default(),
+                        |acc, (i, el)| match i {
                             0 => acc + el,
                             i if names.len() - 1 == i && candidates.len() <= 3 => acc + " or " + el,
                             _ => acc + ", " + el,
-                        }),
-                );
+                        },
+                    ));
+                }
+                msg.push('\n');
             }
-            msg.push('\n');
-        }
-        msg.push_str(&format!("location searched: {}\n", dep.source_id()));
-        msg.push_str("required by ");
-        msg.push_str(&describe_path_in_context(cx, &parent.package_id()));
+            msg.push_str(&format!("location searched: {}\n", dep.source_id()));
+            msg.push_str("required by ");
+            msg.push_str(&describe_path_in_context(cx, &parent.package_id()));
 
-        msg
-    };
+            msg
+        };
 
     if let Some(config) = config {
         if config.offline() {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::HashMap;
 use std::fmt;
+use std::task::Poll;
 
 use crate::core::package::PackageSet;
 use crate::core::{Dependency, Package, PackageId, Summary};
@@ -28,18 +29,21 @@ pub trait Source {
     fn requires_precise(&self) -> bool;
 
     /// Attempts to find the packages that match a dependency request.
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()>;
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>>;
 
     /// Attempts to find the packages that are close to a dependency request.
     /// Each source gets to define what `close` means for it.
     /// Path/Git sources may return all dependencies that are at that URI,
     /// whereas an `Index` source may return dependencies that have the same canonicalization.
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()>;
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>>;
 
-    fn query_vec(&mut self, dep: &Dependency) -> CargoResult<Vec<Summary>> {
+    fn query_vec(&mut self, dep: &Dependency) -> Poll<CargoResult<Vec<Summary>>> {
         let mut ret = Vec::new();
-        self.query(dep, &mut |s| ret.push(s))?;
-        Ok(ret)
+        self.query(dep, &mut |s| ret.push(s)).map_ok(|_| ret)
     }
 
     /// Performs any network operations required to get the entire list of all names,
@@ -101,6 +105,9 @@ pub trait Source {
     /// Query if a package is yanked. Only registry sources can mark packages
     /// as yanked. This ignores the yanked whitelist.
     fn is_yanked(&mut self, _pkg: PackageId) -> CargoResult<bool>;
+
+    /// Block until all outstanding Poll::Pending requests are Poll::Ready.
+    fn block_until_ready(&mut self) -> CargoResult<()>;
 }
 
 pub enum MaybePackage {
@@ -130,12 +137,16 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     }
 
     /// Forwards to `Source::query`.
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
         (**self).query(dep, f)
     }
 
     /// Forwards to `Source::query`.
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
         (**self).fuzzy_query(dep, f)
     }
 
@@ -178,6 +189,10 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     fn is_yanked(&mut self, pkg: PackageId) -> CargoResult<bool> {
         (**self).is_yanked(pkg)
     }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        (**self).block_until_ready()
+    }
 }
 
 impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
@@ -197,11 +212,15 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
         (**self).requires_precise()
     }
 
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
         (**self).query(dep, f)
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
         (**self).fuzzy_query(dep, f)
     }
 
@@ -239,6 +258,10 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
 
     fn is_yanked(&mut self, pkg: PackageId) -> CargoResult<bool> {
         (**self).is_yanked(pkg)
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        (**self).block_until_ready()
     }
 }
 

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -46,9 +46,8 @@ pub trait Source {
         self.query(dep, &mut |s| ret.push(s)).map_ok(|_| ret)
     }
 
-    /// Performs any network operations required to get the entire list of all names,
-    /// versions and dependencies of packages managed by the `Source`.
-    fn update(&mut self) -> CargoResult<()>;
+    /// Ensure that the source is fully up-to-date for the current session on the next query.
+    fn invalidate_cache(&mut self);
 
     /// Fetches the full package for each name and version specified.
     fn download(&mut self, package: PackageId) -> CargoResult<MaybePackage>;
@@ -150,9 +149,8 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
         (**self).fuzzy_query(dep, f)
     }
 
-    /// Forwards to `Source::update`.
-    fn update(&mut self) -> CargoResult<()> {
-        (**self).update()
+    fn invalidate_cache(&mut self) {
+        (**self).invalidate_cache()
     }
 
     /// Forwards to `Source::download`.
@@ -224,8 +222,8 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
         (**self).fuzzy_query(dep, f)
     }
 
-    fn update(&mut self) -> CargoResult<()> {
-        (**self).update()
+    fn invalidate_cache(&mut self) {
+        (**self).invalidate_cache()
     }
 
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -105,7 +105,13 @@ pub trait Source {
     /// as yanked. This ignores the yanked whitelist.
     fn is_yanked(&mut self, _pkg: PackageId) -> CargoResult<bool>;
 
-    /// Block until all outstanding Poll::Pending requests are Poll::Ready.
+    /// Block until all outstanding Poll::Pending requests are `Poll::Ready`.
+    ///
+    /// After calling this function, the source should return `Poll::Ready` for
+    /// any queries that previously returned `Poll::Pending`.
+    ///
+    /// If no queries previously returned `Poll::Pending`, and `invalidate_cache`
+    /// was not called, this function should be a no-op.
     fn block_until_ready(&mut self) -> CargoResult<()>;
 }
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};
 use crate::core::resolver::CliFeatures;
 use crate::core::{Feature, Shell, Verbosity, Workspace};
-use crate::core::{Package, PackageId, PackageSet, Resolve, Source, SourceId};
+use crate::core::{Package, PackageId, PackageSet, Resolve, SourceId};
 use crate::sources::PathSource;
 use crate::util::errors::CargoResult;
 use crate::util::toml::TomlManifest;

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -536,7 +536,7 @@ where
     let _lock = config.acquire_package_cache_lock()?;
 
     if needs_update {
-        source.update()?;
+        source.invalidate_cache();
     }
 
     let deps = loop {
@@ -591,7 +591,7 @@ where
     // with other global Cargos
     let _lock = config.acquire_package_cache_lock()?;
 
-    source.update()?;
+    source.invalidate_cache();
 
     return if let Some(dep) = dep {
         select_dep_pkg(source, dep, config, false)

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -20,9 +20,7 @@ use crate::core::resolver::{
 };
 use crate::core::summary::Summary;
 use crate::core::Feature;
-use crate::core::{
-    GitReference, PackageId, PackageIdSpec, PackageSet, Source, SourceId, Workspace,
-};
+use crate::core::{GitReference, PackageId, PackageIdSpec, PackageSet, SourceId, Workspace};
 use crate::ops;
 use crate::sources::PathSource;
 use crate::util::errors::CargoResult;

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -37,8 +37,58 @@ impl<'cfg> DirectorySource<'cfg> {
             updated: false,
         }
     }
+}
 
-    fn update(&mut self) -> CargoResult<()> {
+impl<'cfg> Debug for DirectorySource<'cfg> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "DirectorySource {{ root: {:?} }}", self.root)
+    }
+}
+
+impl<'cfg> Source for DirectorySource<'cfg> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
+        if !self.updated {
+            return Poll::Pending;
+        }
+        let packages = self.packages.values().map(|p| &p.0);
+        let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
+        for summary in matches.map(|pkg| pkg.summary().clone()) {
+            f(summary);
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn fuzzy_query(
+        &mut self,
+        _dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
+        if !self.updated {
+            return Poll::Pending;
+        }
+        let packages = self.packages.values().map(|p| &p.0);
+        for summary in packages.map(|pkg| pkg.summary().clone()) {
+            f(summary);
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn supports_checksums(&self) -> bool {
+        true
+    }
+
+    fn requires_precise(&self) -> bool {
+        true
+    }
+
+    fn source_id(&self) -> SourceId {
+        self.source_id
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        if self.updated {
+            return Ok(());
+        }
         self.packages.clear();
         let entries = self.root.read_dir().with_context(|| {
             format!(
@@ -109,54 +159,8 @@ impl<'cfg> DirectorySource<'cfg> {
             self.packages.insert(pkg.package_id(), (pkg, cksum));
         }
 
+        self.updated = true;
         Ok(())
-    }
-}
-
-impl<'cfg> Debug for DirectorySource<'cfg> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "DirectorySource {{ root: {:?} }}", self.root)
-    }
-}
-
-impl<'cfg> Source for DirectorySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
-        if !self.updated {
-            return Poll::Pending;
-        }
-        let packages = self.packages.values().map(|p| &p.0);
-        let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
-        for summary in matches.map(|pkg| pkg.summary().clone()) {
-            f(summary);
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    fn fuzzy_query(
-        &mut self,
-        _dep: &Dependency,
-        f: &mut dyn FnMut(Summary),
-    ) -> Poll<CargoResult<()>> {
-        if !self.updated {
-            return Poll::Pending;
-        }
-        let packages = self.packages.values().map(|p| &p.0);
-        for summary in packages.map(|pkg| pkg.summary().clone()) {
-            f(summary);
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    fn supports_checksums(&self) -> bool {
-        true
-    }
-
-    fn requires_precise(&self) -> bool {
-        true
-    }
-
-    fn source_id(&self) -> SourceId {
-        self.source_id
     }
 
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
@@ -219,11 +223,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(false)
     }
 
-    fn block_until_ready(&mut self) -> CargoResult<()> {
-        self.update()?;
-        self.updated = true;
-        Ok(())
+    fn invalidate_cache(&mut self) {
+        // Path source has no local cache.
     }
-
-    fn invalidate_cache(&mut self) {}
 }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::{self, Debug, Formatter};
 use std::path::{Path, PathBuf};
+use std::task::Poll;
 
 use crate::core::source::MaybePackage;
 use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};
@@ -43,21 +44,25 @@ impl<'cfg> Debug for DirectorySource<'cfg> {
 }
 
 impl<'cfg> Source for DirectorySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
         for summary in matches.map(|pkg| pkg.summary().clone()) {
             f(summary);
         }
-        Ok(())
+        Poll::Ready(Ok(()))
     }
 
-    fn fuzzy_query(&mut self, _dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        _dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
         let packages = self.packages.values().map(|p| &p.0);
         for summary in packages.map(|pkg| pkg.summary().clone()) {
             f(summary);
         }
-        Ok(())
+        Poll::Ready(Ok(()))
     }
 
     fn supports_checksums(&self) -> bool {
@@ -204,5 +209,9 @@ impl<'cfg> Source for DirectorySource<'cfg> {
 
     fn is_yanked(&mut self, _pkg: PackageId) -> CargoResult<bool> {
         Ok(false)
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        Ok(())
     }
 }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -9,6 +9,7 @@ use crate::util::Config;
 use anyhow::Context;
 use log::trace;
 use std::fmt::{self, Debug, Formatter};
+use std::task::Poll;
 use url::Url;
 
 pub struct GitSource<'cfg> {
@@ -83,7 +84,7 @@ impl<'cfg> Debug for GitSource<'cfg> {
 }
 
 impl<'cfg> Source for GitSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
         let src = self
             .path_source
             .as_mut()
@@ -91,7 +92,11 @@ impl<'cfg> Source for GitSource<'cfg> {
         src.query(dep, f)
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
         let src = self
             .path_source
             .as_mut()
@@ -211,6 +216,10 @@ impl<'cfg> Source for GitSource<'cfg> {
 
     fn is_yanked(&mut self, _pkg: PackageId) -> CargoResult<bool> {
         Ok(false)
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        Ok(())
     }
 }
 

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -574,5 +574,7 @@ impl<'cfg> Source for PathSource<'cfg> {
         self.update()
     }
 
-    fn invalidate_cache(&mut self) {}
+    fn invalidate_cache(&mut self) {
+        // Path source has no local cache.
+    }
 }

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -72,23 +72,24 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
     }
 
     fn block_until_ready(&mut self) -> CargoResult<()> {
-        if !self.updated {
-            // Nothing to update, we just use what's on disk. Verify it actually
-            // exists though. We don't use any locks as we're just checking whether
-            // these directories exist.
-            let root = self.root.clone().into_path_unlocked();
-            if !root.is_dir() {
-                anyhow::bail!("local registry path is not a directory: {}", root.display());
-            }
-            let index_path = self.index_path.clone().into_path_unlocked();
-            if !index_path.is_dir() {
-                anyhow::bail!(
-                    "local registry index path is not a directory: {}",
-                    index_path.display()
-                );
-            }
-            self.updated = true;
+        if self.updated {
+            return Ok(());
         }
+        // Nothing to update, we just use what's on disk. Verify it actually
+        // exists though. We don't use any locks as we're just checking whether
+        // these directories exist.
+        let root = self.root.clone().into_path_unlocked();
+        if !root.is_dir() {
+            anyhow::bail!("local registry path is not a directory: {}", root.display());
+        }
+        let index_path = self.index_path.clone().into_path_unlocked();
+        if !index_path.is_dir() {
+            anyhow::bail!(
+                "local registry index path is not a directory: {}",
+                index_path.display()
+            );
+        }
+        self.updated = true;
         Ok(())
     }
 

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -8,6 +8,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::Path;
+use std::task::Poll;
 
 /// A local registry is a registry that lives on the filesystem as a set of
 /// `.crate` files with an `index` directory in the same format as a remote
@@ -54,8 +55,8 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         root: &Path,
         path: &Path,
         data: &mut dyn FnMut(&[u8]) -> CargoResult<()>,
-    ) -> CargoResult<()> {
-        data(&paths::read_bytes(&root.join(path))?)
+    ) -> Poll<CargoResult<()>> {
+        Poll::Ready(Ok(data(&paths::read_bytes(&root.join(path))?)?))
     }
 
     fn config(&mut self) -> CargoResult<Option<RegistryConfig>> {
@@ -119,5 +120,9 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         _data: &[u8],
     ) -> CargoResult<File> {
         panic!("this source doesn't download")
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        Ok(())
     }
 }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -164,6 +164,7 @@ use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::task::Poll;
 
 use anyhow::Context as _;
 use flate2::read::GzDecoder;
@@ -179,6 +180,7 @@ use crate::sources::PathSource;
 use crate::util::hex;
 use crate::util::interning::InternedString;
 use crate::util::into_url::IntoUrl;
+use crate::util::network::PollExt;
 use crate::util::{restricted_names, CargoResult, Config, Filesystem, OptVersionReq};
 
 const PACKAGE_SOURCE_LOCK: &str = ".cargo-ok";
@@ -440,12 +442,14 @@ pub trait RegistryData {
     /// * `root` is the root path to the index.
     /// * `path` is the relative path to the package to load (like `ca/rg/cargo`).
     /// * `data` is a callback that will receive the raw bytes of the index JSON file.
+    ///
+    /// If `load` returns a `Poll::Pending` then it must not have called data.
     fn load(
         &self,
         root: &Path,
         path: &Path,
         data: &mut dyn FnMut(&[u8]) -> CargoResult<()>,
-    ) -> CargoResult<()>;
+    ) -> Poll<CargoResult<()>>;
 
     /// Loads the `config.json` file and returns it.
     ///
@@ -508,6 +512,9 @@ pub trait RegistryData {
     ///
     /// This is used by index caching to check if the cache is out of date.
     fn current_version(&self) -> Option<InternedString>;
+
+    /// Block until all outstanding Poll::Pending requests are Poll::Ready.
+    fn block_until_ready(&mut self) -> CargoResult<()>;
 }
 
 /// The status of [`RegistryData::download`] which indicates if a `.crate`
@@ -678,6 +685,7 @@ impl<'cfg> RegistrySource<'cfg> {
         let summary_with_cksum = self
             .index
             .summaries(package.name(), &req, &mut *self.ops)?
+            .expect("a downloaded dep now pending!?")
             .map(|s| s.summary.clone())
             .next()
             .expect("summary not found");
@@ -692,7 +700,7 @@ impl<'cfg> RegistrySource<'cfg> {
 }
 
 impl<'cfg> Source for RegistrySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
         // If this is a precise dependency, then it came from a lock file and in
         // theory the registry is known to contain this version. If, however, we
         // come back with no summaries, then our registry may need to be
@@ -700,15 +708,19 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         if dep.source_id().precise().is_some() && !self.updated {
             debug!("attempting query without update");
             let mut called = false;
-            self.index
-                .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
-                    if dep.matches(&s) {
-                        called = true;
-                        f(s);
-                    }
-                })?;
+            let pend =
+                self.index
+                    .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
+                        if dep.matches(&s) {
+                            called = true;
+                            f(s);
+                        }
+                    })?;
+            if pend.is_pending() {
+                return Poll::Pending;
+            }
             if called {
-                return Ok(());
+                return Poll::Ready(Ok(()));
             } else {
                 debug!("falling back to an update");
                 self.do_update()?;
@@ -723,7 +735,11 @@ impl<'cfg> Source for RegistrySource<'cfg> {
             })
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
         self.index
             .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, f)
     }
@@ -757,7 +773,10 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     }
 
     fn download(&mut self, package: PackageId) -> CargoResult<MaybePackage> {
-        let hash = self.index.hash(package, &mut *self.ops)?;
+        let hash = self
+            .index
+            .hash(package, &mut *self.ops)?
+            .expect("we got to downloading a dep while pending!?");
         match self.ops.download(package, hash)? {
             MaybeLock::Ready(file) => self.get_pkg(package, &file).map(MaybePackage::Ready),
             MaybeLock::Download { url, descriptor } => {
@@ -767,7 +786,10 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     }
 
     fn finish_download(&mut self, package: PackageId, data: Vec<u8>) -> CargoResult<Package> {
-        let hash = self.index.hash(package, &mut *self.ops)?;
+        let hash = self
+            .index
+            .hash(package, &mut *self.ops)?
+            .expect("we got to downloading a dep while pending!?");
         let file = self.ops.finish_download(package, hash, &data)?;
         self.get_pkg(package, &file)
     }
@@ -788,6 +810,19 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         if !self.updated {
             self.do_update()?;
         }
-        self.index.is_yanked(pkg, &mut *self.ops)
+        loop {
+            match self.index.is_yanked(pkg, &mut *self.ops)? {
+                Poll::Ready(yanked) => {
+                    return Ok(yanked);
+                }
+                Poll::Pending => {
+                    self.block_until_ready()?;
+                }
+            }
+        }
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        self.ops.block_until_ready()
     }
 }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -447,9 +447,7 @@ pub trait RegistryData {
     /// Local registries don't have a config, and return `None`.
     fn config(&mut self) -> Poll<CargoResult<Option<RegistryConfig>>>;
 
-    /// Ensures the index is updated with the latest data.
-    ///
-    /// Invalidates cached data.
+    /// Invalidates locally cached data.
     fn invalidate_cache(&mut self);
 
     /// Is the local cached data up-to-date?

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -1,6 +1,7 @@
 use crate::core::source::MaybePackage;
 use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};
 use crate::util::errors::CargoResult;
+use std::task::Poll;
 
 use anyhow::Context as _;
 
@@ -41,7 +42,7 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         self.inner.requires_precise()
     }
 
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
         let (replace_with, to_replace) = (self.replace_with, self.to_replace);
         let dep = dep.clone().map_source(to_replace, replace_with);
 
@@ -49,11 +50,19 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
             .query(&dep, &mut |summary| {
                 f(summary.map_source(replace_with, to_replace))
             })
-            .with_context(|| format!("failed to query replaced source {}", self.to_replace))?;
-        Ok(())
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to query replaced source {}",
+                    self.to_replace
+                ))
+            })
     }
 
-    fn fuzzy_query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> CargoResult<()> {
+    fn fuzzy_query(
+        &mut self,
+        dep: &Dependency,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
         let (replace_with, to_replace) = (self.replace_with, self.to_replace);
         let dep = dep.clone().map_source(to_replace, replace_with);
 
@@ -61,8 +70,12 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
             .fuzzy_query(&dep, &mut |summary| {
                 f(summary.map_source(replace_with, to_replace))
             })
-            .with_context(|| format!("failed to query replaced source {}", self.to_replace))?;
-        Ok(())
+            .map_err(|e| {
+                e.context(format!(
+                    "failed to query replaced source {}",
+                    self.to_replace
+                ))
+            })
     }
 
     fn update(&mut self) -> CargoResult<()> {
@@ -126,5 +139,9 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
 
     fn is_yanked(&mut self, pkg: PackageId) -> CargoResult<bool> {
         self.inner.is_yanked(pkg)
+    }
+
+    fn block_until_ready(&mut self) -> CargoResult<()> {
+        self.inner.block_until_ready()
     }
 }

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -78,11 +78,8 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
             })
     }
 
-    fn update(&mut self) -> CargoResult<()> {
-        self.inner
-            .update()
-            .with_context(|| format!("failed to update replaced source {}", self.to_replace))?;
-        Ok(())
+    fn invalidate_cache(&mut self) {
+        self.inner.invalidate_cache()
     }
 
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
@@ -142,6 +139,8 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
     }
 
     fn block_until_ready(&mut self) -> CargoResult<()> {
-        self.inner.block_until_ready()
+        self.inner
+            .block_until_ready()
+            .with_context(|| format!("failed to update replaced source {}", self.to_replace))
     }
 }

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -2,6 +2,21 @@ use anyhow::Error;
 
 use crate::util::errors::{CargoResult, HttpNot200};
 use crate::util::Config;
+use std::task::Poll;
+
+pub trait PollExt<T> {
+    fn expect(self, msg: &str) -> T;
+}
+
+impl<T> PollExt<T> for Poll<T> {
+    #[track_caller]
+    fn expect(self, msg: &str) -> T {
+        match self {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("{}", msg),
+        }
+    }
+}
 
 pub struct Retry<'a> {
     config: &'a Config,

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -151,7 +151,8 @@ fn not_update() {
     );
     let lock = cfg.acquire_package_cache_lock().unwrap();
     let mut regsrc = RegistrySource::remote(sid, &HashSet::new(), &cfg);
-    regsrc.update().unwrap();
+    regsrc.invalidate_cache();
+    regsrc.block_until_ready().unwrap();
     drop(lock);
 
     cargo_process("search postgres")


### PR DESCRIPTION
Adds `Poll` as a return type for several registry functions to enable parallel fetching of crate metadata with a future http-based registry.

Work is scheduled by calling the `query` and related functions, then waited on with `block_until_ready`.

This PR is based on the draft PR started by eh2406 here [#8985](https://github.com/rust-lang/cargo/pull/8985).

r? @Eh2406
cc @alexcrichton 
cc @jonhoo 