### PR TITLE
Add support for `-Zbuild-std` to `cargo fetch`

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -84,6 +84,11 @@ impl BuildConfig {
             anyhow::bail!("jobs may not be 0");
         }
 
+        if config.cli_unstable().build_std.is_some() && requested_kinds[0].is_host() {
+            // TODO: This should eventually be fixed.
+            anyhow::bail!("-Zbuild-std requires --target");
+        }
+
         Ok(BuildConfig {
             requested_kinds,
             jobs,

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -690,3 +690,22 @@ fn proc_macro_only() {
         .with_stderr_contains("[FINISHED] [..]")
         .run();
 }
+
+#[cargo_test]
+fn fetch() {
+    let setup = match setup() {
+        Some(s) => s,
+        None => return,
+    };
+    let p = project().file("src/main.rs", "fn main() {}").build();
+    p.cargo("fetch")
+        .build_std(&setup)
+        .target_host()
+        .with_stderr_contains("[DOWNLOADED] [..]")
+        .run();
+    p.cargo("build")
+        .build_std(&setup)
+        .target_host()
+        .with_stderr_does_not_contain("[DOWNLOADED] [..]")
+        .run();
+}


### PR DESCRIPTION
This allows downloading the dependencies for libstd in advance, which
can be useful in e.g. sandboxed build environments.

Fixes https://github.com/rust-lang/wg-cargo-std-aware/issues/22.

r? @ehuss