### PR TITLE
Warn when alias shadows external subcommand

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -261,6 +261,18 @@ fn expand_aliases(
             }
             (None, None) => {}
             (_, Some(mut alias)) => {
+                // Check if this alias is shadowing an external subcommand
+                // (binary of the form `cargo-<subcommand>`)
+                // Currently this is only a warning, but after a transition period this will become
+                // a hard error.
+                if let Some(path) = super::find_external_subcommand(config, cmd) {
+                    config.shell().warn(format!(
+                        "user-defined alias `{}` is shadowing an external subcommand found at: `{}`",
+                        cmd,
+                        path.display(),
+                    ))?;
+                }
+
                 alias.extend(
                     args.values_of("")
                         .unwrap_or_default()

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -267,7 +267,10 @@ fn expand_aliases(
                 // a hard error.
                 if let Some(path) = super::find_external_subcommand(config, cmd) {
                     config.shell().warn(format!(
-                        "user-defined alias `{}` is shadowing an external subcommand found at: `{}`",
+                        "\
+user-defined alias `{}` is shadowing an external subcommand found at: `{}`
+This was previously accepted but is being phased out; it will become a hard error in a future release.
+For more information, see issue #10049 <https://github.com/rust-lang/cargo/issues/10049>.",
                         cmd,
                         path.display(),
                     ))?;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -147,12 +147,16 @@ fn list_commands(config: &Config) -> BTreeMap<String, CommandInfo> {
     commands
 }
 
-fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> CliResult {
+fn find_external_subcommand(config: &Config, cmd: &str) -> Option<PathBuf> {
     let command_exe = format!("cargo-{}{}", cmd, env::consts::EXE_SUFFIX);
-    let path = search_directories(config)
+    search_directories(config)
         .iter()
         .map(|dir| dir.join(&command_exe))
-        .find(|file| is_executable(file));
+        .find(|file| is_executable(file))
+}
+
+fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> CliResult {
+    let path = find_external_subcommand(config, cmd);
     let command = match path {
         Some(command) => command,
         None => {

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -101,7 +101,9 @@ fn default_args_alias() {
         .env("PATH", &path)
         .with_status(101)
         .with_stderr("\
-warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
+[WARNING] user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
+This was previously accepted but is being phased out; it will become a hard error in a future release.
+For more information, see issue #10049 <https://github.com/rust-lang/cargo/issues/10049>.
 error: alias echo has unresolvable recursive definition: echo -> echo
 ",
         )
@@ -111,7 +113,9 @@ error: alias echo has unresolvable recursive definition: echo -> echo
         .env("PATH", &path)
         .with_status(101)
         .with_stderr("\
-warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
+[WARNING] user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
+This was previously accepted but is being phased out; it will become a hard error in a future release.
+For more information, see issue #10049 <https://github.com/rust-lang/cargo/issues/10049>.
 error: alias test-1 has unresolvable recursive definition: test-1 -> echo -> echo
 ",
         )

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -111,7 +111,7 @@ error: alias echo has unresolvable recursive definition: echo -> echo
         .env("PATH", &path)
         .with_status(101)
         .with_stderr("\
-warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo`
+warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
 error: alias test-1 has unresolvable recursive definition: test-1 -> echo -> echo
 ",
         )

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -101,7 +101,7 @@ fn default_args_alias() {
         .env("PATH", &path)
         .with_status(101)
         .with_stderr("\
-warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo`
+warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
 error: alias echo has unresolvable recursive definition: echo -> echo
 ",
         )

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -100,14 +100,20 @@ fn default_args_alias() {
     p.cargo("echo")
         .env("PATH", &path)
         .with_status(101)
-        .with_stderr("error: alias echo has unresolvable recursive definition: echo -> echo")
+        .with_stderr("\
+warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo`
+error: alias echo has unresolvable recursive definition: echo -> echo
+",
+        )
         .run();
 
     p.cargo("test-1")
         .env("PATH", &path)
         .with_status(101)
-        .with_stderr(
-            "error: alias test-1 has unresolvable recursive definition: test-1 -> echo -> echo",
+        .with_stderr("\
+warning: user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo`
+error: alias test-1 has unresolvable recursive definition: test-1 -> echo -> echo
+",
         )
         .run();
 

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -77,6 +77,38 @@ fn dependent_alias() {
 }
 
 #[cargo_test]
+fn alias_shadowing_external_subcommand() {
+    let echo = echo_subcommand();
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config",
+            r#"
+                [alias]
+                echo = "build"
+            "#,
+        )
+        .build();
+
+    let mut paths: Vec<_> = env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect();
+    paths.push(echo.target_debug_dir());
+    let path = env::join_paths(paths).unwrap();
+
+    p.cargo("echo")
+        .env("PATH", &path)
+        .with_stderr("\
+[WARNING] user-defined alias `echo` is shadowing an external subcommand found at: `[ROOT]/cargo-echo/target/debug/cargo-echo[EXE]`
+This was previously accepted but is being phased out; it will become a hard error in a future release.
+For more information, see issue #10049 <https://github.com/rust-lang/cargo/issues/10049>.
+[COMPILING] foo v0.5.0 [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn default_args_alias() {
     let echo = echo_subcommand();
     let p = project()


### PR DESCRIPTION
As per #10049, we start by emitting a warning when an alias shadows an
existing external subcommand. After a transition period (duration not
specified), we will make this a hard error.

Should the warning mention that this will become a hard error?
