### PR TITLE
Use `is_symlink()` method

### DIFF
--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -198,14 +198,6 @@ impl CargoPathExt for Path {
     }
 }
 
-// Replace with std implementation when stabilized, see
-// https://github.com/rust-lang/rust/issues/85748
-pub fn is_symlink(path: &Path) -> bool {
-    fs::symlink_metadata(path)
-        .map(|m| m.file_type().is_symlink())
-        .unwrap_or(false)
-}
-
 fn do_op<F>(path: &Path, desc: &str, mut f: F)
 where
     F: FnMut(&Path) -> io::Result<()>,

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -420,7 +420,6 @@ pub fn remove_dir_all<P: AsRef<Path>>(p: P) -> Result<()> {
 fn _remove_dir_all(p: &Path) -> Result<()> {
     if p.symlink_metadata()
         .with_context(|| format!("could not get metadata for `{}` to remove", p.display()))?
-        .file_type()
         .is_symlink()
     {
         return remove_file(p);

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4805,7 +4805,6 @@ fn building_a_dependent_crate_witout_bin_should_fail() {
 #[cargo_test]
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn uplift_dsym_of_bin_on_mac() {
-    use cargo_test_support::paths::is_symlink;
     let p = project()
         .file("src/main.rs", "fn main() { panic!(); }")
         .file("src/bin/b.rs", "fn main() { panic!(); }")
@@ -4818,7 +4817,7 @@ fn uplift_dsym_of_bin_on_mac() {
         .run();
     assert!(p.target_debug_dir().join("foo.dSYM").is_dir());
     assert!(p.target_debug_dir().join("b.dSYM").is_dir());
-    assert!(is_symlink(&p.target_debug_dir().join("b.dSYM")));
+    assert!(p.target_debug_dir().join("b.dSYM").is_symlink());
     assert!(p.target_debug_dir().join("examples/c.dSYM").is_dir());
     assert!(!p.target_debug_dir().join("c.dSYM").exists());
     assert!(!p.target_debug_dir().join("d.dSYM").exists());
@@ -4827,7 +4826,6 @@ fn uplift_dsym_of_bin_on_mac() {
 #[cargo_test]
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn uplift_dsym_of_bin_on_mac_when_broken_link_exists() {
-    use cargo_test_support::paths::is_symlink;
     let p = project()
         .file("src/main.rs", "fn main() { panic!(); }")
         .build();
@@ -4846,7 +4844,7 @@ fn uplift_dsym_of_bin_on_mac_when_broken_link_exists() {
             .join("foo-baaaaaadbaaaaaad.dSYM"),
         &dsym,
     );
-    assert!(is_symlink(&dsym));
+    assert!(dsym.is_symlink());
     assert!(!dsym.exists());
 
     p.cargo("build").enable_mac_dsym().run();

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1,6 +1,5 @@
 //! Tests for the `cargo clean` command.
 
-use cargo_test_support::paths::is_symlink;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{
     basic_bin_manifest, basic_manifest, git, main_file, project, project_in, rustc_host,
@@ -476,7 +475,7 @@ fn assert_all_clean(build_dir: &Path) {
         {
             continue;
         }
-        if is_symlink(path) || path.is_file() {
+        if path.is_symlink() || path.is_file() {
             panic!("{:?} was not cleaned", path);
         }
     }


### PR DESCRIPTION
I've came across this comment
```rust
// Replace with std implementation when stabilized, see
// https://github.com/rust-lang/rust/issues/85748
```
and fixed this due to the method stabilization in 1.58