### PR TITLE
Clarify configuration and workspace interaction

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -36,7 +36,10 @@ it, named `/projects/foo/bar/baz/mylib` and `/projects/foo/bar/baz/mybin`, and
 there are Cargo configs at `/projects/foo/bar/baz/mylib/.cargo/config.toml`
 and `/projects/foo/bar/baz/mybin/.cargo/config.toml`, Cargo does not read
 those configuration files if it is invoked from the workspace root
-(`/projects/foo/bar/baz/`).
+(`/projects/foo/bar/baz/`), or anyways if it is asked to compile a crate from 
+that workspace, even if from outside the workspace root (e.g. via the 
+[`--manifest-path`](https://doc.rust-lang.org/cargo/commands/cargo-build.html#manifest-options)
+flag).
 
 > **Note:** Cargo also reads config files without the `.toml` extension, such as
 > `.cargo/config`. Support for the `.toml` extension was added in version 1.39


### PR DESCRIPTION
The way it is currently phrased is not actually consistent with the behaviour I experienced, in which even I specify the `--manifest-path` flag value, the config value gets ignored if the target crate is in a workspace, regardless of whether I am invoking it from the workspace root. What counts is the crate location w.r.t. the workspace, not where cargo is invoked from (I think). Please feel free to double check my understanding.