### PR TITLE
Use the correct flag in --locked --offline error message 

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -47,7 +47,7 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &mut Resolve) -> CargoRes
     }
 
     if !ws.config().lock_update_allowed() {
-        let flag = if ws.config().network_allowed() {
+        let flag = if ws.config().locked() {
             "--locked"
         } else {
             "--frozen"

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -700,3 +700,16 @@ remove the --frozen flag and use --offline instead.
 ")
         .run();
 }
+
+#[cargo_test]
+fn offline_and_locked_and_no_frozen() {
+    let p = project().file("src/lib.rs", "").build();
+    p.cargo("build --locked --offline")
+        .with_status(101)
+        .with_stderr("\
+error: the lock file [ROOT]/foo/Cargo.lock needs to be updated but --locked was passed to prevent this
+If you want to try to generate the lock file without accessing the network, \
+remove the --locked flag and use --offline instead.
+")
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/10504

[Use the correct the flag in --locked --offline error message](https://github.com/rust-lang/cargo/commit/17ec41515e4908aae0d4848423e0605aafe21196)

[Add offline_and_locked_and_no_frozen test](https://github.com/rust-lang/cargo/commit/7363f43d02bb4144ed78a7361e0c97b02f228da8)

### How should we test and review this PR?

- unit test
