### PR TITLE
Move build-std to Cargo.toml

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -823,6 +823,10 @@ impl<'cfg> RustcTargetData<'cfg> {
         }
     }
 
+    pub fn requested_kinds(&self) -> &[CompileKind] {
+        &self.requested_kinds
+    }
+
     /// If a build script is overridden, this returns the `BuildOutput` to use.
     ///
     /// `lib_name` is the `links` library name and `kind` is whether it is for

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -277,7 +277,7 @@ impl<'cfg> Compilation<'cfg> {
             // libs from the sysroot that ships with rustc. This may not be
             // required (at least I cannot craft a situation where it
             // matters), but is here to be safe.
-            if self.config.cli_unstable().build_std.is_none() {
+            if pkg.manifest().build_std().is_none() {
                 search_path.push(self.sysroot_target_libdir[&kind].clone());
             }
         }

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -133,7 +133,9 @@ pub fn resolve_std<'cfg>(
         })
         .collect();
 
-    Ok((pkg_set.unwrap(), ret?))
+    let ret = ret?;
+
+    Ok((pkg_set.unwrap(), ret))
 }
 
 /// Generate a list of root `Unit`s for the standard library.

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -53,6 +53,8 @@ pub struct Manifest {
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
     resolve_behavior: Option<ResolveBehavior>,
+    build_std: Option<Vec<String>>,
+    build_std_features: Option<Vec<String>>,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -392,6 +394,8 @@ impl Manifest {
         original: Rc<TomlManifest>,
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
+        build_std: Option<Vec<String>>,
+        build_std_features: Option<Vec<String>>,
     ) -> Manifest {
         Manifest {
             summary,
@@ -417,6 +421,8 @@ impl Manifest {
             default_run,
             metabuild,
             resolve_behavior,
+            build_std,
+            build_std_features,
         }
     }
 
@@ -527,6 +533,15 @@ impl Manifest {
                 })?;
         }
 
+        if self.build_std.is_some() || self.build_std_features.is_some() {
+            self.unstable_features
+                .require(Feature::build_std())
+                .with_context(|| {
+                    "the `package.build-std` and `package.build-std-features` \
+                     manifest keys are unstable and may not work properly"
+                })?;
+        }
+
         Ok(())
     }
 
@@ -565,6 +580,16 @@ impl Manifest {
             .into_path_unlocked()
             .join(".metabuild")
             .join(format!("metabuild-{}-{}.rs", self.name(), hash))
+    }
+
+    #[inline]
+    pub fn build_std(&self) -> Option<&Vec<String>> {
+        self.build_std.as_ref()
+    }
+
+    #[inline]
+    pub fn build_std_features(&self) -> Option<&Vec<String>> {
+        self.build_std_features.as_ref()
     }
 }
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -208,6 +208,26 @@ impl Package {
         self.targets().iter().any(|t| t.is_example() || t.is_bin())
     }
 
