### PR TITLE
Add -Z check-cfg-features support for rustdoc

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -224,11 +224,8 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 let mut unstable_opts = false;
                 let mut args = compiler::extern_args(&self, unit, &mut unstable_opts)?;
                 args.extend(compiler::lto_args(&self, unit));
+                args.extend(compiler::features_args(&self, unit));
 
-                for feature in &unit.features {
-                    args.push("--cfg".into());
-                    args.push(format!("feature=\"{}\"", feature).into());
-                }
                 let script_meta = self.find_build_script_metadata(unit);
                 if let Some(meta) = script_meta {
                     if let Some(output) = self.build_script_outputs.lock().unwrap().get(meta) {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1132,9 +1132,9 @@ cargo doc -Z unstable-options -Z rustdoc-scrape-examples=examples
 * RFC: [#3013](https://github.com/rust-lang/rfcs/pull/3013)
 
 The `-Z check-cfg-features` argument tells Cargo to pass all possible features of a package to
-`rustc` unstable `--check-cfg` command line as `--check-cfg=values(feature, ...)`. This enables
-compile time checking of feature values in `#[cfg]`, `cfg!` and `#[cfg_attr]`. Note than this
-command line options will probably become the default when stabilizing.
+`rustc` and `rustdoc` unstable `--check-cfg` command line as `--check-cfg=values(feature, ...)`.
+This enables compile time checking of feature values in `#[cfg]`, `cfg!` and `#[cfg_attr]`.
+Note than this command line options will probably become the default when stabilizing.
 For instance:
 
 ```


### PR DESCRIPTION
This PR is a follow to https://github.com/rust-lang/cargo/pull/10408 where support for compile-time checking of features was implemented for `rustc`.

At the time `rustdoc` support wasn't yet merged, but now that it has been [merged](https://github.com/rust-lang/rust/pull/94154), this pull-request add support for it in the `doc` and `test --doc` (doctest) mode.

r? @alexcrichton 