### PR TITLE
Fix how scrape-examples handles proc macros

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -711,11 +711,6 @@ fn compute_deps_doc(
     // Add all units being scraped for examples as a dependency of Doc units.
     if state.ws.is_member(&unit.pkg) {
         for scrape_unit in state.scrape_units.iter() {
-            // This needs to match the FeaturesFor used in cargo_compile::generate_targets.
-            let unit_for = UnitFor::new_host(
-                scrape_unit.target.proc_macro(),
-                unit_for.root_compile_kind(),
-            );
             deps_of(scrape_unit, state, unit_for)?;
             ret.push(new_unit_dep(
                 state,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -546,6 +546,10 @@ pub fn create_bcx<'a, 'cfg>(
                 &profiles,
                 interner,
             )?
+            .into_iter()
+            // Proc macros should not be scraped for functions, since they only export macros
+            .filter(|unit| !unit.target.proc_macro())
+            .collect::<Vec<_>>()
         }
         None => Vec::new(),
     };


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes #10500.

Previously, the scrape-examples extension did some shenanigans in `build_unit_dependencies` in order to scrape `proc-macro` crates. But this code is useless since `proc-macro` crates cannot export functions, so we avoid this issue entirely by filtering proc-macro targets.

### How should we test and review this PR?

I added the test `scrape_examples_configure_profile` to ensure that the issue in #10500 is fixed.

r? @ehuss 