### PR TITLE
Auto-switch to multi-sources vendor directory layout

### DIFF
--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -29,33 +29,6 @@ fn vendor_simple() {
 
     Package::new("log", "0.3.5").publish();
 
-    p.cargo("vendor --respect-source-config").run();
-    let lock = p.read_file("vendor/log/Cargo.toml");
-    assert!(lock.contains("version = \"0.3.5\""));
-
-    add_vendor_config(&p);
-    p.cargo("build").run();
-}
-
-#[cargo_test]
-fn vendor_sample_config() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-
-                [dependencies]
-                log = "0.3.5"
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    Package::new("log", "0.3.5").publish();
-
     p.cargo("vendor --respect-source-config")
         .with_stdout(
             r#"
@@ -67,6 +40,11 @@ directory = "vendor"
 "#,
         )
         .run();
+    let lock = p.read_file("vendor/log/Cargo.toml");
+    assert!(lock.contains("version = \"0.3.5\""));
+
+    add_vendor_config(&p);
+    p.cargo("build").run();
 }
 
 fn add_vendor_config(p: &Project) {


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

`cargo-vendor` has been broken for a while, there is no a clear alternative way to solve the situation described in #10310. This PR tries to do what `--no-merge-sources` does but automatically switching to multi-sources layout instead of introducing the flag. (see https://github.com/rust-lang/cargo/pull/10344#pullrequestreview-868113795 and https://github.com/rust-lang/cargo/pull/10344#issuecomment-1032994506)

Fixes #10310

### How should we test and review this PR?

Part of the logic is copied from https://github.com/alexcrichton/cargo-vendor.

Several tests are updated and added:

- 🆕 `vendor::duplicate_version_from_multiple_sources`: Auto-switch between non-merged and merged sources.
- ❌ `vendor::git_duplicate`: Removed. cargo-vendor now can auto-switch.
- ❌ `vendor::vendor_sample_config`: Merged into `vendor::vendor_simple`.

### Additional information

There are somethings I am uncertain:

- [x] When switching between non-merged and merged sources. `cargo-vendor` removes the entire vendor directory. Should cargo emit a warning or just error out and tell user the incompatibility between merged and non-merged? Generally removing the vendor dir should not be a destructive operation but thing not always goes as we thought 😆 
**Solved**: See https://github.com/rust-lang/cargo/pull/10344#discussion_r795852617
- [x] The `cargo::util::short_hash` is not compatible with [the one in cargo-vendor]. I personally prefer to use `util::short_hash` instead, but if the compatibility is more important I am also ok to copy it over.
**Solved**: See https://github.com/rust-lang/cargo/pull/10344#discussion_r796996824

[the one in cargo-vendor]: https://github.com/alexcrichton/cargo-vendor/blob/07570e23/src/main.rs#L568-L575

<!-- homu-ignore:end -->
