### PR TITLE
Update curl dependency, remove M1 macOS build error note

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.1.1" }
 crates-io = { path = "crates/crates-io", version = "0.33.0" }
 crossbeam-utils = "0.8"
-curl = { version = "0.4.40", features = ["http2"] }
+curl = { version = "0.4.41", features = ["http2"] }
 curl-sys = "0.4.50"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }

--- a/src/doc/contrib/src/process/working-on-cargo.md
+++ b/src/doc/contrib/src/process/working-on-cargo.md
@@ -46,11 +46,6 @@ If you can successfully run `cargo build`, you should be good to go!
 
 [homebrew]: https://brew.sh/
 
-Note: There is currently a bug on arm64 M1 macOS machines that will cause an error 
-while linking cargo. To fix this, run `export MACOSX_DEPLOYMENT_TARGET=10.7` before 
-attempting to build the cargo project. For more information, see 
-[rust#90342](https://github.com/rust-lang/rust/issues/90342).
-
 ## Running Cargo
 
 You can use `cargo run` to run cargo itself, or you can use the path directly


### PR DESCRIPTION
Curl subversion 41 includes a workaround for the m1 macOS build error. 
See https://github.com/rust-lang/rust/issues/90342#issuecomment-974698158