### PR TITLE
Upgrade clap to 2.34.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ toml = "0.5.7"
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
-clap = "2.31.2"
+clap = "2.34.0"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
 im-rc = "15.0.0"


### PR DESCRIPTION
That includes the fix of preventing panicking on a broken pipe.
https://github.com/clap-rs/clap/commit/accf3d251168e10ecbb0b4ae200c3196b950dac9

Fixes #10131 