### PR TITLE
Part 4 of RFC2906 - Add support for inheriting `readme`

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -286,6 +286,13 @@ fn build_ar_list(
             ))?;
         }
     }
+    if let Some(readme) = &pkg.manifest().metadata().readme {
+        let readme_path = Path::new(readme);
+        let abs_file_path = paths::normalize_path(&pkg.root().join(readme_path));
+        if abs_file_path.exists() {
+            check_for_file_and_add("readme", readme_path, abs_file_path, pkg, &mut result, ws)?;
+        }
+    }
     result.sort_unstable_by(|a, b| a.rel_path.cmp(&b.rel_path));
 
     Ok(result)

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -581,6 +581,7 @@ fn inherit_workspace_fields() {
             authors = ["Rustaceans"]
             description = "This is a crate"
             documentation = "https://www.rust-lang.org/learn"
+            readme = "README.md"
             homepage = "https://www.rust-lang.org"
             repository = "https://github.com/example/example"
             license = "MIT"
@@ -606,6 +607,7 @@ fn inherit_workspace_fields() {
             authors = { workspace = true }
             description = { workspace = true }
             documentation = { workspace = true }
+            readme = { workspace = true }
             homepage = { workspace = true }
             repository = { workspace = true }
             license = { workspace = true }
@@ -617,6 +619,7 @@ fn inherit_workspace_fields() {
         "#,
         )
         .file("LICENSE", "license")
+        .file("README.md", "README.md")
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
@@ -642,8 +645,8 @@ fn inherit_workspace_fields() {
           "license_file": "../LICENSE",
           "links": null,
           "name": "bar",
-          "readme": null,
-          "readme_file": null,
+          "readme": "README.md",
+          "readme_file": "../README.md",
           "repository": "https://github.com/example/example",
           "vers": "1.2.3"
           }
@@ -654,6 +657,7 @@ fn inherit_workspace_fields() {
             "Cargo.toml",
             "Cargo.toml.orig",
             "src/main.rs",
+            "README.md",
             "LICENSE",
             ".cargo_vcs_info.json",
         ],
@@ -672,6 +676,7 @@ publish = true
 description = "This is a crate"
 homepage = "https://www.rust-lang.org"
 documentation = "https://www.rust-lang.org/learn"
+readme = "README.md"
 keywords = ["cli"]
 categories = ["development-tools"]
 license = "MIT"


### PR DESCRIPTION
Tracking issue: #8415
RFC: rust-lang/rfcs#2906

[Part 1](https://github.com/rust-lang/cargo/pull/10497)
[Part 2](https://github.com/rust-lang/cargo/pull/10517)
[Part 3](https://github.com/rust-lang/cargo/pull/10538)

This PR focuses on adding support for inheriting `readme`:
- Added adjusting of a `readme` path when it is outside of the `package_root`
  - Copied from `license-file`'s implementation in `toml::prepare_for_publish()`
- Added copying of a `readme` file when it is outside of the `package_root` for publishing
  - Copied from `license-file`'s implementation in `cargo_package::build_ar_list()`
- Merged copying of a file outside of a `package_root` to reduce duplicated code and allow for other files in the future to be copied in a similar way

Remaining implementation work for the RFC
- Path dependencies infer version directive
- Lock workspace dependencies and warn when unused
- Optimizations, as needed
- Evaluate any new fields for being inheritable (e.g. `rust-version`)
