### PR TITLE
Add unstable `rustc-check-cfg` build script output

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -235,6 +235,14 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                             args.push(cfg.into());
                         }
 
+                        if !output.check_cfgs.is_empty() {
+                            args.push("-Zunstable-options".into());
+                            for check_cfg in &output.check_cfgs {
+                                args.push("--check-cfg".into());
+                                args.push(check_cfg.into());
+                            }
+                        }
+
                         for (lt, arg) in &output.linker_args {
                             if lt.applies_to(&unit.target) {
                                 args.push("-C".into());

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -29,6 +29,8 @@ pub struct BuildOutput {
     pub linker_args: Vec<(LinkType, String)>,
     /// Various `--cfg` flags to pass to the compiler.
     pub cfgs: Vec<String>,
+    /// Various `--check-cfg` flags to pass to the compiler.
+    pub check_cfgs: Vec<String>,
     /// Additional environment variables to run the compiler with.
     pub env: Vec<(String, String)>,
     /// Metadata to pass to the immediate dependencies.
@@ -322,6 +324,10 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     paths::create_dir_all(&script_out_dir)?;
 
     let nightly_features_allowed = cx.bcx.config.nightly_features_allowed;
+    let extra_check_cfg = match cx.bcx.config.cli_unstable().check_cfg {
+        Some((_, _, _, output)) => output,
+        None => false,
+    };
     let targets: Vec<Target> = unit.pkg.targets().to_vec();
     // Need a separate copy for the fresh closure.
     let targets_fresh = targets.clone();
@@ -432,6 +438,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
             &pkg_descr,
             &script_out_dir,
             &script_out_dir,
+            extra_check_cfg,
             nightly_features_allowed,
             &targets,
         )?;
@@ -459,6 +466,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
                 &pkg_descr,
                 &prev_script_out_dir,
                 &script_out_dir,
+                extra_check_cfg,
                 nightly_features_allowed,
                 &targets_fresh,
             )?,
@@ -511,6 +519,7 @@ impl BuildOutput {
         pkg_descr: &str,
         script_out_dir_when_generated: &Path,
         script_out_dir: &Path,
+        extra_check_cfg: bool,
         nightly_features_allowed: bool,
         targets: &[Target],
     ) -> CargoResult<BuildOutput> {
@@ -521,6 +530,7 @@ impl BuildOutput {
             pkg_descr,
             script_out_dir_when_generated,
             script_out_dir,
+            extra_check_cfg,
             nightly_features_allowed,
             targets,
         )
@@ -536,6 +546,7 @@ impl BuildOutput {
         pkg_descr: &str,
         script_out_dir_when_generated: &Path,
         script_out_dir: &Path,
+        extra_check_cfg: bool,
         nightly_features_allowed: bool,
         targets: &[Target],
     ) -> CargoResult<BuildOutput> {
@@ -543,6 +554,7 @@ impl BuildOutput {
         let mut library_links = Vec::new();
         let mut linker_args = Vec::new();
         let mut cfgs = Vec::new();
+        let mut check_cfgs = Vec::new();
         let mut env = Vec::new();
         let mut metadata = Vec::new();
         let mut rerun_if_changed = Vec::new();
@@ -669,6 +681,13 @@ impl BuildOutput {
                     linker_args.push((LinkType::All, value));
                 }
                 "rustc-cfg" => cfgs.push(value.to_string()),
+                "rustc-check-cfg" => {
+                    if extra_check_cfg {
+                        check_cfgs.push(value.to_string());
+                    } else {
+                        warnings.push(format!("cargo:{} requires -Zcheck-cfg=output flag", key));
+                    }
+                }
                 "rustc-env" => {
                     let (key, val) = BuildOutput::parse_rustc_env(&value, &whence)?;
                     // Build scripts aren't allowed to set RUSTC_BOOTSTRAP.
@@ -728,6 +747,7 @@ impl BuildOutput {
             library_links,
             linker_args,
             cfgs,
+            check_cfgs,
             env,
             metadata,
             rerun_if_changed,
@@ -968,6 +988,10 @@ fn prev_build_output(cx: &mut Context<'_, '_>, unit: &Unit) -> (Option<BuildOutp
             &unit.pkg.to_string(),
             &prev_script_out_dir,
             &script_out_dir,
+            match cx.bcx.config.cli_unstable().check_cfg {
+                Some((_, _, _, output)) => output,
+                None => false,
+            },
             cx.bcx.config.nightly_features_allowed,
             unit.pkg.targets(),
         )

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -411,6 +411,12 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                 for cfg in &output.cfgs {
                     rustc.arg("--cfg").arg(cfg);
                 }
+                if !output.check_cfgs.is_empty() {
+                    rustc.arg("-Zunstable-options");
+                    for check_cfg in &output.check_cfgs {
+                        rustc.arg("--check-cfg").arg(check_cfg);
+                    }
+                }
                 if pass_l_flag {
                     for name in output.library_links.iter() {
                         rustc.arg("-l").arg(name);
@@ -717,6 +723,12 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
             if let Some(output) = build_script_outputs.lock().unwrap().get(script_metadata) {
                 for cfg in output.cfgs.iter() {
                     rustdoc.arg("--cfg").arg(cfg);
+                }
+                if !output.check_cfgs.is_empty() {
+                    rustdoc.arg("-Zunstable-options");
+                    for check_cfg in &output.check_cfgs {
+                        rustdoc.arg("--check-cfg").arg(check_cfg);
+                    }
                 }
                 for &(ref name, ref value) in output.env.iter() {
                     rustdoc.env(name, value);
@@ -1055,7 +1067,7 @@ fn features_args(unit: &Unit) -> Vec<OsString> {
 
 /// Generate the --check-cfg arguments for the unit
 fn check_cfg_args(cx: &Context<'_, '_>, unit: &Unit) -> Vec<OsString> {
-    if let Some((features, well_known_names, well_known_values)) =
+    if let Some((features, well_known_names, well_known_values, _output)) =
         cx.bcx.config.cli_unstable().check_cfg
     {
         let mut args = Vec::with_capacity(unit.pkg.summary().features().len() * 2 + 4);

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -641,7 +641,7 @@ unstable_cli_options!(
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
     config_include: bool = ("Enable the `include` key in config files"),
     credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
-    check_cfg: Option<(/*features:*/ bool, /*well_known_names:*/ bool, /*well_known_values:*/ bool)> = ("Specify scope of compile-time checking of `cfg` names/values"),
+    check_cfg: Option<(/*features:*/ bool, /*well_known_names:*/ bool, /*well_known_values:*/ bool, /*output:*/ bool)> = ("Specify scope of compile-time checking of `cfg` names/values"),
     doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
@@ -783,22 +783,29 @@ impl CliUnstable {
             }
         }
 
-        fn parse_check_cfg(value: Option<&str>) -> CargoResult<Option<(bool, bool, bool)>> {
+        fn parse_check_cfg(value: Option<&str>) -> CargoResult<Option<(bool, bool, bool, bool)>> {
             if let Some(value) = value {
                 let mut features = false;
                 let mut well_known_names = false;
                 let mut well_known_values = false;
+                let mut output = false;
 
                 for e in value.split(',') {
                     match e {
                         "features" => features = true,
                         "names" => well_known_names = true,
                         "values" => well_known_values = true,
-                        _ => bail!("flag -Zcheck-cfg only takes `features`, `names` or `values` as valid inputs"),
+                        "output" => output = true,
+                        _ => bail!("flag -Zcheck-cfg only takes `features`, `names`, `values` or `output` as valid inputs"),
                     }
                 }
 
-                Ok(Some((features, well_known_names, well_known_values)))
+                Ok(Some((
+                    features,
+                    well_known_names,
+                    well_known_values,
+                    output,
+                )))
             } else {
                 Ok(None)
             }

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1201,6 +1201,7 @@ It's values are:
     Note than this command line options will probably become the default when stabilizing.
  - `names`: enables well known names checking via `--check-cfg=names()`.
  - `values`: enables well known values checking via `--check-cfg=values()`.
+ - `output`: enable the use of `rustc-check-cfg` in build script.
 
 For instance:
 
@@ -1210,6 +1211,29 @@ cargo check -Z unstable-options -Z check-cfg=names
 cargo check -Z unstable-options -Z check-cfg=values
 cargo check -Z unstable-options -Z check-cfg=features,names,values
 ```
+
+Or for `output`:
+
+```rust,no_run
+// build.rs
+println!("cargo:rustc-check-cfg=names(foo, bar)");
+```
+
+```
+cargo check -Z unstable-options -Z check-cfg=output
+```
+
+### `cargo:rustc-check-cfg=CHECK_CFG`
+
+The `rustc-check-cfg` instruction tells Cargo to pass the given value to the
+`--check-cfg` flag to the compiler. This may be used for compile-time
+detection of unexpected conditional compilation name and/or values.
+
+This can only be used in combination with `-Zcheck-cfg=output` otherwise it is ignored
+with a warning.
+
+If you want to integrate with Cargo features, use `-Zcheck-cfg=features` instead of
+trying to do it manually with this option.
 
 ### workspace-inheritance
 


### PR DESCRIPTION
This PR adds a new build script output as unstable behind `-Zcheck-cfg=output`: `rustc-check-cfg`.

### What does this PR try to resolve?

This PR add a way to add to use the unstable `--check-cfg` command line option of `rustc` and `rustdoc`.

It was discover in [Bump bootstrap compiler to 1.61.0 beta](https://github.com/rust-lang/rust/pull/95678#discussion_r842803445) that `rustc_llvm` sets some custom `cfg` from a build script and because `--check-cfg=values()` is globally enable in the Rust codebase that cause the compilation to fail. For now no values are checked in stage 0 for the entire codebase which is a shame and should be fixed with the addition of this feature.

### How should we test and review this PR?

Commits are separated in: implementation, tests and doc.

Testing should simply be done by adding a valid `cargo:rustc-check-cfg` in a build script.
Watch the added tests or doc to have an example.

### Additional information

This PR is also the logical next step after `-Zcheck-cfg-features`.