### PR TITLE
Separate VCS command paths with "--"

### DIFF
--- a/src/cargo/util/vcs.rs
+++ b/src/cargo/util/vcs.rs
@@ -45,6 +45,7 @@ impl HgRepo {
         ProcessBuilder::new("hg")
             .cwd(cwd)
             .arg("init")
+            .arg("--")
             .arg(path)
             .exec()?;
         Ok(HgRepo)
@@ -65,6 +66,7 @@ impl PijulRepo {
         ProcessBuilder::new("pijul")
             .cwd(cwd)
             .arg("init")
+            .arg("--")
             .arg(path)
             .exec()?;
         Ok(PijulRepo)
@@ -85,6 +87,7 @@ impl FossilRepo {
         ProcessBuilder::new("fossil")
             .cwd(cwd)
             .arg("init")
+            .arg("--")
             .arg(&db_path)
             .exec()?;
 
@@ -92,6 +95,7 @@ impl FossilRepo {
         ProcessBuilder::new("fossil")
             .cwd(&path)
             .arg("open")
+            .arg("--")
             .arg(db_fname)
             .exec()?;
 


### PR DESCRIPTION
When building a VCS command, there may be ambiguity if a relative path
looks like an option, like "-path" or "--path". All of the VCS commands
that we use support a bare "--" separator for non-option arguments,
which is good practice to apply here.

This does not affect the cargo CLI, as it already makes sure to use
absolute paths for these calls via `value_of_path()`.