### PR TITLE
Part 3 of RFC2906 - Add support for inheriting `license-path`, and `depednency.path`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ libgit2-sys = "0.13.2"
 memchr = "2.1.3"
 opener = "0.5"
 os_info = "3.0.7"
+pathdiff = "0.2.1"
 percent-encoding = "2.0"
 rustfix = "0.6.0"
 semver = { version = "1.0.3", features = ["serde"] }

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -11,8 +11,8 @@ pub use self::shell::{Shell, Verbosity};
 pub use self::source::{GitReference, Source, SourceId, SourceMap};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};
 pub use self::workspace::{
-    find_workspace_root, InheritableFields, MaybePackage, Workspace, WorkspaceConfig,
-    WorkspaceRootConfig,
+    find_workspace_root, resolve_relative_path, InheritableFields, MaybePackage, Workspace,
+    WorkspaceConfig, WorkspaceRootConfig,
 };
 
 pub mod compiler;


### PR DESCRIPTION
Tracking issue: #8415
RFC: rust-lang/rfcs#2906


[Part 1](https://github.com/rust-lang/cargo/pull/10497)
[Part 2](https://github.com/rust-lang/cargo/pull/10517)

This PR focuses on adding support for inheriting `license-path`, and `depednency.path`:
- To adjust the relative paths from being workspace-relative to package-relative, we use `pathdiff` which `cargo-add` is also going to be using for a similar purpose
- `ws_path` was added to `InheritableFields` so we can resolve relative paths from  workspace-relative to package-relative
- Moved `resolve` for toml dependencies from `TomlDependency::<P>` to `TomlDependency`
  - This was done since resolving a relative path should be a string
  - You should never inherit from a `.cargo/config.toml` which is the reason `P` was added

Remaining implementation work for the RFC
- Relative paths for `readme`
- Path dependencies infer version directive
- Lock workspace dependencies and warn when unused
- Optimizations, as needed
- Evaluate any new fields for being inheritable (e.g. `rust-version`)