### PR TITLE
Fix a couple issues with cyclic features and dev-dependencies

### DIFF
--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -280,10 +280,12 @@ pub fn resolve_features<'b>(
     // dep_name/feat_name` where `dep_name` does not exist. All other
     // validation is done either in `build_requirements` or
     // `build_feature_map`.
-    for dep_name in reqs.deps.keys() {
-        if !valid_dep_names.contains(dep_name) {
-            let e = RequirementError::MissingDependency(*dep_name);
-            return Err(e.into_activate_error(parent, s));
+    if parent.is_none() {
+        for dep_name in reqs.deps.keys() {
+            if !valid_dep_names.contains(dep_name) {
+                let e = RequirementError::MissingDependency(*dep_name);
+                return Err(e.into_activate_error(parent, s));
+            }
         }
     }
 

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1831,3 +1831,109 @@ foo v0.1.0 ([..]/foo)
         .with_status(101)
         .run();
 }
+
+#[cargo_test]
+fn cyclic_features() {
+    // Check for stack overflow with cyclic features (oops!).
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "1.0.0"
+
+                [features]
+                a = ["b"]
+                b = ["a"]
+                default = ["a"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("tree -e features")
+        .with_stdout("foo v1.0.0 ([ROOT]/foo)")
+        .run();
+
+    p.cargo("tree -e features -i foo")
+        .with_stdout(
+            "\
+foo v1.0.0 ([ROOT]/foo)
+├── foo feature \"a\"
+│   ├── foo feature \"b\"
+│   │   └── foo feature \"a\" (*)
+│   └── foo feature \"default\" (command-line)
+├── foo feature \"b\" (*)
+└── foo feature \"default\" (command-line)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn dev_dep_cycle_with_feature() {
+    // Cycle with features and a dev-dependency.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "1.0.0"
+
+                [dev-dependencies]
+                bar = { path = "bar" }
+
+                [features]
+                a = ["bar/feat1"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "1.0.0"
+
+                [dependencies]
+                foo = { path = ".." }
+
+                [features]
+                feat1 = ["foo/a"]
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("tree -e features --features a")
+        .with_stdout(
+            "\
+foo v1.0.0 ([ROOT]/foo)
+[dev-dependencies]
+└── bar feature \"default\"
+    └── bar v1.0.0 ([ROOT]/foo/bar)
+        └── foo feature \"default\" (command-line)
+            └── foo v1.0.0 ([ROOT]/foo) (*)
+",
+        )
+        .run();
+
+    p.cargo("tree -e features --features a -i foo")
+        .with_stdout(
+            "\
+foo v1.0.0 ([ROOT]/foo)
+├── foo feature \"a\" (command-line)
+│   └── bar feature \"feat1\"
+│       └── foo feature \"a\" (command-line) (*)
+└── foo feature \"default\" (command-line)
+    └── bar v1.0.0 ([ROOT]/foo/bar)
+        ├── bar feature \"default\"
+        │   [dev-dependencies]
+        │   └── foo v1.0.0 ([ROOT]/foo) (*)
+        └── bar feature \"feat1\" (*)
+",
+        )
+        .run();
+}


### PR DESCRIPTION
This fixes two issues with cyclic features and dev-dependencies:

* `cargo tree` would enter an infinite loop for cyclic features.
* The resolver would return a confusing error if a cyclic dev-dependency attempted to enable a feature on its parent that resulted in a cycle.  This fixes it to resolve correctly.

Fixes #10101