### PR TITLE
Support inheriting jobserver fd for external subcommands

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -174,11 +174,12 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&str]) -> Cli
     };
 
     let cargo_exe = config.cargo_exe()?;
-    let err = match ProcessBuilder::new(&command)
-        .env(cargo::CARGO_ENV, cargo_exe)
-        .args(args)
-        .exec_replace()
-    {
+    let mut cmd = ProcessBuilder::new(&command);
+    cmd.env(cargo::CARGO_ENV, cargo_exe).args(args);
+    if let Some(client) = config.jobserver_from_env() {
+        cmd.inherit_jobserver(client);
+    }
+    let err = match cmd.exec_replace() {
         Ok(()) => return Ok(()),
         Err(e) => e,
     };

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -4,50 +4,50 @@ use std::net::TcpListener;
 use std::process::Command;
 use std::thread;
 
+use cargo_test_support::install::{assert_has_installed_exe, cargo_home};
 use cargo_test_support::{cargo_exe, project};
+
+const EXE_CONTENT: &str = r#"
+use std::env;
+
+fn main() {
+    let var = env::var("CARGO_MAKEFLAGS").unwrap();
+    let arg = var.split(' ')
+                 .find(|p| p.starts_with("--jobserver"))
+                .unwrap();
+    let val = &arg[arg.find('=').unwrap() + 1..];
+    validate(val);
+}
+
+#[cfg(unix)]
+fn validate(s: &str) {
+    use std::fs::File;
+    use std::io::*;
+    use std::os::unix::prelude::*;
+
+    let fds = s.split(',').collect::<Vec<_>>();
+    println!("{}", s);
+    assert_eq!(fds.len(), 2);
+    unsafe {
+        let mut read = File::from_raw_fd(fds[0].parse().unwrap());
+        let mut write = File::from_raw_fd(fds[1].parse().unwrap());
+
+        let mut buf = [0];
+        assert_eq!(read.read(&mut buf).unwrap(), 1);
+        assert_eq!(write.write(&buf).unwrap(), 1);
+    }
+}
+
+#[cfg(windows)]
+fn validate(_: &str) {
+    // a little too complicated for a test...
+}
+"#;
 
 #[cargo_test]
 fn jobserver_exists() {
     let p = project()
-        .file(
-            "build.rs",
-            r#"
-                use std::env;
-
-                fn main() {
-                    let var = env::var("CARGO_MAKEFLAGS").unwrap();
-                    let arg = var.split(' ')
-                                 .find(|p| p.starts_with("--jobserver"))
-                                 .unwrap();
-                    let val = &arg[arg.find('=').unwrap() + 1..];
-                    validate(val);
-                }
-
-                #[cfg(unix)]
-                fn validate(s: &str) {
-                    use std::fs::File;
-                    use std::io::*;
-                    use std::os::unix::prelude::*;
-
-                    let fds = s.split(',').collect::<Vec<_>>();
-                    println!("{}", s);
-                    assert_eq!(fds.len(), 2);
-                    unsafe {
-                        let mut read = File::from_raw_fd(fds[0].parse().unwrap());
-                        let mut write = File::from_raw_fd(fds[1].parse().unwrap());
-
-                        let mut buf = [0];
-                        assert_eq!(read.read(&mut buf).unwrap(), 1);
-                        assert_eq!(write.write(&buf).unwrap(), 1);
-                    }
-                }
-
-                #[cfg(windows)]
-                fn validate(_: &str) {
-                    // a little too complicated for a test...
-                }
-            "#,
-        )
+        .file("build.rs", EXE_CONTENT)
         .file("src/lib.rs", "")
         .build();
 
@@ -55,6 +55,45 @@ fn jobserver_exists() {
     // token to read from `validate` above, since running the build script
     // itself consumes a token.
     p.cargo("build -j2").run();
+}
+
+#[cargo_test]
+fn external_subcommand_inherits_jobserver() {
+    let make = if cfg!(windows) {
+        "mingw32-make"
+    } else {
+        "make"
+    };
+    if Command::new(make).arg("--version").output().is_err() {
+        return;
+    }
+
+    let name = "cargo-jobserver-check";
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "{name}"
+                    version = "0.0.1"
+                "#
+            ),
+        )
+        .file("src/main.rs", EXE_CONTENT)
+        .file(
+            "Makefile",
+            "\
+all:
+\t+$(CARGO) jobserver-check
+",
+        )
+        .build();
+
+    p.cargo("install --path .").run();
+    assert_has_installed_exe(cargo_home(), name);
+
+    p.process(make).env("CARGO", cargo_exe()).arg("-j2").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

If cargo detects the existence of a jobserver, cargo should pass the
jobserver down to the external subcommand. Here are the reasons:

1. The existence of jobserver implies the user "expects" the amount of
   job is under control. However, before this commit, external
   subcommands cannnot benefit from the global view of the jobserver.
2. `cargo-clippy` as an external subcommand migth also love to respect
   the jobserver protocol.
3. There are several well-known external subcommands calling "cargo"
   interally (cargo-fuzz, cargo-tarpaulin, etc.)

Fixes #10477 

[zulip stream](https://zulip-archive.rust-lang.org/stream/246057-t-cargo/topic/external.20subcommand.20inherits.20jobserver.20fd.html)

### How should we test and review this PR?

A new test `jobserver::external_subcommand_inherits_jobserver` is added.

You can also execute cargo-clippy from `make -j2` to test the behaviour 
(I usually run [`procs -w rustc`] to observe the amount of rustc invocations):

```make
# Makefile
all:
	+./target/debug/cargo clippy --release
```

### Caveats

Job without special prefix `+` might still be considered as a sub-make
and would inherit the jobserver, though I don't see it as an issue.

According to GNU Make Manual ["13.1.1 POSIX Jobserver Interaction"],
if `--jobserver-auth` option is available in `MAKEFLAGS` but the file
descriptors are closed, it means that the calling `make` didn't consider
our tool awas a recursive `make` invocation. I make an assumption that
if those fds are still open, we are happy to use those jobserver tokens.

["13.1.1 POSIX Jobserver Interaction"]: https://www.gnu.org/software/make/manual/make.html#POSIX-Jobserver
[`procs -w rustc`]: https://github.com/dalance/procs
<!-- homu-ignore:end -->
