### PR TITLE
Add a link to the document in the timings report

### DIFF
--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -642,10 +642,6 @@ h1 {
   border-bottom: 1px solid #c0c0c0;
 }
 
-h1 > a {
-  font-size: 14px;
-}
-
 .graph {
   display: block;
 }
@@ -736,7 +732,8 @@ h1 > a {
 </head>
 <body>
 
-<h1>Cargo Build Timings <a href="https://doc.rust-lang.org/nightly/cargo/reference/timings.html">Documentation</a></h1>
+<h1>Cargo Build Timings</h1>
+See <a href="https://doc.rust-lang.org/nightly/cargo/reference/timings.html">Documentation</a>
 "#;
 
 static HTML_CANVAS: &str = r#"

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -642,6 +642,10 @@ h1 {
   border-bottom: 1px solid #c0c0c0;
 }
 
+h1 > a {
+  font-size: 14px;
+}
+
 .graph {
   display: block;
 }
@@ -732,7 +736,7 @@ h1 {
 </head>
 <body>
 
-<h1>Cargo Build Timings</h1>
+<h1>Cargo Build Timings <a href="https://doc.rust-lang.org/nightly/cargo/reference/timings.html">Documentation</a></h1>
 "#;
 
 static HTML_CANVAS: &str = r#"


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/10487

Add a link to the document in the header of timings report.

### How should we test and review this PR?

`cargo build --timings`

![image](https://user-images.githubusercontent.com/29879298/163180843-152b032d-8276-4f93-a5b8-f492bcc6c8d5.png)

