### PR TITLE
Turn off debuginfo for build dependencies to improve compile times

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -399,7 +399,20 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
                 },
                 true,
             )
-            .with_context(|| format!("failed to run custom build command for `{}`", pkg_descr));
+            .with_context(|| {
+                let mut build_error_context = format!("failed to run custom build command for `{}`", pkg_descr);
+
+                // If we're opting into backtraces, mention that build dependencies' backtraces can
+                // be improved by setting a higher debuginfo level.
+                if let Ok(show_backtraces) = std::env::var("RUST_BACKTRACE") {
+                    if show_backtraces != "0" {
+                        build_error_context.push_str("\n\
+                            note: To improve backtraces for build dependencies, make sure full debug info is turned on. More details at https://doc.rust-lang.org/cargo/reference/profiles.html#build-dependencies");
+                    }
+                }
+
+                build_error_context
+            });
 
         if let Err(error) = output {
             insert_warnings_in_build_outputs(

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -408,8 +408,11 @@ impl ProfileMaker {
             // basically turning down the optimization level and avoid limiting
             // codegen units. This ensures that we spend little time optimizing as
             // well as enabling parallelism by not constraining codegen units.
+            // Turning off debuginfo also allows the compiler to noticeably perform
+            // less work.
             profile.opt_level = InternedString::new("0");
             profile.codegen_units = None;
+            profile.debuginfo = None;
         }
         // ... and next comes any other sorts of overrides specified in
         // profiles, such as `[profile.release.build-override]` or

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -298,18 +298,27 @@ The `bench` profile inherits the settings from the [`release`](#release) profile
 
 #### Build Dependencies
 
-All profiles, by default, do not optimize build dependencies (build scripts,
-proc macros, and their dependencies). The default settings for build overrides
-are:
+To compile quickly, all profiles, by default, do not optimize build
+dependencies (build scripts, proc macros, and their dependencies), and avoid
+computing debug info. The default settings for build overrides are:
 
 ```toml
 [profile.dev.build-override]
 opt-level = 0
 codegen-units = 256
+debug = false
 
 [profile.release.build-override]
 opt-level = 0
 codegen-units = 256
+debug = false
+```
+
+However, if errors occur while running build dependencies, turning full debug
+info on will improve backtraces and debuggability when needed:
+
+```toml
+debug = true
 ```
 
 Build dependencies otherwise inherit settings from the active profile in use, as

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3777,7 +3777,7 @@ fn compiler_json_error_format() {
                 },
                 "profile": {
                     "debug_assertions": true,
-                    "debuginfo": 2,
+                    "debuginfo": null,
                     "opt_level": "0",
                     "overflow_checks": true,
                     "test": false

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4379,6 +4379,10 @@ fn optional_build_script_dep() {
 
 #[cargo_test]
 fn optional_build_dep_and_required_normal_dep() {
+    // Note: `dev` and `dev.build-override` have different defaults. `bar` would
+    // be built twice in the general case: once without debuginfo and once with
+    // debuginfo = 2. Setting `debug = 2` in `dev.build-override` ensures it's
+    // only built once in this test.
     let p = project()
         .file(
             "Cargo.toml",
@@ -4393,6 +4397,9 @@ fn optional_build_dep_and_required_normal_dep() {
 
             [build-dependencies]
             bar = { path = "./bar" }
+
+            [profile.dev.build-override]
+            debug = 2 # see note above
             "#,
         )
         .file("build.rs", "extern crate bar; fn main() { bar::bar(); }")

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -45,6 +45,43 @@ Caused by:
 }
 
 #[cargo_test]
+fn custom_build_script_failed_backtraces_message() {
+    // debuginfo is turned off by default in `dev.build-override`. However,
+    // if an error occurs running e.g. a build script, a message explaining
+    // how to improve backtraces is also displayed.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+
+                name = "foo"
+                version = "0.5.0"
+                authors = ["wycats@example.com"]
+                build = "build.rs"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("build.rs", "fn main() { std::process::exit(101); }")
+        .build();
+    p.cargo("build -v")
+        .env("RUST_BACKTRACE", "1")
+        .with_status(101)
+        .with_stderr(
+            "\
+[COMPILING] foo v0.5.0 ([CWD])
+[RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin [..]`
+[RUNNING] `[..]/build-script-build`
+[ERROR] failed to run custom build command for `foo v0.5.0 ([CWD])`
+note: To improve backtraces for build dependencies[..]
+
+Caused by:
+  process didn't exit successfully: `[..]/build-script-build` (exit [..]: 101)",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn custom_build_env_vars() {
     let p = project()
         .file(

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1629,14 +1629,14 @@ fn build_cmd_with_a_build_cmd() {
 [RUNNING] `rustc [..] a/build.rs [..] --extern b=[..]`
 [RUNNING] `[..]/a-[..]/build-script-build`
 [RUNNING] `rustc --crate-name a [..]lib.rs [..]--crate-type lib \
-    --emit=[..]link[..]-C debuginfo=2 \
+    --emit=[..]link[..] \
     -C metadata=[..] \
     --out-dir [..]target/debug/deps \
     -L [..]target/debug/deps`
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name build_script_build build.rs [..]--crate-type bin \
     --emit=[..]link[..]\
-    -C debuginfo=2 -C metadata=[..] --out-dir [..] \
+    -C metadata=[..] --out-dir [..] \
     -L [..]target/debug/deps \
     --extern a=[..]liba[..].rlib`
 [RUNNING] `[..]/foo-[..]/build-script-build`

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -238,6 +238,11 @@ fn relative_depinfo_paths_ws() {
 
     // Test relative dep-info paths in a workspace with --target with
     // proc-macros and other dependency kinds.
+    //
+    // Note: `dev` and `dev.build-override` have different defaults. `pmdep`
+    // would be built twice in the general case: once without debuginfo and once
+    // with debuginfo = 2. Setting `debug = 2` in `dev.build-override` ensures
+    // it will only create a single dep-info file.
     Package::new("regdep", "0.1.0")
         .file("src/lib.rs", "pub fn f() {}")
         .publish();
@@ -255,6 +260,9 @@ fn relative_depinfo_paths_ws() {
             r#"
             [workspace]
             members = ["foo"]
+
+            [profile.dev.build-override]
+            debug = 2 # see note above
             "#,
         )
         /*********** Main Project ***********/

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1050,6 +1050,11 @@ fn decouple_proc_macro() {
 #[cargo_test]
 fn proc_macro_ws() {
     // Checks for bug with proc-macro in a workspace with dependency (shouldn't panic).
+    //
+    // Note, `dev` and `dev.build-override` have different defaults. `pm` would
+    // be built twice in the general case: once without debuginfo and once with
+    // debuginfo = 2. Setting `debug = 2` in `dev.build-override` ensures it's
+    // only built once and `foo` remains fresh during the second check build.
     let p = project()
         .file(
             "Cargo.toml",
@@ -1057,6 +1062,9 @@ fn proc_macro_ws() {
             [workspace]
             members = ["foo", "pm"]
             resolver = "2"
+
+            [profile.dev.build-override]
+            debug = 2 # see note above
             "#,
         )
         .file(
@@ -2161,6 +2169,11 @@ fn pm_with_int_shared() {
     // with `--workspace`, see https://github.com/rust-lang/cargo/issues/8312.
     //
     // This uses a const-eval hack to do compile-time feature checking.
+    //
+    // Note, `dev` and `dev.build-override` have different defaults. `pm` would
+    // be built twice in the general case: once without debuginfo and once with
+    // debuginfo = 2. Setting `debug = 2` in `dev.build-override` ensures it's
+    // only built once in this test.
     let p = project()
         .file(
             "Cargo.toml",
@@ -2168,6 +2181,9 @@ fn pm_with_int_shared() {
                 [workspace]
                 members = ["foo", "pm", "shared"]
                 resolver = "2"
+
+                [profile.dev.build-override]
+                debug = 2 # see note above
             "#,
         )
         .file(

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1438,7 +1438,7 @@ fn reuse_panic_pm() {
         .with_stderr_unordered(
             "\
 [COMPILING] bar [..]
-[RUNNING] `rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C debuginfo=2 [..]
+[RUNNING] `rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]
 [RUNNING] `rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C debuginfo=2 [..]
 [COMPILING] somepm [..]
 [RUNNING] `rustc --crate-name somepm [..]

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1344,6 +1344,10 @@ fn fingerprint_cleaner_does_not_rebuild() {
 
 #[cargo_test]
 fn reuse_panic_build_dep_test() {
+    // Note: `dev` and `dev.build-override` have different defaults. `bar` would
+    // be built twice in the general case: once without debuginfo and once with
+    // debuginfo = 2. Setting `debug = 2` in `dev.build-override` ensures it's
+    // only built once in this test.
     let p = project()
         .file(
             "Cargo.toml",
@@ -1360,6 +1364,9 @@ fn reuse_panic_build_dep_test() {
 
                 [profile.dev]
                 panic = "abort"
+
+                [profile.dev.build-override]
+                debug = 2 # see note above
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -498,6 +498,10 @@ fn proc_macro_extern_prelude() {
 
 #[cargo_test]
 fn proc_macro_built_once() {
+    // Note: `dev` and `dev.build-override` have different defaults. `the-macro`
+    // would be built twice in the general case: once without debuginfo and once
+    // with debuginfo = 2. Setting `debug = 2` in `dev.build-override` ensures
+    // it's only built once in this test.
     let p = project()
         .file(
             "Cargo.toml",
@@ -505,6 +509,9 @@ fn proc_macro_built_once() {
                 [workspace]
                 members = ['a', 'b']
                 resolver = "2"
+
+                [profile.dev.build-override]
+                debug = 2 # see note above
             "#,
         )
         .file(

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -384,7 +384,7 @@ fn named_config_profile() {
     assert_eq!(bo.name, "foo");
     assert_eq!(bo.codegen_units, Some(6)); // "foo" build override from config
     assert_eq!(bo.opt_level, "0"); // default to zero
-    assert_eq!(bo.debuginfo, Some(1)); // SAME as normal
+    assert_eq!(bo.debuginfo, None); // default to none
     assert_eq!(bo.debug_assertions, false); // "foo" build override from manifest
     assert_eq!(bo.overflow_checks, true); // SAME as normal
 

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -135,6 +135,9 @@ fn profile_override_bad_settings() {
 #[cargo_test]
 fn profile_override_hierarchy() {
     // Test that the precedence rules are correct for different types.
+    // Note, `dev` and `dev.build-override` have different defaults. `dep` would be built twice in
+    // the general case: once without debuginfo and once with debuginfo = 2. Setting `debug = 2` in
+    // `dev.build-override` ensures it's only built once in this test.
     let p = project()
         .file(
             "Cargo.toml",
@@ -153,6 +156,7 @@ fn profile_override_hierarchy() {
 
             [profile.dev.build-override]
             codegen-units = 4
+            debug = 2 # see note above
             "#,
         )
         // m1

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -85,11 +85,11 @@ fn profile_selection_build() {
     p.cargo("build -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -173,11 +173,11 @@ fn profile_selection_build_all_targets() {
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -295,12 +295,12 @@ fn profile_selection_test() {
     p.cargo("test -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]
@@ -492,13 +492,13 @@ fn profile_selection_check_all_targets() {
     //
     p.cargo("check --all-targets -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -596,12 +596,12 @@ fn profile_selection_check_all_targets_test() {
     //
     p.cargo("check --all-targets --profile=test -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]
 [COMPILING] bdep[..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]
@@ -642,13 +642,13 @@ fn profile_selection_doc() {
     p.cargo("doc -vv").with_stderr_unordered("\
 [COMPILING] bar [..]
 [DOCUMENTING] bar [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `rustdoc [..]--crate-name bar bar/src/lib.rs [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=2 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..]target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo [..]


### PR DESCRIPTION
This PR is a draft towards the possible state of build-override defaults described in #10481, in order to improve compile times for build dependencies (mostly proc-macros and their dependencies benefit from this):
- debuginfo is turned off by default (stripping and incremental are less impactful and can be done as improvements in future PRs, since they also require more analysis and work) to match [this comment](https://github.com/rust-lang/cargo/issues/10481#issuecomment-1068467069) and [zulip message](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Defaults.20for.20faster.20compilation.20of.20.22for.20host.22.20units/near/275717621)
- the new defaults are documented, and explain how to turn it back on when needed
- when a build script fails, and backtraces are requested, a custom note mentions how to improve backtraces and links to the documentation

Opening as draft for feedback and guidance:
- [x] on the build script error message itself (it tries to only show when applicable, when backtraces are opted into, but I wonder if that interferes with how diagnostics are usually buffered). **Update**: the current approach and message [look acceptable](https://github.com/rust-lang/cargo/pull/10493#issuecomment-1074345394).
- [x] a bunch of tests rely on the fact that dependencies and build dependencies will not be rebuilt under the current defaults: now that the `dev` profile defaults and `dev.build-override` differ on whether debuginfo is turned on, these dependencies will be built twice. To leave the tests as is, either debuginfo could be turned off, or manually set to 2, which I've done in the "tmp: update tests relying on dev and build-deps reuse" commit. I am not sure it's the expected way to do this ? **Update**: the test changes [look acceptable](https://github.com/rust-lang/cargo/pull/10493#issuecomment-1074345394) so I've turned the temporary commit into a permanent one.
- [x] I need some help for `-Zscrape-examples`: the feature seems to depend implicitly on a similar build reuse, with a mapping from for-host dependencies to regular dependencies. I'm not sure that this works correctly in all situations: it seems focused on feature flags, but reuse can also be different depending on other flags. In our case, debuginfo is now different, making some of the mapping memoization panic, causing the tests to fail. So I've temporarily disabled them in the "tmp: disable -Zscrape-examples unit tests" commit, and would need help to know what to do there. My expectation is that these panics would already happen today if someone manually opted into different debuginfo level in their `build-override` (or panic method, etc) but have not tested it (it seems sensible in a context where only the default settings have changed to a value users can already set). **Update**: This issue is now tracked in #10500. We've discussed it with @willcrichton, and I've incorporated a fix and tests in #10524.

---
**Edit**: with the updates above, this is ready to take out of draft.

The discussion issue #10481 also mentions the possible small `strip` addition that this PR doesn't do (and that could be done in the future), but since it's not a huge improvement, I'd say this closes #10481.
