### PR TITLE
Fix new::git_default_branch with different default

### DIFF
--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -5,11 +5,23 @@ use cargo_test_support::paths;
 use std::env;
 use std::fs::{self, File};
 
-fn create_empty_gitconfig() {
+fn create_default_gitconfig() {
     // This helps on Windows where libgit2 is very aggressive in attempting to
     // find a git config file.
     let gitconfig = paths::home().join(".gitconfig");
     File::create(gitconfig).unwrap();
+
+    // If we're running this under a user account that has a different default branch set up
+    // then tests that assume the default branch is master will fail. We set the default branch
+    // to master explicitly so that tests that rely on this behavior still pass.
+    fs::write(
+        paths::home().join(".gitconfig"),
+        r#"
+        [init]
+            defaultBranch = master
+        "#,
+    )
+    .unwrap();
 }
 
 #[cargo_test]
@@ -471,19 +483,7 @@ or change the name in Cargo.toml with:
 #[cargo_test]
 fn git_default_branch() {
     // Check for init.defaultBranch support.
-    create_empty_gitconfig();
-
-    // If we're running this under a user account that has a different default branch set up
-    // this test will fail. We avoid that setting the defaultBranch and then ensuring that
-    // the changed setting is respected.
-    fs::write(
-        paths::home().join(".gitconfig"),
-        r#"
-        [init]
-            defaultBranch = master
-        "#,
-    )
-    .unwrap();
+    create_default_gitconfig();
 
     cargo_process("new foo").run();
     let repo = git2::Repository::open(paths::root().join("foo")).unwrap();

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -472,6 +472,19 @@ or change the name in Cargo.toml with:
 fn git_default_branch() {
     // Check for init.defaultBranch support.
     create_empty_gitconfig();
+
+    // If we're running this under a user account that has a different default branch set up
+    // this test will fail. We avoid that setting the defaultBranch and then ensuring that
+    // the changed setting is respected.
+    fs::write(
+        paths::home().join(".gitconfig"),
+        r#"
+        [init]
+            defaultBranch = master
+        "#,
+    )
+    .unwrap();
+
     cargo_process("new foo").run();
     let repo = git2::Repository::open(paths::root().join("foo")).unwrap();
     let head = repo.find_reference("HEAD").unwrap();


### PR DESCRIPTION
The test `new::git_default_branch` would fail if the current user had already configured a different default branch.

This patch changes the test to first write a `.gitconfig` file with the default branch set to master. This puts us in a state where we still have the old default, and then the subsequent change to the config file will make sure that config changes are still respected.

