### PR TITLE
Produce sane CARGO when invoked through ld.so

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -161,8 +161,18 @@ fn issue_10113() {
 
     p.cargo("build").run();
 
-    let ld = Path::new("/usr/lib64/ld-linux-x86-64.so.2");
     if cfg!(target_os = "linux") {
+        let ld = if cfg!(target_arch = "x86_64") {
+            Some(Path::new("/usr/lib64/ld-linux-x86-64.so.2"))
+        } else if cfg!(target_arch = "x86") {
+            Some(Path::new("/usr/lib/ld-linux.so.2"))
+        } else {
+            None
+        };
+
+        // This test needs to be updated with the path to ld.so for this arch.
+        // We error on an unknown ld path to catch typos in the `cfg!`s above and such.
+        let ld = ld.expect("path to ld-linux.so unknown for current architecture");
         assert!(ld.exists());
         let mut proc = process(ld);
         proc.cwd(p.root());

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -151,7 +151,7 @@ fn issue_10113() {
             fn main() {
                 let cargo = dbg!(env::var("CARGO").unwrap());
                 let cargo = Path::new(&cargo);
-                assert!(cargo.ends_with("cargo"));
+                assert!(cargo.ends_with(&format!("cargo{}", env::consts::EXE_SUFFIX)));
                 assert!(cargo.exists());
             }
         "#,


### PR DESCRIPTION
If `current_exe` indicates that the current exe is `ld-*.so.*` (so it "looks like" the dynamic linker), we fall back to using `argv[0]` instead.

Fixes #10113, which also has further details on the problem.