### PR TITLE
Improve unused patch message when source URLs mismatched

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -413,11 +413,12 @@ impl<'cfg> PackageRegistry<'cfg> {
         self.patches_locked = true;
     }
 
-    pub fn patches(&self) -> Vec<Summary> {
-        self.patches
-            .values()
-            .flat_map(|v| v.iter().cloned())
-            .collect()
+    /// Gets all patches grouped by the source URLS they are going to patch.
+    ///
+    /// These patches are mainly collected from [`patch`](Self::patch).
+    /// They might not be the same as patches actually used during dependency resolving.
+    pub fn patches(&self) -> &HashMap<CanonicalUrl, Vec<Summary>> {
+        &self.patches
     }
 
     fn load(&mut self, source_id: SourceId, kind: Kind) -> CargoResult<()> {


### PR DESCRIPTION
Resolves #8690 

`Resolve.unused_patches` does not contains info about which source
URLs they are going to patch. As a result, we cannot provide a precise
message but only list all possible URLs of the packages with the same
name in the resolved graph.

There is a little flaw that if multiple patches are patching the same 
package, the source URL of the used one would be shown as a possible 
URL in the warning.