### PR TITLE
Properly set dylib search path for doctests

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -267,6 +267,10 @@ impl<'cfg> Compilation<'cfg> {
     ) -> CargoResult<ProcessBuilder> {
         let mut search_path = Vec::new();
         if is_rustc_tool {
+            search_path.extend(super::filter_dynamic_search_path(
+                self.native_dirs.iter(),
+                &self.root_output[&CompileKind::Host],
+            ));
             search_path.push(self.deps_output[&CompileKind::Host].clone());
             search_path.push(self.sysroot_host_libdir.clone());
         } else {

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1146,9 +1146,27 @@ fn run_with_library_paths() {
         )
         .file(
             "src/main.rs",
+            r##"
+            extern crate foo;
+
+            fn main() {
+                foo::assert_search_path();
+            }
+            "##,
+        )
+        .file(
+            "src/lib.rs",
             &format!(
                 r##"
-                    fn main() {{
+                    #[test]
+                    fn test_search_path() {{
+                        assert_search_path();
+                    }}
+
+                    /// ```
+                    /// foo::assert_search_path();
+                    /// ```
+                    pub fn assert_search_path() {{
                         let search_path = std::env::var_os("{}").unwrap();
                         let paths = std::env::split_paths(&search_path).collect::<Vec<_>>();
                         println!("{{:#?}}", paths);
@@ -1164,6 +1182,7 @@ fn run_with_library_paths() {
         .build();
 
     p.cargo("run").run();
+    p.cargo("test").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
Fixes #8531.

This issue was introduced by 3fd28143de72d2d0e63186273d68aa890d8297e7.
Prior to that commit, the `rustdoc_process` function took other branch
of the if statement being modified by this commit. The flag was
previously called `is_host`, and `rustdoc` was run reporting `false`. In
that commit, the flag was changed to `is_rustc_tool`, and rustdoc began
reporting `true`, which resulted in the native directories added by
build scripts no longer being appended to LD_LIBRARY_PATH when running
doctests.

This commit changes the behavior so that we are always appending the
same set of paths, and the only variance is if we are cross compiling or
not. An alternative would be to change rustdoc to always pass
`kind: CompileKind::Host, is_rustc_tool: false`, but as rustdoc is in
fact a rustc tool, that feels wrong. The commit which introduced the bug
did not include context on why the flag was changed to `is_rustc_tool`,
so I don't have a sense for if we should just change that flag to mean
something else.

While the test suite previously had an explicit test for the
library path behavior of `cargo run`, it did not test this for various
test forms. This commit modifies the test to ensure the behavior is
consistent across `run`, normal tests, and doctests.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
