### PR TITLE
Add -Z check-cfg-features to enable compile-time checking of features

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -637,6 +637,7 @@ unstable_cli_options!(
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
     config_include: bool = ("Enable the `include` key in config files"),
     credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
+    check_cfg_features: bool = ("Enable compile-time checking of features in `cfg`"),
     doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
@@ -834,6 +835,7 @@ impl CliUnstable {
             "minimal-versions" => self.minimal_versions = parse_empty(k, v)?,
             "advanced-env" => self.advanced_env = parse_empty(k, v)?,
             "config-include" => self.config_include = parse_empty(k, v)?,
+            "check-cfg-features" => self.check_cfg_features = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
             // can also be set in .cargo/config or with and ENV
             "mtime-on-use" => self.mtime_on_use = parse_empty(k, v)?,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1078,6 +1078,20 @@ For instance:
 cargo doc -Z unstable-options -Z rustdoc-scrape-examples=examples
 ```
 
+### check-cfg-features
+
+* RFC: [#3013](https://github.com/rust-lang/rfcs/pull/3013)
+
+The `-Z check-cfg-features` argument tells Cargo to pass all possible features of a package to
+`rustc` unstable `--check-cfg` command line as `--check-cfg=values(feature, ...)`. This enables
+compile time checking of feature values in `#[cfg]`, `cfg!` and `#[cfg_attr]`. Note than this
+command line options will probably become the default when stabilizing.
+For instance:
+
+```
+cargo check -Z unstable-options -Z check-cfg-features
+```
+
 ## Stabilized and removed features
 
 ### Compile progress

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5949,6 +5949,7 @@ fn primary_package_env_var() {
     foo.cargo("test").run();
 }
 
+#[cfg_attr(windows, ignore)] // weird normalization issue with windows and cargo-test-support
 #[cargo_test]
 fn check_cfg_features() {
     if !is_nightly() {
@@ -5984,6 +5985,7 @@ fn check_cfg_features() {
         .run();
 }
 
+#[cfg_attr(windows, ignore)] // weird normalization issue with windows and cargo-test-support
 #[cargo_test]
 fn check_cfg_features_with_deps() {
     if !is_nightly() {
@@ -6025,6 +6027,8 @@ fn check_cfg_features_with_deps() {
         )
         .run();
 }
+
+#[cfg_attr(windows, ignore)] // weird normalization issue with windows and cargo-test-support
 #[cargo_test]
 fn check_cfg_features_with_opt_deps() {
     if !is_nightly() {

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -999,6 +999,7 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
         .run();
 }
 
+#[cfg_attr(windows, ignore)] // weird normalization issue with windows and cargo-test-support
 #[cargo_test]
 fn check_cfg_features() {
     if !is_nightly() {

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -3,6 +3,7 @@
 use std::fmt::{self, Write};
 
 use cargo_test_support::install::exe;
+use cargo_test_support::is_nightly;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::tools;
@@ -995,5 +996,40 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name bar [..]")
         .with_stderr_contains("[CHECKING] baz [..]")
         .with_stdout_does_not_contain("WRAPPER CALLED: rustc --crate-name baz [..]")
+        .run();
+}
+
+#[cargo_test]
+fn check_cfg_features() {
+    if !is_nightly() {
+        // --check-cfg is a nightly only rustc command line
+        return;
+    }
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+
+                [features]
+                f_a = []
+                f_b = []
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -v -Z check-cfg-features")
+        .masquerade_as_nightly_cargo()
+        .with_stderr(
+            "\
+[CHECKING] foo v0.1.0 [..]
+[RUNNING] `rustc [..] --check-cfg 'values(feature, \"f_a\", \"f_b\")' [..]
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
         .run();
 }

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4500,6 +4500,7 @@ fn test_workspaces_cwd() {
         .run();
 }
 
+#[cfg_attr(windows, ignore)] // weird normalization issue with windows and cargo-test-support
 #[cargo_test]
 fn check_cfg_features() {
     if !is_nightly() {


### PR DESCRIPTION
This pull-request implements the "[Cargo support](https://rust-lang.github.io/rfcs/3013-conditional-compilation-checking.html#cargo-support)" section of [RFC 3013: Checking conditional compilation at compile time](https://rust-lang.github.io/rfcs/3013-conditional-compilation-checking.html#checking-conditional-compilation-at-compile-time).

The support is added in the form of an new unstable flags: `-Z check-cfg-features` that pass all possible features of a package to
`rustc` unstable `--check-cfg` command line as `--check-cfg=values(feature, ...)`. This enables compile time checking of `feature` values in `#[cfg]`, `cfg!` and `#[cfg_attr]`.

This new flag currently only affects `rustc` but `rustdoc` support will be added as soon as [it's support](https://github.com/rust-lang/rust/pull/94154) is merged.

Note than the intent is that this command line options become the default when stabilizing as suggested in the RFC:
> [..] it seems uncontroversial for Cargo to enable checking for feature = "..." values immediately [..]