### PR TITLE
Improve startup time of bash completion.

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -105,7 +105,8 @@ _cargo()
 		elif [[ "$cur" == +* ]]; then
 			COMPREPLY=( $( compgen -W "$(_toolchains)" -- "$cur" ) )
 		else
-			COMPREPLY=( $( compgen -W "$__cargo_commands" -- "$cur" ) )
+			_ensure_cargo_commands_cache_filled
+			COMPREPLY=( $( compgen -W "$__cargo_commands_cache" -- "$cur" ) )
 		fi
 	else
 		case "${prev}" in
@@ -140,7 +141,8 @@ _cargo()
 				_filedir -d
 				;;
 			help)
-				COMPREPLY=( $( compgen -W "$__cargo_commands" -- "$cur" ) )
+				_ensure_cargo_commands_cache_filled
+				COMPREPLY=( $( compgen -W "$__cargo_commands_cache" -- "$cur" ) )
 				;;
 			*)
 				if [[ "$cmd" == "report" && "$prev" == future-incompat* ]]; then
@@ -164,7 +166,12 @@ _cargo()
 } &&
 complete -F _cargo cargo
 
-__cargo_commands=$(cargo --list 2>/dev/null | awk 'NR>1 {print $1}')
+__cargo_commands_cache=
+_ensure_cargo_commands_cache_filled(){
+	if [[ -z $__cargo_commands_cache ]]; then
+		__cargo_commands_cache="$(cargo --list 2>/dev/null | awk 'NR>1 {print $1}')"
+	fi
+}
 
 _locate_manifest(){
 	cargo locate-project --message-format plain 2>/dev/null


### PR DESCRIPTION
`cargo list` takes about .15 seconds on my computer which is
substantial enough to be the slowest command run when my shell starts
according to [sstephenson's bashprof](https://github.com/sstephenson/bashprof).

This commit defers running `cargo list` until we need it for the first
time.

# Testing

After starting a new shell (which has loaded cargo's bash completion)
type `cargo <TAB><TAB>` and see the output matches the output prior to
this change (ie: the commands given by `cargo list`). You should
observe a small delay. You should observe no such delay on subsequent
attempts within the same session.