### PR TITLE
Enable shortcut for triage bot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -10,3 +10,6 @@ Thanks! <3
 [instructions]: https://rustc-dev-guide.rust-lang.org/notification-groups/windows.html
 """
 label = "O-windows"
+
+[shortcut]
+


### PR DESCRIPTION
### What does this PR try to resolve?

Enable shortcut for triage bot. See: https://github.com/rust-lang/cargo/pull/10167#issuecomment-1013815453
### How should we test and review this PR?

We need to test it after the merge. But there should be no problem with the robot. I refer to the rust configuration file.

### Additional information

I don't know if it is accepted to open it, if we don't want to open it please feel free to close my PR.
