### PR TITLE
File Cache is valid if checkout or contents hasn't changed

### DIFF
--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -171,7 +171,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         // Check if the cache is valid.
         let current_version = self.current_version();
         if let (Some(c), Some(i)) = (current_version, index_version) {
-            if c.ends_with(i) {
+            if i.ends_with(c.as_str()) {
                 return Poll::Ready(Ok(LoadResponse::CacheValid));
             }
         }


### PR DESCRIPTION
#10482 allow the registry to have cashe keys at a per file level.
On master if the currently checked out commit changes all cached files are regenerated.
After this commit we also check if GITs hash of the particular file has changed.

To avoid thrashing cached files this PR only checks for the presence of both hashes, but does not write them both. This means that nightly after this branch will still be able to share file caches with older versions, specifically current stable.

When sufficient versions of stable know how to read the new format, a one line change can be made to start writing the new format.