### PR TITLE
Add unstable documentation dependencies under [doc-dependencies]

### DIFF
--- a/benches/benchsuite/benches/resolve.rs
+++ b/benches/benchsuite/benches/resolve.rs
@@ -1,6 +1,6 @@
 use cargo::core::compiler::{CompileKind, RustcTargetData};
 use cargo::core::resolver::features::{CliFeatures, FeatureOpts, FeatureResolver, ForceAllTargets};
-use cargo::core::resolver::{HasDevUnits, ResolveBehavior};
+use cargo::core::resolver::{HasTransitiveUnits, ResolveBehavior};
 use cargo::core::{PackageIdSpec, Workspace};
 use cargo::ops::WorkspaceResolve;
 use cargo::Config;
@@ -147,7 +147,7 @@ struct ResolveInfo<'cfg> {
     target_data: RustcTargetData<'cfg>,
     cli_features: CliFeatures,
     specs: Vec<PackageIdSpec>,
-    has_dev_units: HasDevUnits,
+    has_dev_units: HasTransitiveUnits,
     force_all_targets: ForceAllTargets,
     ws_resolve: WorkspaceResolve<'cfg>,
 }
@@ -186,7 +186,7 @@ fn do_resolve<'cfg>(config: &'cfg Config, ws_root: &Path) -> ResolveInfo<'cfg> {
     let cli_features = CliFeatures::from_command_line(&[], false, true).unwrap();
     let pkgs = cargo::ops::Packages::Default;
     let specs = pkgs.to_package_id_specs(&ws).unwrap();
