### PR TITLE
Use local git info for version.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,8 +2,10 @@ use flate2::{Compression, GzBuilder};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 fn main() {
+    commit_info();
     compress_man();
     println!(
         "cargo:rustc-env=RUST_HOST_TARGET={}",
@@ -40,4 +42,26 @@ fn compress_man() {
     add_files(Path::new("src/doc/man/generated_txt"), OsStr::new("txt"));
     let encoder = ar.into_inner().unwrap();
     encoder.finish().unwrap();
+}
+
+fn commit_info() {
+    if !Path::new(".git").exists() {
+        return;
+    }
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--format=%H %h %cd")
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return,
+    };
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let mut parts = stdout.split_whitespace();
+    let mut next = || parts.next().unwrap();
+    println!("cargo:rustc-env=CARGO_COMMIT_HASH={}", next());
+    println!("cargo:rustc-env=CARGO_COMMIT_SHORT_HASH={}", next());
+    println!("cargo:rustc-env=CARGO_COMMIT_DATE={}", next())
 }

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -169,12 +169,10 @@ pub fn get_version_string(is_verbose: bool) -> String {
     let version = cargo::version();
     let mut version_string = format!("cargo {}\n", version);
     if is_verbose {
-        version_string.push_str(&format!("release: {}\n", version.version,));
-        if let Some(ref cfg) = version.cfg_info {
-            if let Some(ref ci) = cfg.commit_info {
-                version_string.push_str(&format!("commit-hash: {}\n", ci.commit_hash));
-                version_string.push_str(&format!("commit-date: {}\n", ci.commit_date));
-            }
+        version_string.push_str(&format!("release: {}\n", version.version));
+        if let Some(ref ci) = version.commit_info {
+            version_string.push_str(&format!("commit-hash: {}\n", ci.commit_hash));
+            version_string.push_str(&format!("commit-date: {}\n", ci.commit_date));
         }
         writeln!(version_string, "host: {}", env!("RUST_HOST_TARGET")).unwrap();
         add_libgit2(&mut version_string);

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -993,7 +993,6 @@ pub fn channel() -> String {
         }
     }
     crate::version()
-        .cfg_info
-        .map(|c| c.release_channel)
+        .release_channel
         .unwrap_or_else(|| String::from("dev"))
 }


### PR DESCRIPTION
#10178 caused an unintended change where cargo is being built twice in rust-lang/rust's CI.  It is being built once as a CLI, and a second time for RLS.  The cause is the `CFG_COMMIT_HASH` environment variable changes between those two builds (it is set for the tool being built).

The solution here is to grab the git information from cargo's own build script. This is guaranteed to always be in the `src/tools/cargo` directory for both tools.

This should help save a minute or two in the dist builders.
