### PR TITLE
Explicitly mark aliases in `cargo list`.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -139,7 +139,12 @@ Run with 'cargo -Z [FLAG] [SUBCOMMAND]'",
                     }
                 }
                 CommandInfo::Alias { target } => {
-                    drop_println!(config, "    {:<20} {}", name, target.iter().join(" "));
+                    drop_println!(
+                        config,
+                        "    {:<20} alias: {}",
+                        name,
+                        target.iter().join(" ")
+                    );
                 }
             }
         }

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -57,8 +57,8 @@ fn list_custom_aliases_with_descriptions() {
         .build();
 
     p.cargo("--list")
-        .with_stdout_contains("    myaliasstr           foo --bar")
-        .with_stdout_contains("    myaliasvec           foo --bar")
+        .with_stdout_contains("    myaliasstr           alias: foo --bar")
+        .with_stdout_contains("    myaliasvec           alias: foo --bar")
         .run();
 }
 


### PR DESCRIPTION
This I think makes it a little clearer that these are aliases, and matches the form used for built-in aliases.
