### PR TITLE
[docs] Adds basic CI yaml for GitHub Actions

### DIFF
--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -50,6 +50,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+          override: true
       - run: cargo build --verbose
       - run: cargo test --verbose
 ```

--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -48,7 +48,7 @@ jobs:
       - run: cargo test --verbose
 ```
 
-This will test all three release channels, see [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
+This will test all three release channels. You can also click `"Actions" > "new workflow"` in the GitHub UI and select Rust to add the [default configuration](https://github.com/actions/starter-workflows/blob/main/ci/rust.yml) to your repo. See [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
 
 ### GitLab CI
 

--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -21,6 +21,41 @@ will not fail your overall build. Please see the [Travis CI Rust
 documentation](https://docs.travis-ci.com/user/languages/rust/) for more
 information.
 
+### GitHub Actions
+
+To test your package on GitHub Actions, here is a sample `.github/workflows/ci.yml` file:
+
+```yaml
+name: Cargo Build & Test
+
+on:
+  push:
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ${{ matrix.operating-system }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+        operating-system:
+          - "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+```
+
+This will test all three release channels, see [actions-rs documentation](https://github.com/actions-rs/cargo) and [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
+
 ### GitLab CI
 
 To test your package on GitLab CI, here is a sample `.gitlab-ci.yml` file:

--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -34,28 +34,21 @@ on:
 jobs:
   build_and_test:
     name: Rust project - latest
-    runs-on: ${{ matrix.operating-system }}
-    continue-on-error: true
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         toolchain:
           - stable
           - beta
           - nightly
-        operating-system:
-          - "ubuntu-latest"
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          override: true
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
 ```
 
-This will test all three release channels, see [actions-rs documentation](https://github.com/actions-rs/cargo) and [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
+This will test all three release channels, see [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
 
 ### GitLab CI
 

--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -30,6 +30,10 @@ name: Cargo Build & Test
 
 on:
   push:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
 
 jobs:
   build_and_test:
@@ -46,9 +50,10 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
+  
 ```
 
-This will test all three release channels. You can also click `"Actions" > "new workflow"` in the GitHub UI and select Rust to add the [default configuration](https://github.com/actions/starter-workflows/blob/main/ci/rust.yml) to your repo. See [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
+This will test all three release channels (note a failure in any toolchain version will fail the entire job). You can also click `"Actions" > "new workflow"` in the GitHub UI and select Rust to add the [default configuration](https://github.com/actions/starter-workflows/blob/main/ci/rust.yml) to your repo. See [GitHub Actions documentation](https://docs.github.com/en/actions) for more information.
 
 ### GitLab CI
 


### PR DESCRIPTION
Currently there is no documentation for GitHub Actions, so I have attempted to add an Actions Workflow that is equivalent to the other CI snippets in the file. You can view a successful run of this Action in my repo for experimenting with this here: https://github.com/SamMorrowDrums/rust-action-test/actions/runs/1593666172

The Rust code I tested it with is just the boilerplate from `cargo init`.