### PR TITLE
Remove deprecated --host arg for search and publish cmds

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -211,11 +211,6 @@ pub trait AppExt: Sized {
 
     fn arg_index(self) -> Self {
         self._arg(opt("index", "Registry index URL to upload the package to").value_name("INDEX"))
-            ._arg(
-                opt("host", "DEPRECATED, renamed to '--index'")
-                    .value_name("HOST")
-                    .hide(true),
-            )
     }
 
     fn arg_dry_run(self, dry_run: &'static str) -> Self {


### PR DESCRIPTION

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/10304

### How should we test and review this PR?

Remove deprecated --host arg for search and publish cmds.