### PR TITLE
Part 2 of RFC2906 -- allow inheriting from a different `Cargo.toml`

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -26,6 +26,15 @@ pub enum EitherManifest {
     Virtual(VirtualManifest),
 }
 
+impl EitherManifest {
+    pub(crate) fn workspace_config(&self) -> &WorkspaceConfig {
+        match *self {
+            EitherManifest::Real(ref r) => r.workspace_config(),
+            EitherManifest::Virtual(ref v) => v.workspace_config(),
+        }
+    }
+}
+
 /// Contains all the information about a package, as loaded from a `Cargo.toml`.
 ///
 /// This is deserialized using the [`TomlManifest`] type.

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -11,7 +11,8 @@ pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};
 pub use self::workspace::{
-    InheritableFields, MaybePackage, Workspace, WorkspaceConfig, WorkspaceRootConfig,
+    find_workspace_root, InheritableFields, MaybePackage, Workspace, WorkspaceConfig,
+    WorkspaceRootConfig,
 };
 
 pub mod compiler;

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2196,7 +2196,18 @@ impl<P: ResolveToPath + Clone> TomlDependency<P> {
                     label, label
                 )).map(|dep| {
                     match dep {
-                        TomlDependency::Simple(s) => TomlDependency::Simple(s),
+                        TomlDependency::Simple(s) => {
+                            if optional.is_some() || features.is_some() {
+                                TomlDependency::Detailed(DetailedTomlDependency::<P> {
+                                    version: Some(s),
+                                    optional,
+                                    features,
+                                    ..Default::default()
+                                })
+                            } else {
+                                TomlDependency::Simple(s)
+                            }
+                        },
                         TomlDependency::Detailed(d) => {
                             let mut dep = d.clone();
                             dep.add_features(features);


### PR DESCRIPTION
Tracking issue: #8415
RFC: rust-lang/rfcs#2906


[Part 1](https://github.com/rust-lang/cargo/pull/10497)

This PR focuses on inheriting from a root workspace:
- Allow inheriting from a different `Cargo.toml`
- Add in searching for a workspace root in `to_real_manifest` as needed
- Fixed problem where a package would try to pull a dependency from a workspace and specify `{ workspace = true, optional = true }` and it would not respect the `optional`
- Added tests to verify everything is in working order


Remaining implementation work for the RFC
- Correctly inherit fields that are relative paths
  - Including adding support for inheriting `license_file`,  `readme`, and path-dependencies
-  Path dependencies infer version directive
- Lock workspace dependencies and warn when unused
- Optimizations, as needed
- Evaluate any new fields for being inheritable (e.g. `rust-version`)


Problems:
- There is duplication of code that can't be removed without significant refactoring
- Potential to parse the same manifest many times when searching for a root
  - This should not happen when a `[package]` specifies its workspace
  - This should only happen if the workspace root is greater than one folder above