### PR TITLE
Add function for parsing already-read manifest

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -52,12 +52,20 @@ pub fn read_manifest(
     );
     let contents = paths::read(path).map_err(|err| ManifestError::new(err, path.into()))?;
 
-    do_read_manifest(&contents, path, source_id, config)
+    read_manifest_from_str(&contents, path, source_id, config)
         .with_context(|| format!("failed to parse manifest at `{}`", path.display()))
         .map_err(|err| ManifestError::new(err, path.into()))
 }
 
-fn do_read_manifest(
+/// Parse an already-loaded `Cargo.toml` as a Cargo manifest.
+///
+/// This could result in a real or virtual manifest being returned.
+///
+/// A list of nested paths is also returned, one for each path dependency
+/// within the manifest. For virtual manifests, these paths can only
+/// come from patched or replaced dependencies. These paths are not
+/// canonicalized.
+pub fn read_manifest_from_str(
     contents: &str,
     manifest_file: &Path,
     source_id: SourceId,


### PR DESCRIPTION
This makes the function formerly known as `do_read_manifest` public
under the name `read_manifest_from_str` so that Cargo-as-a-library users
can parse a manifest without re-reading a `Cargo.toml` file they have
already read from disk themselves.