### PR TITLE
Make levenshtein distance case insensitive.

### DIFF
--- a/src/cargo/util/lev_distance.rs
+++ b/src/cargo/util/lev_distance.rs
@@ -1,6 +1,9 @@
 use std::cmp;
 
 pub fn lev_distance(me: &str, t: &str) -> usize {
+    let me = me.to_lowercase();
+    let t = t.to_lowercase();
+
     let t_len = t.chars().count();
     if me.is_empty() {
         return t_len;

--- a/src/cargo/util/lev_distance.rs
+++ b/src/cargo/util/lev_distance.rs
@@ -1,6 +1,11 @@
 use std::cmp;
 
 pub fn lev_distance(me: &str, t: &str) -> usize {
+    // Comparing the strings lowercased will result in a difference in capitalization being less distance away
+    // than being a completely different letter. Otherwise `CHECK` is as far away from `check` as it
+    // is from `build` (both with a distance of 5). For a single letter shortcut (e.g. `b` or `c`), they will
+    // all be as far away from any capital single letter entry (all with a distance of 1).
+    // By first lowercasing the strings, `C` and `c` are closer than `C` and `b`, for example.
     let me = me.to_lowercase();
     let t = t.to_lowercase();
 

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -148,6 +148,34 @@ fn list_command_resolves_symlinks() {
 }
 
 #[cargo_test]
+fn find_closest_capital_c_to_c() {
+    cargo_process("C")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+error: no such subcommand: `C`
+
+<tab>Did you mean `c`?
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn find_closest_captial_b_to_b() {
+    cargo_process("B")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+error: no such subcommand: `B`
+
+<tab>Did you mean `b`?
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn find_closest_biuld_to_build() {
     cargo_process("biuld")
         .with_status(101)


### PR DESCRIPTION
When typing in a single character shortcut as a capital, it always
returns `b` as the suggestion as every one-letter abbreviation
is a lev distance 1 away from the capitalized one.
By making the levenshtein distance case insensitive, the case-mismatched
one-letter abbriviation (e.g. `C` to `c`) will be suggested, rather
than `b`