### PR TITLE
Stabilize `-Ztimings` as `--timings`

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -47,6 +47,7 @@ pub fn cli() -> App {
             "Run all benchmarks regardless of failure",
         ))
         .arg_unit_graph()
+        .arg_timings()
         .after_help("Run `cargo help bench` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -44,6 +44,7 @@ pub fn cli() -> App {
         .arg_build_plan()
         .arg_unit_graph()
         .arg_future_incompat_report()
+        .arg_timings()
         .after_help("Run `cargo help build` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -36,6 +36,7 @@ pub fn cli() -> App {
         .arg_message_format()
         .arg_unit_graph()
         .arg_future_incompat_report()
+        .arg_timings()
         .after_help("Run `cargo help check` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -36,6 +36,7 @@ pub fn cli() -> App {
         .arg_message_format()
         .arg_ignore_rust_version()
         .arg_unit_graph()
+        .arg_timings()
         .after_help("Run `cargo help doc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -62,6 +62,7 @@ pub fn cli() -> App {
                 .help("Fix code even if the working directory has staged changes"),
         )
         .arg_ignore_rust_version()
+        .arg_timings()
         .after_help("Run `cargo help fix` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -78,6 +78,7 @@ pub fn cli() -> App {
                 .conflicts_with_all(&["git", "path", "index"]),
         )
         .arg_message_format()
+        .arg_timings()
         .after_help("Run `cargo help install` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -31,6 +31,7 @@ pub fn cli() -> App {
         .arg_message_format()
         .arg_unit_graph()
         .arg_ignore_rust_version()
+        .arg_timings()
         .after_help("Run `cargo help run` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -47,6 +47,7 @@ pub fn cli() -> App {
         .arg_unit_graph()
         .arg_ignore_rust_version()
         .arg_future_incompat_report()
+        .arg_timings()
         .after_help("Run `cargo help rustc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -35,6 +35,7 @@ pub fn cli() -> App {
         .arg_message_format()
         .arg_unit_graph()
         .arg_ignore_rust_version()
+        .arg_timings()
         .after_help("Run `cargo help rustdoc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -56,6 +56,7 @@ pub fn cli() -> App {
         .arg_message_format()
         .arg_unit_graph()
         .arg_future_incompat_report()
+        .arg_timings()
         .after_help(
             "Run `cargo help test` for more detailed information.\n\
              Run `cargo test -- --help` for test binary options.\n",

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -39,6 +39,8 @@ pub struct BuildConfig {
     pub export_dir: Option<PathBuf>,
     /// `true` to output a future incompatibility report at the end of the build
     pub future_incompat_report: bool,
+    /// Which kinds of build timings to output (empty if none).
+    pub timing_outputs: Vec<TimingOutput>,
 }
 
 impl BuildConfig {
@@ -86,6 +88,7 @@ impl BuildConfig {
             rustfix_diagnostic_server: RefCell::new(None),
             export_dir: None,
             future_incompat_report: false,
+            timing_outputs: Vec::new(),
         })
     }
 
@@ -230,4 +233,13 @@ impl CompileMode {
             CompileMode::Test | CompileMode::Bench | CompileMode::Build
         )
     }
+}
+
+/// Kinds of build timings we can output.
+#[derive(Clone, Copy, PartialEq, Debug, Eq, Hash, PartialOrd, Ord)]
+pub enum TimingOutput {
+    /// Human-readable HTML report
+    Html,
+    /// Machine-readable JSON (unstable)
+    Json,
 }

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -906,7 +906,7 @@ impl<'cfg> DrainState<'cfg> {
     // this as often as we spin on the events receiver (at least every 500ms or
     // so).
     fn tick_progress(&mut self) {
-        // Record some timing information if `-Ztimings` is enabled, and
+        // Record some timing information if `--timings` is enabled, and
         // this'll end up being a noop if we're not recording this
         // information.
         self.timings.mark_concurrency(

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -839,7 +839,7 @@ impl<'cfg> DrainState<'cfg> {
         }
 
         let time_elapsed = util::elapsed(cx.bcx.config.creation_time().elapsed());
-        if let Err(e) = self.timings.finished(cx.bcx, &error) {
+        if let Err(e) = self.timings.finished(cx, &error) {
             if error.is_some() {
                 crate::display_error(&e, &mut cx.bcx.config.shell());
             } else {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -33,7 +33,7 @@ use anyhow::{Context as _, Error};
 use lazycell::LazyCell;
 use log::{debug, trace};
 
-pub use self::build_config::{BuildConfig, CompileMode, MessageFormat};
+pub use self::build_config::{BuildConfig, CompileMode, MessageFormat, TimingOutput};
 pub use self::build_context::{
     BuildContext, FileFlavor, FileType, RustDocFingerprint, RustcTargetData, TargetInfo,
 };

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -4,7 +4,7 @@
 //! long it takes for different units to compile.
 use super::{CompileMode, Unit};
 use crate::core::compiler::job_queue::JobId;
-use crate::core::compiler::BuildContext;
+use crate::core::compiler::{BuildContext, TimingOutput};
 use crate::core::PackageId;
 use crate::util::cpu::State;
 use crate::util::machine_message::{self, Message};
@@ -92,15 +92,9 @@ struct Concurrency {
 
 impl<'cfg> Timings<'cfg> {
     pub fn new(bcx: &BuildContext<'_, 'cfg>, root_units: &[Unit]) -> Timings<'cfg> {
-        let has_report = |what| {
-            bcx.config
-                .cli_unstable()
-                .timings
-                .as_ref()
-                .map_or(false, |t| t.iter().any(|opt| opt == what))
-        };
-        let report_html = has_report("html");
-        let report_json = has_report("json");
+        let has_report = |what| bcx.build_config.timing_outputs.contains(&what);
+        let report_html = has_report(TimingOutput::Html);
+        let report_json = has_report(TimingOutput::Json);
         let enabled = report_html | report_json;
 
         let mut root_map: HashMap<PackageId, Vec<String>> = HashMap::new();

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -21,8 +21,6 @@ pub struct Timings<'cfg> {
     enabled: bool,
     /// If true, saves an HTML report to disk.
     report_html: bool,
-    /// If true, reports unit completion to stderr.
-    report_info: bool,
     /// If true, emits JSON information with timing information.
     report_json: bool,
     /// When Cargo started.
@@ -102,9 +100,8 @@ impl<'cfg> Timings<'cfg> {
                 .map_or(false, |t| t.iter().any(|opt| opt == what))
         };
         let report_html = has_report("html");
-        let report_info = has_report("info");
         let report_json = has_report("json");
-        let enabled = report_html | report_info | report_json;
+        let enabled = report_html | report_json;
 
         let mut root_map: HashMap<PackageId, Vec<String>> = HashMap::new();
         for unit in root_units {
@@ -139,7 +136,6 @@ impl<'cfg> Timings<'cfg> {
             config: bcx.config,
             enabled,
             report_html,
-            report_info,
             report_json,
             start: bcx.config.creation_time(),
             start_str,
@@ -227,18 +223,6 @@ impl<'cfg> Timings<'cfg> {
         unit_time
             .unlocked_units
             .extend(unlocked.iter().cloned().cloned());
-        if self.report_info {
-            let msg = format!(
-                "{}{} in {:.1}s",
-                unit_time.name_ver(),
-                unit_time.target,
-                unit_time.duration
-            );
-            let _ = self
-                .config
-                .shell()
-                .status_with_color("Completed", msg, termcolor::Color::Cyan);
-        }
         if self.report_json {
             let msg = machine_message::TimingInfo {
                 package_id: unit_time.unit.pkg.package_id(),

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -770,7 +770,7 @@ impl CliUnstable {
 
         fn parse_timings(value: Option<&str>) -> Vec<String> {
             match value {
-                None => vec!["html".to_string(), "info".to_string()],
+                None => vec!["html".to_string()],
                 Some(v) => v.split(',').map(|s| s.to_string()).collect(),
             }
         }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -652,7 +652,6 @@ unstable_cli_options!(
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     separate_nightlies: bool = (HIDDEN),
     terminal_width: Option<Option<usize>>  = ("Provide a terminal width to rustc for error truncation"),
-    timings: Option<Vec<String>>  = ("Display concurrency information"),
     unstable_options: bool = ("Allow the usage of unstable options"),
     // TODO(wcrichto): move scrape example configuration into Cargo.toml before stabilization
     // See: https://github.com/rust-lang/cargo/pull/9525#discussion_r728470927
@@ -712,6 +711,8 @@ const STABILIZED_WEAK_DEP_FEATURES: &str = "Weak dependency features are now alw
 
 const STABILISED_NAMESPACED_FEATURES: &str = "Namespaced features are now always available.";
 
+const STABILIZED_TIMINGS: &str = "The -Ztimings option has been stabilized as --timings.";
+
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -765,13 +766,6 @@ impl CliUnstable {
                 None | Some("yes") => Ok(true),
                 Some("no") => Ok(false),
                 Some(s) => bail!("flag -Z{} expected `no` or `yes`, found: `{}`", key, s),
-            }
-        }
-
-        fn parse_timings(value: Option<&str>) -> Vec<String> {
-            match value {
-                None => vec!["html".to_string()],
-                Some(v) => v.split(',').map(|s| s.to_string()).collect(),
             }
         }
 
@@ -849,7 +843,6 @@ impl CliUnstable {
                 self.build_std = Some(crate::core::compiler::standard_lib::parse_unstable_flag(v))
             }
             "build-std-features" => self.build_std_features = Some(parse_features(v)),
-            "timings" => self.timings = Some(parse_timings(v)),
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "doctest-in-workspace" => self.doctest_in_workspace = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
@@ -904,6 +897,7 @@ impl CliUnstable {
             "future-incompat-report" => {
                 stabilized_warn(k, "1.59.0", STABILIZED_FUTURE_INCOMPAT_REPORT)
             }
+            "timings" => stabilized_warn(k, "1.60", STABILIZED_TIMINGS),
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -236,11 +236,14 @@ pub trait AppExt: Sized {
     }
 
     fn arg_timings(self) -> Self {
-        self._arg(optional_multi_opt(
-            "timings",
-            "FMTS",
-            "Timing output formats (comma separated): html, json (unstable)",
-        ))
+        self._arg(
+            optional_opt(
+                "timings",
+                "Timing output formats (comma separated): html, json (unstable)",
+            )
+            .value_name("FMTS")
+            .require_equals(true),
+        )
     }
 }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1,4 +1,4 @@
-use crate::core::compiler::{BuildConfig, MessageFormat};
+use crate::core::compiler::{BuildConfig, MessageFormat, TimingOutput};
 use crate::core::resolver::CliFeatures;
 use crate::core::{Edition, Workspace};
 use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
@@ -233,6 +233,14 @@ pub trait AppExt: Sized {
 
     fn arg_quiet(self) -> Self {
         self._arg(opt("quiet", "Do not print cargo log messages").short('q'))
+    }
+
+    fn arg_timings(self) -> Self {
+        self._arg(optional_multi_opt(
+            "timings",
+            "FMTS",
+            "Timing output formats (comma separated): html, json (unstable)",
+        ))
     }
 }
 
@@ -499,6 +507,29 @@ pub trait ArgMatchesExt {
         build_config.build_plan = self.is_valid_and_present("build-plan");
         build_config.unit_graph = self.is_valid_and_present("unit-graph");
         build_config.future_incompat_report = self.is_valid_and_present("future-incompat-report");
+
+        if self.is_valid_and_present("timings") {
+            for timing_output in self._values_of("timings") {
+                for timing_output in timing_output.split(',') {
+                    let timing_output = timing_output.to_ascii_lowercase();
+                    let timing_output = match timing_output.as_str() {
+                        "html" => TimingOutput::Html,
+                        "json" => {
+                            config
+                                .cli_unstable()
+                                .fail_if_stable_opt("--timings=json", 7405)?;
+                            TimingOutput::Json
+                        }
+                        s => bail!("invalid timings output specifier: `{}`", s),
+                    };
+                    build_config.timing_outputs.push(timing_output);
+                }
+            }
+            if build_config.timing_outputs.is_empty() {
+                build_config.timing_outputs.push(TimingOutput::Html);
+            }
+        }
+
         if build_config.build_plan {
             config
                 .cli_unstable()

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -239,7 +239,7 @@ pub trait AppExt: Sized {
         self._arg(
             optional_opt(
                 "timings",
-                "Timing output formats (comma separated): html, json (unstable)",
+                "Timing output formats (unstable) (comma separated): html, json",
             )
             .value_name("FMTS")
             .require_equals(true),
@@ -516,7 +516,12 @@ pub trait ArgMatchesExt {
                 for timing_output in timing_output.split(',') {
                     let timing_output = timing_output.to_ascii_lowercase();
                     let timing_output = match timing_output.as_str() {
-                        "html" => TimingOutput::Html,
+                        "html" => {
+                            config
+                                .cli_unstable()
+                                .fail_if_stable_opt("--timings=html", 7405)?;
+                            TimingOutput::Html
+                        }
                         "json" => {
                             config
                                 .cli_unstable()

--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -95,6 +95,8 @@ target.
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-build.md
+++ b/src/doc/man/cargo-build.md
@@ -39,6 +39,8 @@ they have `required-features` that are missing.
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-check.md
+++ b/src/doc/man/cargo-check.md
@@ -44,6 +44,8 @@ they have `required-features` that are missing.
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -78,6 +78,8 @@ and supports common Unix glob patterns.
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -124,6 +124,8 @@ When no target selection options are given, `cargo fix` will fix all targets
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -167,6 +167,8 @@ See also the `--profile` option for choosing a specific profile by name.
 
 {{> options-profile }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Manifest Options

--- a/src/doc/man/cargo-run.md
+++ b/src/doc/man/cargo-run.md
@@ -54,6 +54,8 @@ Run the specified example.
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-rustc.md
+++ b/src/doc/man/cargo-rustc.md
@@ -66,6 +66,8 @@ See the [the reference](../reference/profiles.html) for more details on profiles
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-rustdoc.md
+++ b/src/doc/man/cargo-rustdoc.md
@@ -66,6 +66,8 @@ if its name is the same as the lib target. Binaries are skipped if they have
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -106,6 +106,8 @@ target options.
 
 {{> options-ignore-rust-version }}
 
+{{> options-timings }}
+
 {{/options}}
 
 ### Output Options

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -226,10 +226,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -223,7 +223,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -219,7 +219,7 @@ OPTIONS
            than the required Rust version as configured in the project's
            rust-version field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -222,10 +222,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -219,6 +219,21 @@ OPTIONS
            than the required Rust version as configured in the project's
            rust-version field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -163,10 +163,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -156,6 +156,21 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -156,7 +156,7 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -159,10 +159,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -160,7 +160,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -176,10 +176,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -169,7 +169,7 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -169,6 +169,21 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -173,7 +173,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -172,10 +172,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -147,10 +147,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -140,6 +140,21 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -143,10 +143,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -140,7 +140,7 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -144,7 +144,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -242,6 +242,21 @@ OPTIONS
            required Rust version as configured in the project's rust-version
            field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -249,10 +249,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -246,7 +246,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -242,7 +242,7 @@ OPTIONS
            required Rust version as configured in the project's rust-version
            field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -245,10 +245,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -212,10 +212,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -205,7 +205,7 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -209,7 +209,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -205,6 +205,21 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/profiles.html> for more
            details on profiles.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Manifest Options
        --frozen, --locked
            Either of these flags requires that the Cargo.lock file is

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -208,10 +208,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -89,7 +89,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -85,7 +85,7 @@ OPTIONS
            required Rust version as configured in the project's rust-version
            field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -92,10 +92,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -85,6 +85,21 @@ OPTIONS
            required Rust version as configured in the project's rust-version
            field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -88,10 +88,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -171,10 +171,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -164,6 +164,21 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -164,7 +164,7 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -168,7 +168,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -167,10 +167,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -163,10 +163,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -156,6 +156,21 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -156,7 +156,7 @@ OPTIONS
            the required Rust version as configured in the project's
            rust-version field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -159,10 +159,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -160,7 +160,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -233,6 +233,21 @@ OPTIONS
            required Rust version as configured in the project's rust-version
            field.
 
+       --timings fmts
+           Output information how long each compilation takes, and track
+           concurrency information over time. Accepts an optional
+           comma-separated list of output formats; --timing without an argument
+           will default to --timing=html. Valid output formats:
+
+           o  html: Write a human-readable file cargo-timing.html to the
+              current directory with a report of the compilation. Also write a
+              report with a timestamp in the filename if you want to look at
+              older runs. HTML output is suitable for human consumption only,
+              and does not provide machine-readable timing data.
+
+           o  json (unstable, requires -Zunstable-options): Emit
+              machine-readable JSON information about timing information.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -236,10 +236,10 @@ OPTIONS
        --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
-           comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Specifying an output format (rather
-           than the default) is unstable and requires -Zunstable-options. Valid
-           output formats:
+           comma-separated list of output formats; --timings without an
+           argument will default to --timings=html. Specifying an output format
+           (rather than the default) is unstable and requires
+           -Zunstable-options. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -240,10 +240,11 @@ OPTIONS
            will default to --timing=html. Valid output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
-              current directory with a report of the compilation. Also write a
-              report with a timestamp in the filename if you want to look at
-              older runs. HTML output is suitable for human consumption only,
-              and does not provide machine-readable timing data.
+              target/cargo-timings directory with a report of the compilation.
+              Also write a report to the same directory with a timestamp in the
+              filename if you want to look at older runs. HTML output is
+              suitable for human consumption only, and does not provide
+              machine-readable timing data.
 
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -233,7 +233,7 @@ OPTIONS
            required Rust version as configured in the project's rust-version
            field.
 
-       --timings fmts
+       --timings=fmts
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -237,7 +237,9 @@ OPTIONS
            Output information how long each compilation takes, and track
            concurrency information over time. Accepts an optional
            comma-separated list of output formats; --timing without an argument
-           will default to --timing=html. Valid output formats:
+           will default to --timing=html. Specifying an output format (rather
+           than the default) is unstable and requires -Zunstable-options. Valid
+           output formats:
 
            o  html: Write a human-readable file cargo-timing.html to the
               target/cargo-timings directory with a report of the compilation.

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -1,8 +1,9 @@
 {{#option "`--timings=`_fmts_"}}
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; `--timing` without an argument will default to `--timing=html`. Valid
-output formats:
+formats; `--timing` without an argument will default to `--timing=html`.
+Specifying an output format (rather than the default) is unstable and requires
+`-Zunstable-options`. Valid output formats:
 
 - `html`: Write a human-readable file `cargo-timing.html` to the
   `target/cargo-timings` directory with a report of the compilation. Also write

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -4,11 +4,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; `--timing` without an argument will default to `--timing=html`. Valid
 output formats:
 
-- `html`: Write a human-readable file `cargo-timing.html` to the current
-  directory with a report of the compilation. Also write a report with a
-  timestamp in the filename if you want to look at older runs. HTML output is
-  suitable for human consumption only, and does not provide machine-readable
-  timing data.
+- `html`: Write a human-readable file `cargo-timing.html` to the
+  `target/cargo-timings` directory with a report of the compilation. Also write
+  a report to the same directory with a timestamp in the filename if you want
+  to look at older runs. HTML output is suitable for human consumption only,
+  and does not provide machine-readable timing data.
 - `json` (unstable, requires `-Zunstable-options`): Emit machine-readable JSON
   information about timing information.
 {{/option}}

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -1,4 +1,4 @@
-{{#option "`--timings` _fmts_"}}
+{{#option "`--timings=`_fmts_"}}
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; `--timing` without an argument will default to `--timing=html`. Valid

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -1,0 +1,15 @@
+{{#option "`--timings` _fmts_"}}
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; `--timing` without an argument will default to `--timing=html`. Valid
+output formats:
+
+- `html`: Write a human-readable file `cargo-timing.html` to the current
+  directory with a report of the compilation. Also write a report with a
+  timestamp in the filename if you want to look at older runs. HTML output is
+  suitable for human consumption only, and does not provide machine-readable
+  timing data.
+- `json` (unstable, requires `-Zunstable-options`): Emit machine-readable JSON
+  information about timing information.
+{{/option}}
+

--- a/src/doc/man/includes/options-timings.md
+++ b/src/doc/man/includes/options-timings.md
@@ -1,7 +1,7 @@
 {{#option "`--timings=`_fmts_"}}
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; `--timing` without an argument will default to `--timing=html`.
+formats; `--timings` without an argument will default to `--timings=html`.
 Specifying an output format (rather than the default) is unstable and requires
 `-Zunstable-options`. Valid output formats:
 

--- a/src/doc/src/SUMMARY.md
+++ b/src/doc/src/SUMMARY.md
@@ -39,6 +39,7 @@
     * [Dependency Resolution](reference/resolver.md)
     * [SemVer Compatibility](reference/semver.md)
     * [Future incompat report](reference/future-incompat-report.md)
+    * [Reporting build timings](reference/timings.md)
     * [Unstable Features](reference/unstable.md)
 
 * [Cargo Commands](commands/index.md)

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -265,6 +265,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-bench---timings"><a class="option-anchor" href="#option-cargo-bench---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -268,8 +268,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-bench---timings=fmts"><a class="option-anchor" href="#option-cargo-bench---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -271,11 +271,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -265,7 +265,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-bench---timings"><a class="option-anchor" href="#option-cargo-bench---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-bench---timings=fmts"><a class="option-anchor" href="#option-cargo-bench---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -268,7 +268,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-bench---timings=fmts"><a class="option-anchor" href="#option-cargo-bench---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -203,7 +203,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-build---timings=fmts"><a class="option-anchor" href="#option-cargo-build---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -203,8 +203,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-build---timings=fmts"><a class="option-anchor" href="#option-cargo-build---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -200,6 +200,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-build---timings"><a class="option-anchor" href="#option-cargo-build---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -200,7 +200,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-build---timings"><a class="option-anchor" href="#option-cargo-build---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-build---timings=fmts"><a class="option-anchor" href="#option-cargo-build---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -206,11 +206,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -215,11 +215,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -212,7 +212,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-check---timings=fmts"><a class="option-anchor" href="#option-cargo-check---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -212,8 +212,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-check---timings=fmts"><a class="option-anchor" href="#option-cargo-check---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -209,7 +209,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-check---timings"><a class="option-anchor" href="#option-cargo-check---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-check---timings=fmts"><a class="option-anchor" href="#option-cargo-check---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -209,6 +209,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-check---timings"><a class="option-anchor" href="#option-cargo-check---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -189,11 +189,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -186,8 +186,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-doc---timings=fmts"><a class="option-anchor" href="#option-cargo-doc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -186,7 +186,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-doc---timings=fmts"><a class="option-anchor" href="#option-cargo-doc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -183,7 +183,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-doc---timings"><a class="option-anchor" href="#option-cargo-doc---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-doc---timings=fmts"><a class="option-anchor" href="#option-cargo-doc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -183,6 +183,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-doc---timings"><a class="option-anchor" href="#option-cargo-doc---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -292,7 +292,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-fix---timings=fmts"><a class="option-anchor" href="#option-cargo-fix---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -295,11 +295,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -289,7 +289,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-fix---timings"><a class="option-anchor" href="#option-cargo-fix---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-fix---timings=fmts"><a class="option-anchor" href="#option-cargo-fix---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -289,6 +289,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-fix---timings"><a class="option-anchor" href="#option-cargo-fix---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -292,8 +292,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-fix---timings=fmts"><a class="option-anchor" href="#option-cargo-fix---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -236,7 +236,7 @@ See the <a href="../reference/profiles.html">the reference</a> for more details 
 
 
 
-<dt class="option-term" id="option-cargo-install---timings"><a class="option-anchor" href="#option-cargo-install---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-install---timings=fmts"><a class="option-anchor" href="#option-cargo-install---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -236,6 +236,24 @@ See the <a href="../reference/profiles.html">the reference</a> for more details 
 
 
 
+<dt class="option-term" id="option-cargo-install---timings"><a class="option-anchor" href="#option-cargo-install---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Manifest Options

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -242,11 +242,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -239,7 +239,7 @@ See the <a href="../reference/profiles.html">the reference</a> for more details 
 <dt class="option-term" id="option-cargo-install---timings=fmts"><a class="option-anchor" href="#option-cargo-install---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -239,8 +239,9 @@ See the <a href="../reference/profiles.html">the reference</a> for more details 
 <dt class="option-term" id="option-cargo-install---timings=fmts"><a class="option-anchor" href="#option-cargo-install---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -121,8 +121,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-run---timings=fmts"><a class="option-anchor" href="#option-cargo-run---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -118,7 +118,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-run---timings"><a class="option-anchor" href="#option-cargo-run---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-run---timings=fmts"><a class="option-anchor" href="#option-cargo-run---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -121,7 +121,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-run---timings=fmts"><a class="option-anchor" href="#option-cargo-run---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -118,6 +118,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-run---timings"><a class="option-anchor" href="#option-cargo-run---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -124,11 +124,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -197,7 +197,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-rustc---timings"><a class="option-anchor" href="#option-cargo-rustc---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-rustc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -200,8 +200,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-rustc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -200,7 +200,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-rustc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -203,11 +203,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -197,6 +197,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-rustc---timings"><a class="option-anchor" href="#option-cargo-rustc---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -205,8 +205,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-rustdoc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustdoc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -205,7 +205,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-rustdoc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustdoc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -202,6 +202,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-rustdoc---timings"><a class="option-anchor" href="#option-cargo-rustdoc---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -202,7 +202,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-rustdoc---timings"><a class="option-anchor" href="#option-cargo-rustdoc---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-rustdoc---timings=fmts"><a class="option-anchor" href="#option-cargo-rustdoc---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -208,11 +208,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -287,11 +287,11 @@ information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
 output formats:</p>
 <ul>
-<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine-readable
-timing data.</li>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
+<code>target/cargo-timings</code> directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine-readable timing data.</li>
 <li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
 information about timing information.</li>
 </ul></dd>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -281,6 +281,24 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
+<dt class="option-term" id="option-cargo-test---timings"><a class="option-anchor" href="#option-cargo-test---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dd class="option-desc">Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma-separated list of output
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
+output formats:</p>
+<ul>
+<li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine-readable
+timing data.</li>
+<li><code>json</code> (unstable, requires <code>-Zunstable-options</code>): Emit machine-readable JSON
+information about timing information.</li>
+</ul></dd>
+
+
+
+
 </dl>
 
 ### Output Options

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -284,7 +284,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-test---timings=fmts"><a class="option-anchor" href="#option-cargo-test---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+formats; <code>--timings</code> without an argument will default to <code>--timings=html</code>.
 Specifying an output format (rather than the default) is unstable and requires
 <code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -284,8 +284,9 @@ required Rust version as configured in the project's <code>rust-version</code> f
 <dt class="option-term" id="option-cargo-test---timings=fmts"><a class="option-anchor" href="#option-cargo-test---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
-formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid
-output formats:</p>
+formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>.
+Specifying an output format (rather than the default) is unstable and requires
+<code>-Zunstable-options</code>. Valid output formats:</p>
 <ul>
 <li><code>html</code>: Write a human-readable file <code>cargo-timing.html</code> to the
 <code>target/cargo-timings</code> directory with a report of the compilation. Also write

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -281,7 +281,7 @@ required Rust version as configured in the project's <code>rust-version</code> f
 
 
 
-<dt class="option-term" id="option-cargo-test---timings"><a class="option-anchor" href="#option-cargo-test---timings"></a><code>--timings</code> <em>fmts</em></dt>
+<dt class="option-term" id="option-cargo-test---timings=fmts"><a class="option-anchor" href="#option-cargo-test---timings=fmts"></a><code>--timings=</code><em>fmts</em></dt>
 <dd class="option-desc">Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma-separated list of output
 formats; <code>--timing</code> without an argument will default to <code>--timing=html</code>. Valid

--- a/src/doc/src/reference/index.md
+++ b/src/doc/src/reference/index.md
@@ -22,4 +22,5 @@ The reference covers the details of various areas of Cargo.
 * [Dependency Resolution](resolver.md)
 * [SemVer Compatibility](semver.md)
 * [Future incompat report](future-incompat-report.md)
+* [Reporting build timings](timings.md)
 * [Unstable Features](unstable.md)

--- a/src/doc/src/reference/timings.md
+++ b/src/doc/src/reference/timings.md
@@ -1,0 +1,51 @@
+# Reporting build timings
+The `--timings` option gives some information about how long each compilation
+takes, and tracks concurrency information over time.
+
+```sh
+cargo build --timings
+```
+
+This writes an HTML report in `target/cargo-timings/cargo-timings.html`. This
+also writes a copy of the report to the same directory with a timestamp in the
+filename, if you want to look at older runs.
+
+#### Reading the graphs
+
+There are two graphs in the output. The "unit" graph shows the duration of
+each unit over time. A "unit" is a single compiler invocation. There are lines
+that show which additional units are "unlocked" when a unit finishes. That is,
+it shows the new units that are now allowed to run because their dependencies
+are all finished. Hover the mouse over a unit to highlight the lines. This can
+help visualize the critical path of dependencies. This may change between runs
+because the units may finish in different orders.
+
+The "codegen" times are highlighted in a lavender color. In some cases, build
+pipelining allows units to start when their dependencies are performing code
+generation. This information is not always displayed (for example, binary
+units do not show when code generation starts).
+
+The "custom build" units are `build.rs` scripts, which when run are
+highlighted in orange.
+
+The second graph shows Cargo's concurrency over time. The background
+indicates CPU usage. The three lines are:
+- "Waiting" (red) — This is the number of units waiting for a CPU slot to
+  open.
+- "Inactive" (blue) — This is the number of units that are waiting for their
+  dependencies to finish.
+- "Active" (green) — This is the number of units currently running.
+
+Note: This does not show the concurrency in the compiler itself. `rustc`
+coordinates with Cargo via the "job server" to stay within the concurrency
+limit. This currently mostly applies to the code generation phase.
+
+Tips for addressing compile times:
+- Look for slow dependencies.
+    - Check if they have features that you may wish to consider disabling.
+    - Consider trying to remove the dependency completely.
+- Look for a crate being built multiple times with different versions. Try to
+  remove the older versions from the dependency graph.
+- Split large crates into smaller pieces.
+- If there are a large number of crates bottlenecked on a single crate, focus
+  your attention on improving that one crate to improve parallelism.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -419,11 +419,9 @@ following values:
 - `html` — Saves a file called `cargo-timing.html` to the current directory
   with a report of the compilation. Files are also saved with a timestamp in
   the filename if you want to look at older runs.
-- `info` — Displays a message to stdout after each compilation finishes with
-  how long it took.
 - `json` — Emits some JSON information about timing information.
 
-The default if none are specified is `html,info`.
+The default if none are specified is `html`.
 
 #### Reading the graphs
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -401,46 +401,6 @@ library. The default enabled features, at this time, are `backtrace` and
 `panic_unwind`. This flag expects a comma-separated list and, if provided, will
 override the default list of features enabled.
 
-#### Reading the graphs
-
-There are two graphs in the output. The "unit" graph shows the duration of
-each unit over time. A "unit" is a single compiler invocation. There are lines
-that show which additional units are "unlocked" when a unit finishes. That is,
-it shows the new units that are now allowed to run because their dependencies
-are all finished. Hover the mouse over a unit to highlight the lines. This can
-help visualize the critical path of dependencies. This may change between runs
-because the units may finish in different orders.
-
-The "codegen" times are highlighted in a lavender color. In some cases, build
-pipelining allows units to start when their dependencies are performing code
-generation. This information is not always displayed (for example, binary
-units do not show when code generation starts).
-
-The "custom build" units are `build.rs` scripts, which when run are
-highlighted in orange.
-
-The second graph shows Cargo's concurrency over time. The background
-indicates CPU usage. The three lines are:
-- "Waiting" (red) — This is the number of units waiting for a CPU slot to
-  open.
-- "Inactive" (blue) — This is the number of units that are waiting for their
-  dependencies to finish.
-- "Active" (green) — This is the number of units currently running.
-
-Note: This does not show the concurrency in the compiler itself. `rustc`
-coordinates with Cargo via the "job server" to stay within the concurrency
-limit. This currently mostly applies to the code generation phase.
-
-Tips for addressing compile times:
-- Look for slow dependencies.
-    - Check if they have features that you may wish to consider disabling.
-    - Consider trying to remove the dependency completely.
-- Look for a crate being built multiple times with different versions. Try to
-  remove the older versions from the dependency graph.
-- Split large crates into smaller pieces.
-- If there are a large number of crates bottlenecked on a single crate, focus
-  your attention on improving that one crate to improve parallelism.
-
 ### binary-dep-depinfo
 * Tracking rustc issue: [#63012](https://github.com/rust-lang/rust/issues/63012)
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1297,5 +1297,5 @@ See the [Features chapter](features.md#dependency-features) for more information
 ### timings
 
 The `-Ztimings` option has been stabilized as `--timings` in the 1.60 release.
-(The machine-readable `--timings=json` output remains unstable and requires
-`-Zunstable-options`.)
+(`--timings=html` and the machine-readable `--timings=json` output remain
+unstable and require `-Zunstable-options`.)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -35,9 +35,9 @@ how the feature works:
 * `-Z` command-line flags are used to enable new functionality that may not
   have an interface, or the interface has not yet been designed, or for more
   complex features that affect multiple parts of Cargo. For example, the
-  [timings](#timings) feature can be enabled with:
+  [mtime-on-use](#mtime-on-use) feature can be enabled with:
 
-  ```cargo +nightly build -Z timings```
+  ```cargo +nightly build -Z mtime-on-use```
 
   Run `cargo -Z help` to see a list of flags available.
 
@@ -49,7 +49,6 @@ how the feature works:
   [unstable]
   mtime-on-use = true
   multitarget = true
-  timings = ["html"]
   ```
 
 Each new feature described below should explain how to use it.
@@ -91,7 +90,6 @@ Each new feature described below should explain how to use it.
     * [per-package-target](#per-package-target) — Sets the `--target` to use for each individual package.
 * Information and metadata
     * [Build-plan](#build-plan) — Emits JSON information on which commands will be run.
-    * [timings](#timings) — Generates a report on how long individual dependencies took to run.
     * [unit-graph](#unit-graph) — Emits JSON for Cargo's internal graph structure.
     * [`cargo rustc --print`](#rustc---print) — Calls rustc with `--print` to display information from rustc.
 * Configuration
@@ -402,26 +400,6 @@ the features enabled for the standard library itself when building the standard
 library. The default enabled features, at this time, are `backtrace` and
 `panic_unwind`. This flag expects a comma-separated list and, if provided, will
 override the default list of features enabled.
-
-### timings
-* Tracking Issue: [#7405](https://github.com/rust-lang/cargo/issues/7405)
-
-The `timings` feature gives some information about how long each compilation
-takes, and tracks concurrency information over time.
-
-```sh
-cargo +nightly build -Z timings
-```
-
-The `-Ztimings` flag can optionally take a comma-separated list of the
-following values:
-
-- `html` — Saves a file called `cargo-timing.html` to the current directory
-  with a report of the compilation. Files are also saved with a timestamp in
-  the filename if you want to look at older runs.
-- `json` — Emits some JSON information about timing information.
-
-The default if none are specified is `html`.
 
 #### Reading the graphs
 
@@ -1315,3 +1293,9 @@ See the [Features chapter](features.md#optional-dependencies) for more informati
 
 Weak dependency features has been stabilized in the 1.60 release.
 See the [Features chapter](features.md#dependency-features) for more information.
+
+### timings
+
+The `-Ztimings` option has been stabilized as `--timings` in the 1.60 release.
+(The machine-readable `--timings=json` output remains unstable and requires
+`-Zunstable-options`.)

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -273,7 +273,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -268,6 +268,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Benchmark the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -269,7 +269,7 @@ Benchmark the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -273,8 +273,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -277,11 +277,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -188,7 +188,7 @@ Build the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -192,7 +192,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -196,11 +196,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -187,6 +187,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Build the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -192,8 +192,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -203,8 +203,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -199,7 +199,7 @@ Check the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -207,11 +207,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -198,6 +198,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Check the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -203,7 +203,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -166,7 +166,7 @@ Document the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -170,8 +170,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -174,11 +174,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -170,7 +170,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -165,6 +165,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Document the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -298,7 +298,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -293,6 +293,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Fix the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -294,7 +294,7 @@ Fix the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -302,11 +302,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -298,8 +298,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -271,7 +271,7 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -271,8 +271,9 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -267,7 +267,7 @@ Install with the given profile.
 See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -275,11 +275,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -266,6 +266,27 @@ See also the \fB\-\-profile\fR option for choosing a specific profile by name.
 Install with the given profile.
 See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles.html> for more details on profiles.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Manifest Options"
 .sp
 \fB\-\-frozen\fR, 

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -103,7 +103,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -99,7 +99,7 @@ Run the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -103,8 +103,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -107,11 +107,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -98,6 +98,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Run the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -198,8 +198,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -194,7 +194,7 @@ Build the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -193,6 +193,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Build the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -202,11 +202,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -198,7 +198,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -189,7 +189,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -189,8 +189,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -193,11 +193,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -185,7 +185,7 @@ Document the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -184,6 +184,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Document the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -289,7 +289,7 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+formats; \fB\-\-timings\fR without an argument will default to \fB\-\-timings=html\fR\&.
 Specifying an output format (rather than the default) is unstable and requires
 \fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -284,6 +284,27 @@ See the \fIthe reference\fR <https://doc.rust\-lang.org/cargo/reference/profiles
 Test the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
+.sp
+\fB\-\-timings\fR \fIfmts\fR
+.RS 4
+Output information how long each compilation takes, and track concurrency
+information over time. Accepts an optional comma\-separated list of output
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
+output formats:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
+directory with a report of the compilation. Also write a report with a
+timestamp in the filename if you want to look at older runs. HTML output is
+suitable for human consumption only, and does not provide machine\-readable
+timing data.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'\fBjson\fR (unstable, requires \fB\-Zunstable\-options\fR): Emit machine\-readable JSON
+information about timing information.
+.RE
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -289,8 +289,9 @@ required Rust version as configured in the project's \fBrust\-version\fR field.
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output
-formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&. Valid
-output formats:
+formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html\fR\&.
+Specifying an output format (rather than the default) is unstable and requires
+\fB\-Zunstable\-options\fR\&. Valid output formats:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -285,7 +285,7 @@ Test the target even if the selected Rust compiler is older than the
 required Rust version as configured in the project's \fBrust\-version\fR field.
 .RE
 .sp
-\fB\-\-timings\fR \fIfmts\fR
+\fB\-\-timings=\fR\fIfmts\fR
 .RS 4
 Output information how long each compilation takes, and track concurrency
 information over time. Accepts an optional comma\-separated list of output

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -293,11 +293,11 @@ formats; \fB\-\-timing\fR without an argument will default to \fB\-\-timing=html
 output formats:
 .sp
 .RS 4
-\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the current
-directory with a report of the compilation. Also write a report with a
-timestamp in the filename if you want to look at older runs. HTML output is
-suitable for human consumption only, and does not provide machine\-readable
-timing data.
+\h'-04'\(bu\h'+02'\fBhtml\fR: Write a human\-readable file \fBcargo\-timing.html\fR to the
+\fBtarget/cargo\-timings\fR directory with a report of the compilation. Also write
+a report to the same directory with a timestamp in the filename if you want
+to look at older runs. HTML output is suitable for human consumption only,
+and does not provide machine\-readable timing data.
 .RE
 .sp
 .RS 4

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -34,7 +34,7 @@ fn timings_works() {
 [COMPILING] dep v0.1.0
 [COMPILING] foo v0.1.0 [..]
 [FINISHED] [..]
-      Timing report saved to [..]/foo/cargo-timing-[..].html
+      Timing report saved to [..]/foo/target/cargo-timings/cargo-timing-[..].html
 ",
         )
         .run();

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -1,4 +1,4 @@
-//! Tests for -Ztimings.
+//! Tests for --timings.
 
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
@@ -25,8 +25,7 @@ fn timings_works() {
         .file("examples/ex1.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --all-targets -Ztimings")
-        .masquerade_as_nightly_cargo()
+    p.cargo("build --all-targets --timings")
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
@@ -42,17 +41,13 @@ fn timings_works() {
 
     p.cargo("clean").run();
 
-    p.cargo("test -Ztimings")
-        .masquerade_as_nightly_cargo()
-        .run();
+    p.cargo("test --timings").run();
 
     p.cargo("clean").run();
 
-    p.cargo("check -Ztimings")
-        .masquerade_as_nightly_cargo()
-        .run();
+    p.cargo("check --timings").run();
 
     p.cargo("clean").run();
 
-    p.cargo("doc -Ztimings").masquerade_as_nightly_cargo().run();
+    p.cargo("doc --timings").run();
 }

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -34,13 +34,6 @@ fn timings_works() {
 [DOWNLOADED] dep v0.1.0 [..]
 [COMPILING] dep v0.1.0
 [COMPILING] foo v0.1.0 [..]
-[COMPLETED] dep v0.1.0 in [..]s
-[COMPLETED] foo v0.1.0 in [..]s
-[COMPLETED] foo v0.1.0 bin \"foo\" in [..]s
-[COMPLETED] foo v0.1.0 example \"ex1\" in [..]s
-[COMPLETED] foo v0.1.0 lib (test) in [..]s
-[COMPLETED] foo v0.1.0 bin \"foo\" (test) in [..]s
-[COMPLETED] foo v0.1.0 test \"t1\" (test) in [..]s
 [FINISHED] [..]
       Timing report saved to [..]/foo/cargo-timing-[..].html
 ",


### PR DESCRIPTION
The `-Ztimings` option has existed for years, and many people use it to
profile and optimize their builds. It's one of the common reasons people
use nightly cargo.

The machine-readable JSON output may warrant further careful inspection
before we commit to a stable format. However, for the human-readable
output we don't need to make any commitment about the exact output.

Add a `--timings` option, as the stable equivalent to `-Ztimings`.
(Passing `html` or `json` requires `-Zunstable-options`, but the default `--timings` does not.)

Document the new option, and update the testsuite.