### PR TITLE
vendor: Document how to terminate --sync list

### DIFF
--- a/src/doc/man/cargo-vendor.md
+++ b/src/doc/man/cargo-vendor.md
@@ -27,7 +27,7 @@ to use the vendored sources, which you will need to add to `.cargo/config.toml`.
 
 {{#option "`-s` _manifest_" "`--sync` _manifest_" }}
 Specify extra `Cargo.toml` manifests to workspaces which should also be
-vendored and synced to the output.
+vendored and synced to the output. Terminate the list with `--`.
 {{/option}}
 
 {{#option "`--no-delete`" }}


### PR DESCRIPTION
It's not obvious that the `--sync` argument to `cargo vendor` is a list, which makes it easy for it to eat the final path argument:

````
cargo vendor --manifest-path foo/Cargo.toml -s bar/Cargo.toml ./test_vendor/
error: failed to read ./test_vendor/

Caused by:
  No such file or directory (os error 2)
````

This patch adds tests showing this is expected behavior, and also documents the `--` list terminator in the cargo-vendor manpage.

I didn't regenerate other doc files as it's not clear to me how/when that should be done.