### PR TITLE
re-enable lto_build test on 32-bit MSVC

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1707,11 +1707,6 @@ Caused by:
 
 #[cargo_test]
 fn lto_build() {
-    // FIXME: currently this hits a linker bug on 32-bit MSVC
-    if cfg!(all(target_env = "msvc", target_pointer_width = "32")) {
-        return;
-    }
-
     let p = project()
         .file(
             "Cargo.toml",


### PR DESCRIPTION
re-enable lto_build test on 32-bit MSVC. Because https://github.com/rust-lang/rust/pull/27224 landed.