### PR TITLE
Include `help` in `--list`

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -144,6 +144,14 @@ fn list_commands(config: &Config) -> BTreeMap<String, CommandInfo> {
         }
     }
 
+    // `help` is special, so it needs to be inserted separately.
+    commands.insert(
+        "help".to_string(),
+        CommandInfo::BuiltIn {
+            about: Some("Displays help for a cargo subcommand".to_string()),
+        },
+    );
+
     commands
 }
 


### PR DESCRIPTION
This adds the `help` subcommand to the `--list` output. It previously was not included because `help` is handled differently from built-in subcommands.
