### PR TITLE
Use types to make clere (credential process || token)

### DIFF
--- a/src/cargo/ops/registry/auth.rs
+++ b/src/cargo/ops/registry/auth.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
-use super::Credential;
+use super::RegistryConfig;
 
 enum Action {
     Get,
@@ -20,17 +20,17 @@ enum Action {
 pub(super) fn auth_token(
     config: &Config,
     cli_token: Option<&str>,
-    credential: &Credential,
+    credential: &RegistryConfig,
     registry_name: Option<&str>,
     api_url: &str,
 ) -> CargoResult<String> {
     let token = match (cli_token, credential) {
-        (None, Credential::None) => {
+        (None, RegistryConfig::None) => {
             bail!("no upload token found, please run `cargo login` or pass `--token`");
         }
         (Some(cli_token), _) => cli_token.to_string(),
-        (None, Credential::Token(config_token)) => config_token.to_string(),
-        (None, Credential::Process(process)) => {
+        (None, RegistryConfig::Token(config_token)) => config_token.to_string(),
+        (None, RegistryConfig::Process(process)) => {
             let registry_name = registry_name.unwrap_or(CRATES_IO_REGISTRY);
             run_command(config, process, registry_name, api_url, Action::Get)?.unwrap()
         }

--- a/src/cargo/ops/registry/auth.rs
+++ b/src/cargo/ops/registry/auth.rs
@@ -8,6 +8,8 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
+use super::Credential;
+
 enum Action {
     Get,
     Store(String),
@@ -18,18 +20,17 @@ enum Action {
 pub(super) fn auth_token(
     config: &Config,
     cli_token: Option<&str>,
-    config_token: Option<&str>,
-    credential_process: Option<&(PathBuf, Vec<String>)>,
+    credential: &Credential,
     registry_name: Option<&str>,
     api_url: &str,
 ) -> CargoResult<String> {
-    let token = match (cli_token, config_token, credential_process) {
-        (None, None, None) => {
+    let token = match (cli_token, credential) {
+        (None, Credential::None) => {
             bail!("no upload token found, please run `cargo login` or pass `--token`");
         }
-        (Some(cli_token), _, _) => cli_token.to_string(),
-        (None, Some(config_token), _) => config_token.to_string(),
-        (None, None, Some(process)) => {
+        (Some(cli_token), _) => cli_token.to_string(),
+        (None, Credential::Token(config_token)) => config_token.to_string(),
+        (None, Credential::Process(process)) => {
             let registry_name = registry_name.unwrap_or(CRATES_IO_REGISTRY);
             run_command(config, process, registry_name, api_url, Action::Get)?.unwrap()
         }


### PR DESCRIPTION
`RegistryConfig` represents what credentials we have read from disk. It was a 
```
   token: Option<String>,
   credential_process: Option<(PathBuf, Vec<String>)>,
```
with runtime checks that they were not both `Some`.
This changes it to be an Enum `None|Token|Process`.
There is somewhat more code, but I think this is clearer.

This also changed some `Option<String>` arguments to `Option<&str>`.