### PR TITLE
Cache submodules between different git checkouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/cargo/lib.rs"
 
 [dependencies]
 atty = "0.2"
+base64 = "0.13"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.1.2" }

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1287,7 +1287,8 @@ fn dep_with_changed_submodule() {
     println!("last run");
     p.cargo("run")
         .with_stderr(
-            "[COMPILING] dep1 v0.5.0 ([..])\n\
+            "[UPDATING] git submodule `file://[..]/dep3`\n\
+             [COMPILING] dep1 v0.5.0 ([..])\n\
              [COMPILING] foo v0.5.0 ([..])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in \
              [..]\n\


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Rather than letting git manage each submodule checkout individually, this uses a shared bare submodule directory in `target/git/checkouts/submodules` and makes a checkout of the shared directory in the relative path.

This caches based on the URL, but base64-encodes the URL to avoid errors about invalid FS paths. I'm hesitant to cache based on the relative path in the git checkout because it could use a different remote between commits of the parent.

Fixes https://github.com/rust-lang/cargo/issues/7987.

### How should we test and review this PR?

I tested like so:

```
$ cargo init
$ echo 'boring = { git = "https://github.com/cloudflare/boring", branch = "master" }' >> Cargo.toml
$ /home/jnelson/rust-lang/cargo/target/debug/cargo update -p boring --precise 46787b7b6909cadf81cf3a8cd9dc351c9efdfdbd
$ /home/jnelson/rust-lang/cargo/target/debug/cargo update -p boring --precise c037a438f8d7b91533524570237afcfeffffe496
```

and confirmed that the time to do the second update is negligible. I'm not sure how to test this automatically using the `cargo_test` framework since cargo still prints "Updating git submodule" on the second checkout (because it has to create the symlink).