### PR TITLE
cargo doc: Add --publish-dir option

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -112,6 +112,7 @@ fn substitute_macros(input: &str) -> String {
         ("[COMPLETED]", "   Completed"),
         ("[CREATED]", "     Created"),
         ("[FINISHED]", "    Finished"),
+        ("[PUBLISHING]", "  Publishing"),
         ("[ERROR]", "error:"),
         ("[WARNING]", "warning:"),
         ("[NOTE]", "note:"),

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -1,3 +1,4 @@
+use crate::commands::doc::resolved_doc_publish_dir;
 use cargo::ops::{self, DocOptions};
 
 use crate::command_prelude::*;
@@ -12,6 +13,13 @@ pub fn cli() -> App {
             "open",
             "Opens the docs in a browser after the operation",
         ))
+        .arg(
+            opt(
+                "publish-dir",
+                "Directory to copy the generated documentation to",
+            )
+            .value_name("DIR"),
+        )
         .arg_package("Package to document")
         .arg_jobs()
         .arg_targets_all(
@@ -52,8 +60,12 @@ pub fn exec(config: &mut Config, args: &ArgMatches<'_>) -> CliResult {
     } else {
         Some(target_args)
     };
+    let publish_dir_arg = args.value_of("publish-dir");
+    let publish_dir = resolved_doc_publish_dir(publish_dir_arg, config)?;
+
     let doc_opts = DocOptions {
         open_result: args.is_present("open"),
+        publish_dir,
         compile_opts,
     };
     ops::doc(&ws, &doc_opts)?;

--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -27,6 +27,16 @@ or use the [`doc.browser`](../reference/config.html#docbrowser) configuration
 option.
 {{/option}}
 
+{{#option "`--publish-dir`" }}
+The generated documentation will be copied to the specified publish directory.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
+This will override the corresponding
+[`doc.publish-dir`](../reference/config.html#docpublish-dir) configuration option and
+[`CARGO_DOC_PUBLISH_DIR`](../reference/environment-variables.html#configuration-environment-variables)
+environment variable.
+{{/option}}
+
 {{#option "`--no-deps`" }}
 Do not build documentation for dependencies.
 {{/option}}

--- a/src/doc/man/cargo-rustdoc.md
+++ b/src/doc/man/cargo-rustdoc.md
@@ -39,6 +39,16 @@ or use the [`doc.browser`](../reference/config.html#docbrowser) configuration
 option.
 {{/option}}
 
+{{#option "`--publish-dir`" }}
+The generated documentation will be copied to the specified publish directory.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
+This will override the corresponding
+[`doc.publish-dir`](../reference/config.html#docpublish-dir) configuration option and
+[`CARGO_DOC_PUBLISH_DIR`](../reference/environment-variables.html#configuration-environment-variables)
+environment variable.
+{{/option}}
+
 {{/options}}
 
 {{> section-options-package }}

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -19,6 +19,16 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#docbrowser>
            configuration option.
 
+       --publish-dir
+           The generated documentation will be copied to the specified publish
+           directory. This can be used to publish documentation straight into,
+           for example, a directory that is being served up by a local web
+           server already. This will override the corresponding doc.publish-dir
+           <https://doc.rust-lang.org/cargo/reference/config.html#docpublish-dir>
+           configuration option and CARGO_DOC_PUBLISH_DIR
+           <https://doc.rust-lang.org/cargo/reference/environment-variables.html#configuration-environment-variables>
+           environment variable.
+
        --no-deps
            Do not build documentation for dependencies.
 

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -38,6 +38,16 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#docbrowser>
            configuration option.
 
+       --publish-dir
+           The generated documentation will be copied to the specified publish
+           directory. This can be used to publish documentation straight into,
+           for example, a directory that is being served up by a local web
+           server already. This will override the corresponding doc.publish-dir
+           <https://doc.rust-lang.org/cargo/reference/config.html#docpublish-dir>
+           configuration option and CARGO_DOC_PUBLISH_DIR
+           <https://doc.rust-lang.org/cargo/reference/environment-variables.html#configuration-environment-variables>
+           environment variable.
+
    Package Selection
        By default, the package in the current working directory is selected.
        The -p flag can be used to choose a different package in a workspace.

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -27,6 +27,16 @@ or use the <a href="../reference/config.html#docbrowser"><code>doc.browser</code
 option.</dd>
 
 
+<dt class="option-term" id="option-cargo-doc---publish-dir"><a class="option-anchor" href="#option-cargo-doc---publish-dir"></a><code>--publish-dir</code></dt>
+<dd class="option-desc">The generated documentation will be copied to the specified publish directory.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
+This will override the corresponding
+<a href="../reference/config.html#docpublish-dir"><code>doc.publish-dir</code></a> configuration option and
+<a href="../reference/environment-variables.html#configuration-environment-variables"><code>CARGO_DOC_PUBLISH_DIR</code></a>
+environment variable.</dd>
+
+
 <dt class="option-term" id="option-cargo-doc---no-deps"><a class="option-anchor" href="#option-cargo-doc---no-deps"></a><code>--no-deps</code></dt>
 <dd class="option-desc">Do not build documentation for dependencies.</dd>
 

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -43,6 +43,16 @@ or use the <a href="../reference/config.html#docbrowser"><code>doc.browser</code
 option.</dd>
 
 
+<dt class="option-term" id="option-cargo-rustdoc---publish-dir"><a class="option-anchor" href="#option-cargo-rustdoc---publish-dir"></a><code>--publish-dir</code></dt>
+<dd class="option-desc">The generated documentation will be copied to the specified publish directory.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
+This will override the corresponding
+<a href="../reference/config.html#docpublish-dir"><code>doc.publish-dir</code></a> configuration option and
+<a href="../reference/environment-variables.html#configuration-environment-variables"><code>CARGO_DOC_PUBLISH_DIR</code></a>
+environment variable.</dd>
+
+
 </dl>
 
 ### Package Selection

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -78,6 +78,8 @@ pipelining = true             # rustc pipelining
 [doc]
 browser = "chromium"          # browser to use with `cargo doc --open`,
                               # overrides the `BROWSER` environment variable
+publish-dir = "/var/www/html" # directory to copy the generated documentation to
+                              # overrides the `CARGO_DOC_PUBLISH_DIR` environment variable
 
 [env]
 # Set ENV_VAR_NAME=value for any process run by Cargo
@@ -457,6 +459,18 @@ The `[doc]` table defines options for the [`cargo doc`] command.
 This option sets the browser to be used by [`cargo doc`], overriding the
 `BROWSER` environment variable when opening documentation with the `--open`
 option.
+
+##### `doc.publish-dir`
+
+* Type: string
+* Default: `CARGO_DOC_PUBLISH_DIR` environment variable, or, if that is
+  missing, documentation is not published.
+
+This option is used by [`cargo doc`] as a directory to copy the generated
+documentation to, overriding the `CARGO_DOC_PUBLISH_DIR` environment variable.
+It can also be set with the `--publish-dir` CLI option.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
 
 #### `[cargo-new]`
 

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -118,6 +118,7 @@ supported environment variables are:
 * `CARGO_TERM_COLOR` — The default color mode, see [`term.color`].
 * `CARGO_TERM_PROGRESS_WHEN` — The default progress bar showing mode, see [`term.progress.when`].
 * `CARGO_TERM_PROGRESS_WIDTH` — The default progress bar width, see [`term.progress.width`].
+* `CARGO_DOC_PUBLISH_DIR` — Directory to copy the generated documentation to, see [`doc.publish-dir`] for more details.
 
 [`cargo doc`]: ../commands/cargo-doc.md
 [`cargo install`]: ../commands/cargo-install.md
@@ -141,6 +142,7 @@ supported environment variables are:
 [`build.dep-info-basedir`]: config.md#builddep-info-basedir
 [`build.pipelining`]: config.md#buildpipelining
 [`doc.browser`]: config.md#docbrowser
+[`doc.publish-dir`]: config.md#docpublish-dir
 [`cargo-new.name`]: config.md#cargo-newname
 [`cargo-new.email`]: config.md#cargo-newemail
 [`cargo-new.vcs`]: config.md#cargo-newvcs

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -21,6 +21,17 @@ or use the \fI\f(BIdoc.browser\fI\fR <https://doc.rust\-lang.org/cargo/reference
 option.
 .RE
 .sp
+\fB\-\-publish\-dir\fR
+.RS 4
+The generated documentation will be copied to the specified publish directory.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
+This will override the corresponding
+\fI\f(BIdoc.publish\-dir\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#docpublish\-dir> configuration option and
+\fI\f(BICARGO_DOC_PUBLISH_DIR\fI\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#configuration\-environment\-variables>
+environment variable.
+.RE
+.sp
 \fB\-\-no\-deps\fR
 .RS 4
 Do not build documentation for dependencies.

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -36,6 +36,17 @@ browser unless you define another one in the \fBBROWSER\fR environment variable
 or use the \fI\f(BIdoc.browser\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#docbrowser> configuration
 option.
 .RE
+.sp
+\fB\-\-publish\-dir\fR
+.RS 4
+The generated documentation will be copied to the specified publish directory.
+This can be used to publish documentation straight into, for example, a
+directory that is being served up by a local web server already.
+This will override the corresponding
+\fI\f(BIdoc.publish\-dir\fI\fR <https://doc.rust\-lang.org/cargo/reference/config.html#docpublish\-dir> configuration option and
+\fI\f(BICARGO_DOC_PUBLISH_DIR\fI\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#configuration\-environment\-variables>
+environment variable.
+.RE
 .SS "Package Selection"
 By default, the package in the current working directory is selected. The \fB\-p\fR
 flag can be used to choose a different package in a workspace.

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -188,6 +188,66 @@ fn doc_only_bin() {
 }
 
 #[cargo_test]
+fn doc_publish() {
+    let p = project().file("src/lib.rs", "pub fn foo() {}").build();
+
+    p.cargo("doc --publish-dir bar")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PUBLISHING] bar
+",
+        )
+        .run();
+
+    assert!(p.root().join("bar/foo/index.html").is_file());
+}
+
+#[cargo_test]
+fn doc_publish_env() {
+    let p = project().file("src/lib.rs", "pub fn foo() {}").build();
+
+    p.cargo("doc")
+        .env("CARGO_DOC_PUBLISH_DIR", "bar")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PUBLISHING] bar
+",
+        )
+        .run();
+
+    assert!(p.root().join("bar/foo/index.html").is_file());
+}
+
+#[cargo_test]
+fn doc_publish_config() {
+    let p = project().file("src/lib.rs", "pub fn foo() {}").build();
+
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [doc]
+            publish-dir = "bar"
+        "#,
+    );
+
+    p.cargo("doc")
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PUBLISHING] bar
+",
+        )
+        .run();
+
+    assert!(p.root().join("bar/foo/index.html").is_file());
+}
+
+#[cargo_test]
 fn doc_multiple_targets_same_name_lib() {
     let p = project()
         .file(


### PR DESCRIPTION
Resolves #10089

The PR adds a new option to `cargo doc`/`cargo rustdoc`: `--publish-dir`

When using this new option, the generated documentation will be copied to the specified publish directory.
This can be used to publish documentation straight into, for example, a directory that is being served up by a local web server already.
