### PR TITLE
Don't recommend leaking tokens into the console history

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -13,11 +13,16 @@ limit to the number of versions which can be published, however.
 First things first, you’ll need an account on [crates.io] to acquire
 an API token. To do so, [visit the home page][crates.io] and log in via a GitHub
 account (required for now). After this, visit your [Account
-Settings](https://crates.io/me) page and run the [`cargo login`] command
-specified.
+Settings](https://crates.io/me) page and run the [`cargo login`] command.
 
 ```console
-$ cargo login abcdefghijklmnopqrstuvwxyz012345
+$ cargo login
+```
+
+Then at the propt put in the token specified.
+```console
+please paste the API Token found on https://crates.io/me below
+abcdefghijklmnopqrstuvwxyz012345
 ```
 
 This command will inform Cargo of your API token and store it locally in your

--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -19,7 +19,7 @@ Settings](https://crates.io/me) page and run the [`cargo login`] command.
 $ cargo login
 ```
 
-Then at the propt put in the token specified.
+Then at the prompt put in the token specified.
 ```console
 please paste the API Token found on https://crates.io/me below
 abcdefghijklmnopqrstuvwxyz012345


### PR DESCRIPTION
Passing a secret on the command line leeks it into the history witch is available to other applications on the same system.

Removing the functionality is a braking change, a big ask. But it is not hard to change the docs to not recommend using `cargo login` that way.

cc:
- https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/If.20RFC.203231.20Private.20tokens.20on.20the.20command.20line
- https://github.com/rust-lang/rfcs/pull/3231#discussion_r812435273