### PR TITLE
Fix panic when artifact target is used for `[target.'cfg(<target>)'.dependencies`

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -464,10 +464,7 @@ fn compute_deps_custom_build(
     // All dependencies of this unit should use profiles for custom builds.
     // If this is a build script of a proc macro, make sure it uses host
     // features.
-    let script_unit_for = UnitFor::new_host(
-        unit_for.is_for_host_features(),
-        unit_for.root_compile_kind(),
-    );
+    let script_unit_for = unit_for.for_custom_build();
     // When not overridden, then the dependencies to run a build script are:
     //
     // 1. Compiling the build script itself.
@@ -782,7 +779,7 @@ fn dep_build_script(
             // The profile stored in the Unit is the profile for the thing
             // the custom build script is running for.
             let profile = state.profiles.get_profile_run_custom_build(&unit.profile);
-            // UnitFor::new_host is used because we want the `host` flag set
+            // UnitFor::for_custom_build is used because we want the `host` flag set
             // for all of our build dependencies (so they all get
             // build-override profiles), including compiling the build.rs
             // script itself.
@@ -807,10 +804,7 @@ fn dep_build_script(
             // compiled twice. I believe it is not feasible to only build it
             // once because it would break a large number of scripts (they
             // would think they have the wrong set of features enabled).
-            let script_unit_for = UnitFor::new_host(
-                unit_for.is_for_host_features(),
-                unit_for.root_compile_kind(),
-            );
+            let script_unit_for = unit_for.for_custom_build();
             new_unit_dep_with_profile(
                 state,
                 unit,

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1097,6 +1097,18 @@ impl UnitFor {
         }
     }
 
+    pub fn for_custom_build(self) -> UnitFor {
+        UnitFor {
+            host: true,
+            host_features: self.host_features,
+            // Force build scripts to always use `panic=unwind` for now to
+            // maximally share dependencies with procedural macros.
+            panic_setting: PanicSetting::AlwaysUnwind,
+            root_compile_kind: self.root_compile_kind,
+            artifact_target_for_features: self.artifact_target_for_features,
+        }
+    }
+
     /// Set the artifact compile target for use in features using the given `artifact`.
     pub(crate) fn with_artifact_features(mut self, artifact: &Artifact) -> UnitFor {
         self.artifact_target_for_features = artifact.target().and_then(|t| t.to_compile_target());

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -772,8 +772,13 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
             // We always count platforms as activated if the target stems from an artifact
             // dependency's target specification. This triggers in conjunction with
             // `[target.'cfg(…)'.dependencies]` manifest sections.
-            if matches!(fk, FeaturesFor::NormalOrDevOrArtifactTarget(Some(_))) {
-                return true;
+            if let FeaturesFor::NormalOrDevOrArtifactTarget(Some(target)) = fk {
+                if self
+                    .target_data
+                    .dep_platform_activated(dep, CompileKind::Target(target))
+                {
+                    return true;
+                }
             }
             // Not a build dependency, and not for a build script, so must be Target.
             self.requested_targets

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -858,12 +858,14 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                             // targets.
                             // The library's feature key needs to be used alongside
                             // the keys artifact targets.
-                            // For good measure, we always add the lib_fk as build scripts
-                            // may trigger it to be queried.
-                            Some((_, Some(mut dep_fks))) => {
+                            Some((is_lib, Some(mut dep_fks))) if is_lib => {
                                 dep_fks.push(lib_fk);
                                 dep_fks
                             }
+                            // The artifact is not a library, but does specify
+                            // custom targets.
+                            // Use only these targets feature keys.
+                            Some((_, Some(dep_fks))) => dep_fks,
                             // There is no artifact in the current dependency
                             // or there is no target specified on the artifact.
                             // Use the standard feature key without any alteration.

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -769,6 +769,12 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                     .target_data
                     .dep_platform_activated(dep, CompileKind::Host);
             }
+            // We always count platforms as activated if the target stems from an artifact
+            // dependency's target specification. This triggers in conjunction with
+            // `[target.'cfg(…)'.dependencies]` manifest sections.
+            if matches!(fk, FeaturesFor::NormalOrDevOrArtifactTarget(Some(_))) {
+                return true;
+            }
             // Not a build dependency, and not for a build script, so must be Target.
             self.requested_targets
                 .iter()

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -857,14 +857,12 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                             // targets.
                             // The library's feature key needs to be used alongside
                             // the keys artifact targets.
-                            Some((is_lib, Some(mut dep_fks))) if is_lib => {
+                            // For good measure, we always add the lib_fk as build scripts
+                            // may trigger it to be queried.
+                            Some((_, Some(mut dep_fks))) => {
                                 dep_fks.push(lib_fk);
                                 dep_fks
                             }
-                            // The artifact is not a library, but does specify
-                            // custom targets.
-                            // Use only these targets feature keys.
-                            Some((_, Some(dep_fks))) => dep_fks,
                             // There is no artifact in the current dependency
                             // or there is no target specified on the artifact.
                             // Use the standard feature key without any alteration.

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -431,7 +431,6 @@ fn feature_resolution_works_for_cfg_target_specification() {
         return;
     }
     let target = cross_compile::alternate();
-    let target_arch = cross_compile::alternate_arch();
     let p = project()
         .file(
             "Cargo.toml",
@@ -465,10 +464,10 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 version = "0.0.1"
                 authors = []
 
-                [target.'cfg(target_arch = "$ARCH")'.dependencies]
+                [target.'$TARGET'.dependencies]
                 d2 = { path = "../d2" }
             "#
-            .replace("$ARCH", target_arch),
+            .replace("$TARGET", target),
         )
         .file(
             "d1/src/main.rs",
@@ -480,11 +479,11 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .file(
             "d1/src/lib.rs",
             &r#"pub fn f() {
-                #[cfg(target_arch = "$ARCH")]
+                #[cfg(target = "$TARGET")]
                 d2::f();
             }
             "#
-            .replace("$ARCH", target_arch),
+            .replace("$TARGET", target),
         )
         .file(
             "d2/Cargo.toml",

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2153,3 +2153,114 @@ fn build_script_output_string(p: &Project, package_name: &str) -> String {
     assert_eq!(paths.len(), 1);
     std::fs::read_to_string(&paths[0]).unwrap()
 }
+
+#[cargo_test]
+#[ignore]
+fn build_script_features_for_shared_dependency() {
+    // When a build script is built and run, its features should match. Here:
+    //
+    // foo
+    //   -> artifact on d1 with target
+    //   -> common with features f1
+    //
+    // d1
+    //   -> common with features f2
+    //
+    // common has features f1 and f2, with a build script.
+    //
+    // When common is built as a dependency of d1, it should have features
+    // `f2` (for the library and the build script).
+    //
+    // When common is built as a dependency of foo, it should have features
+    // `f1` (for the library and the build script).
+    if cross_compile::disabled() {
+        return;
+    }
+    let target = cross_compile::alternate();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                resolver = "2"
+
+                [dependencies]
+                d1 = { path = "d1", artifact = "bin", target = "$TARGET" }
+                common = { path = "common", features = ["f1"] }
+            "#
+            .replace("$TARGET", target),
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    let _b = include_bytes!(env!("CARGO_BIN_FILE_D1"));
+                    common::f1();
+                }
+            "#,
+        )
+        .file(
+            "d1/Cargo.toml",
+            r#"
+                [package]
+                name = "d1"
+                version = "0.0.1"
+
+                [dependencies]
+                common = { path = "../common", features = ["f2"] }
+            "#,
+        )
+        .file(
+            "d1/src/main.rs",
+            r#"fn main() {
+                common::f2();
+            }"#,
+        )
+        .file(
+            "common/Cargo.toml",
+            r#"
+                [package]
+                name = "common"
+                version = "0.0.1"
+
+                [features]
+                f1 = []
+                f2 = []
+            "#,
+        )
+        .file(
+            "common/src/lib.rs",
+            r#"
+                #[cfg(feature = "f1")]
+                pub fn f1() {}
+
+                #[cfg(feature = "f2")]
+                pub fn f2() {}
+            "#,
+        )
+        .file(
+            "common/build.rs",
+            &r#"
+                use std::env::var_os;
+                fn main() {
+                    assert_eq!(var_os("CARGO_FEATURE_F1").is_some(), cfg!(feature="f1"));
+                    assert_eq!(var_os("CARGO_FEATURE_F2").is_some(), cfg!(feature="f2"));
+                    if std::env::var("TARGET").unwrap() == "$TARGET" {
+                        assert!(var_os("CARGO_FEATURE_F1").is_none());
+                        assert!(var_os("CARGO_FEATURE_F2").is_some());
+                    } else {
+                        assert!(var_os("CARGO_FEATURE_F1").is_some());
+                        assert!(var_os("CARGO_FEATURE_F2").is_none());
+                    }
+                }
+            "#
+            .replace("$TARGET", target),
+        )
+        .build();
+
+    p.cargo("build -Z bindeps -v")
+        .masquerade_as_nightly_cargo()
+        .run();
+}

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -426,6 +426,7 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
 }
 
 #[cargo_test]
+#[ignore]
 fn feature_resolution_works_for_cfg_target_specification() {
     if cross_compile::disabled() {
         return;
@@ -465,8 +466,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 version = "0.0.1"
                 authors = []
 
-                # [target.'cfg(target_arch = "$ARCH")'.dependencies]
-                [dependencies]
+                [target.'cfg(target_arch = "$ARCH")'.dependencies]
                 d2 = { path = "../d2" }
             "#
             .replace("$ARCH", target_arch),
@@ -481,7 +481,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .file(
             "d1/src/lib.rs",
             &r#"pub fn f() {
-                // #[cfg(target_arch = "$ARCH")]
+                #[cfg(target_arch = "$ARCH")]
                 d2::f();
             }
             "#

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -426,7 +426,6 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
 }
 
 #[cargo_test]
-#[ignore]
 fn feature_resolution_works_for_cfg_target_specification() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -426,6 +426,7 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
 }
 
 #[cargo_test]
+#[ignore]
 fn feature_resolution_works_for_cfg_target_specification() {
     if cross_compile::disabled() {
         return;
@@ -465,8 +466,8 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 version = "0.0.1"
                 authors = []
 
-                [target.'cfg(target_arch = "$ARCH")'.dependencies.d2]
-                path = "../d2"
+                [target.'cfg(target_arch = "$ARCH")'.dependencies]
+                d2 = { path = "../d2" }
             "#
             .replace("$ARCH", target_arch),
         )
@@ -476,6 +477,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 d1::f();
             }"#,
         )
+        .file("d1/build.rs", r#"fn main() { }"#)
         .file(
             "d1/src/lib.rs",
             &r#"pub fn f() {
@@ -497,7 +499,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .file("d2/src/lib.rs", "pub fn f() {}")
         .build();
 
-    p.cargo("build -Z bindeps")
+    p.cargo("test -Z bindeps")
         .masquerade_as_nightly_cargo()
         .run();
 }

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2155,7 +2155,6 @@ fn build_script_output_string(p: &Project, package_name: &str) -> String {
 }
 
 #[cargo_test]
-#[ignore]
 fn build_script_features_for_shared_dependency() {
     // When a build script is built and run, its features should match. Here:
     //
@@ -2252,7 +2251,7 @@ fn build_script_features_for_shared_dependency() {
                         assert!(var_os("CARGO_FEATURE_F2").is_some());
                     } else {
                         assert!(var_os("CARGO_FEATURE_F1").is_some());
-                        assert!(var_os("CARGO_FEATURE_F2").is_none());
+                        assert!(var_os("CARGO_FEATURE_F2").is_none()); 
                     }
                 }
             "#

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -466,8 +466,9 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 version = "0.0.1"
                 authors = []
 
-                [target.'cfg(target_arch = "$ARCH")'.dependencies]
-                d2 = { path = "../d2" }
+                # [target.'cfg(target_arch = "$ARCH")'.dependencies]
+                # [dependencies]
+                # d2 = { path = "../d2" }
             "#
             .replace("$ARCH", target_arch),
         )
@@ -481,8 +482,8 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .file(
             "d1/src/lib.rs",
             &r#"pub fn f() {
-                #[cfg(target_arch = "$ARCH")]
-                d2::f();
+                // #[cfg(target_arch = "$ARCH")]
+                // d2::f();
             }
             "#
             .replace("$ARCH", target_arch),
@@ -496,6 +497,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 authors = []
             "#,
         )
+        .file("d2/build.rs", r#"fn main() { }"#)
         .file("d2/src/lib.rs", "pub fn f() {}")
         .build();
 

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -426,7 +426,6 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
 }
 
 #[cargo_test]
-#[ignore]
 fn feature_resolution_works_for_cfg_target_specification() {
     if cross_compile::disabled() {
         return;
@@ -467,8 +466,8 @@ fn feature_resolution_works_for_cfg_target_specification() {
                 authors = []
 
                 # [target.'cfg(target_arch = "$ARCH")'.dependencies]
-                # [dependencies]
-                # d2 = { path = "../d2" }
+                [dependencies]
+                d2 = { path = "../d2" }
             "#
             .replace("$ARCH", target_arch),
         )
@@ -483,7 +482,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
             "d1/src/lib.rs",
             &r#"pub fn f() {
                 // #[cfg(target_arch = "$ARCH")]
-                // d2::f();
+                d2::f();
             }
             "#
             .replace("$ARCH", target_arch),


### PR DESCRIPTION
With an artifact dependency like this in package `a`…

```toml
[dependencies.a]
path = "b"
artifact = "bin"
target = "$TARGET"
```

…and when using `$TARGET` like this in another package `b`…

```toml
[target.'cfg(target_arch = "$ARCHOF_$TARGET")'.dependencies]
c = { path = "../c" }
```

…it panics with `thread 'main' panicked at 'activated_features for invalid package: features did not find PackageId <dbg-info>`, but we would expect this to work normally.

### Tasks

- [x] reproduce issue in new test
   - [x] figure out why the test is fixed but the real-world example isn't
- [x] find a fix

Fixes #10431 and  #10452.