### PR TITLE
Handle Windows-reserved paths consistently on all platforms

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -623,17 +623,15 @@ impl<'cfg> RegistrySource<'cfg> {
                     prefix
                 )
             }
-            // Unpacking failed
-            let mut result = entry.unpack_in(parent).map_err(anyhow::Error::from);
-            if cfg!(windows) && restricted_names::is_windows_reserved_path(&entry_path) {
-                result = result.with_context(|| {
-                    format!(
-                        "`{}` appears to contain a reserved Windows path, \
-                        it cannot be extracted on Windows",
-                        entry_path.display()
-                    )
-                });
+            if restricted_names::is_windows_reserved_path(&entry_path) {
+                anyhow::bail!(
+                    "`{}` appears to contain a reserved Windows path, \
+                    it cannot be extracted on Windows",
+                    entry_path.display()
+                )
             }
+            // Unpacking failed
+            let result = entry.unpack_in(parent).map_err(anyhow::Error::from);
             result
                 .with_context(|| format!("failed to unpack entry at `{}`", entry_path.display()))?;
         }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1888,7 +1888,6 @@ src/lib.rs
 }
 
 #[cargo_test]
-#[cfg(windows)]
 fn reserved_windows_name() {
     Package::new("bar", "1.0.0")
         .file("src/lib.rs", "pub mod aux;")
@@ -1925,16 +1924,7 @@ Caused by:
   failed to unpack package `[..] `[..]`)`
 
 Caused by:
-  failed to unpack entry at `[..]aux.rs`
-
-Caused by:
-  `[..]aux.rs` appears to contain a reserved Windows path, it cannot be extracted on Windows
-
-Caused by:
-  failed to unpack `[..]aux.rs`
-
-Caused by:
-  failed to unpack `[..]aux.rs` into `[..]aux.rs`",
+  `[..]aux.rs` appears to contain a reserved Windows path, it cannot be extracted on Windows",
         )
         .run();
 }


### PR DESCRIPTION
Cargo had error handling and test coverage for the fact that path names such as `aux.rs` are not allowed on Windows. More recent versions of Windows do support such path names, but given that Cargo still supports older versions it would be better to have consistent handling of path names across all platforms. Indeed, there is already code to prevent packages containing reserved path names from being published, so it makes sense to be consistent elsewhere.

This commit changes the behavior to be consistent and tested on all platforms that Cargo supports.

This PR is a better way of doing what #10322 tried to do.