### PR TITLE
vendor: fix vendoring git repo paths that contain symlinks

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -317,7 +317,7 @@ fn cp_sources(
     tmp_buf: &mut [u8],
 ) -> CargoResult<()> {
     for p in paths {
-        let relative = p.strip_prefix(&src).unwrap();
+        let relative = paths::strip_prefix_canonical(p as &Path, src).unwrap();
 
         match relative.to_str() {
             // Skip git config files as they're not relevant to builds most of

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -151,8 +151,9 @@ impl<'cfg> PathSource<'cfg> {
         };
 
         let mut filter = |path: &Path, is_dir: bool| {
-            let relative_path = match path.strip_prefix(root) {
-                Ok(p) => p,
+            let s = paths::strip_prefix_canonical(path, root);
+            let relative_path = match s {
+                Ok(ref p) => p,
                 Err(_) => return false,
             };
 
@@ -229,7 +230,7 @@ impl<'cfg> PathSource<'cfg> {
         let root = repo
             .workdir()
             .ok_or_else(|| anyhow::format_err!("can't list files on a bare repository"))?;
-        let pkg_path = pkg.root();
+        let pkg_path = pkg.root().canonicalize()?;
 
         let mut ret = Vec::<PathBuf>::new();
 
@@ -293,7 +294,7 @@ impl<'cfg> PathSource<'cfg> {
             // Filter out files blatantly outside this package. This is helped a
             // bit above via the `pathspec` function call, but we need to filter
             // the entries in the index as well.
-            if !file_path.starts_with(pkg_path) {
+            if !file_path.starts_with(&pkg_path) {
                 continue;
             }
 


### PR DESCRIPTION

### What does this PR try to resolve?

When listing files from a git repository, paths should be normalized
because libgit2 returns paths that are normalized. Change the code to
work with normalized paths.

Fixes #10270

### How should we test and review this PR?

Steps to reproduce and test is in #10270 

### Additional information

I don't have time to write a test case. Sorry. Feel free to do whatever you want with this PR (including rejecting it).

I did not test cross build test cases. There was one test case that I cannot run due to local constraint, but that test `init::terminating_newline_in_new_mercurial_ignore` is specific to mercurial. All other test cases passed.