### PR TITLE
Remove invalid target-specific dependency example.

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -255,10 +255,10 @@ winhttp = "0.4.0"
 openssl = "1.0.1"
 
 [target.'cfg(target_arch = "x86")'.dependencies]
-native = { path = "native/i686" }
+native-i686 = { path = "native/i686" }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-native = { path = "native/x86_64" }
+native-x86_64 = { path = "native/x86_64" }
 ```
 
 Like with Rust, the syntax here supports the `not`, `any`, and `all` operators


### PR DESCRIPTION
The example with disjoint target configs does not work (and AFAIK has never worked).  It fails with the error:

```
  Dependency 'native' has different source paths depending on the build target. Each dependency must have a single canonical source path irrespective of build target.
```

This removes it to avoid confusion.

cc #7753