### PR TITLE
Avoid new deprecation warnings from clap 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ toml_edit =  { version = "0.13.4", features = ["serde", "easy"] }
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
-clap = "3.0.13"
+clap = "3.1.0"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
 im-rc = "15.0.0"

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -1,7 +1,10 @@
 use anyhow::anyhow;
 use cargo::core::{features, CliUnstable};
 use cargo::{self, drop_print, drop_println, CliResult, Config};
-use clap::{AppSettings, Arg, ArgMatches};
+use clap::{
+    error::{ContextKind, ContextValue},
+    AppSettings, Arg, ArgMatches,
+};
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::fmt::Write;
@@ -33,9 +36,18 @@ pub fn main(config: &mut Config) -> CliResult {
     let args = match cli().try_get_matches() {
         Ok(args) => args,
         Err(e) => {
-            if e.kind == clap::ErrorKind::UnrecognizedSubcommand {
+            if e.kind() == clap::ErrorKind::UnrecognizedSubcommand {
                 // An unrecognized subcommand might be an external subcommand.
-                let cmd = e.info[0].clone();
+                let cmd = e
+                    .context()
+                    .find_map(|c| match c {
+                        (ContextKind::InvalidSubcommand, &ContextValue::String(ref cmd)) => {
+                            Some(cmd)
+                        }
+                        (ContextKind::InvalidSubcommand, _) => unreachable!(),
+                        _ => None,
+                    })
+                    .unwrap();
                 return super::execute_external_subcommand(config, &cmd, &[&cmd, "--help"])
                     .map_err(|_| e.into());
             } else {
@@ -286,9 +298,7 @@ For more information, see issue #10049 <https://github.com/rust-lang/cargo/issue
                 // Note that an alias to an external command will not receive
                 // these arguments. That may be confusing, but such is life.
                 let global_args = GlobalArgs::new(args);
-                let new_args = cli()
-                    .setting(AppSettings::NoBinaryName)
-                    .try_get_matches_from(alias)?;
+                let new_args = cli().no_binary_name(true).try_get_matches_from(alias)?;
 
                 let new_cmd = new_args.subcommand_name().expect("subcommand is required");
                 already_expanded.push(cmd.to_string());
@@ -406,14 +416,11 @@ fn cli() -> App {
         "cargo [OPTIONS] [SUBCOMMAND]"
     };
     App::new("cargo")
-        .setting(
-            AppSettings::DeriveDisplayOrder
-                | AppSettings::AllowExternalSubcommands
-                | AppSettings::NoAutoVersion,
-        )
+        .allow_external_subcommands(true)
+        .setting(AppSettings::DeriveDisplayOrder | AppSettings::NoAutoVersion)
         // Doesn't mix well with our list of common cargo commands.  See clap-rs/clap#3108 for
         // opening clap up to allow us to style our help template
-        .global_setting(AppSettings::DisableColoredHelp)
+        .disable_colored_help(true)
         .override_usage(usage)
         .help_template(
             "\

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -44,10 +44,9 @@ pub fn main(config: &mut Config) -> CliResult {
                         (ContextKind::InvalidSubcommand, &ContextValue::String(ref cmd)) => {
                             Some(cmd)
                         }
-                        (ContextKind::InvalidSubcommand, _) => unreachable!(),
                         _ => None,
                     })
-                    .unwrap();
+                    .expect("UnrecognizedSubcommand implies the presence of InvalidSubcommand");
                 return super::execute_external_subcommand(config, &cmd, &[&cmd, "--help"])
                     .map_err(|_| e.into());
             } else {

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -3,7 +3,7 @@ use cargo::ops::{self, TestOptions};
 
 pub fn cli() -> App {
     subcommand("bench")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Execute all benchmarks of a local package")
         .arg_quiet()
         .arg(

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -6,6 +6,7 @@ pub fn cli() -> App {
         .about("Inspect configuration values")
         .after_help("Run `cargo help config` for more detailed information.\n")
         .subcommand_required(true)
+        .arg_required_else_help(true)
         .subcommand(
             subcommand("get")
                 .arg(Arg::new("key").help("The config key to display"))

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -5,7 +5,7 @@ pub fn cli() -> App {
     subcommand("config")
         .about("Inspect configuration values")
         .after_help("Run `cargo help config` for more detailed information.\n")
-        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand_required(true)
         .subcommand(
             subcommand("get")
                 .arg(Arg::new("key").help("The config key to display"))

--- a/src/bin/cargo/commands/git_checkout.rs
+++ b/src/bin/cargo/commands/git_checkout.rs
@@ -5,7 +5,7 @@ const REMOVED: &str = "The `git-checkout` subcommand has been removed.";
 pub fn cli() -> App {
     subcommand("git-checkout")
         .about("This subcommand has been removed")
-        .setting(AppSettings::Hidden)
+        .hide(true)
         .override_help(REMOVED)
 }
 

--- a/src/bin/cargo/commands/report.rs
+++ b/src/bin/cargo/commands/report.rs
@@ -7,6 +7,7 @@ pub fn cli() -> App {
         .about("Generate and display various kinds of reports")
         .after_help("Run `cargo help report` for more detailed information.\n")
         .subcommand_required(true)
+        .arg_required_else_help(true)
         .subcommand(
             subcommand("future-incompatibilities")
                 .alias("future-incompat")

--- a/src/bin/cargo/commands/report.rs
+++ b/src/bin/cargo/commands/report.rs
@@ -6,7 +6,7 @@ pub fn cli() -> App {
     subcommand("report")
         .about("Generate and display various kinds of reports")
         .after_help("Run `cargo help report` for more detailed information.\n")
-        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand_required(true)
         .subcommand(
             subcommand("future-incompatibilities")
                 .alias("future-incompat")

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -8,7 +8,7 @@ pub fn cli() -> App {
     subcommand("run")
         // subcommand aliases are handled in aliased_command()
         // .alias("r")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Run a binary or example of the local package")
         .arg_quiet()
         .arg(

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -7,7 +7,7 @@ const CRATE_TYPE_ARG_NAME: &str = "crate-type";
 
 pub fn cli() -> App {
     subcommand("rustc")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Compile a package, and pass extra options to the compiler")
         .arg_quiet()
         .arg(Arg::new("args").multiple_values(true).help("Rustc flags"))

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -4,7 +4,7 @@ use crate::command_prelude::*;
 
 pub fn cli() -> App {
     subcommand("rustdoc")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Build a package's documentation, using specified custom flags.")
         .arg_quiet()
         .arg(Arg::new("args").multiple_values(true))

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -6,7 +6,7 @@ pub fn cli() -> App {
     subcommand("test")
         // Subcommand aliases are handled in `aliased_command()`.
         // .alias("t")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Execute all unit and integration tests and build examples of a local package")
         .arg(
             Arg::new("TESTNAME")

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -22,7 +22,7 @@ pub use crate::core::compiler::CompileMode;
 pub use crate::{CliError, CliResult, Config};
 pub use clap::{AppSettings, Arg, ArgMatches};
 
-pub type App = clap::App<'static>;
+pub type App = clap::Command<'static>;
 
 pub trait AppExt: Sized {
     fn _arg(self, arg: Arg<'static>) -> Self;
@@ -281,7 +281,9 @@ pub fn multi_opt(name: &'static str, value_name: &'static str, help: &'static st
 }
 
 pub fn subcommand(name: &'static str) -> App {
-    App::new(name).setting(AppSettings::DeriveDisplayOrder | AppSettings::DontCollapseArgsInUsage)
+    App::new(name)
+        .dont_collapse_args_in_usage(true)
+        .setting(AppSettings::DeriveDisplayOrder)
 }
 
 /// Determines whether or not to gate `--profile` as unstable when resolving it.


### PR DESCRIPTION
### What does this PR try to resolve?

This fixes a number of new deprecations in [clap 3.1.0](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#310---2022-02-16) that are currently causing CI to fail for all other PRs due to `-Dwarnings`.