### PR TITLE
Don't error if no binaries were installed

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -353,7 +353,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
             //
             // Note that we know at this point that _if_ bins or examples is set to `::Just`,
             // they're `::Just([])`, which is `FilterRule::none()`.
-            if self.pkg.targets().iter().any(|t| t.is_bin()) {
+            if self.pkg.targets().iter().any(|t| t.is_executable()) {
                 self.config
                     .shell()
                     .warn("none of the package's binaries are available for install using the selected features")?;

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -650,12 +650,11 @@ fn install_default_features() {
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --no-default-features")
-        .with_status(101)
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[ERROR] no binaries are available for install using the selected features
+[WARNING] none of the package's binaries are available for install using the selected features
 ",
         )
         .run();
@@ -772,12 +771,11 @@ fn install_multiple_required_features() {
     p.cargo("uninstall foo").run();
 
     p.cargo("install --path . --no-default-features")
-        .with_status(101)
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[ERROR] no binaries are available for install using the selected features
+[WARNING] none of the package's binaries are available for install using the selected features
 ",
         )
         .run();
@@ -1029,12 +1027,11 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
 
     // install
     p.cargo("install --path .")
-        .with_status(101)
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [FINISHED] release [optimized] target(s) in [..]
-[ERROR] no binaries are available for install using the selected features
+[WARNING] none of the package's binaries are available for install using the selected features
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #10289, which contains a thorough description of the problem.

Briefly, if we interpret `cargo install` and `cargo install --bins` as "install
the binaries that are available", it should not be considered an error
if no binaries ended up being installed due to required features.
Instead, this should provide the user with a warning that this may not
have been what they intended.

### Additional information

Given that #9576 seems to have stalled, I figured I'd try to land this first [after all](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/cargo.20install.20--bins.20when.20no.20binaries.20match).