### PR TITLE
Fix some tests with output collisions.

### DIFF
--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -416,7 +416,7 @@ fn package_cleans_all_the_things() {
             "#,
         )
         .file("src/lib.rs", "")
-        .file("src/main.rs", "fn main() {}")
+        .file("src/lib/some-main.rs", "fn main() {}")
         .file("src/bin/other-main.rs", "fn main() {}")
         .file("examples/foo-ex-rlib.rs", "")
         .file("examples/foo-ex-cdylib.rs", "")

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1242,8 +1242,24 @@ fn doc_all_member_dependency_same_name() {
     Package::new("bar", "0.1.0").publish();
 
     p.cargo("doc --workspace")
-        .with_stderr_contains("[..] Updating `[..]` index")
-        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
+        .with_stderr_unordered(
+            "\
+[UPDATING] [..]
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
+warning: output filename collision.
+The lib target `bar` in package `bar v0.1.0` has the same output filename as \
+the lib target `bar` in package `bar v0.1.0 ([ROOT]/foo/bar)`.
+Colliding filename is: [ROOT]/foo/target/doc/bar/index.html
+The targets should have unique names.
+This is a known bug where multiple crates with the same name use
+the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
+[DOCUMENTING] bar v0.1.0
+[CHECKING] bar v0.1.0
+[DOCUMENTING] bar v0.1.0 [..]
+[FINISHED] [..]
+",
+        )
         .run();
 }
 

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -177,7 +177,7 @@ fn complicated() {
         )
         .file("build.rs", "fn main() { dep_build::foo() }")
         .file(
-            "src/main.rs",
+            "src/bin/foo-bin.rs",
             "#[dep_proc_macro::foo] fn main() { dep_normal::foo() }",
         )
         .file(
@@ -206,7 +206,9 @@ fn complicated() {
         .with_stderr_contains(
             "[..]`rustc[..]--crate-name dep_proc_macro [..]-C embed-bitcode=no[..]`",
         )
-        .with_stderr_contains("[..]`rustc[..]--crate-name test [..]--crate-type bin[..]-C lto[..]`")
+        .with_stderr_contains(
+            "[..]`rustc[..]--crate-name foo_bin [..]--crate-type bin[..]-C lto[..]`",
+        )
         .with_stderr_contains(
             "[..]`rustc[..]--crate-name test [..]--crate-type cdylib[..]-C lto[..]`",
         )
@@ -753,7 +755,7 @@ fn dylib_rlib_bin() {
             "#,
         )
         .file("src/lib.rs", "pub fn foo() { println!(\"hi!\"); }")
-        .file("src/main.rs", "fn main() { foo::foo(); }")
+        .file("src/bin/ferret.rs", "fn main() { foo::foo(); }")
         .build();
 
     let output = p.cargo("build --release -v").exec_with_output().unwrap();
@@ -763,7 +765,7 @@ fn dylib_rlib_bin() {
         "--crate-type dylib --crate-type rlib",
         Lto::ObjectAndBitcode,
     );
-    verify_lto(&output, "foo", "--crate-type bin", Lto::Run(None));
+    verify_lto(&output, "ferret", "--crate-type bin", Lto::Run(None));
 }
 
 #[cargo_test]


### PR DESCRIPTION
This fixes some tests which run afoul of creating colliding outputs (tracked in #6313). In particular, these tests are creating duplicate pdb files on Windows because they have a binary and a library (dylib) with the same name. This is causing significant issues on rust-lang's CI (https://github.com/rust-lang/rust/issues/81890) where the MSVC linker is failing with a mysterious LNK1201 error. Presumably two LINK.exe processes are trying to write to the same PDB file at the same time, which causes it to fail.

Ideally this shouldn't happen, but I don't really have any ideas on how to resolve it, as the name of the PDB has some importance.

I have not been able to reproduce the LNK1201 error. My hope is that this change will help alleviate the issue, though.

I updated the `doc_all_member_dependency_same_name` test to illustrate that it is hitting a collision, which is a fundamental part of that test (and something we should probably figure out how to resolve in the future).
