### PR TITLE
Normalize --path when install bin outside current workspace

### DIFF
--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -530,15 +530,28 @@ fn install_relative_path_outside_current_ws() {
         .build();
 
     p.cargo("install --path ../bar/foo")
+        .with_stderr(&format!(
+            "\
+[INSTALLING] foo v0.0.1 ([..]/bar/foo)
+[COMPILING] foo v0.0.1 ([..]/bar/foo)
+[FINISHED] release [..]
+[INSTALLING] {home}/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1 ([..]/bar/foo)` (executable `foo[EXE]`)
+[WARNING] be sure to add [..]
+",
+            home = cargo_home().display(),
+        ))
+        .run();
+
+    // Validate the workspace error message to display available targets.
+    p.cargo("install --path ../bar/foo --bin")
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] current package believes it's in a workspace when it's not:
-current:   [CWD]/../bar/foo/Cargo.toml
-workspace: [CWD]/Cargo.toml
+[ERROR] \"--bin\" takes one argument.
+Available binaries:
+    foo
 
-this may be fixable by adding `../bar/foo` to the `workspace.members` [..]
-Alternatively, [..]
 ",
         )
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #10283

For `Workspace::find_root`, `cargo_util::path::PathAncestors` won't do
path normalization while walking back the ancestors. The responsibility
lies in the caller. Thus, `cargo install` should normalize its `--path`
argument before passing in `SourceId::for_path` and `Workspace::new`.

`Config::reload_rooted_at` is not affected because cargo always starts
searching and merging configs from where it is invoked.

### How should we test and review this PR?

A new test `install::install_relative_path_outside_current_ws` should cover this case.
You can also follow the reproducible steps described in #10283.
<!-- homu-ignore:end -->