### PR TITLE
cargo-new should not add ignore rule on Cargo.lock inside subdirs

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -716,7 +716,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     let mut ignore = IgnoreList::new();
     ignore.push("/target", "^target/", "target");
     if !opts.bin {
-        ignore.push("Cargo.lock", "glob:Cargo.lock", "Cargo.lock,*/Cargo.lock");
+        ignore.push("/Cargo.lock", "^Cargo.lock$", "Cargo.lock");
     }
 
     let vcs = opts.version_control.unwrap_or_else(|| {

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -89,7 +89,7 @@ fn simple_git() {
 
     let fp = paths::root().join("foo/.gitignore");
     let contents = fs::read_to_string(&fp).unwrap();
-    assert_eq!(contents, "/target\nCargo.lock\n",);
+    assert_eq!(contents, "/target\n/Cargo.lock\n",);
 
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fixes #10370

Have traced down the issue. It feel like the original intent is to
ignore `Cargo.lock` and `target` at project root but not subdirectories.

1. The original implementation did ignore root `/Cargo.lock`.
   https://github.com/rust-lang/cargo/pull/321
2. Someday one wanted to support both gitignore and hgingore's syntax
   and removed the leading slash.
   https://github.com/rust-lang/cargo/pull/1247
3. Later, one found that we should not ignore `target` other than
   under root directory and added `/target` back.
   https://github.com/rust-lang/cargo/pull/4099
4. It turns out that the syntax is not compatible between gitignore
   and hgignore. Therefore, one started to use hgignore special syntax
   to handle `Cargo.lock`.
   https://github.com/rust-lang/cargo/pull/4342

This commit rollbacks to what original implementation tries to do.

### How should we test and review this PR?

I've manual tested git/hg/fossil and all ignore rules work as expected.
I feel like adding tests on hg/fossil/pijul is not worthy since our CI 
does not have tools to run those tests. But maybe I am wrong.

For your convenience, here is ignore rule syntax for each VCS

- git: https://git-scm.com/docs/gitignore
- mercurial: https://www.mercurial-scm.org/wiki/.hgignore
- fossil: https://www.fossil-scm.org/home/doc/trunk/www/globs.md
- pijul: not found in official doc but in forum ([1](https://discourse.pijul.org/t/newbie-feedback/328/2), [2](https://discourse.pijul.org/t/ignoring-files-and-folders-with-pijul/614))

<!-- homu-ignore:end -->
