### PR TITLE
Update to clap 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ toml_edit =  { version = "0.13.4", features = ["serde", "easy"] }
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
-clap = "3.0.13"
+clap = "3.1.0"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
 im-rc = "15.0.0"

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -3,7 +3,7 @@ use cargo::ops::{self, TestOptions};
 
 pub fn cli() -> App {
     subcommand("bench")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Execute all benchmarks of a local package")
         .arg_quiet()
         .arg(

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -5,7 +5,7 @@ pub fn cli() -> App {
     subcommand("config")
         .about("Inspect configuration values")
         .after_help("Run `cargo help config` for more detailed information.\n")
-        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand_required(true)
         .subcommand(
             subcommand("get")
                 .arg(Arg::new("key").help("The config key to display"))

--- a/src/bin/cargo/commands/git_checkout.rs
+++ b/src/bin/cargo/commands/git_checkout.rs
@@ -5,7 +5,7 @@ const REMOVED: &str = "The `git-checkout` subcommand has been removed.";
 pub fn cli() -> App {
     subcommand("git-checkout")
         .about("This subcommand has been removed")
-        .setting(AppSettings::Hidden)
+        .hide(true)
         .override_help(REMOVED)
 }
 

--- a/src/bin/cargo/commands/report.rs
+++ b/src/bin/cargo/commands/report.rs
@@ -6,7 +6,7 @@ pub fn cli() -> App {
     subcommand("report")
         .about("Generate and display various kinds of reports")
         .after_help("Run `cargo help report` for more detailed information.\n")
-        .setting(clap::AppSettings::SubcommandRequiredElseHelp)
+        .subcommand_required(true)
         .subcommand(
             subcommand("future-incompatibilities")
                 .alias("future-incompat")

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -8,7 +8,7 @@ pub fn cli() -> App {
     subcommand("run")
         // subcommand aliases are handled in aliased_command()
         // .alias("r")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Run a binary or example of the local package")
         .arg_quiet()
         .arg(

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -7,7 +7,7 @@ const CRATE_TYPE_ARG_NAME: &str = "crate-type";
 
 pub fn cli() -> App {
     subcommand("rustc")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Compile a package, and pass extra options to the compiler")
         .arg_quiet()
         .arg(Arg::new("args").multiple_values(true).help("Rustc flags"))

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -4,7 +4,7 @@ use crate::command_prelude::*;
 
 pub fn cli() -> App {
     subcommand("rustdoc")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Build a package's documentation, using specified custom flags.")
         .arg_quiet()
         .arg(Arg::new("args").multiple_values(true))

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -6,7 +6,7 @@ pub fn cli() -> App {
     subcommand("test")
         // Subcommand aliases are handled in `aliased_command()`.
         // .alias("t")
-        .setting(AppSettings::TrailingVarArg)
+        .trailing_var_arg(true)
         .about("Execute all unit and integration tests and build examples of a local package")
         .arg(
             Arg::new("TESTNAME")

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -22,7 +22,7 @@ pub use crate::core::compiler::CompileMode;
 pub use crate::{CliError, CliResult, Config};
 pub use clap::{AppSettings, Arg, ArgMatches};
 
-pub type App = clap::App<'static>;
+pub type App = clap::Command<'static>;
 
 pub trait AppExt: Sized {
     fn _arg(self, arg: Arg<'static>) -> Self;
@@ -281,7 +281,9 @@ pub fn multi_opt(name: &'static str, value_name: &'static str, help: &'static st
 }
 
 pub fn subcommand(name: &'static str) -> App {
-    App::new(name).setting(AppSettings::DeriveDisplayOrder | AppSettings::DontCollapseArgsInUsage)
+    App::new(name)
+        .setting(AppSettings::DeriveDisplayOrder)
+        .dont_collapse_args_in_usage(true)
 }
 
 /// Determines whether or not to gate `--profile` as unstable when resolving it.


### PR DESCRIPTION
This PR fixes the deprecation errors I saw in the CI of #10394.

Clap 3.1.0 introduced some new deprecations: https://github.com/clap-rs/clap/releases/tag/v3.1.0

```console
warning: use of deprecated struct `clap::App`: Replaced with `Command`
  --> src/cargo/util/command_prelude.rs:25:22
   |
25 | pub type App = clap::App<'static>;
   |                      ^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated variant `clap::AppSettings::DontCollapseArgsInUsage`: Replaced with `Command::dont_collapse_args_in_usage` and `Command::is_dont_collapse_args_in_usage_set`
   --> src/cargo/util/command_prelude.rs:284:75
    |
284 |     App::new(name).setting(AppSettings::DeriveDisplayOrder | AppSettings::DontCollapseArgsInUsage)
    |                                                                           ^^^^^^^^^^^^^^^^^^^^^^^

warning: `cargo` (lib) generated 2 warnings
warning: use of deprecated variant `clap::AppSettings::NoBinaryName`: Replaced with `Command::no_binary_name`
   --> src/bin/cargo/cli.rs:290:43
    |
290 |                     .setting(AppSettings::NoBinaryName)
    |                                           ^^^^^^^^^^^^
    |
    = note: `#[warn(deprecated)]` on by default

warning: use of deprecated variant `clap::AppSettings::AllowExternalSubcommands`: Replaced with `Command::allow_external_subcommands` and `Command::is_allow_external_subcommands_set`
   --> src/bin/cargo/cli.rs:411:32
    |
411 |                 | AppSettings::AllowExternalSubcommands
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::DisableColoredHelp`: Replaced with `Command::disable_colored_help` and `Command::is_disable_colored_help_set`
   --> src/bin/cargo/cli.rs:416:38
    |
416 |         .global_setting(AppSettings::DisableColoredHelp)
    |                                      ^^^^^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::TrailingVarArg`: Replaced with `Command::trailing_var_arg` and `Command::is_trailing_var_arg_set`
 --> src/bin/cargo/commands/bench.rs:6:31
  |
6 |         .setting(AppSettings::TrailingVarArg)
  |                               ^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::SubcommandRequiredElseHelp`: Replaced with `Command::subcommand_required` combined with `Command::arg_required_else_help`
 --> src/bin/cargo/commands/config.rs:8:37
  |
8 |         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::Hidden`: Replaced with `Command::hide` and `Command::is_hide_set`
 --> src/bin/cargo/commands/git_checkout.rs:8:31
  |
8 |         .setting(AppSettings::Hidden)
  |                               ^^^^^^

warning: use of deprecated variant `clap::AppSettings::SubcommandRequiredElseHelp`: Replaced with `Command::subcommand_required` combined with `Command::arg_required_else_help`
 --> src/bin/cargo/commands/report.rs:9:37
  |
9 |         .setting(clap::AppSettings::SubcommandRequiredElseHelp)
  |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::TrailingVarArg`: Replaced with `Command::trailing_var_arg` and `Command::is_trailing_var_arg_set`
  --> src/bin/cargo/commands/run.rs:11:31
   |
11 |         .setting(AppSettings::TrailingVarArg)
   |                               ^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::TrailingVarArg`: Replaced with `Command::trailing_var_arg` and `Command::is_trailing_var_arg_set`
  --> src/bin/cargo/commands/rustc.rs:10:31
   |
10 |         .setting(AppSettings::TrailingVarArg)
   |                               ^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::TrailingVarArg`: Replaced with `Command::trailing_var_arg` and `Command::is_trailing_var_arg_set`
 --> src/bin/cargo/commands/rustdoc.rs:7:31
  |
7 |         .setting(AppSettings::TrailingVarArg)
  |                               ^^^^^^^^^^^^^^

warning: use of deprecated variant `clap::AppSettings::TrailingVarArg`: Replaced with `Command::trailing_var_arg` and `Command::is_trailing_var_arg_set`
 --> src/bin/cargo/commands/test.rs:9:31
  |
9 |         .setting(AppSettings::TrailingVarArg)
  |                               ^^^^^^^^^^^^^^

warning: use of deprecated field `clap::Error::kind`: Replaced with `Error::kind()`
  --> src/bin/cargo/cli.rs:36:16
   |
36 |             if e.kind == clap::ErrorKind::UnrecognizedSubcommand {
   |                ^^^^^^

warning: use of deprecated field `clap::Error::info`: Replaced with `Error::context()`
  --> src/bin/cargo/cli.rs:38:27
   |
38 |                 let cmd = e.info[0].clone();
   |                           ^^^^^^

warning: `cargo` (bin "cargo") generated 13 warnings
```