### PR TITLE
Consistently use crate::display_error on errors during drain

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -13,7 +13,7 @@ use crate::core::Shell;
 use anyhow::Error;
 use log::debug;
 
-pub use crate::util::errors::{InternalError, VerboseError};
+pub use crate::util::errors::{AlreadyPrintedError, InternalError, VerboseError};
 pub use crate::util::{indented_lines, CargoResult, CliError, CliResult, Config};
 pub use crate::version::version;
 
@@ -76,31 +76,27 @@ pub fn display_warning_with_error(warning: &str, err: &Error, shell: &mut Shell)
 }
 
 fn _display_error(err: &Error, shell: &mut Shell, as_err: bool) -> bool {
-    let verbosity = shell.verbosity();
-    let is_verbose = |e: &(dyn std::error::Error + 'static)| -> bool {
-        verbosity != Verbose && e.downcast_ref::<VerboseError>().is_some()
-    };
-    // Generally the top error shouldn't be verbose, but check it anyways.
-    if is_verbose(err.as_ref()) {
-        return true;
-    }
-    if as_err {
-        drop(shell.error(&err));
-    } else {
-        drop(writeln!(shell.err(), "{}", err));
-    }
-    for cause in err.chain().skip(1) {
-        // If we're not in verbose mode then print remaining errors until one
+    for (i, err) in err.chain().enumerate() {
+        // If we're not in verbose mode then only print cause chain until one
         // marked as `VerboseError` appears.
-        if is_verbose(cause) {
+        //
+        // Generally the top error shouldn't be verbose, but check it anyways.
+        if shell.verbosity() != Verbose && err.is::<VerboseError>() {
             return true;
         }
-        drop(writeln!(shell.err(), "\nCaused by:"));
-        drop(write!(
-            shell.err(),
-            "{}",
-            indented_lines(&cause.to_string())
-        ));
+        if err.is::<AlreadyPrintedError>() {
+            break;
+        }
+        if i == 0 {
+            if as_err {
+                drop(shell.error(&err));
+            } else {
+                drop(writeln!(shell.err(), "{}", err));
+            }
+        } else {
+            drop(writeln!(shell.err(), "\nCaused by:"));
+            drop(write!(shell.err(), "{}", indented_lines(&err.to_string())));
+        }
     }
     false
 }

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -100,6 +100,39 @@ impl fmt::Display for InternalError {
 }
 
 // =============================================================================
+// Already printed error
+
+/// An error that does not need to be printed because it does not add any new
+/// information to what has already been printed.
+pub struct AlreadyPrintedError {
+    inner: Error,
+}
+
+impl AlreadyPrintedError {
+    pub fn new(inner: Error) -> Self {
+        AlreadyPrintedError { inner }
+    }
+}
+
+impl std::error::Error for AlreadyPrintedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.inner.source()
+    }
+}
+
+impl fmt::Debug for AlreadyPrintedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+impl fmt::Display for AlreadyPrintedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+// =============================================================================
 // Manifest error
 
 /// Error wrapper related to a particular manifest and providing it's path.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5672,7 +5672,6 @@ fn close_output() {
 hello stderr!
 [ERROR] [..]
 [WARNING] build failed, waiting for other jobs to finish...
-[ERROR] [..]
 ",
         &stderr,
         None,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -879,11 +879,9 @@ fn compile_failure() {
         .with_status(101)
         .with_stderr_contains(
             "\
+[ERROR] could not compile `foo` due to previous error
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be \
     found at `[..]target`
-
-Caused by:
-  could not compile `foo` due to previous error
 ",
         )
         .run();


### PR DESCRIPTION
As suggested in https://github.com/rust-lang/cargo/pull/10383#discussion_r808178038 and https://github.com/rust-lang/cargo/pull/10383#discussion_r808182199.