### PR TITLE
Override target crate-type for `cargo rustc --crate-type`

### DIFF
--- a/src/cargo/core/compiler/build_context/mod.rs
+++ b/src/cargo/core/compiler/build_context/mod.rs
@@ -33,9 +33,6 @@ pub struct BuildContext<'a, 'cfg> {
     /// Extra compiler args for either `rustc` or `rustdoc`.
     pub extra_compiler_args: HashMap<Unit, Vec<String>>,
 
-    // Crate types for `rustc`.
-    pub target_rustc_crate_types: HashMap<Unit, Vec<String>>,
-
     /// Package downloader.
     ///
     /// This holds ownership of the `Package` objects.
@@ -64,7 +61,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
         build_config: &'a BuildConfig,
         profiles: Profiles,
         extra_compiler_args: HashMap<Unit, Vec<String>>,
-        target_rustc_crate_types: HashMap<Unit, Vec<String>>,
         target_data: RustcTargetData<'cfg>,
         roots: Vec<Unit>,
         unit_graph: UnitGraph,
@@ -84,7 +80,6 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
             build_config,
             profiles,
             extra_compiler_args,
-            target_rustc_crate_types,
             target_data,
             roots,
             unit_graph,
@@ -131,9 +126,5 @@ impl<'a, 'cfg> BuildContext<'a, 'cfg> {
 
     pub fn extra_args_for(&self, unit: &Unit) -> Option<&Vec<String>> {
         self.extra_compiler_args.get(unit)
-    }
-
-    pub fn rustc_crate_types_args_for(&self, unit: &Unit) -> Option<&Vec<String>> {
-        self.target_rustc_crate_types.get(unit)
     }
 }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -890,18 +890,9 @@ fn build_base_args(
 
     let mut contains_dy_lib = false;
     if !test {
-        let mut crate_types = &crate_types
-            .iter()
-            .map(|t| t.as_str().to_string())
-            .collect::<Vec<String>>();
-        if let Some(types) = cx.bcx.rustc_crate_types_args_for(unit) {
-            crate_types = types;
-        }
-        for crate_type in crate_types.iter() {
-            cmd.arg("--crate-type").arg(crate_type);
-            if crate_type == CrateType::Dylib.as_str() {
-                contains_dy_lib = true;
-            }
+        for crate_type in crate_types {
+            cmd.arg("--crate-type").arg(crate_type.as_str());
+            contains_dy_lib |= crate_type == &CrateType::Dylib;
         }
     }
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -232,6 +232,46 @@ fn build_with_crate_type_for_foo() {
 }
 
 #[cargo_test]
+fn build_with_crate_type_for_foo_with_deps() {
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+            extern crate a;
+            pub fn foo() { a::hello(); }
+            "#,
+        )
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            authors = []
+
+            [dependencies]
+            a = { path = "a" }
+            "#,
+        )
+        .file("a/Cargo.toml", &basic_manifest("a", "0.1.0"))
+        .file("a/src/lib.rs", "pub fn hello() {}")
+        .build();
+
+    p.cargo("rustc -v --crate-type cdylib -Zunstable-options")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[COMPILING] a v0.1.0 ([CWD]/a)
+[RUNNING] `rustc --crate-name a a/src/lib.rs [..]--crate-type lib [..]
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type cdylib [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn build_with_crate_types_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -217,17 +217,14 @@ Binaries, tests, and benchmarks are always the `bin` crate type",
 
 #[cargo_test]
 fn build_with_crate_type_for_foo() {
-    let p = project()
-        .file("src/main.rs", "fn main() {}")
-        .file("src/lib.rs", r#" "#)
-        .build();
+    let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustc -v --lib --crate-type lib -Zunstable-options")
+    p.cargo("rustc -v --crate-type cdylib -Zunstable-options")
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib [..]
+[RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type cdylib [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -236,12 +233,9 @@ fn build_with_crate_type_for_foo() {
 
 #[cargo_test]
 fn build_with_crate_types_for_foo() {
-    let p = project()
-        .file("src/main.rs", "fn main() {}")
-        .file("src/lib.rs", r#" "#)
-        .build();
+    let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustc -v --lib --crate-type lib,cdylib -Zunstable-options")
+    p.cargo("rustc -v --crate-type lib,cdylib -Zunstable-options")
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #10356, fixes #10389

This might not be the best solution, but at least it avoids duplicating 
overridden rules all over the compilation logic.

r? @ehuss since you're the reviewer of #10093

### How should we test and review this PR?

Perform reproducible steps as #10356 described. 

This PR includes a new test `rustc::build_with_crate_type_for_foo_with_deps`
to validate the behavior of overridden crate-types with dependencies.

<!-- homu-ignore:end -->
