### PR TITLE
Make rmeta_required no longer depend on whether timing is enabled

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -604,7 +604,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
     /// Returns whether when `unit` is built whether it should emit metadata as
     /// well because some compilations rely on that.
     pub fn rmeta_required(&self, unit: &Unit) -> bool {
-        self.rmeta_required.contains(unit) || self.bcx.config.cli_unstable().timings.is_some()
+        self.rmeta_required.contains(unit)
     }
 
     pub fn new_jobserver(&mut self) -> CargoResult<Client> {


### PR DESCRIPTION
This doesn't appear to affect the quality of the timing information at
all.

If there's additional information we need from rustc about what it's
doing at any given time, we could add mechanisms to retrieve that
information, but enabling timing shouldn't force building more than we
otherwise would have.
