### PR TITLE
[beta] Remove `strip = "off"` (and undocumented `strip = "n"`/`strip = "no"`)

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -629,7 +629,7 @@ fn merge_profile(profile: &mut Profile, toml: &TomlProfile) {
     profile.strip = match toml.strip {
         Some(StringOrBool::Bool(true)) => Strip::Named(InternedString::new("symbols")),
         None | Some(StringOrBool::Bool(false)) => Strip::None,
-        Some(StringOrBool::String(ref n)) if is_off(n.as_str()) => Strip::None,
+        Some(StringOrBool::String(ref n)) if n.as_str() == "none" => Strip::None,
         Some(StringOrBool::String(ref n)) => Strip::Named(InternedString::new(n)),
     };
 }

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -106,12 +106,12 @@ strip either symbols or debuginfo from a binary. This can be enabled like so:
 strip = "debuginfo"
 ```
 
-Other possible string values of `strip` are `none`, `symbols`, and `off`. The
-default is `none`.
+Possible string values of `strip` are `"none"`, `"debuginfo"`, and `"symbols"`.
+The default is `"none"`.
 
-You can also configure this option with the two absolute boolean values
-`true` and `false`. The former enables `strip` at its higher level, `symbols`,
-while the latter disables `strip` completely.
+You can also configure this option with the boolean values `true` or `false`.
+`strip = true` is equivalent to `strip = "symbols"`. `strip = false` is
+equivalent to `strip = "none"` and disables `strip` completely.
 
 [`-C strip` flag]: ../../rustc/codegen-options/index.html#strip
 


### PR DESCRIPTION
Beta backport of #10376

The `strip` option allows the string `"off"`, which `rustc` doesn't
have, and maps it to `"none"`. Remove that equivalent, and just keep
`"none"`.

Simplify and clarify the documentation for `strip` accordingly.

`strip` reused the `is_off` function from `lto`, which also had the net
effect of allowing `"n"` and `"no"`, which weren't documented as
supported. This change drops those as well.
