### PR TITLE
Support `-Zmultitarget` in cargo config

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2224,8 +2224,8 @@ impl BuildTargetConfig {
         let values = match &self.inner.val {
             BuildTargetConfigInner::One(s) => vec![map(s)],
             BuildTargetConfigInner::Many(v) => {
-                if v.len() > 1 && !config.cli_unstable().multitarget {
-                    bail!("specifying multiple `target` in `build.target` config value requires `-Zmultitarget`")
+                if !config.cli_unstable().multitarget {
+                    bail!("specifying an array in `build.target` config value requires `-Zmultitarget`")
                 } else {
                     v.iter().map(map).collect()
                 }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2222,6 +2222,7 @@ impl BuildTargetConfig {
 }
 
 /// Represents a value of `build.target`.
+#[derive(Debug)]
 pub enum BuildTargetConfigValue<'a> {
     /// Path to a target specification file (in JSON).
     /// <https://doc.rust-lang.org/rustc/targets/custom.html>

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -235,6 +235,12 @@ or running tests for both targets:
 cargo test --target x86_64-unknown-linux-gnu --target i686-unknown-linux-gnu
 ```
 
+This can also be specified in `.cargo/config.toml` files.
+
+```toml
+[build]
+target = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
+```
 
 #### New `dir-name` attribute
 

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -30,7 +30,7 @@ fn double_target_rejected_with_config() {
         .build();
 
     p.cargo("build")
-        .with_stderr("[ERROR] specifying multiple `--target` flags requires `-Zmultitarget`")
+        .with_stderr("[ERROR] specifying multiple `target` in `build.target` config value requires `-Zmultitarget`")
         .with_status(101)
         .run();
 }

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -10,7 +10,27 @@ fn double_target_rejected() {
         .build();
 
     p.cargo("build --target a --target b")
-        .with_stderr("error: specifying multiple `--target` flags requires `-Zmultitarget`")
+        .with_stderr("[ERROR] specifying multiple `--target` flags requires `-Zmultitarget`")
+        .with_status(101)
+        .run();
+}
+
+#[cargo_test]
+fn double_target_rejected_with_config() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [build]
+                target = ["a", "b"]
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .with_stderr("[ERROR] specifying multiple `--target` flags requires `-Zmultitarget`")
         .with_status(101)
         .run();
 }
@@ -34,6 +54,35 @@ fn simple_build() {
         .arg(&t2)
         .masquerade_as_nightly_cargo()
         .run();
+
+    assert!(p.target_bin(t1, "foo").is_file());
+    assert!(p.target_bin(t2, "foo").is_file());
+}
+
+#[cargo_test]
+fn simple_build_with_config() {
+    if cross_compile::disabled() {
+        return;
+    }
+    let t1 = cross_compile::alternate();
+    let t2 = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [unstable]
+                    multitarget = true
+                    [build]
+                    target = ["{t1}", "{t2}"]
+                "#
+            ),
+        )
+        .build();
+
+    p.cargo("build").masquerade_as_nightly_cargo().run();
 
     assert!(p.target_bin(t1, "foo").is_file());
     assert!(p.target_bin(t2, "foo").is_file());
@@ -70,7 +119,7 @@ fn simple_run() {
         .build();
 
     p.cargo("run -Z multitarget --target a --target b")
-        .with_stderr("error: only one `--target` argument is supported")
+        .with_stderr("[ERROR] only one `--target` argument is supported")
         .with_status(101)
         .masquerade_as_nightly_cargo()
         .run();
@@ -137,6 +186,94 @@ fn same_value_twice() {
         .arg(&t)
         .arg("--target")
         .arg(&t)
+        .masquerade_as_nightly_cargo()
+        .run();
+
+    assert!(p.target_bin(t, "foo").is_file());
+}
+
+#[cargo_test]
+fn same_value_twice_with_config() {
+    if cross_compile::disabled() {
+        return;
+    }
+    let t = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [unstable]
+                    multitarget = true
+                    [build]
+                    target = ["{t}", "{t}"]
+                "#
+            ),
+        )
+        .build();
+
+    p.cargo("build").masquerade_as_nightly_cargo().run();
+
+    assert!(p.target_bin(t, "foo").is_file());
+}
+
+#[cargo_test]
+fn works_with_config_in_both_string_or_list() {
+    if cross_compile::disabled() {
+        return;
+    }
+    let t = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config.toml",
+            &format!(
+                r#"
+                    [unstable]
+                    multitarget = true
+                    [build]
+                    target = "{t}"
+                "#
+            ),
+        )
+        .build();
+
+    p.cargo("build").masquerade_as_nightly_cargo().run();
+
+    assert!(p.target_bin(t, "foo").is_file());
+
+    p.cargo("clean").run();
+
+    p.change_file(
+        ".cargo/config.toml",
+        &format!(
+            r#"
+                [unstable]
+                multitarget = true
+                [build]
+                target = ["{t}"]
+            "#
+        ),
+    );
+
+    p.cargo("build").masquerade_as_nightly_cargo().run();
+
+    assert!(p.target_bin(t, "foo").is_file());
+}
+
+#[cargo_test]
+fn works_with_env() {
+    let t = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build")
+        .env("CARGO_BUILD_TARGET", t)
         .masquerade_as_nightly_cargo()
         .run();
 

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -272,10 +272,7 @@ fn works_with_env() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
-        .env("CARGO_BUILD_TARGET", t)
-        .masquerade_as_nightly_cargo()
-        .run();
+    p.cargo("build").env("CARGO_BUILD_TARGET", t).run();
 
     assert!(p.target_bin(t, "foo").is_file());
 }

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -16,7 +16,7 @@ fn double_target_rejected() {
 }
 
 #[cargo_test]
-fn double_target_rejected_with_config() {
+fn array_of_target_rejected_with_config() {
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
         .file("src/main.rs", "fn main() {}")
@@ -30,7 +30,24 @@ fn double_target_rejected_with_config() {
         .build();
 
     p.cargo("build")
-        .with_stderr("[ERROR] specifying multiple `target` in `build.target` config value requires `-Zmultitarget`")
+        .with_stderr(
+            "[ERROR] specifying an array in `build.target` config value requires `-Zmultitarget`",
+        )
+        .with_status(101)
+        .run();
+
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [build]
+            target = ["a"]
+        "#,
+    );
+
+    p.cargo("build")
+        .with_stderr(
+            "[ERROR] specifying an array in `build.target` config value requires `-Zmultitarget`",
+        )
         .with_status(101)
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Support `-Zmultitarget` in cargo config. This patch also takes care of backward compatibility, so basically it means that `build.target` accepts input from both string and array.

https://github.com/rust-lang/cargo/issues/8176#issuecomment-733043914

```toml
[unstable]
multitarget = true

[build]
target = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
```

### How should we test and review this PR?

Several new tests in `multitarget`.

I didn't add tests for all compile modes, since doing that would produce too many duplications. If anyone thinks it necessary to avoid potential regression please tell me.

### Unresolved questions

- How to handle `CARGO_BUILD_TARGET` environment variable? Should it remain accepting a single target value only and hope [`advanced-env`] save us?
- This unstable feature on CLI has landed for a while. What are other difficulties blocking it from stabilizing?

[`advanced-env`]: https://github.com/rust-lang/cargo/issues/7406

<!-- homu-ignore:end -->
