### PR TITLE
Fix documenting with undocumented dependencies.

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -431,7 +431,7 @@ fn compute_deps_doc(
     let mut ret = Vec::new();
     for (id, _deps) in deps {
         let dep = state.get(id);
-        let lib = match dep.targets().iter().find(|t| t.is_lib() && t.documented()) {
+        let lib = match dep.targets().iter().find(|t| t.is_lib()) {
             Some(lib) => lib,
             None => continue,
         };
@@ -449,18 +449,20 @@ fn compute_deps_doc(
             mode,
         )?;
         ret.push(lib_unit_dep);
-        if let CompileMode::Doc { deps: true } = unit.mode {
-            // Document this lib as well.
-            let doc_unit_dep = new_unit_dep(
-                state,
-                unit,
-                dep,
-                lib,
-                dep_unit_for,
-                unit.kind.for_target(lib),
-                unit.mode,
-            )?;
-            ret.push(doc_unit_dep);
+        if lib.documented() {
+            if let CompileMode::Doc { deps: true } = unit.mode {
+                // Document this lib as well.
+                let doc_unit_dep = new_unit_dep(
+                    state,
+                    unit,
+                    dep,
+                    lib,
+                    dep_unit_for,
+                    unit.kind.for_target(lib),
+                    unit.mode,
+                )?;
+                ret.push(doc_unit_dep);
+            }
         }
     }
 


### PR DESCRIPTION
#10201 introduced a bug where dependencies that have `doc=false` weren't being built at all when running `cargo doc` if the project did not have any binaries.  That means the rmeta file was missing, and the `--extern` flag was not being passed to rustdoc.

The solution is to ensure the `rmeta` file gets generated, but only skip generating the `CompileMode::Doc` unit for undocumented dependencies.
 
This unblocks the bootstrap bump.
