### PR TITLE
Make ProfileChecking comments a doc comments

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -287,15 +287,15 @@ pub fn subcommand(name: &'static str) -> App {
     ])
 }
 
-// Determines whether or not to gate `--profile` as unstable when resolving it.
+/// Determines whether or not to gate `--profile` as unstable when resolving it.
 pub enum ProfileChecking {
-    // `cargo rustc` historically has allowed "test", "bench", and "check". This
-    // variant explicitly allows those.
+    /// `cargo rustc` historically has allowed "test", "bench", and "check". This
+    /// variant explicitly allows those.
     LegacyRustc,
-    // `cargo check` and `cargo fix` historically has allowed "test". This variant
-    // explicitly allows that on stable.
+    /// `cargo check` and `cargo fix` historically has allowed "test". This variant
+    /// explicitly allows that on stable.
     LegacyTestOnly,
-    // All other commands, which allow any valid custom named profile.
+    /// All other commands, which allow any valid custom named profile.
     Custom,
 }
 


### PR DESCRIPTION
A little PR that makes rustdoc render comments for ProfileChecking struct. 

Before: 
![image](https://user-images.githubusercontent.com/910977/141529033-34bca263-abb1-4a1d-8e13-3c42edc2189e.png)


After:
![image](https://user-images.githubusercontent.com/910977/141529011-756ac54f-c0b2-4c03-bdb6-c9434e00afe5.png)
