### PR TITLE
Stabilize the `strip` profile option, now that rustc has stable `-C strip`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1023,7 +1023,7 @@ fn build_base_args(
     }
 
     if strip != Strip::None {
-        cmd.arg("-Z").arg(format!("strip={}", strip));
+        cmd.arg("-C").arg(format!("strip={}", strip));
     }
 
     if unit.is_std {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -393,7 +393,7 @@ features! {
     (stable, resolver, "1.51", "reference/resolver.html#resolver-versions"),
 
     // Allow to specify whether binaries should be stripped.
-    (unstable, strip, "", "reference/unstable.html#profile-strip-option"),
+    (stable, strip, "1.58", "reference/profiles.html#strip-option"),
 
     // Specifying a minimal 'rust-version' attribute for crates
     (stable, rust_version, "1.56", "reference/manifest.html#the-rust-version-field"),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -530,10 +530,6 @@ impl TomlProfile {
             }
         }
 
-        if self.strip.is_some() {
-            features.require(Feature::strip())?;
-        }
-
         if let Some(codegen_backend) = &self.codegen_backend {
             features.require(Feature::codegen_backend())?;
             if codegen_backend.contains(|c: char| !c.is_ascii_alphanumeric() && c != '_') {

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -93,6 +93,27 @@ once more testing has been performed, and support for DWARF is stabilized.
 [nightly channel]: ../../book/appendix-07-nightly-rust.html
 [`-C split-debuginfo` flag]: ../../rustc/codegen-options/index.html#split-debuginfo
 
+#### strip
+
+The `strip` option controls the rustc `-C strip` option, which directs rustc to
+strip either symbols or debuginfo from a binary. This can be enabled like so:
+
+```toml
+[package]
+# ...
+
+[profile.release]
+strip = "debuginfo"
+```
+
+Other possible string values of `strip` are `none`, `symbols`, and `off`. The
+default is `none`.
+
+You can also configure this option with the two absolute boolean values
+`true` and `false`. The former enables `strip` at its higher level, `symbols`,
+while the latter disables `strip` completely.
+
+
 #### debug-assertions
 
 The `debug-assertions` setting controls the [`-C debug-assertions` flag] which

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -95,7 +95,7 @@ once more testing has been performed, and support for DWARF is stabilized.
 
 #### strip
 
-The `strip` option controls the rustc `-C strip` option, which directs rustc to
+The `strip` option controls the [`-C strip` flag], which directs rustc to
 strip either symbols or debuginfo from a binary. This can be enabled like so:
 
 ```toml
@@ -113,6 +113,7 @@ You can also configure this option with the two absolute boolean values
 `true` and `false`. The former enables `strip` at its higher level, `symbols`,
 while the latter disables `strip` completely.
 
+[`-C strip` flag]: ../../rustc/codegen-options/index.html#strip
 
 #### debug-assertions
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1367,7 +1367,7 @@ Custom named profiles have been stabilized in the 1.57 release. See the
 
 ### Profile `strip` option
 
-The profile `strip` option has been stabilized in the 1.58 release. See the
+The profile `strip` option has been stabilized in the 1.59 release. See the
 [profiles chapter](profiles.md#strip) for more information.
 
 ### Future incompat report

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -820,28 +820,6 @@ The following is a description of the JSON structure:
 }
 ```
 
-### Profile `strip` option
-* Tracking Issue: [rust-lang/rust#72110](https://github.com/rust-lang/rust/issues/72110)
-
-This feature provides a new option in the `[profile]` section to strip either
-symbols or debuginfo from a binary. This can be enabled like so:
-
-```toml
-cargo-features = ["strip"]
-
-[package]
-# ...
-
-[profile.release]
-strip = "debuginfo"
-```
-
-Other possible string values of `strip` are `none`, `symbols`, and `off`. The default is `none`.
-
-You can also configure this option with the two absolute boolean values
-`true` and `false`. The former enables `strip` at its higher level, `symbols`,
-while the latter disables `strip` completely.
-
 ### rustdoc-map
 * Tracking Issue: [#8296](https://github.com/rust-lang/cargo/issues/8296)
 
@@ -1386,6 +1364,11 @@ See [`cargo fix --edition`](../commands/cargo-fix.md) and [The Edition Guide](..
 
 Custom named profiles have been stabilized in the 1.57 release. See the
 [profiles chapter](profiles.md#custom-profiles) for more information.
+
+### Profile `strip` option
+
+The profile `strip` option has been stabilized in the 1.58 release. See the
+[profiles chapter](profiles.md#strip) for more information.
 
 ### Future incompat report
 

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -472,7 +472,7 @@ fn thin_lto_works() {
 #[cargo_test]
 fn strip_works() {
     if !is_nightly() {
-        // -Zstrip is unstable
+        // rustc 1.58 stabilized -C strip; disable the test until that ships.
         return;
     }
 
@@ -480,8 +480,6 @@ fn strip_works() {
         .file(
             "Cargo.toml",
             r#"
-                cargo-features = ["strip"]
-
                 [package]
                 name = "foo"
                 version = "0.1.0"
@@ -494,55 +492,11 @@ fn strip_works() {
         .build();
 
     p.cargo("build --release -v")
-        .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[RUNNING] `rustc [..] -Z strip=symbols [..]`
+[RUNNING] `rustc [..] -C strip=symbols [..]`
 [FINISHED] [..]
-",
-        )
-        .run();
-}
-
-#[cargo_test]
-fn strip_requires_cargo_feature() {
-    if !is_nightly() {
-        // -Zstrip is unstable
-        return;
-    }
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-
-                [profile.release]
-                strip = 'symbols'
-            "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    p.cargo("build --release -v")
-        .masquerade_as_nightly_cargo()
-        .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  feature `strip` is required
-
-  The package requires the Cargo feature called `strip`, but that feature is \
-  not stabilized in this version of Cargo (1.[..]).
-  Consider adding `cargo-features = [\"strip\"]` to the top of Cargo.toml \
-  (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
-  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#profile-strip-option \
-  for more information about the status of this feature.
 ",
         )
         .run();
@@ -551,7 +505,7 @@ Caused by:
 #[cargo_test]
 fn strip_passes_unknown_option_to_rustc() {
     if !is_nightly() {
-        // -Zstrip is unstable
+        // rustc 1.58 stabilized -C strip; disable the test until that ships.
         return;
     }
 
@@ -559,8 +513,6 @@ fn strip_passes_unknown_option_to_rustc() {
         .file(
             "Cargo.toml",
             r#"
-                cargo-features = ["strip"]
-
                 [package]
                 name = "foo"
                 version = "0.1.0"
@@ -573,13 +525,12 @@ fn strip_passes_unknown_option_to_rustc() {
         .build();
 
     p.cargo("build --release -v")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr_contains(
             "\
 [COMPILING] foo [..]
-[RUNNING] `rustc [..] -Z strip=unknown [..]`
-error: incorrect value `unknown` for debugging option `strip` - either `none`, `debuginfo`, or `symbols` was expected
+[RUNNING] `rustc [..] -C strip=unknown [..]`
+error: incorrect value `unknown` for [..] `strip` [..] was expected
 ",
         )
         .run();
@@ -588,7 +539,7 @@ error: incorrect value `unknown` for debugging option `strip` - either `none`, `
 #[cargo_test]
 fn strip_accepts_true_to_strip_symbols() {
     if !is_nightly() {
-        // -Zstrip is unstable
+        // rustc 1.58 stabilized -C strip; disable the test until that ships.
         return;
     }
 
@@ -596,8 +547,6 @@ fn strip_accepts_true_to_strip_symbols() {
         .file(
             "Cargo.toml",
             r#"
-                cargo-features = ["strip"]
-
                 [package]
                 name = "foo"
                 version = "0.1.0"
@@ -610,11 +559,10 @@ fn strip_accepts_true_to_strip_symbols() {
         .build();
 
     p.cargo("build --release -v")
-        .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[RUNNING] `rustc [..] -Z strip=symbols [..]`
+[RUNNING] `rustc [..] -C strip=symbols [..]`
 [FINISHED] [..]
 ",
         )
@@ -624,15 +572,14 @@ fn strip_accepts_true_to_strip_symbols() {
 #[cargo_test]
 fn strip_accepts_false_to_disable_strip() {
     if !is_nightly() {
-        // -Zstrip is unstable
+        // rustc 1.58 stabilized -C strip; disable the test until that ships.
         return;
     }
+
     let p = project()
         .file(
             "Cargo.toml",
             r#"
-                cargo-features = ["strip"]
-
                 [package]
                 name = "foo"
                 version = "0.1.0"
@@ -645,7 +592,6 @@ fn strip_accepts_false_to_disable_strip() {
         .build();
 
     p.cargo("build --release -v")
-        .masquerade_as_nightly_cargo()
-        .with_stderr_does_not_contain("-Z strip")
+        .with_stderr_does_not_contain("-C strip")
         .run();
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/90058/ stabilized `-Z strip` as `-C strip`. Stabilize the corresponding Cargo option.

Update the documentation to move it from the unstable reference to the profiles documentation.

Update the tests to account for stabilization.