### PR TITLE
[beta] backport remove --host flag

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -212,11 +212,6 @@ pub trait AppExt: Sized {
 
     fn arg_index(self) -> Self {
         self._arg(opt("index", "Registry index URL to upload the package to").value_name("INDEX"))
-            ._arg(
-                opt("host", "DEPRECATED, renamed to '--index'")
-                    .value_name("HOST")
-                    .hidden(true),
-            )
     }
 
     fn arg_dry_run(self, dry_run: &'static str) -> Self {


### PR DESCRIPTION
This is a beta backport of #10327.  I would feel more comfortable having the complete fix for #10145 since the deprecation notice was removed in that PR.
