### PR TITLE
Make profile name and for_host target available as environment variables

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -373,6 +373,8 @@ fn fill_rustc_tool_env(mut cmd: ProcessBuilder, unit: &Unit) -> ProcessBuilder {
         cmd.env("CARGO_BIN_NAME", name);
     }
     cmd.env("CARGO_CRATE_NAME", unit.target.crate_name());
+    cmd.env("CARGO_PROFILE_NAME", unit.profile.name);
+    cmd.env("CARGO_FOR_HOST", (unit.target.for_host()).to_string());
     cmd
 }
 

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -214,6 +214,8 @@ corresponding environment variable is set to the empty string, `""`.
 * `CARGO_PKG_LICENSE_FILE` — The license file from the manifest of your package.
 * `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled.
 * `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as `.exe`.
+* `CARGO_PROFILE_NAME` - The name of the [cargo profile](profiles.md) used. Can be one of the built-in profiles `dev`, `release`, `test`, `bench` or a custom profile's name. Is not set for `proc-macro` crates.
+* `CARGO_FOR_HOST` - Is `true` when building `build.rs` files, `false` for normal compilations and not set for `proc-macro` crates.
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1340,6 +1340,8 @@ fn crate_env_vars() {
                 static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
                 static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
                 static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
+                static PROFILE_NAME: &'static str = env!("CARGO_PROFILE_NAME");
+                static FOR_HOST: &'static str = env!("CARGO_FOR_HOST");
 
 
                 fn main() {
@@ -1362,6 +1364,9 @@ fn crate_env_vars() {
 
                     // Verify CARGO_TARGET_TMPDIR isn't set for bins
                     assert!(option_env!("CARGO_TARGET_TMPDIR").is_none());
+
+                    assert_eq!("dev", PROFILE_NAME);
+                    assert_eq!("false", FOR_HOST);
                 }
             "#,
         )


### PR DESCRIPTION
### Motivation

I want to use custom profiles to create special targets like `coverage` or `sanitized`. In a mixed Rust and C program this requires *per profile* control over the environment (`CFLAGS` and more), but also over the `rustc` command line parameters. Using the `rustc-wrapper` and `rustc-workspace-wrapper` this can be controlled very fine grained, but there is information missing:

- The profile name I am compiling for to set the environment and `rustc` flags accordingly
- The compile mode: I want to be able to skip setting some options for `build.rs` and `proc-macro` compilations

### Approach

This PR makes the cargo profile name available as the environment variable `CARGO_PROFILE_NAME`. The `target.for_host()` is made available as `CARGO_FOR_HOST`. This seems to be true for build scripts and false in other cases.

### Discussion

- Obviously the env variable names are flawed and can be improved
- `for_host` seems to be true for build scripts and false otherwise, but I am not sure if this is correct
- For `proc-macro` crates both variables are just not set
- There is #10271, which at some point in the future will make part of this easier. But this will still lack the full control especially over the environment, which is important for the C compilation flags.