### PR TITLE
Error about not having any crates with documentation

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -20,7 +20,10 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
     let compilation = ops::compile(ws, &options.compile_opts)?;
 
     if options.open_result {
-        let name = &compilation.root_crate_names[0];
+        let name = &compilation
+            .root_crate_names
+            .get(0)
+            .ok_or_else(|| anyhow::anyhow!("no crates with documentation"))?;
         let kind = options.compile_opts.build_config.single_requested_kind()?;
         let path = compilation.root_output[&kind]
             .with_file_name("doc")

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1345,6 +1345,31 @@ fn doc_extern_map_local() {
 }
 
 #[cargo_test]
+fn open_no_doc_crate() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            version = "0.0.1"
+            authors = []
+
+            [lib]
+            doc = false
+        "#,
+        )
+        .file("src/lib.rs", "#[cfg(feature)] pub fn f();")
+        .build();
+
+    p.cargo("doc --open")
+        .env("BROWSER", "do_not_run_me")
+        .with_status(101)
+        .with_stderr_contains("error: no crates with documentation")
+        .run();
+}
+
+#[cargo_test]
 fn doc_workspace_open_different_library_and_package_names() {
     let p = project()
         .file(


### PR DESCRIPTION
close https://github.com/rust-lang/cargo/issues/10194

Error about not having any crates with documentation.