### PR TITLE
Add a note about doctest xcompile.

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -173,6 +173,16 @@ fn run_doc_tests(
                 CompileKind::Target(target) => {
                     if target.short_name() != compilation.host {
                         // Skip doctests, -Zdoctest-xcompile not enabled.
+                        config.shell().verbose(|shell| {
+                            shell.note(format!(
+                                "skipping doctests for {} ({}), \
+                                 cross-compilation doctests are not yet supported\n\
+                                 See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile \
+                                 for more information.",
+                                unit.pkg,
+                                unit.target.description_named()
+                            ))
+                        })?;
                         continue;
                     }
                 }

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -617,6 +617,10 @@ fn no_cross_doctests() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[NOTE] skipping doctests for foo v0.0.1 ([ROOT]/foo) (lib), \
+cross-compilation doctests are not yet supported
+See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile \
+for more information.
 ",
         )
         .run();
@@ -634,6 +638,10 @@ fn no_cross_doctests() {
 [RUNNING] `rustc --crate-name foo [..]--test[..]
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[CWD]/target/{triple}/debug/deps/foo-[..][EXE]`
+[NOTE] skipping doctests for foo v0.0.1 ([ROOT]/foo) (lib), \
+cross-compilation doctests are not yet supported
+See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile \
+for more information.
 ",
             triple = target
         ))


### PR DESCRIPTION
This adds a note when running with `--verbose` if doctests are being skipped because they do not support cross-compiling.

I decided to use verbose instead of always displaying it because I felt it could get really noisy.  However, I'm a bit on the fence.  I'm kinda curious what is blocking doctest-xcompile from being stabilized?
