### PR TITLE
Detect filesystem loop during walking the projects

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4653,7 +4653,7 @@ Caused by:
   failed to determine list of files in [..]/foo
 
 Caused by:
-  cannot read \"[..]/foo/secrets\"
+  IO error for operation on [..]/foo/secrets: [..]
 
 Caused by:
   [..]

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -794,10 +794,10 @@ fn broken_symlink() {
         .with_status(101)
         .with_stderr_contains(
             "\
-error: failed to prepare local package for uploading
+error: failed to determine list of files [..]/foo
 
 Caused by:
-  failed to open for archiving: `[..]foo.rs`
+  IO error for operation on [..]/foo/src/foo.rs: [..]
 
 Caused by:
   [..]
@@ -823,6 +823,28 @@ fn package_symlink_to_dir() {
         .build()
         .cargo("package -v")
         .with_stderr_contains("[ARCHIVING] foo/Makefile")
+        .run();
+}
+
+#[cargo_test]
+/// Tests if a symlink to ancestor causes filesystem loop error.
+///
+/// This test requires you to be able to make symlinks.
+/// For windows, this may require you to enable developer mode.
+fn filesystem_loop() {
+    if !symlink_supported() {
+        return;
+    }
+
+    project()
+        .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .symlink_dir("a/b", "a/b/c/d/foo")
+        .build()
+        .cargo("package -v")
+        .with_status(101)
+        .with_stderr_contains(
+            "  File system loop found: [..]/a/b/c/d/foo points to an ancestor [..]/a/b",
+        )
         .run();
 }
 
@@ -1798,7 +1820,8 @@ fn package_restricted_windows() {
         .build();
 
     p.cargo("package")
-        .with_stderr(
+        // use unordered here because the order of the warning is different on each platform.
+        .with_stderr_unordered(
             "\
 [WARNING] file src/aux/mod.rs is a reserved Windows filename, it will not work on Windows platforms
 [WARNING] file src/con.rs is a reserved Windows filename, it will not work on Windows platforms


### PR DESCRIPTION
Resolves #9528

~~This PR also adds a new dependency `same-file` but since it's already a
dependency of `cargo-util`, so nothing added actually.~~

Use `walkdir` to detect filesystem loop and gain performance boost!
