### PR TITLE
Improve I/O error message for fingerprint of build script

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4639,6 +4639,12 @@ fn build_script_scan_eacces() {
         .with_stderr(
             "\
 [ERROR] failed to determine package fingerprint for build script for foo v0.0.1 ([..]/foo)
+An I/O error happened[..]
+
+By default[..]
+it to[..]
+file[..]
+See[..]
 
 Caused by:
   failed to determine the most recently modified file in [..]/foo


### PR DESCRIPTION
It is a bit rough but I don't think there is a network I/O error
in `pkg_fingerprint`. Checking only `io::Error` type should be fine.

Resolves #9881 