### PR TITLE
Add semver guidelines for changing the `repr` of structs/enums to ref…

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -305,20 +305,22 @@ pub struct Foo {
 
 ///////////////////////////////////////////////////////////
 // Example usage that will break.
+use updated_crate::Foo;
+
 fn main() {
     let foo = Foo {
         f1: 1,
         f2: 1000,
         f3: 5,
     };
-    
+
     let foo_ptr = &foo as *const Foo as *const u8;
-    
+
     // this is now unsound because of the change
     // SAFETY: Foo is repr(C), so we are guaranteed that there will be `3` at this offset (u8, 8 pad, u16)
-    let f2 = unsafe { foo_ptr.offset(4).read() };
-    
-    println!("{}", f2);
+    let f3 = unsafe { foo_ptr.offset(4).read() };
+
+    assert_eq!(5, f3);
 }
 ```
 
@@ -534,12 +536,12 @@ pub enum Number {
 ///////////////////////////////////////////////////////////
 // Example usage that will break.
 fn main() {
-    let num_three = Number::Three;
-    
+    let num_three = updated_crate::Number::Three;
+
     // SAFETY: `Number` is `#[repr(i32)]`
     let three: i32 = unsafe { std::mem::transmute(num_three) }; // Error: cannot transmute between types of different sizes
-    
-    println!("{}", three)
+
+    assert_eq!(3, three)
 }
 ```
 

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -283,7 +283,7 @@ that repr.
 
 Adding a well-defined repr to a `repr(Rust)` struct is *not* a breaking change.
 
-```rust,ignore
+```rust,ignore,run-fail
 // MAJOR CHANGE
 
 ///////////////////////////////////////////////////////////


### PR DESCRIPTION
The current semver guidelines do not mention `repr` at all. Changing the `repr` of a struct/enum will break code, especially unsafe code relying on layout. These breaking changes will rarely manifest themselves as compiler errors, which makes them all the more dangerous.

The new guidelines specify removing a well-defined repr from a struct or enum to be a breaking change.

This is more of a suggestion on how it could be done, and I'm very open for improvements for the wording and other details.

Another thing I'm not sure about is how this interacts with `#[non_exhaustive]`, and therefore don't mention it at all.

There are also some other breaking changes that are related to this, like reordering the fields of a `#[repr(C)]` struct, and it's open for discussion whether these should be added as well.

[discussion on zulip](https://rust-lang.zulipchat.com/#narrow/stream/122651-general/topic/.23.5Brepr.28transparent.29.5D.20stability.20guarantees)