### PR TITLE
Part 5 of RFC2906 - Add support for inheriting `rust-version`

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1662,6 +1662,7 @@ pub struct InheritableFields {
     publish: Option<VecStringOrBool>,
     edition: Option<String>,
     badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
+    rust_version: Option<String>,
     ws_root: PathBuf,
 }
 
@@ -1682,6 +1683,7 @@ impl InheritableFields {
         publish: Option<VecStringOrBool>,
         edition: Option<String>,
         badges: Option<BTreeMap<String, BTreeMap<String, String>>>,
+        rust_version: Option<String>,
         ws_root: PathBuf,
     ) -> InheritableFields {
         Self {
@@ -1700,6 +1702,7 @@ impl InheritableFields {
             publish,
             edition,
             badges,
+            rust_version,
             ws_root,
         }
     }
@@ -1826,6 +1829,13 @@ impl InheritableFields {
             .map_or(Err(anyhow!("`workspace.edition` was not defined")), |d| {
                 Ok(d)
             })
+    }
+
+    pub fn rust_version(&self) -> CargoResult<String> {
+        self.rust_version.clone().map_or(
+            Err(anyhow!("`workspace.rust-version` was not defined")),
+            |d| Ok(d),
+        )
     }
 
     pub fn badges(&self) -> CargoResult<BTreeMap<String, BTreeMap<String, String>>> {

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -25,6 +25,7 @@ fn permit_additional_workspace_fields() {
             categories = ["development-tools"]
             publish = false
             edition = "2018"
+            rust-version = "1.60"
 
             [workspace.badges]
             gitlab = { repository = "https://gitlab.com/rust-lang/rust", branch = "master" }
@@ -130,6 +131,7 @@ fn inherit_own_workspace_fields() {
             categories = { workspace = true }
             publish = { workspace = true }
             edition = { workspace = true }
+            rust-version = { workspace = true }
 
             [workspace]
             members = []
@@ -144,6 +146,7 @@ fn inherit_own_workspace_fields() {
             categories = ["development-tools"]
             publish = true
             edition = "2018"
+            rust-version = "1.60"
             [workspace.badges]
             gitlab = { repository = "https://gitlab.com/rust-lang/rust", branch = "master" }
             "#,
@@ -194,6 +197,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 edition = "2018"
+rust-version = "1.60"
 name = "foo"
 version = "1.2.3"
 authors = ["Rustaceans"]
@@ -590,6 +594,7 @@ fn inherit_workspace_fields() {
             categories = ["development-tools"]
             publish = true
             edition = "2018"
+            rust-version = "1.60"
             [workspace.badges]
             gitlab = { repository = "https://gitlab.com/rust-lang/rust", branch = "master" }
             "#,
@@ -616,6 +621,7 @@ fn inherit_workspace_fields() {
             categories = { workspace = true }
             publish = { workspace = true }
             edition = { workspace = true }
+            rust-version = { workspace = true }
         "#,
         )
         .file("LICENSE", "license")
@@ -669,6 +675,7 @@ cargo-features = ["workspace-inheritance"]
 
 [package]
 edition = "2018"
+rust-version = "1.60"
 name = "bar"
 version = "1.2.3"
 authors = ["Rustaceans"]


### PR DESCRIPTION
Tracking issue: #8415
RFC: rust-lang/rfcs#2906

Part 1: #10497
Part 2: #10517
Part 3: #10538
Part 4: #10548

This PR focuses on adding support for inheriting `rust-version`. While this was not in the original RFC it was decided that it should be added per [epage's comment](https://github.com/rust-lang/cargo/issues/8415#issuecomment-1093362940).
- Changed `rust-version` to `Option<MaybeWorkspace<String>>` in `TomlProject`
- Added `rust-version` to `TomlWorkspace` to allow for inheritance
- Added `rust-version` to `InheritableFields1 and a method to get it as needed
- Updated tests to include `rust-version`

Remaining implementation work for the RFC
- Switch the inheritance source from `workspace` to `workspace.package`, see [epage's comment](https://github.com/rust-lang/cargo/issues/8415#issuecomment-1097422198)
- Add `include` and `exclude` now that `workspace.package` is done, see [epage's comment](https://github.com/rust-lang/cargo/issues/8415#issuecomment-1097422198)
- `cargo-add` support, see [epage's comment](https://github.com/rust-lang/cargo/issues/8415#issuecomment-1075544790)
- Optimizations, as needed
