### PR TITLE
Treat EOPNOTSUPP the same as ENOTSUP when ignoring failed flock calls.

### DIFF
--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -374,7 +374,10 @@ mod sys {
 
     pub(super) fn error_unsupported(err: &Error) -> bool {
         match err.raw_os_error() {
-            Some(libc::ENOTSUP) => true,
+            // Unfortunately, depending on the target, these may or may not be the same.
+            // For targets in which they are the same, the duplicate pattern causes a warning.
+            #[allow(unreachable_patterns)]
+            Some(libc::ENOTSUP | libc::EOPNOTSUPP) => true,
             #[cfg(target_os = "linux")]
             Some(libc::ENOSYS) => true,
             _ => false,


### PR DESCRIPTION
On some platforms, `ENOTSUP` and `EOPNOTSUPP` are distinct and it's not consistent which error is returned. e.g. the BSDs will return `EOPNOTSUPP` ([FreeBSD](https://www.freebsd.org/cgi/man.cgi?query=flock&sektion=2#ERRORS), [OpenBSD](https://man.openbsd.org/flock.2#ERRORS)) whereas [macOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/flock.2.html) returns `ENOTSUP`.