### PR TITLE
Retry command invocation with argfile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,13 @@ jobs:
 
     # Deny warnings on CI to avoid warnings getting into the codebase.
     - run: cargo test --features 'deny-warnings'
+    - name: Check operability of rustc invocation with argfile
+      env:
+        __CARGO_TEST_FORCE_ARGFILE: 1
+      run: |
+        # This only tests `cargo fix` because fix-proxy-mode is one of the most
+        # complicated subprocess management in Cargo.
+        cargo test --test testsuite --features 'deny-warnings' -- fix::
     - run: cargo test --features 'deny-warnings' --manifest-path crates/cargo-test-support/Cargo.toml
       env:
         CARGO_TARGET_DIR: target

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/cargo/lib.rs"
 atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
-cargo-util = { path = "crates/cargo-util", version = "0.1.2" }
+cargo-util = { path = "crates/cargo-util", version = "0.1.3" }
 crates-io = { path = "crates/crates-io", version = "0.34.0" }
 crossbeam-utils = "0.8"
 curl = { version = "0.4.41", features = ["http2"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -413,10 +413,11 @@ impl ProcessBuilder {
             .prefix("cargo-argfile.")
             .tempfile()?;
 
-        let path = tmp.path().display();
+        let mut arg = OsString::from("@");
+        arg.push(tmp.path());
         let mut cmd = self.build_command_without_args();
-        cmd.arg(format!("@{path}"));
-        log::debug!("created argfile at {path} for `{self}`");
+        cmd.arg(arg);
+        log::debug!("created argfile at {} for {self}", tmp.path().display());
 
         let cap = self.get_args().map(|arg| arg.len() + 1).sum::<usize>();
         let mut buf = Vec::with_capacity(cap);

--- a/crates/cargo-util/src/process_error.rs
+++ b/crates/cargo-util/src/process_error.rs
@@ -95,6 +95,13 @@ impl ProcessError {
             stderr: stderr.map(|s| s.to_vec()),
         }
     }
+
+    /// Creates a [`ProcessError`] with "could not execute process {cmd}".
+    ///
+    /// * `cmd` is usually but not limited to [`std::process::Command`].
+    pub fn could_not_execute(cmd: impl fmt::Display) -> ProcessError {
+        ProcessError::new(&format!("could not execute process {cmd}"), None, None)
+    }
 }
 
 /// Converts an [`ExitStatus`]  to a human-readable string suitable for

--- a/src/cargo/core/compiler/build_plan.rs
+++ b/src/cargo/core/compiler/build_plan.rs
@@ -78,7 +78,7 @@ impl Invocation {
             .ok_or_else(|| anyhow::format_err!("unicode program string required"))?
             .to_string();
         self.cwd = Some(cmd.get_cwd().unwrap().to_path_buf());
-        for arg in cmd.get_args().iter() {
+        for arg in cmd.get_args() {
             self.args.push(
                 arg.to_str()
                     .ok_or_else(|| anyhow::format_err!("unicode argument string required"))?

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -194,6 +194,7 @@ impl<'cfg> Compilation<'cfg> {
         let rustdoc = ProcessBuilder::new(&*self.config.rustdoc()?);
         let cmd = fill_rustc_tool_env(rustdoc, unit);
         let mut cmd = self.fill_env(cmd, &unit.pkg, script_meta, unit.kind, true)?;
+        cmd.retry_with_argfile(true);
         unit.target.edition().cmd_edition_arg(&mut cmd);
 
         for crate_type in unit.target.rustc_crate_types() {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -754,7 +754,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
 // The --crate-version flag could have already been passed in RUSTDOCFLAGS
 // or as an extra compiler argument for rustdoc
 fn crate_version_flag_already_present(rustdoc: &ProcessBuilder) -> bool {
-    rustdoc.get_args().iter().any(|flag| {
+    rustdoc.get_args().any(|flag| {
         flag.to_str()
             .map_or(false, |flag| flag.starts_with(RUSTDOC_CRATE_VERSION_FLAG))
     })

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -351,7 +351,7 @@ fn rustc_fingerprint(
 fn process_fingerprint(cmd: &ProcessBuilder, extra_fingerprint: u64) -> u64 {
     let mut hasher = StableHasher::new();
     extra_fingerprint.hash(&mut hasher);
-    cmd.get_args().hash(&mut hasher);
+    cmd.get_args().for_each(|arg| arg.hash(&mut hasher));
     let mut env = cmd.get_envs().iter().collect::<Vec<_>>();
     env.sort_unstable();
     env.hash(&mut hasher);

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -93,18 +93,24 @@ impl Rustc {
 
     /// Gets a process builder set up to use the found rustc version, with a wrapper if `Some`.
     pub fn process(&self) -> ProcessBuilder {
-        ProcessBuilder::new(self.path.as_path()).wrapped(self.wrapper.as_ref())
+        let mut cmd = ProcessBuilder::new(self.path.as_path()).wrapped(self.wrapper.as_ref());
+        cmd.retry_with_argfile(true);
+        cmd
     }
 
     /// Gets a process builder set up to use the found rustc version, with a wrapper if `Some`.
     pub fn workspace_process(&self) -> ProcessBuilder {
-        ProcessBuilder::new(self.path.as_path())
+        let mut cmd = ProcessBuilder::new(self.path.as_path())
             .wrapped(self.workspace_wrapper.as_ref())
-            .wrapped(self.wrapper.as_ref())
+            .wrapped(self.wrapper.as_ref());
+        cmd.retry_with_argfile(true);
+        cmd
     }
 
     pub fn process_no_wrapper(&self) -> ProcessBuilder {
-        ProcessBuilder::new(&self.path)
+        let mut cmd = ProcessBuilder::new(&self.path);
+        cmd.retry_with_argfile(true);
+        cmd
     }
 
     /// Gets the output for the given command.

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -231,10 +231,7 @@ impl Cache {
         } else {
             debug!("rustc info cache miss");
             debug!("running {}", cmd);
-            let output = cmd
-                .build_command()
-                .output()
-                .with_context(|| format!("could not execute process {} (never executed)", cmd))?;
+            let output = cmd.output()?;
             let stdout = String::from_utf8(output.stdout)
                 .map_err(|e| anyhow::anyhow!("{}: {:?}", e, e.as_bytes()))
                 .with_context(|| format!("`{}` didn't return utf8 output", cmd))?;

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -89,8 +89,14 @@ fn broken_fixes_backed_out() {
 
                 fn main() {
                     // Ignore calls to things like --print=file-names and compiling build.rs.
+                    // Also compatible for rustc invocations with `@path` argfile.
                     let is_lib_rs = env::args_os()
                         .map(PathBuf::from)
+                        .flat_map(|p| if let Some(p) = p.to_str().unwrap_or_default().strip_prefix("@") {
+                            fs::read_to_string(p).unwrap().lines().map(PathBuf::from).collect()
+                        } else {
+                            vec![p]
+                        })
                         .any(|l| l == Path::new("src/lib.rs"));
                     if is_lib_rs {
                         let path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -1319,8 +1325,15 @@ fn fix_to_broken_code() {
                 use std::process::{self, Command};
 
                 fn main() {
+                    // Ignore calls to things like --print=file-names and compiling build.rs.
+                    // Also compatible for rustc invocations with `@path` argfile.
                     let is_lib_rs = env::args_os()
                         .map(PathBuf::from)
+                        .flat_map(|p| if let Some(p) = p.to_str().unwrap_or_default().strip_prefix("@") {
+                            fs::read_to_string(p).unwrap().lines().map(PathBuf::from).collect()
+                        } else {
+                            vec![p]
+                        })
                         .any(|l| l == Path::new("src/lib.rs"));
                     if is_lib_rs {
                         let path = PathBuf::from(env::var_os("OUT_DIR").unwrap());

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -112,6 +112,7 @@ fn whitespace() {
 
     const SPACED_VERSION: &str = "a\nb\tc\u{00a0}d";
     p.cargo("doc")
+        .env_remove("__CARGO_TEST_FORCE_ARGFILE") // Not applicable for argfile.
         .env(
             "RUSTDOCFLAGS",
             format!("--crate-version {}", SPACED_VERSION),


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #10381

The goal is to invoke `rustc` and `rustdoc` with `@path` arg file as a fallback.

Since the `-Zcheck-cfg-features`[^1] has already been implemented, in the foreseeable future cargo will probably hit the “**command line too big**” more often on Windows. `rustdoc` and `rustc` both support `@path` argfile [^2][^3], so we can leverage the feature for the fallback logic.

The idea behind this PR is that we put the **retry logic** in `ProcessBuilder::exec*` functions and reuse them as much as possible.

### How should we test and review this PR?

Review it commit by commit is recommended.

Argfile fallback is hard to tested with integration tests, so I added some unit tests for `cargo_util::ProcessBuilder` and `cargo::ops::fix::FixArgs`.

If you do want to test the support of argfile manually, a new environment variable `__CARGO_TEST_FORCE_ARGFILE` is added for the sake of forcing cargo to use argfile for rustc invocations. For example, `__CARGO_TEST_FORCE_ARGFILE cargo test --test testsuite -- fix::` is usually a good start to test this feature.

[^1]: https://doc.rust-lang.org/beta/cargo/reference/unstable.html?highlight=check#check-cfg-features
[^2]: https://doc.rust-lang.org/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path
[^3]: https://doc.rust-lang.org/rustdoc/command-line-arguments.html#path-load-command-line-flags-from-a-path

<!-- homu-ignore:start -->
### Additional information

Should we escape line feed when writing into argfile and unescape while reading? 82781929b8fffd65f363aab1549e1b8f6773920f implements that but I am not sure whether it is necessary.
<!-- homu-ignore:end -->

