### PR TITLE
Add note about RUSTFLAGS removal from build scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
 
 ### Changed
 
+- ❗ `RUSTFLAGS` is no longer set for build scripts. This change was made in
+  1.55, but the release notes did not highlight this change. Build scripts
+  should use `CARGO_ENCODED_RUSTFLAGS` instead. See the
+  [documentation](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)
+  for more details.
 - The `cargo version` command now includes some extra information.
   [#9968](https://github.com/rust-lang/cargo/pull/9968)
 - Updated libgit2 to 1.3 which brings in a number of fixes and changes to git
@@ -186,8 +191,10 @@
 - The package definition in `cargo metadata` now includes the `"default_run"`
   field from the manifest.
   [#9550](https://github.com/rust-lang/cargo/pull/9550)
-- Build scripts now have access to the following environment variables:
+- ❗ Build scripts now have access to the following environment variables:
   `RUSTC_WRAPPER`, `RUSTC_WORKSPACE_WRAPPER`, `CARGO_ENCODED_RUSTFLAGS`.
+  `RUSTFLAGS` is no longer set for build scripts; they should use
+  `CARGO_ENCODED_RUSTFLAGS` instead.
   [docs](https://doc.rust-lang.org/nightly/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts)
   [#9601](https://github.com/rust-lang/cargo/pull/9601)
 - Added `cargo d` as an alias for `cargo doc`.

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -353,10 +353,10 @@ let out_dir = env::var("OUT_DIR").unwrap();
                    changed by editing `.cargo/config.toml`; see the documentation
                    about [cargo configuration][cargo-config] for more
                    information.
-* `CARGO_ENCODED_RUSTFLAGS` — extra flags that Cargo invokes `rustc`
-			      with, separated by a `0x1f` character
-			      (ASCII Unit Separator). See
-			      [`build.rustflags`].
+* `CARGO_ENCODED_RUSTFLAGS` — extra flags that Cargo invokes `rustc` with,
+  separated by a `0x1f` character (ASCII Unit Separator). See
+  [`build.rustflags`]. Note that since Rust 1.55, `RUSTFLAGS` is removed from
+  the environment; scripts should use `CARGO_ENCODED_RUSTFLAGS` instead.
 * `CARGO_PKG_<var>` - The package information variables, with the same names and values as are [provided during crate building][variables set for crates].
 
 [unix-like platforms]: ../../reference/conditional-compilation.html#unix-and-windows


### PR DESCRIPTION
The RUSTFLAGS environment variable was removed from build scripts in #9601, but the release notes did not make a note of this change. This adds a highlight to this potentially breaking change.