-    let has_dev_units = HasDevUnits::Yes;
+    let has_dev_units = HasTransitiveUnits::Yes;
     let force_all_targets = ForceAllTargets::No;
     // Do an initial run to download anything necessary so that it does
     // not confuse criterion's warmup.

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -696,6 +696,7 @@ impl fmt::Debug for PrettyPrintRegistry {
                             d.version_req(),
                             match d.kind() {
                                 DepKind::Development => "DepKind::Development",
+                                DepKind::Documentation => "DepKind::Documentation",
                                 DepKind::Build => "DepKind::Build",
                                 DepKind::Normal => "DepKind::Normal",
                             },

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -238,7 +238,7 @@ fn parse_edge_kinds(config: &Config, args: &ArgMatches) -> CargoResult<(HashSet<
         }
 
         if kinds.is_empty() {
-            kinds.extend(&["normal", "build", "dev"]);
+            kinds.extend(&["normal", "build", "dev", "doc"]);
         }
 
         (kinds, no_proc_macro)
@@ -249,8 +249,10 @@ fn parse_edge_kinds(config: &Config, args: &ArgMatches) -> CargoResult<(HashSet<
         result.insert(EdgeKind::Dep(DepKind::Normal));
         result.insert(EdgeKind::Dep(DepKind::Build));
         result.insert(EdgeKind::Dep(DepKind::Development));
+        result.insert(EdgeKind::Dep(DepKind::Documentation));
     };
     let unknown = |k| {
+        // FIXME: Should include no-doc when stable
         bail!(
             "unknown edge kind `{}`, valid values are \
                 \"normal\", \"build\", \"dev\", \
@@ -266,8 +268,10 @@ fn parse_edge_kinds(config: &Config, args: &ArgMatches) -> CargoResult<(HashSet<
                 "no-normal" => result.remove(&EdgeKind::Dep(DepKind::Normal)),
                 "no-build" => result.remove(&EdgeKind::Dep(DepKind::Build)),
                 "no-dev" => result.remove(&EdgeKind::Dep(DepKind::Development)),
+                "no-doc" => result.remove(&EdgeKind::Dep(DepKind::Documentation)),
                 "features" => result.insert(EdgeKind::Feature),
-                "normal" | "build" | "dev" | "all" => {
+                "normal" | "build" | "dev" | "doc" | "all" => {
+                    // FIXME: Should include no-doc when stable
                     bail!(
                         "`{}` dependency kind cannot be mixed with \
                             \"no-normal\", \"no-build\", or \"no-dev\" \
@@ -297,6 +301,9 @@ fn parse_edge_kinds(config: &Config, args: &ArgMatches) -> CargoResult<(HashSet<
             }
             "dev" => {
                 result.insert(EdgeKind::Dep(DepKind::Development));
+            }
+            "doc" => {
+                result.insert(EdgeKind::Dep(DepKind::Documentation));
             }
             k => return unknown(k),
         }

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -5,7 +5,7 @@ use crate::core::compiler::UnitInterner;
 use crate::core::compiler::{CompileKind, CompileMode, RustcTargetData, Unit};
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::resolver::features::{CliFeatures, FeaturesFor, ResolvedFeatures};
-use crate::core::resolver::HasDevUnits;
+use crate::core::resolver::HasTransitiveUnits;
 use crate::core::{Dependency, PackageId, PackageSet, Resolve, SourceId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::errors::CargoResult;
@@ -116,7 +116,7 @@ pub fn resolve_std<'cfg>(
         requested_targets,
         &cli_features,
         &specs,
-        HasDevUnits::No,
+        HasTransitiveUnits::No,
         crate::core::resolver::features::ForceAllTargets::No,
     )?;
     Ok((

--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -103,6 +103,7 @@ impl ser::Serialize for Dependency {
 pub enum DepKind {
     Normal,
     Development,
+    Documentation,
     Build,
 }
 
@@ -114,6 +115,7 @@ impl ser::Serialize for DepKind {
         match *self {
             DepKind::Normal => None,
             DepKind::Development => Some("dev"),
+            DepKind::Documentation => Some("doc"),
             DepKind::Build => Some("build"),
         }
         .serialize(s)
@@ -369,7 +371,7 @@ impl Dependency {
     pub fn is_transitive(&self) -> bool {
         match self.inner.kind {
             DepKind::Normal | DepKind::Build => true,
-            DepKind::Development => false,
+            DepKind::Development | DepKind::Documentation => false,
         }
     }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -412,6 +412,9 @@ features! {
 
     // Allow specifying rustflags directly in a profile
     (unstable, profile_rustflags, "", "reference/unstable.html#profile-rustflags-option"),
+
+    // Allow specifying dependencies under [doc-dependencies]
+    (unstable, doc_dependencies, "", "reference/unstable.html#documentation-dependencies"),
 }
 
 pub struct Feature {

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -247,7 +247,7 @@ pub fn resolve_features<'b>(
     s: &'b Summary,
     opts: &'b ResolveOpts,
 ) -> ActivateResult<(HashSet<InternedString>, Vec<(Dependency, FeaturesSet)>)> {
-    // First, filter by dev-dependencies.
+    // First, filter by dev-dependencies or doc-dependencies.
     let deps = s.dependencies();
     let deps = deps.iter().filter(|d| d.is_transitive() || opts.dev_deps);
 

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -249,7 +249,9 @@ pub fn resolve_features<'b>(
 ) -> ActivateResult<(HashSet<InternedString>, Vec<(Dependency, FeaturesSet)>)> {
     // First, filter by dev-dependencies or doc-dependencies.
     let deps = s.dependencies();
-    let deps = deps.iter().filter(|d| d.is_transitive() || opts.dev_deps);
+    let deps = deps
+        .iter()
+        .filter(|d| d.is_transitive() || opts.transitive_deps);
 
     let reqs = build_requirements(parent, s, opts)?;
     let mut ret = Vec::new();

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -86,7 +86,7 @@ pub struct FeatureOpts {
 /// `cargo test` because the lib may need to be built 3 times instead of
 /// twice.
 #[derive(Copy, Clone, PartialEq)]
-pub enum HasDevUnits {
+pub enum HasTransitiveUnits {
     Yes,
     No,
 }
@@ -163,7 +163,7 @@ impl FeaturesFor {
 impl FeatureOpts {
     pub fn new(
         ws: &Workspace<'_>,
-        has_dev_units: HasDevUnits,
+        has_dev_units: HasTransitiveUnits,
         force_all_targets: ForceAllTargets,
     ) -> CargoResult<FeatureOpts> {
         let mut opts = FeatureOpts::default();
@@ -195,7 +195,7 @@ impl FeatureOpts {
                 enable(&vec!["all".to_string()]).unwrap();
             }
         }
-        if let HasDevUnits::Yes = has_dev_units {
+        if let HasTransitiveUnits::Yes = has_dev_units {
             // Dev deps cannot be decoupled when they are in use.
             opts.decouple_dev_deps = false;
         }
@@ -206,12 +206,15 @@ impl FeatureOpts {
     }
 
     /// Creates a new FeatureOpts for the given behavior.
-    pub fn new_behavior(behavior: ResolveBehavior, has_dev_units: HasDevUnits) -> FeatureOpts {
+    pub fn new_behavior(
+        behavior: ResolveBehavior,
+        has_dev_units: HasTransitiveUnits,
+    ) -> FeatureOpts {
         match behavior {
             ResolveBehavior::V1 => FeatureOpts::default(),
             ResolveBehavior::V2 => FeatureOpts {
                 decouple_host_deps: true,
-                decouple_dev_deps: has_dev_units == HasDevUnits::No,
+                decouple_dev_deps: has_dev_units == HasTransitiveUnits::No,
                 ignore_inactive_targets: true,
                 compare: false,
             },

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -69,7 +69,7 @@ use self::types::{FeaturesSet, RcVecIter, RemainingDeps, ResolverProgress};
 pub use self::encode::Metadata;
 pub use self::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
 pub use self::errors::{ActivateError, ActivateResult, ResolveError};
-pub use self::features::{CliFeatures, ForceAllTargets, HasDevUnits};
+pub use self::features::{CliFeatures, ForceAllTargets, HasTransitiveUnits};
 pub use self::resolve::{Resolve, ResolveVersion};
 pub use self::types::{ResolveBehavior, ResolveOpts};
 pub use self::version_prefs::{VersionOrdering, VersionPreferences};
@@ -378,7 +378,7 @@ fn activate_deps_loop(
 
             let pid = candidate.package_id();
             let opts = ResolveOpts {
-                dev_deps: false,
+                transitive_deps: false,
                 features: RequestedFeatures::DepFeatures {
                     features: Rc::clone(&features),
                     uses_default_features: dep.uses_default_features(),

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -130,11 +130,11 @@ impl ResolveBehavior {
 /// Options for how the resolve should work.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ResolveOpts {
-    /// Whether or not dev-dependencies should be included.
+    /// Whether or not {doc,dev}-dependencies should be included.
     ///
     /// This may be set to `false` by things like `cargo install` or `-Z avoid-dev-deps`.
     /// It also gets set to `false` when activating dependencies in the resolver.
-    pub dev_deps: bool,
+    pub transitive_deps: bool,
     /// Set of features requested on the command-line.
     pub features: RequestedFeatures,
 }
@@ -143,13 +143,16 @@ impl ResolveOpts {
     /// Creates a ResolveOpts that resolves everything.
     pub fn everything() -> ResolveOpts {
         ResolveOpts {
-            dev_deps: true,
+            transitive_deps: true,
             features: RequestedFeatures::CliFeatures(CliFeatures::new_all(true)),
         }
     }
 
-    pub fn new(dev_deps: bool, features: RequestedFeatures) -> ResolveOpts {
-        ResolveOpts { dev_deps, features }
+    pub fn new(transitive_deps: bool, features: RequestedFeatures) -> ResolveOpts {
+        ResolveOpts {
+            transitive_deps,
+            features,
+        }
     }
 }
 

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -1,3 +1,4 @@
+use crate::core::dependency::DepKind;
 use crate::core::{Dependency, PackageId, SourceId};
 use crate::util::interning::InternedString;
 use crate::util::{CargoResult, Config};
@@ -41,8 +42,14 @@ impl Summary {
         for dep in dependencies.iter() {
             let dep_name = dep.name_in_toml();
             if dep.is_optional() && !dep.is_transitive() {
+                let kind = match dep.kind() {
+                    DepKind::Documentation => "doc",
+                    DepKind::Development => "dev",
+                    _ => unreachable!(),
+                };
                 bail!(
-                    "dev-dependencies are not allowed to be optional: `{}`",
+                    "{}-dependencies are not allowed to be optional: `{}`",
+                    kind,
                     dep_name
                 )
             }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -34,7 +34,7 @@ use crate::core::compiler::{CompileKind, CompileMode, CompileTarget, RustcTarget
 use crate::core::compiler::{DefaultExecutor, Executor, UnitInterner};
 use crate::core::profiles::{Profiles, UnitFor};
 use crate::core::resolver::features::{self, CliFeatures, FeaturesFor};
-use crate::core::resolver::{HasDevUnits, Resolve};
+use crate::core::resolver::{HasTransitiveUnits, Resolve};
 use crate::core::{FeatureValue, Package, PackageSet, Shell, Summary, Target};
 use crate::core::{PackageId, PackageIdSpec, SourceId, TargetKind, Workspace};
 use crate::drop_println;
@@ -377,18 +377,19 @@ pub fn create_bcx<'a, 'cfg>(
     };
 
     let resolve_specs = full_specs.to_package_id_specs(ws)?;
-    let has_dev_units = if filter.need_dev_deps(build_config.mode) || need_reverse_dependencies {
-        HasDevUnits::Yes
-    } else {
-        HasDevUnits::No
-    };
+    let has_transitive_units =
+        if filter.need_dev_deps(build_config.mode) || need_reverse_dependencies {
+            HasTransitiveUnits::Yes
+        } else {
+            HasTransitiveUnits::No
+        };
     let resolve = ops::resolve_ws_with_opts(
         ws,
         &target_data,
         &build_config.requested_kinds,
         cli_features,
         &resolve_specs,
-        has_dev_units,
+        has_transitive_units,
         crate::core::resolver::features::ForceAllTargets::No,
     )?;
     let WorkspaceResolve {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -444,9 +444,10 @@ pub fn create_bcx<'a, 'cfg>(
             && !ws.is_member(pkg)
             && pkg.dependencies().iter().any(|dep| !dep.is_transitive())
         {
+            // FIXME: Should include doc-dependencies when stable
             anyhow::bail!(
                 "package `{}` cannot be tested because it requires dev-dependencies \
-                 and is not a member of the workspace",
+                and is not a member of the workspace",
                 pkg.name()
             );
         }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -1,5 +1,5 @@
 use crate::core::registry::PackageRegistry;
-use crate::core::resolver::features::{CliFeatures, HasDevUnits};
+use crate::core::resolver::features::{CliFeatures, HasTransitiveUnits};
 use crate::core::{PackageId, PackageIdSpec};
 use crate::core::{Resolve, SourceId, Workspace};
 use crate::ops;
@@ -25,7 +25,7 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
         &mut registry,
         ws,
         &CliFeatures::new_all(true),
-        HasDevUnits::Yes,
+        HasTransitiveUnits::Yes,
         None,
         None,
         &[],
@@ -62,7 +62,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                         &mut registry,
                         ws,
                         &CliFeatures::new_all(true),
-                        HasDevUnits::Yes,
+                        HasTransitiveUnits::Yes,
                         None,
                         None,
                         &[],
@@ -120,7 +120,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
         &mut registry,
         ws,
         &CliFeatures::new_all(true),
-        HasDevUnits::Yes,
+        HasTransitiveUnits::Yes,
         Some(&previous_resolve),
         Some(&to_avoid),
         &[],

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -1,7 +1,7 @@
 use crate::core::compiler::{CompileKind, RustcTargetData};
 use crate::core::dependency::DepKind;
 use crate::core::package::SerializedPackage;
-use crate::core::resolver::{features::CliFeatures, HasDevUnits, Resolve};
+use crate::core::resolver::{features::CliFeatures, HasTransitiveUnits, Resolve};
 use crate::core::{Dependency, Package, PackageId, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::interning::InternedString;
@@ -127,7 +127,7 @@ fn build_resolve_graph(
         &requested_kinds,
         &metadata_opts.cli_features,
         &specs,
-        HasDevUnits::Yes,
+        HasTransitiveUnits::Yes,
         force_all,
     )?;
 

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -302,7 +302,7 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
         // FIXME: Include doc-dependencies when stable
         drop_eprintln!(
             config,
-            "The following differences only apply when building with dev-dependencies or doc-dependencies:\n"
+            "The following differences only apply when building with dev-dependencies:\n"
         );
         show_diffs(with_transitive_diffs);
     }

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -299,6 +299,7 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
         show_diffs(without_dev_diffs);
     }
     if !with_dev_diffs.is_empty() {
+        // FIXME: Include doc-dependencies when stable
         drop_eprintln!(
             config,
             "The following differences only apply when building with dev-dependencies:\n"

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -183,7 +183,7 @@ fn transmit(
         .dependencies()
         .iter()
         .filter(|dep| {
-            // Skip dev-dependency without version.
+            // Skip {dev,doc}-dependency without version.
             dep.is_transitive() || dep.specified_req()
         })
         .map(|dep| {
@@ -212,6 +212,7 @@ fn transmit(
                     DepKind::Normal => "normal",
                     DepKind::Build => "build",
                     DepKind::Development => "dev",
+                    DepKind::Documentation => "doc",
                 }
                 .to_string(),
                 registry: dep_registry,

--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -329,6 +329,7 @@ fn add_pkg(
                     (_, DepKind::Build) => CompileKind::Host,
                     (_, DepKind::Normal) => node_kind,
                     (_, DepKind::Development) => node_kind,
+                    (_, DepKind::Documentation) => node_kind,
                 };
                 // Filter out inactivated targets.
                 if !show_all_targets && !target_data.dep_platform_activated(dep, kind) {

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -328,6 +328,7 @@ fn print_node<'a>(
         EdgeKind::Dep(DepKind::Normal),
         EdgeKind::Dep(DepKind::Build),
         EdgeKind::Dep(DepKind::Development),
+        EdgeKind::Dep(DepKind::Documentation),
         EdgeKind::Feature,
     ] {
         print_dependencies(
@@ -376,6 +377,7 @@ fn print_dependencies<'a>(
         EdgeKind::Dep(DepKind::Normal) => None,
         EdgeKind::Dep(DepKind::Build) => Some("[build-dependencies]"),
         EdgeKind::Dep(DepKind::Development) => Some("[dev-dependencies]"),
+        EdgeKind::Dep(DepKind::Documentation) => Some("[doc-dependencies]"),
         EdgeKind::Feature => None,
     };
 

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -3,7 +3,7 @@
 use self::format::Pattern;
 use crate::core::compiler::{CompileKind, RustcTargetData};
 use crate::core::dependency::DepKind;
-use crate::core::resolver::{features::CliFeatures, ForceAllTargets, HasDevUnits};
+use crate::core::resolver::{features::CliFeatures, ForceAllTargets, HasTransitiveUnits};
 use crate::core::{Package, PackageId, PackageIdSpec, Workspace};
 use crate::ops::{self, Packages};
 use crate::util::{CargoResult, Config};
@@ -140,10 +140,13 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     let has_dev = if opts
         .edge_kinds
         .contains(&EdgeKind::Dep(DepKind::Development))
+        || opts
+            .edge_kinds
+            .contains(&EdgeKind::Dep(DepKind::Documentation))
     {
-        HasDevUnits::Yes
+        HasTransitiveUnits::Yes
     } else {
-        HasDevUnits::No
+        HasTransitiveUnits::No
     };
     let force_all = if opts.target == Target::All {
         ForceAllTargets::Yes

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -382,6 +382,7 @@ impl<'a> RegistryDependency<'a> {
         }
         let kind = match kind.as_deref().unwrap_or("") {
             "dev" => DepKind::Development,
+            "doc" => DepKind::Documentation,
             "build" => DepKind::Build,
             _ => DepKind::Normal,
         };

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -328,6 +328,9 @@ pub struct TomlManifest {
     dev_dependencies: Option<BTreeMap<String, TomlDependency>>,
     #[serde(rename = "dev_dependencies")]
     dev_dependencies2: Option<BTreeMap<String, TomlDependency>>,
+    doc_dependencies: Option<BTreeMap<String, TomlDependency>>,
+    #[serde(rename = "doc_dependencies")]
+    doc_dependencies2: Option<BTreeMap<String, TomlDependency>>,
     build_dependencies: Option<BTreeMap<String, TomlDependency>>,
     #[serde(rename = "build_dependencies")]
     build_dependencies2: Option<BTreeMap<String, TomlDependency>>,
@@ -1026,6 +1029,14 @@ impl TomlManifest {
                 TomlDependency::is_version_specified,
             )?,
             dev_dependencies2: None,
+            doc_dependencies: map_deps(
+                config,
+                self.doc_dependencies
+                    .as_ref()
+                    .or_else(|| self.doc_dependencies2.as_ref()),
+                TomlDependency::is_version_specified,
+            )?,
+            doc_dependencies2: None,
             build_dependencies: map_deps(
                 config,
                 self.build_dependencies
@@ -1051,6 +1062,14 @@ impl TomlManifest {
                                     TomlDependency::is_version_specified,
                                 )?,
                                 dev_dependencies2: None,
+                                doc_dependencies: map_deps(
+                                    config,
+                                    v.doc_dependencies
+                                        .as_ref()
+                                        .or_else(|| v.doc_dependencies2.as_ref()),
+                                    TomlDependency::is_version_specified,
+                                )?,
+                                doc_dependencies2: None,
                                 build_dependencies: map_deps(
                                     config,
                                     v.build_dependencies
@@ -1291,6 +1310,14 @@ impl TomlManifest {
                 .as_ref()
                 .or_else(|| me.dev_dependencies2.as_ref());
             process_dependencies(&mut cx, dev_deps, Some(DepKind::Development))?;
+            let doc_deps = me
+                .doc_dependencies
+                .as_ref()
+                .or_else(|| me.doc_dependencies2.as_ref());
+            if doc_deps.filter(|doc_deps| !doc_deps.is_empty()).is_some() {
+                features.require(Feature::doc_dependencies())?;
+            }
+            process_dependencies(&mut cx, doc_deps, Some(DepKind::Documentation))?;
             let build_deps = me
                 .build_dependencies
                 .as_ref()
@@ -1314,6 +1341,14 @@ impl TomlManifest {
                     .as_ref()
                     .or_else(|| platform.dev_dependencies2.as_ref());
                 process_dependencies(&mut cx, dev_deps, Some(DepKind::Development))?;
+                let doc_deps = platform
+                    .doc_dependencies
+                    .as_ref()
+                    .or_else(|| platform.doc_dependencies2.as_ref());
+                if doc_deps.filter(|doc_deps| !doc_deps.is_empty()).is_some() {
+                    features.require(Feature::doc_dependencies())?;
+                }
+                process_dependencies(&mut cx, doc_deps, Some(DepKind::Documentation))?;
             }
 
             replace = me.replace(&mut cx)?;
@@ -2073,6 +2108,10 @@ struct TomlPlatform {
     dev_dependencies: Option<BTreeMap<String, TomlDependency>>,
     #[serde(rename = "dev_dependencies")]
     dev_dependencies2: Option<BTreeMap<String, TomlDependency>>,
+    #[serde(rename = "doc-dependencies")]
+    doc_dependencies: Option<BTreeMap<String, TomlDependency>>,
+    #[serde(rename = "doc_dependencies")]
+    doc_dependencies2: Option<BTreeMap<String, TomlDependency>>,
 }
 
 impl TomlTarget {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1141,6 +1141,38 @@ For instance:
 cargo check -Z unstable-options -Z check-cfg-features
 ```
 
+### Documentation dependencies
+
+* Tracking Issue: [#XXXX](https://github.com/rust-lang/cargo/issues/XXX)
+* PR: [#XXXX](https://github.com/rust-lang/cargo/pull/XXXX)
+
+The `doc-dependencies` feature allows documentation specific dependencies.
+You can add a [doc-dependencies] section to your Cargo.toml whose format is equivalent to [dependencies]:
+
+```
+cargo-features = ["doc-dependencies"]
+
+[project]
+name =  "foo"
+version = "0.0.1"
+
+[doc-dependencies]
+tempdir = "0.3"
+```
+
+Doc-dependencies are not used when compiling a package for building, but are used for documenting
+or running documentation tests.
+
+These dependencies are not propagated to other packages which depend on this package.
+
+You can also have target-specific documentation dependencies by using doc-dependencies in the target
+section header instead of dependencies. For example:
+
+```
+[target.'cfg(unix)'.doc-dependencies]
+mio = "0.0.1"
+```
+
 ## Stabilized and removed features
 
 ### Compile progress

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4690,7 +4690,6 @@ fn dev_dep_with_links() {
     p.cargo("check --tests").run()
 }
 
-#[ignore] // FIXME: overflow it's stack
 #[cargo_test]
 fn doc_dep_with_links() {
     let p = project()
@@ -4728,7 +4727,11 @@ fn doc_dep_with_links() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("doc").masquerade_as_nightly_cargo().run()
+    p.cargo("doc")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr_contains("[..]cyclic package dependency[..]")
+        .run()
 }
 
 #[cargo_test]

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -709,6 +709,66 @@ fn cyclical_dev_dep() {
     p.cargo("test").run();
 }
 
+#[ignore] // FIXME: overflow it's stack
+#[cargo_test]
+fn cyclical_doc_dep() {
+    // Check how a cyclical doc-dependency will work.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["doc-dependencies"]
+
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2018"
+
+            [features]
+            doc = []
+
+            [doc-dependencies]
+            foo = { path = '.', features = ["doc"] }
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+            pub fn assert_doc(enabled: bool) {
+                assert_eq!(enabled, cfg!(feature="doc"));
+            }
+
+            #[test]
+            fn test_in_lib() {
+                assert_doc(true);
+            }
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {
+                let expected: bool = std::env::args().skip(1).next().unwrap().parse().unwrap();
+                foo::assert_doc(expected);
+            }
+            "#,
+        )
+        .build();
+
+    // Old way unifies features.
+    p.cargo("run true").masquerade_as_nightly_cargo().run();
+    // dev feature should always be enabled in tests.
+    p.cargo("doc").masquerade_as_nightly_cargo().run();
+
+    // New behavior.
+    switch_to_resolver_2(&p);
+    // Should decouple main.
+    p.cargo("run false").masquerade_as_nightly_cargo().run();
+
+    // And this should be no different.
+    p.cargo("doc").masquerade_as_nightly_cargo().run();
+}
+
 #[cargo_test]
 fn all_feature_opts() {
     // All feature options at once.

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -661,8 +661,8 @@ fn no_rebuild_transitive_target_deps_doc() {
             "\
 [CHECKING] c v0.0.1 ([..])
 [DOCUMENTING] c v0.0.1 ([..])
-[CHECKING] a v0.0.1 ([..])
-[DOCUMENTING] a v0.0.1 ([..])
+[..] a v0.0.1 ([..])
+[..] a v0.0.1 ([..])
 [CHECKING] b v0.0.1 ([..])
 [DOCUMENTING] b v0.0.1 ([..])
 [DOCUMENTING] foo v0.0.1 ([..])

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1350,6 +1350,36 @@ fn dev_dependencies_lock_file_untouched() {
 }
 
 #[cargo_test]
+fn doc_dependencies_lock_file_untouched() {
+    Package::new("foo", "1.0.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["doc-dependencies"]
+
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+
+                [doc-dependencies]
+                bar = { path = "a" }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("a/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("a/src/lib.rs", "")
+        .build();
+
+    p.cargo("build").masquerade_as_nightly_cargo().run();
+    let lock = p.read_lockfile();
+    p.cargo("install").masquerade_as_nightly_cargo().run();
+    let lock2 = p.read_lockfile();
+    assert!(lock == lock2, "different lockfiles");
+}
+
+#[cargo_test]
 fn install_target_native() {
     pkg("foo", "0.1.0");
 

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1148,7 +1148,6 @@ fn workspace_metadata_with_dependencies_and_resolve() {
             "bar/Cargo.toml",
             &r#"
                 [package]
-
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -3523,11 +3522,16 @@ fn dep_kinds() {
         .file(
             "Cargo.toml",
             r#"
+            cargo-features = ["doc-dependencies"]
+
             [package]
             name = "foo"
             version = "0.1.0"
 
             [dependencies]
+            bar = "0.1"
+
+            [doc-dependencies]
             bar = "0.1"
 
             [dev-dependencies]
@@ -3544,6 +3548,7 @@ fn dep_kinds() {
         .build();
 
     p.cargo("metadata")
+        .masquerade_as_nightly_cargo()
         .with_json(
             r#"
             {
@@ -3578,6 +3583,10 @@ fn dep_kinds() {
                           },
                           {
                             "kind": "dev",
+                            "target": null
+                          },
+                          {
+                            "kind": "doc",
                             "target": null
                           },
                           {


### PR DESCRIPTION
This pull-request introduce the concept of documentation dependencies similar to development dependencies except that documentation dependencies are only activated for doc and doc-test.

### How should we test this PR?

**Cargo.toml**:
```toml
cargo-features = ["doc-dependencies"]

[package]
name = "foo"
version = "0.1.0"

[doc-dependencies]
sysinfo = "0.23" 
```
**src/lib.rs**
```rust
#[cfg(doc)]
pub use sysinfo::System;
```
`cargo doc` you should see the `System` type.

### How should we review this PR?

Commit by commit.

<details>

The most important change is in `src/cargo/core/compiler/unit_dependencies.rs`:

```diff
                         // If this dependency is **not** a transitive dependency, then it
-                        // only applies to test/example targets.
-                        if !dep.is_transitive()
-                            && !unit.target.is_test()
-                            && !unit.target.is_example()
-                            && !unit.mode.is_doc_scrape()
-                            && !unit.mode.is_any_test()
-                        {
-                            return false;
+                        // only applies to test/example or doc/doctest targets.
+                        match dep.kind() {
+                            DepKind::Development => {
+                                if !unit.target.is_test()
+                                    && !unit.target.is_example()
+                                    && !unit.mode.is_doc_scrape()
+                                    && !unit.mode.is_any_test()
+                                {
+                                    return false;
+                                }
+                            }
+                            DepKind::Documentation => {
+                                if !unit.mode.is_doc() && !unit.mode.is_doc_test() {
+                                    return false;
+                                }
+                            }
+                            DepKind::Normal | DepKind::Build => {}
+                        }
```

</details>

### Additional information

- [ ] Decouple `-Z avoid-dev-deps` from interacting with doc deps
- [ ] Add unstable flag for the documentation interaction in `cargo tree`
- [x] Resolve the cycle dependency stack overflow

Fixes https://github.com/rust-lang/cargo/issues/8905
cc @GuillaumeGomez 