### PR TITLE
Enhance descriptions of issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Question
+    url: https://users.rust-lang.org
+    about: >
+      Got a question about Cargo? Ask the community on the user forum.
+  - name: Inspiring Idea
+    url: https://internals.rust-lang.org/c/tools-and-infrastructure/cargo
+    about: >
+      Need more discussions with your next big idea?
+      Reach out the coummunity on the internals forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,15 @@ labels: ["C-feature-request"]
 body:
   - type: markdown
     attributes:
-      value: Thanks for filing a 🙋 feature request 😄!
+      value: |
+        Thanks for filing a 🙋 feature request 😄!
+
+        If the feature request is relatively small and already with a possible solution, this might be the place for you.
+
+        If you are brewing a big feature that needs feedback from the community, [the internal forum] is the best fit, especially for pre-RFC. You can also talk the idea over with other developers in [#t-cargo Zulip stream].
+
+        [the internal forum]: https://internals.rust-lang.org/c/tools-and-infrastructure/cargo/15
+        [#t-cargo Zulip stream]: https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo
   - type: textarea
     id: problem
     attributes:


### PR DESCRIPTION
## Why

To discuss new features with larger scope, I think it's better discuss with the community, not just people in this repo. Hope these changes can guide people to a more proper place for this kind of feature request.

## Screenshots

#### Add two new types of issue template

- Question
- Inspiring Idea

<img width="500" alt="image" src="https://user-images.githubusercontent.com/14314532/146328466-f234c431-e355-4da1-a34a-b7b4c2490599.png">

#### Mention internal forum and zulip to guide user to discuss

<img width="500" alt="image" src="https://user-images.githubusercontent.com/14314532/146328580-4798983a-58d3-4e5e-9006-bf6d1d089c83.png">
