### PR TITLE
Remove unused lifetimes

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -554,7 +554,7 @@ impl<'de> de::Deserialize<'de> for EncodablePackageId {
     }
 }
 
-impl<'a> ser::Serialize for Resolve {
+impl ser::Serialize for Resolve {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -83,7 +83,7 @@ pub struct CompileOptions {
     pub honor_rust_version: bool,
 }
 
-impl<'a> CompileOptions {
+impl CompileOptions {
     pub fn new(config: &Config, mode: CompileMode) -> CargoResult<CompileOptions> {
         Ok(CompileOptions {
             build_config: BuildConfig::new(config, None, &[], mode)?,


### PR DESCRIPTION
This is blocking the Crater run in https://github.com/rust-lang/rust/pull/92413,
since a 'try' build needs to build Cargo.