### PR TITLE
Remove remaining 2 warn(clippy::*) instances

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -3,8 +3,6 @@
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
 
 #![allow(clippy::all)]
-#![warn(clippy::needless_borrow)]
-#![warn(clippy::redundant_clone)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 
 use std::env;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,7 +1,5 @@
 #![warn(rust_2018_idioms)] // while we're getting used to 2018
 #![allow(clippy::all)]
-#![warn(clippy::needless_borrow)]
-#![warn(clippy::redundant_clone)]
 
 use cargo::core::shell::Shell;
 use cargo::util::toml::StringOrVec;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -5,8 +5,6 @@
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]
-#![warn(clippy::needless_borrow)]
-#![warn(clippy::redundant_clone)]
 
 use crate::core::shell::Verbosity::Verbose;
 use crate::core::Shell;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,8 +1,6 @@
 // See src/cargo/lib.rs for notes on these lint settings.
 #![warn(rust_2018_idioms)]
 #![allow(clippy::all)]
-#![warn(clippy::needless_borrow)]
-#![warn(clippy::redundant_clone)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 
 #[macro_use]


### PR DESCRIPTION
<!-- homu-ignore:start -->


### What does this PR try to resolve?
Developers often have to manually fix clippy issues in cargo: https://github.com/rust-lang/cargo/pulls?q=clippy
This PR fixes this problem once and for all by denying clippy lints in CI.

### Why this is ok actually
CI already denies warnings and this causes CI breakage from time to time due to [deprecation in dependencies](https://github.com/rust-lang/cargo/pull/10396) and new rustc warnings.

We currently only have 2 clippy lints enabled:
```rust
#![warn(clippy::needless_borrow)]
#![warn(clippy::redundant_clone)]
```

As such we are at higher risk of breakage due to rustc warnings then we are due to changes in the detection of these 2 clippy lints.
So we may as well deny clippy as well and get full coverage.

For the tiny cargo-credential etc crates maybe I should just set those to `#[allow(clippy::all)]` without the additional denies?
This would prevent developers from seeing potential issues when we dont really care about clippy and also avoid all the deny-warnings noise.
I dont really mind either way.

<!-- homu-ignore:end -->