### PR TITLE
Check minimum rust-version for recently stabilized features.

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -88,8 +88,11 @@
 //! 2. Remove `masquerade_as_nightly_cargo` from any tests, and remove
 //!    `cargo-features` from `Cargo.toml` test files if any.
 //! 3. Update the docs in unstable.md to move the section to the bottom
-//!    and summarize it similar to the other entries. Update the rest of the
-//!    documentation to add the new feature.
+//!    and summarize it similar to the other entries.
+//!    Also remove it from the list at the top of the file.
+//!    Update the rest of the documentation to add the new feature.
+//! 4. Update `Manifest::check_rust_version` if applicable to check that the
+//!    `rust-version` field is valid.
 
 use std::collections::BTreeSet;
 use std::env;

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1143,30 +1143,6 @@ impl TomlManifest {
             )));
         }
 
-        let rust_version = if let Some(rust_version) = &project.rust_version {
-            let req = match semver::VersionReq::parse(rust_version) {
-                // Exclude semver operators like `^` and pre-release identifiers
-                Ok(req) if rust_version.chars().all(|c| c.is_ascii_digit() || c == '.') => req,
-                _ => bail!("`rust-version` must be a value like \"1.32\""),
-            };
-            if let Some(first_version) = edition.first_version() {
-                let unsupported =
-                    semver::Version::new(first_version.major, first_version.minor - 1, 9999);
-                if req.matches(&unsupported) {
-                    bail!(
-                        "rust-version {} is older than first version ({}) required by \
-                            the specified edition ({})",
-                        rust_version,
-                        first_version,
-                        edition,
-                    )
-                }
-            }
-            Some(rust_version.clone())
-        } else {
-            None
-        };
-
         if project.metabuild.is_some() {
             features.require(Feature::metabuild())?;
         }
@@ -1418,7 +1394,7 @@ impl TomlManifest {
             workspace_config,
             features,
             edition,
-            rust_version,
+            project.rust_version.clone(),
             project.im_a_teapot,
             project.default_run.clone(),
             Rc::clone(me),
@@ -1444,6 +1420,7 @@ impl TomlManifest {
         }
 
         manifest.feature_gate()?;
+        manifest.check_rust_version()?;
 
         Ok((manifest, nested_paths))
     }


### PR DESCRIPTION
This adds some checks for the `rust-version` field in `Cargo.toml` to check that it isn't too low for any recently stabilized features in the manifest.  The intent here is to ensure that the rust-version is truly compatible with the package.

It checks:
* Edition
* named profiles (minimum 1.57)
* profile strip (1.59)
* weak and namespaced features (1.60)

