### PR TITLE
Update `--timings=json` output include data similar to the HTML output 

### DIFF
--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -316,21 +316,20 @@ impl<'cfg> Timings<'cfg> {
                 .with_context(|| "failed to save html timing report")?;
         }
         if self.report_json {
-            self.report_json(cx, error)
+            self.report_json(cx)
                 .with_context(|| "failed to save json timing report")?;
         }
         Ok(())
     }
 
-    fn report_json(&self, cx: &Context<'_, '_>, _error: &Option<anyhow::Error>) -> CargoResult<()> {
-        let _duration = self.start.elapsed().as_secs_f64();
+    /// Save JSON report to disk
+    fn report_json(&self, cx: &Context<'_, '_>) -> CargoResult<()> {
         let timestamp = self.start_str.replace(&['-', ':'][..], "");
         let timings_path = cx.files().host_root().join("cargo-timings");
         paths::create_dir_all(&timings_path)?;
         let filename = timings_path.join(format!("cargo-timing-{}.json", timestamp));
         let mut f = BufWriter::new(paths::create(&filename)?);
-        let json = serde_json::to_string(self)?;
-        f.write_all(json.as_bytes())?;
+        f.write_all(serde_json::to_string(self)?.as_bytes())?;
         let msg = format!(
             "report saved to {}",
             std::env::current_dir()

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -10,7 +10,7 @@ use crate::util::cpu::State;
 use crate::util::{CargoResult, Config};
 use anyhow::Context as _;
 use cargo_util::paths;
-use serde::{Serialize, Serializer, ser::SerializeStruct};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::collections::HashMap;
 use std::io::{BufWriter, Write};
 use std::thread::available_parallelism;

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -4,7 +4,7 @@ use crate::core::{profiles::Profile, Package};
 use crate::util::hex::short_hash;
 use crate::util::interning::InternedString;
 use crate::util::Config;
-use serde::{Serialize, Serializer, ser::SerializeStruct};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fmt;

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -4,6 +4,7 @@ use crate::core::{profiles::Profile, Package};
 use crate::util::hex::short_hash;
 use crate::util::interning::InternedString;
 use crate::util::Config;
+use serde::{Serialize, Serializer, ser::SerializeStruct};
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::fmt;
@@ -142,6 +143,25 @@ impl fmt::Debug for Unit {
             .field("is_std", &self.is_std)
             .field("dep_hash", &self.dep_hash)
             .finish()
+    }
+}
+
+impl Serialize for Unit {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("Unit", 9)?;
+        state.serialize_field("pkg_id", &self.pkg.package_id())?;
+        state.serialize_field("target", &self.target)?;
+        state.serialize_field("profile", &self.profile)?;
+        state.serialize_field("kind", &self.kind)?;
+        state.serialize_field("mode", &self.mode)?;
+        state.serialize_field("features", &self.features)?;
+        state.serialize_field("artifact", &self.artifact.is_true())?;
+        state.serialize_field("is_std", &self.is_std)?;
+        state.serialize_field("dep_hash", &self.dep_hash)?;
+        state.end()
     }
 }
 

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -4,7 +4,7 @@ use serde::ser;
 use serde::Serialize;
 use serde_json::{self, json, value::RawValue};
 
-use crate::core::{compiler::CompileMode, PackageId, Target};
+use crate::core::{PackageId, Target};
 
 pub trait Message: ser::Serialize {
     fn reason(&self) -> &str;
@@ -74,22 +74,6 @@ pub struct BuildScript<'a> {
 impl<'a> Message for BuildScript<'a> {
     fn reason(&self) -> &str {
         "build-script-executed"
-    }
-}
-
-#[derive(Serialize)]
-pub struct TimingInfo<'a> {
-    pub package_id: PackageId,
-    pub target: &'a Target,
-    pub mode: CompileMode,
-    pub duration: f64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub rmeta_time: Option<f64>,
-}
-
-impl<'a> Message for TimingInfo<'a> {
-    fn reason(&self) -> &str {
-        "timing-info"
     }
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

## Content
This PR attempts to bring the JSON output when using the `--timings=json` flag more inline with the data that is output when requesting HTML.

* Added custom `Serialization` impls to the `Timings`, and `Unit` structs.
* Added a `report_json` function to output the data in a manner similar to the HTML output.
* Removed the output of the timing reports on stdout during unit completion when the `--timings=json` flag was used.  That information in now collected in the final report.

## Testing
This was my method.  There is probably a better way.
1. Built a release version of Cargo.  `cargo build --release`
2. In a test project ran `cargo clean && <path-to-cargo>/target/release/cargo build --timings=json -Z unstable-options`
3. Verified that JSON output was generated in the `<basedir>/target/cargo-timings/` folder.

