### PR TITLE
Remove `-Z future-incompat-report` from message displayed to user

### DIFF
--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -439,7 +439,7 @@ https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch
         drop(bcx.config.shell().note(&suggestion_message));
         drop(bcx.config.shell().note(&format!(
             "this report can be shown with `cargo report \
-             future-incompatibilities -Z future-incompat-report --id {}`",
+             future-incompatibilities --id {}`",
             report_id
         )));
     } else if should_display_message {


### PR DESCRIPTION
This was missed during stabilization