+    pub fn explicit_compile_kinds(
+        &self,
+        fallback_host_kind: CompileKind,
+        requested_kinds: &[CompileKind],
+    ) -> Vec<CompileKind> {
+        if let Some(k) = self.manifest().forced_kind() {
+            vec![k]
+        } else {
+            requested_kinds
+                .iter()
+                .map(|kind| match kind {
+                    CompileKind::Host => {
+                        self.manifest().default_kind().unwrap_or(fallback_host_kind)
+                    }
+                    CompileKind::Target(t) => CompileKind::Target(*t),
+                })
+                .collect()
+        }
+    }
+
     pub fn serialized(&self) -> SerializedPackage {
         let summary = self.manifest().summary();
         let package_id = summary.package_id();

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -28,10 +28,10 @@ fn basic() {
         .file(
             "Cargo.toml",
             r#"
-            unstable-features = ["build-std"]
+            cargo-features = ["build-std"]
             [package]
             name = "foo"
-            version = "0.1.0"
+            version = "0.0.1"
             edition = "2018"
             build-std = ["std"]
             "#,
@@ -78,8 +78,9 @@ fn basic() {
         )
         .build();
 
-    p.cargo("check").run();
+    p.cargo("check").masquerade_as_nightly_cargo().run();
     p.cargo("build")
+        .masquerade_as_nightly_cargo()
         // Importantly, this should not say [UPDATING]
         // There have been multiple bugs where every build triggers and update.
         .with_stderr(
@@ -87,12 +88,11 @@ fn basic() {
              [FINISHED] dev [..]",
         )
         .run();
-    p.cargo("run").run();
-    p.cargo("test").run();
+    p.cargo("run").masquerade_as_nightly_cargo().run();
+    p.cargo("test").masquerade_as_nightly_cargo().run();
 
     // Check for hack that removes dylibs.
     let deps_dir = Path::new("target")
-        .join(rustc_host())
         .join("debug")
         .join("deps");
     assert!(p.glob(deps_dir.join("*.rlib")).count() > 0);
@@ -105,7 +105,7 @@ fn cross_custom() {
         .file(
             "Cargo.toml",
             r#"
-                unstable-features = ["build-std"]
+                cargo-features = ["build-std"]
                 [package]
                 name = "foo"
                 version = "0.1.0"
@@ -139,7 +139,9 @@ fn cross_custom() {
         )
         .build();
 
-    p.cargo("build --target custom-target.json -v").run();
+    p.cargo("build --target custom-target.json -v")
+        .masquerade_as_nightly_cargo()
+        .run();
 }
 
 #[cargo_test(build_std)]
@@ -148,7 +150,7 @@ fn custom_test_framework() {
         .file(
             "Cargo.toml",
             r#"
-                unstable-features = ["build-std"]
+                cargo-features = ["build-std"]
                 [package]
                 name = "foo"
                 version = "0.1.0"
@@ -206,6 +208,7 @@ fn custom_test_framework() {
     let new_path = env::join_paths(paths).unwrap();
 
     p.cargo("test --target target.json --no-run -v")
+        .masquerade_as_nightly_cargo()
         .env("PATH", new_path)
         .run();
 }

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -161,20 +161,12 @@ fn enable_build_std(e: &mut Execs, setup: &Setup) {
 // Helper methods used in the tests below
 trait BuildStd: Sized {
     fn build_std(&mut self, setup: &Setup) -> &mut Self;
-    fn build_std_arg(&mut self, setup: &Setup, arg: &str) -> &mut Self;
     fn target_host(&mut self) -> &mut Self;
 }
 
 impl BuildStd for Execs {
     fn build_std(&mut self, setup: &Setup) -> &mut Self {
         enable_build_std(self, setup);
-        self.arg("-Zbuild-std");
-        self
-    }
-
-    fn build_std_arg(&mut self, setup: &Setup, arg: &str) -> &mut Self {
-        enable_build_std(self, setup);
-        self.arg(format!("-Zbuild-std={}", arg));
         self
     }
 
@@ -192,6 +184,17 @@ fn basic() {
     };
 
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
         .file(
             "src/main.rs",
             "
@@ -254,7 +257,20 @@ fn simple_lib_std() {
         Some(s) => s,
         None => return,
     };
-    let p = project().file("src/lib.rs", "").build();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        cargo-features = ["build-std"]
+        [package]
+        name = "foo"
+        version = "0.1.0"
+        edition = "2018"
+        build-std = ["std"]
+    "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
     p.cargo("build -v")
         .build_std(&setup)
         .target_host()
@@ -275,7 +291,20 @@ fn simple_bin_std() {
         Some(s) => s,
         None => return,
     };
-    let p = project().file("src/main.rs", "fn main() {}").build();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        cargo-features = ["build-std"]
+        [package]
+        name = "foo"
+        version = "0.1.0"
+        edition = "2018"
+        build-std = ["std"]
+    "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
     p.cargo("run -v").build_std(&setup).target_host().run();
 }
 
@@ -287,6 +316,17 @@ fn lib_nostd() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["core"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             r#"
                 #![no_std]
@@ -297,7 +337,7 @@ fn lib_nostd() {
         )
         .build();
     p.cargo("build -v --lib")
-        .build_std_arg(&setup, "core")
+        .build_std(&setup)
         .target_host()
         .with_stderr_does_not_contain("[..]libstd[..]")
         .run();
@@ -310,11 +350,22 @@ fn check_core() {
         None => return,
     };
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["core"]
+        "#,
+        )
         .file("src/lib.rs", "#![no_std] fn unused_fn() {}")
         .build();
 
     p.cargo("check -v")
-        .build_std_arg(&setup, "core")
+        .build_std(&setup)
         .target_host()
         .with_stderr_contains("[WARNING] [..]unused_fn[..]`")
         .run();
@@ -341,10 +392,12 @@ fn depend_same_as_std() {
         .file(
             "Cargo.toml",
             r#"
+                cargo-features = ["build-std"]
                 [package]
                 name = "foo"
                 version = "0.1.0"
                 edition = "2018"
+                build-std = ["std"]
 
                 [dependencies]
                 registry-dep-using-core = "1.0"
@@ -364,6 +417,17 @@ fn test() {
         None => return,
     };
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
         .file(
             "src/lib.rs",
             r#"
@@ -393,6 +457,17 @@ fn target_proc_macro() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             r#"
                 extern crate proc_macro;
@@ -413,6 +488,17 @@ fn bench() {
         None => return,
     };
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
         .file(
             "src/lib.rs",
             r#"
@@ -438,6 +524,17 @@ fn doc() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             r#"
                 /// Doc
@@ -456,6 +553,17 @@ fn check_std() {
         None => return,
     };
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
         .file(
             "src/lib.rs",
             "
@@ -495,6 +603,17 @@ fn doctest() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             r#"
                 /// Doc
@@ -521,6 +640,17 @@ fn no_implicit_alloc() {
         None => return,
     };
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
         .file(
             "src/lib.rs",
             r#"
@@ -552,6 +682,17 @@ fn macro_expanded_shadow() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             r#"
                 macro_rules! a {
@@ -574,7 +715,20 @@ fn ignores_incremental() {
         Some(s) => s,
         None => return,
     };
-    let p = project().file("src/lib.rs", "").build();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+        cargo-features = ["build-std"]
+        [package]
+        name = "foo"
+        version = "0.1.0"
+        edition = "2018"
+        build-std = ["std"]
+    "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
     p.cargo("build")
         .env("CARGO_INCREMENTAL", "1")
         .build_std(&setup)
@@ -601,19 +755,23 @@ fn cargo_config_injects_compiler_builtins() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["core"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             r#"
                 #![no_std]
                 pub fn foo() {
                     assert_eq!(u8::MIN, 0);
                 }
-            "#,
-        )
-        .file(
-            ".cargo/config.toml",
-            r#"
-                [unstable]
-                build-std = ['core']
             "#,
         )
         .build();
@@ -633,6 +791,18 @@ fn different_features() {
     };
     let p = project()
         .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+            build-std-features = ["feature1"]
+        "#,
+        )
+        .file(
             "src/lib.rs",
             "
                 pub fn foo() {
@@ -641,11 +811,7 @@ fn different_features() {
             ",
         )
         .build();
-    p.cargo("build")
-        .build_std(&setup)
-        .arg("-Zbuild-std-features=feature1")
-        .target_host()
-        .run();
+    p.cargo("build").build_std(&setup).target_host().run();
 }
 
 #[cargo_test]
@@ -671,6 +837,17 @@ fn proc_macro_only() {
         None => return,
     };
     let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["build-std"]
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+            build-std = ["std"]
+        "#,
+        )
         .file(
             "Cargo.toml",
             r#"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Resolves #9451. Moves the unstable feature `build-std` to `Cargo.toml` per the [Rust Internals discussion](https://internals.rust-lang.org/t/proposal-move-some-cargo-config-settings-to-cargo-toml/13336/14?u=fee1-dead)