### PR TITLE
Display alias target on 'cargo help <alias>`

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -803,6 +803,15 @@ impl Execs {
         }
     }
 
+    #[track_caller]
+    pub fn run_expect_error(&mut self) {
+        self.ran = true;
+        let p = (&self.process_builder).clone().unwrap();
+        if self.match_process(&p).is_ok() {
+            panic!("test was expected to fail, but succeeded running {}", p);
+        }
+    }
+
     /// Runs the process, checks the expected output, and returns the first
     /// JSON object on stdout.
     #[track_caller]

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -94,11 +94,8 @@ fn check_alias(config: &Config, subcommand: &str) -> Option<Vec<String>> {
 /// Checks if the given subcommand is a built-in command (not via an alias).
 ///
 /// Returns None if it is not a built-in command.
-fn check_builtin(subcommand: &str) -> Option<String> {
-    match super::builtin_exec(subcommand) {
-        Some(_) => Some(subcommand.to_string()),
-        None => None,
-    }
+fn check_builtin(subcommand: &str) -> Option<&str> {
+    super::builtin_exec(subcommand).map(|_| subcommand)
 }
 
 /// Extracts the given man page from the compressed archive.

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -85,10 +85,7 @@ fn try_help(config: &Config) -> CargoResult<bool> {
 ///
 /// Returns None if it is not an alias.
 fn check_alias(config: &Config, subcommand: &str) -> Option<Vec<String>> {
-    match aliased_command(config, subcommand) {
-        Ok(Some(alias)) => Some(alias),
-        _ => None,
-    }
+    aliased_command(config, subcommand).ok().flatten()
 }
 
 /// Checks if the given subcommand is a built-in command (not via an alias).

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -55,7 +55,11 @@ fn try_help(config: &Config) -> CargoResult<bool> {
             return Ok(true);
         }
         // Otherwise, resolve the alias into its subcommand.
-        Some(argv) => argv[0].clone(),
+        Some(argv) => {
+            // An alias with an empty argv can be created via `"empty-alias" = ""`.
+            let first = argv.get(0).map(String::as_str).unwrap_or(subcommand);
+            first.to_string()
+        }
         None => subcommand.to_string(),
     };
 

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -110,6 +110,20 @@ fn help_with_man_and_path(
     assert_eq!(stdout, contents);
 }
 
+fn help_with_stdout_and_path(subcommand: &str, path: &Path) -> String {
+    let output = process(&cargo_exe())
+        .arg("help")
+        .arg(subcommand)
+        .env("PATH", path)
+        .exec_with_output()
+        .unwrap();
+    assert!(output.status.success());
+    let stderr = from_utf8(&output.stderr).unwrap();
+    assert_eq!(stderr, "");
+    let stdout = from_utf8(&output.stdout).unwrap();
+    stdout.to_string()
+}
+
 #[cargo_test]
 fn help_man() {
     // Checks that `help command` displays the man page using the given command.
@@ -124,7 +138,8 @@ fn help_man() {
 #[cargo_test]
 fn help_alias() {
     // Check that `help some_alias` will resolve.
-    help_with_man_and_path("", "b", "build", Path::new(""));
+    let out = help_with_stdout_and_path("b", Path::new(""));
+    assert_eq!(out, "'b' is aliased to 'build'\n");
 
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
@@ -136,7 +151,8 @@ fn help_alias() {
         "#,
     )
     .unwrap();
-    help_with_man_and_path("", "my-alias", "build", Path::new(""));
+    let out = help_with_stdout_and_path("my-alias", Path::new(""));
+    assert_eq!(out, "'my-alias' is aliased to 'build --release'\n");
 }
 
 #[cargo_test]

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -138,8 +138,7 @@ fn help_man() {
 #[cargo_test]
 fn help_alias() {
     // Check that `help some_alias` will resolve.
-    let out = help_with_stdout_and_path("b", Path::new(""));
-    assert_eq!(out, "'b' is aliased to 'build'\n");
+    help_with_man_and_path("", "b", "build", Path::new(""));
 
     let config = paths::root().join(".cargo/config");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
@@ -147,12 +146,18 @@ fn help_alias() {
         config,
         r#"
             [alias]
-            my-alias = ["build", "--release"]
+            simple-alias  = ["build"]
+            complex-alias = ["build", "--release"]
         "#,
     )
     .unwrap();
-    let out = help_with_stdout_and_path("my-alias", Path::new(""));
-    assert_eq!(out, "'my-alias' is aliased to 'build --release'\n");
+
+    // Because `simple-alias` aliases a subcommand with no arguments, help shows the manpage.
+    help_with_man_and_path("", "simple-alias", "build", Path::new(""));
+
+    // Help for `complex-alias` displays the full alias command.
+    let out = help_with_stdout_and_path("complex-alias", Path::new(""));
+    assert_eq!(out, "`complex-alias` is aliased to `build --release`\n");
 }
 
 #[cargo_test]

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -146,11 +146,18 @@ fn help_alias() {
         config,
         r#"
             [alias]
-            simple-alias  = ["build"]
+            empty-alias   = ""
+            simple-alias  = "build"
             complex-alias = ["build", "--release"]
         "#,
     )
     .unwrap();
+
+    // The `empty-alias` returns an error.
+    cargo_process("help empty-alias")
+        .env("PATH", Path::new(""))
+        .with_stderr_contains("[..]The subcommand 'empty-alias' wasn't recognized[..]")
+        .run_expect_error();
 
     // Because `simple-alias` aliases a subcommand with no arguments, help shows the manpage.
     help_with_man_and_path("", "simple-alias", "build", Path::new(""));


### PR DESCRIPTION
```
Previously, `cargo help <alias>` resolved the alias and displayed the
help for the targeted subcommand. For example, if `br` were aliased to
`build --release`, `cargo help br` would display the manpage for
cargo-build.

With this patch, it will print "'br' is aliased to 'build --release'".
```

Addresses issue #10138.

This is my first patch to Cargo. I attempted to follow the style of the surrounding code. Please let me know if any changes are required: happy to make them. In particular, I wasn't sure if any tests exist for this path.