### PR TITLE
Stop gating stable features

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -169,7 +169,6 @@ pub fn generate_std_roots(
                 /*is_member*/ false,
                 /*is_local*/ false,
                 unit_for,
-                mode,
                 *kind,
             );
             list.push(interner.intern(

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -861,7 +861,6 @@ fn new_unit_dep(
         state.ws.is_member(pkg),
         is_local,
         unit_for,
-        mode,
         kind,
     );
     new_unit_dep_with_profile(

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -1068,7 +1068,6 @@ fn generate_targets(
                 ws.is_member(pkg),
                 is_local,
                 unit_for,
-                target_mode,
                 *kind,
             );
             let unit = interner.intern(

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -506,21 +506,8 @@ impl TomlProfile {
             }
         }
 
-        // Feature gate definition of named profiles
-        match name {
-            "dev" | "release" | "bench" | "test" | "doc" => {}
-            _ => {
-                features.require(Feature::named_profiles())?;
-            }
-        }
-
         // Profile name validation
         Self::validate_name(name)?;
-
-        // Feature gate on uses of keys related to named profiles
-        if self.inherits.is_some() {
-            features.require(Feature::named_profiles())?;
-        }
 
         if let Some(dir_name) = self.dir_name {
             // This is disabled for now, as we would like to stabilize named

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -496,12 +496,10 @@ impl TomlProfile {
     ) -> CargoResult<()> {
         self.validate_profile(name, features)?;
         if let Some(ref profile) = self.build_override {
-            features.require(Feature::profile_overrides())?;
             profile.validate_override("build-override")?;
             profile.validate_profile(&format!("{name}.build-override"), features)?;
         }
         if let Some(ref packages) = self.package {
-            features.require(Feature::profile_overrides())?;
             for (override_name, profile) in packages {
                 profile.validate_override("package")?;
                 profile.validate_profile(&format!("{name}.package.{override_name}"), features)?;

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1146,9 +1146,6 @@ impl TomlManifest {
         let pkgid = project.to_package_id(source_id)?;
 
         let edition = if let Some(ref edition) = project.edition {
-            features
-                .require(Feature::edition())
-                .with_context(|| "editions are unstable")?;
             edition
                 .parse()
                 .with_context(|| "failed to parse the `edition` key")?

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1956,7 +1956,6 @@ impl<P: ResolveToPath> DetailedTomlDependency<P> {
             dep.set_kind(kind);
         }
         if let Some(name_in_toml) = explicit_name_in_toml {
-            cx.features.require(Feature::rename_dependency())?;
             dep.set_explicit_name_in_toml(name_in_toml);
         }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1175,14 +1175,6 @@ impl TomlManifest {
             features.require(Feature::metabuild())?;
         }
 
-        if project.resolver.is_some()
-            || me
-                .workspace
-                .as_ref()
-                .map_or(false, |ws| ws.resolver.is_some())
-        {
-            features.require(Feature::resolver())?;
-        }
         let resolve_behavior = match (
             project.resolver.as_ref(),
             me.workspace.as_ref().and_then(|ws| ws.resolver.as_ref()),
@@ -1521,13 +1513,6 @@ impl TomlManifest {
         let profiles = me.profile.clone();
         if let Some(profiles) = &profiles {
             profiles.validate(&features, &mut warnings)?;
-        }
-        if me
-            .workspace
-            .as_ref()
-            .map_or(false, |ws| ws.resolver.is_some())
-        {
-            features.require(Feature::resolver())?;
         }
         let resolve_behavior = me
             .workspace

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1137,9 +1137,13 @@ impl TomlManifest {
         } else {
             Edition::Edition2015
         };
-        if edition == Edition::Edition2021 {
-            features.require(Feature::edition2021())?;
-        } else if !edition.is_stable() {
+        // Add these lines if start a new unstable edition.
+        // ```
+        // if edition == Edition::Edition20xx {
+        //     features.require(Feature::edition20xx))?;
+        // }
+        // ```
+        if !edition.is_stable() {
             // Guard in case someone forgets to add .require()
             return Err(util::errors::internal(format!(
                 "edition {} should be gated",

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -312,7 +312,7 @@ fn named_config_profile() {
     // foo -> middle -> bar -> dev
     // middle exists in Cargo.toml, the others in .cargo/config
     use super::config::ConfigBuilder;
-    use cargo::core::compiler::{CompileKind, CompileMode};
+    use cargo::core::compiler::CompileKind;
     use cargo::core::profiles::{Profiles, UnitFor};
     use cargo::core::{PackageId, Workspace};
     use cargo::util::interning::InternedString;
@@ -370,9 +370,8 @@ fn named_config_profile() {
     let dep_pkg = PackageId::new("dep", "0.1.0", crates_io).unwrap();
 
     // normal package
-    let mode = CompileMode::Build;
     let kind = CompileKind::Host;
-    let p = profiles.get_profile(a_pkg, true, true, UnitFor::new_normal(kind), mode, kind);
+    let p = profiles.get_profile(a_pkg, true, true, UnitFor::new_normal(kind), kind);
     assert_eq!(p.name, "foo");
     assert_eq!(p.codegen_units, Some(2)); // "foo" from config
     assert_eq!(p.opt_level, "1"); // "middle" from manifest
@@ -381,14 +380,7 @@ fn named_config_profile() {
     assert_eq!(p.overflow_checks, true); // "dev" built-in (ignore package override)
 
     // build-override
-    let bo = profiles.get_profile(
-        a_pkg,
-        true,
-        true,
-        UnitFor::new_host(false, kind),
-        mode,
-        kind,
-    );
+    let bo = profiles.get_profile(a_pkg, true, true, UnitFor::new_host(false, kind), kind);
     assert_eq!(bo.name, "foo");
     assert_eq!(bo.codegen_units, Some(6)); // "foo" build override from config
     assert_eq!(bo.opt_level, "0"); // default to zero
@@ -397,7 +389,7 @@ fn named_config_profile() {
     assert_eq!(bo.overflow_checks, true); // SAME as normal
 
     // package overrides
-    let po = profiles.get_profile(dep_pkg, false, true, UnitFor::new_normal(kind), mode, kind);
+    let po = profiles.get_profile(dep_pkg, false, true, UnitFor::new_normal(kind), kind);
     assert_eq!(po.name, "foo");
     assert_eq!(po.codegen_units, Some(7)); // "foo" package override from config
     assert_eq!(po.opt_level, "1"); // SAME as normal


### PR DESCRIPTION
<!-- homu-ignore:start -->

A small cleanup. I believe that cargo can stop gating stable features without breaking things. Would there be any drawback in removing them?

Gating removed:

- `edition`
- `rename-dependency`
- `profile-overrides`
- `named-profiles`
- `resolver`
- `edition2021`

<!-- homu-ignore:end -->
