### PR TITLE
Use clap::ArgEnum to auto-generate possible cli arguments from Rust enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ toml_edit =  { version = "0.13.4", features = ["serde", "easy"] }
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
-clap = "3.1.0"
+clap = { version = "3.1.0", features = ["derive"] }
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
 im-rc = "15.0.0"

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -12,8 +12,8 @@ pub fn cli() -> App {
                 .arg(Arg::new("key").help("The config key to display"))
                 .arg(
                     opt("format", "Display format")
-                        .possible_values(cargo_config::ConfigFormat::POSSIBLE_VALUES)
-                        .default_value("toml"),
+                        .possible_values(cargo_config::ConfigFormat::possible_values())
+                        .default_value(cargo_config::ConfigFormat::Toml.as_ref()),
                 )
                 .arg(opt(
                     "show-origin",
@@ -35,7 +35,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         Some(("get", args)) => {
             let opts = cargo_config::GetOptions {
                 key: args.value_of("key"),
-                format: args.value_of("format").unwrap().parse()?,
+                format: args.value_of_t_or_exit("format"),
                 show_origin: args.is_present("show-origin"),
                 merged: args.value_of("merged") == Some("yes"),
             };

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -35,7 +35,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         Some(("get", args)) => {
             let opts = cargo_config::GetOptions {
                 key: args.value_of("key"),
-                format: args.value_of_t_or_exit("format"),
+                format: args.value_of_t("format")?,
                 show_origin: args.is_present("show-origin"),
                 merged: args.value_of("merged") == Some("yes"),
             };

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -120,7 +120,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             .warn("the --prefix-depth flag has been changed to --prefix=depth")?;
         tree::Prefix::Depth
     } else {
-        args.value_of_t_or_exit("prefix")
+        args.value_of_t("prefix")?
     };
 
     let no_dedupe = args.is_present("no-dedupe") || args.is_present("all");

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -68,8 +68,8 @@ pub fn cli() -> App {
                 "Change the prefix (indentation) of how each entry is displayed",
             )
             .value_name("PREFIX")
-            .possible_values(&["depth", "indent", "none"])
-            .default_value("indent"),
+            .possible_values(tree::Prefix::possible_values())
+            .default_value(tree::Prefix::Indent.as_ref()),
         )
         .arg(opt(
             "no-dedupe",
@@ -113,16 +113,15 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         config
             .shell()
             .warn("the --no-indent flag has been changed to --prefix=none")?;
-        "none"
+        tree::Prefix::None
     } else if args.is_present("prefix-depth") {
         config
             .shell()
             .warn("the --prefix-depth flag has been changed to --prefix=depth")?;
-        "depth"
+        tree::Prefix::Depth
     } else {
-        args.value_of("prefix").unwrap()
+        args.value_of_t_or_exit("prefix")
     };
-    let prefix = tree::Prefix::from_str(prefix).map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let no_dedupe = args.is_present("no-dedupe") || args.is_present("all");
     if args.is_present("all") {

--- a/src/cargo/ops/cargo_config.rs
+++ b/src/cargo/ops/cargo_config.rs
@@ -25,16 +25,6 @@ impl ConfigFormat {
     }
 }
 
-impl AsRef<str> for ConfigFormat {
-    fn as_ref(&self) -> &str {
-        match self {
-            ConfigFormat::Toml => "toml",
-            ConfigFormat::Json => "json",
-            ConfigFormat::JsonValue => "json-value",
-        }
-    }
-}
-
 impl FromStr for ConfigFormat {
     type Err = Error;
     fn from_str(s: &str) -> CargoResult<Self> {
@@ -49,11 +39,21 @@ impl FromStr for ConfigFormat {
 
 impl fmt::Display for ConfigFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {
-            ConfigFormat::Toml => write!(f, "toml"),
-            ConfigFormat::Json => write!(f, "json"),
-            ConfigFormat::JsonValue => write!(f, "json-value"),
-        }
+        write!(
+            f,
+            "{}",
+            self.to_possible_value()
+                .expect("No value is skipped")
+                .get_name()
+        )
+    }
+}
+
+impl AsRef<str> for ConfigFormat {
+    fn as_ref(&self) -> &str {
+        self.to_possible_value()
+            .expect("No value is skipped")
+            .get_name()
     }
 }
 

--- a/src/cargo/ops/cargo_config.rs
+++ b/src/cargo/ops/cargo_config.rs
@@ -4,11 +4,13 @@ use crate::util::config::{Config, ConfigKey, ConfigValue as CV, Definition};
 use crate::util::errors::CargoResult;
 use crate::{drop_eprintln, drop_println};
 use anyhow::{bail, format_err, Error};
+use clap::{ArgEnum, PossibleValue};
 use serde_json::json;
 use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
 
+#[derive(clap::ArgEnum, Clone)]
 pub enum ConfigFormat {
     Toml,
     Json,
@@ -16,8 +18,21 @@ pub enum ConfigFormat {
 }
 
 impl ConfigFormat {
-    /// For clap.
-    pub const POSSIBLE_VALUES: &'static [&'static str] = &["toml", "json", "json-value"];
+    pub fn possible_values() -> impl Iterator<Item = PossibleValue<'static>> {
+        ConfigFormat::value_variants()
+            .iter()
+            .filter_map(ArgEnum::to_possible_value)
+    }
+}
+
+impl AsRef<str> for ConfigFormat {
+    fn as_ref(&self) -> &str {
+        match self {
+            ConfigFormat::Toml => "toml",
+            ConfigFormat::Json => "json",
+            ConfigFormat::JsonValue => "json-value",
+        }
+    }
 }
 
 impl FromStr for ConfigFormat {

--- a/src/cargo/ops/cargo_config.rs
+++ b/src/cargo/ops/cargo_config.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::str::FromStr;
 
-#[derive(clap::ArgEnum, Clone)]
+#[derive(clap::ArgEnum, Copy, Clone)]
 pub enum ConfigFormat {
     Toml,
     Json,

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -86,7 +86,7 @@ impl FromStr for Charset {
     }
 }
 
-#[derive(clap::ArgEnum, Clone, Copy)]
+#[derive(clap::ArgEnum, Copy, Clone)]
 pub enum Prefix {
     None,
     Indent,

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -116,11 +116,9 @@ impl FromStr for Prefix {
 
 impl AsRef<str> for Prefix {
     fn as_ref(&self) -> &str {
-        match self {
-            Prefix::None => "none",
-            Prefix::Indent => "indent",
-            Prefix::Depth => "depth",
-        }
+        self.to_possible_value()
+            .expect("No value is skipped")
+            .get_name()
     }
 }
 

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -9,6 +9,7 @@ use crate::ops::{self, Packages};
 use crate::util::{CargoResult, Config};
 use crate::{drop_print, drop_println};
 use anyhow::Context;
+use clap::{ArgEnum, PossibleValue};
 use graph::Graph;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
@@ -85,11 +86,19 @@ impl FromStr for Charset {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(clap::ArgEnum, Clone, Copy)]
 pub enum Prefix {
     None,
     Indent,
     Depth,
+}
+
+impl Prefix {
+    pub fn possible_values() -> impl Iterator<Item = PossibleValue<'static>> {
+        Prefix::value_variants()
+            .iter()
+            .filter_map(ArgEnum::to_possible_value)
+    }
 }
 
 impl FromStr for Prefix {
@@ -101,6 +110,16 @@ impl FromStr for Prefix {
             "indent" => Ok(Prefix::Indent),
             "depth" => Ok(Prefix::Depth),
             _ => Err("invalid prefix"),
+        }
+    }
+}
+
+impl AsRef<str> for Prefix {
+    fn as_ref(&self) -> &str {
+        match self {
+            Prefix::None => "none",
+            Prefix::Indent => "indent",
+            Prefix::Depth => "depth",
         }
     }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

I was familiarising myself with the codebase after the upgrade to clap-3.0 PR #10265 and 
spotted a couple of low-hanging refactors. Vectors of strings were duplicated as cli representations
of enums. Those strings can be exhaustively auto-generated from the enum variants. 

Tangentially related to #6104, since this automates the need to manually keep the
vectors of static strings up to date with the possible values of ConfigFormat and tree::Prefix.

### How should we test and review this PR?

The PR is split into 2 commits - one to set up the whole cargo workspace with 
clap + derive feature and refactor ConfigFormat. The second follows up with a
refactor to use clap derive ArgEnum for tree::Prefix. 
Feel free to suggest tests, if you feel this is too untested as is. 

### Additional information

+ Confirm that the derive feature of clap is acceptable as a dependency addition 