### PR TITLE
Wait up to one second while waiting for curl

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1000,11 +1000,9 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                 break Ok(pair);
             }
             assert!(!self.pending.is_empty());
-            let timeout = self
-                .set
-                .multi
-                .get_timeout()?
-                .unwrap_or_else(|| Duration::new(5, 0));
+            let min_timeout = Duration::new(1, 0);
+            let timeout = self.set.multi.get_timeout()?.unwrap_or(min_timeout);
+            let timeout = timeout.min(min_timeout);
             self.set
                 .multi
                 .wait(&mut [], timeout)


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/8516

Wait up to one second while waiting for curl. 

### How should we test and review this PR?

1. Build cargo
2. Start a network transfer (cargo fetch).
3. Pull the network cord.
4. Wait.
