### PR TITLE
Introduce `dl` key to allow per-crate download links

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -324,6 +324,7 @@ pub struct Package {
     rust_version: Option<String>,
     cargo_features: Vec<String>,
     v: Option<u32>,
+    dl: Option<String>,
 }
 
 type FeatureMap = BTreeMap<String, Vec<String>>;
@@ -561,6 +562,7 @@ impl Package {
             rust_version: None,
             cargo_features: Vec::new(),
             v: None,
+            dl: None,
         }
     }
 
@@ -709,6 +711,12 @@ impl Package {
         self
     }
 
+    /// Specifies a different download URI for the package.
+    pub fn dl(&mut self, dl: &str) -> &mut Package {
+        self.dl = Some(dl.to_string());
+        self
+    }
+
     pub fn cargo_feature(&mut self, feature: &str) -> &mut Package {
         self.cargo_features.push(feature.to_owned());
         self
@@ -787,6 +795,9 @@ impl Package {
         }
         if let Some(v) = self.v {
             json["v"] = serde_json::json!(v);
+        }
+        if let Some(dl) = &self.dl {
+            json["dl"] = serde_json::json!(dl);
         }
         let line = json.to_string();
 

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -180,6 +180,7 @@ pub fn resolve_with_config_raw(
         deps,
         &BTreeMap::new(),
         None::<&String>,
+        None,
     )
     .unwrap();
     let opts = ResolveOpts::everything();
@@ -581,6 +582,7 @@ pub fn pkg_dep<T: ToPkgId>(name: T, dep: Vec<Dependency>) -> Summary {
         dep,
         &BTreeMap::new(),
         link,
+        None,
     )
     .unwrap()
 }
@@ -609,6 +611,7 @@ pub fn pkg_loc(name: &str, loc: &str) -> Summary {
         Vec::new(),
         &BTreeMap::new(),
         link,
+        None,
     )
     .unwrap()
 }
@@ -623,6 +626,7 @@ pub fn remove_dep(sum: &Summary, ind: usize) -> Summary {
         deps,
         &BTreeMap::new(),
         sum.links().map(|a| a.as_str()),
+        None,
     )
     .unwrap()
 }

--- a/src/cargo/core/resolver/version_prefs.rs
+++ b/src/cargo/core/resolver/version_prefs.rs
@@ -92,7 +92,15 @@ mod test {
         let pkg_id = pkgid(name, version);
         let config = Config::default().unwrap();
         let features = BTreeMap::new();
-        Summary::new(&config, pkg_id, Vec::new(), &features, None::<&String>).unwrap()
+        Summary::new(
+            &config,
+            pkg_id,
+            Vec::new(),
+            &features,
+            None::<&String>,
+            None,
+        )
+        .unwrap()
     }
 
     fn describe(summaries: &Vec<Summary>) -> String {

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -25,6 +25,7 @@ struct Inner {
     features: Rc<FeatureMap>,
     checksum: Option<String>,
     links: Option<InternedString>,
+    dl: Option<InternedString>,
 }
 
 impl Summary {
@@ -34,6 +35,7 @@ impl Summary {
         dependencies: Vec<Dependency>,
         features: &BTreeMap<InternedString, Vec<InternedString>>,
         links: Option<impl Into<InternedString>>,
+        dl: Option<InternedString>,
     ) -> CargoResult<Summary> {
         // ****CAUTION**** If you change anything here that may raise a new
         // error, be sure to coordinate that change with either the index
@@ -55,6 +57,7 @@ impl Summary {
                 features: Rc::new(feature_map),
                 checksum: None,
                 links: links.map(|l| l.into()),
+                dl,
             }),
         })
     }
@@ -83,6 +86,9 @@ impl Summary {
     }
     pub fn links(&self) -> Option<InternedString> {
         self.inner.links
+    }
+    pub fn dl(&self) -> Option<InternedString> {
+        self.inner.dl
     }
 
     pub fn override_id(mut self, id: PackageId) -> Summary {

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -548,7 +548,12 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
         self.requested_update = true;
     }
 
-    fn download(&mut self, pkg: PackageId, checksum: &str) -> CargoResult<MaybeLock> {
+    fn download(
+        &mut self,
+        pkg: PackageId,
+        override_dl: Option<&str>,
+        checksum: &str,
+    ) -> CargoResult<MaybeLock> {
         let registry_config = loop {
             match self.config()? {
                 Poll::Pending => self.block_until_ready()?,
@@ -559,6 +564,7 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
             &self.cache_path,
             &self.config,
             pkg,
+            override_dl,
             checksum,
             registry_config,
         )

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -99,7 +99,12 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         self.updated
     }
 
-    fn download(&mut self, pkg: PackageId, checksum: &str) -> CargoResult<MaybeLock> {
+    fn download(
+        &mut self,
+        pkg: PackageId,
+        _override_dl: Option<&str>,
+        checksum: &str,
+    ) -> CargoResult<MaybeLock> {
         let crate_file = format!("{}-{}.crate", pkg.name(), pkg.version());
 
         // Note that the usage of `into_path_unlocked` here is because the local

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -296,7 +296,12 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         self.updated
     }
 
-    fn download(&mut self, pkg: PackageId, checksum: &str) -> CargoResult<MaybeLock> {
+    fn download(
+        &mut self,
+        pkg: PackageId,
+        override_dl: Option<&str>,
+        checksum: &str,
+    ) -> CargoResult<MaybeLock> {
         let registry_config = loop {
             match self.config()? {
                 Poll::Pending => self.block_until_ready()?,
@@ -308,6 +313,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
             &self.cache_path,
             &self.config,
             pkg,
+            override_dl,
             checksum,
             registry_config,
         )

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1627,6 +1627,7 @@ impl TomlManifest {
             deps,
             me.features.as_ref().unwrap_or(&empty_features),
             project.links.as_deref(),
+            None,
         )?;
 
         let metadata = ManifestMetadata {

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -264,6 +264,11 @@ explaining the format of the entry.
     // The `links` string value from the package's manifest, or null if not
     // specified. This field is optional and defaults to null.
     "links": null,
+    // This optional field specifies the download link for this package
+    // only, overriding the global `dl` link declared in the registry's
+    // `config.toml`. The `{crate}` markers et al. are not interpolated
+    // in this context.
+    "dl": "https://crates.io/api/v1/crates/foo/0.1.0/download"
     // An unsigned 32-bit integer value indicating the schema version of this
     // entry.
     //


### PR DESCRIPTION
This change allows the registry to override its own global `dl` key defined in the root config.json for each package version.

```
    // This optional field specifies the download link for this package
    // only, overriding the global `dl` link declared in the registry's
    // `config.toml`. The `{crate}` markers et al. are not interpolated
    // in this context.
    "dl": "https://crates.io/api/v1/crates/foo/0.1.0/download"
```

### What does this PR try to resolve?

Some third-party 'generic' registries can't (or aren't willing to) support the global 'one `dl` for everything' API that Cargo currently exposes for registries. This change allows much more flexibility by allowing the registry to return unique `dl` links for each individual package version.

### How should we test and review this PR?

Create a new registry with a mock `dl` in the `config.json` and set the real link in the package version JSON line instead.