### PR TITLE
fix(yank): Use '--version' like install

### DIFF
--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -8,7 +8,8 @@ pub fn cli() -> App {
         .arg_quiet()
         .arg(Arg::new("crate"))
         .arg(
-            opt("vers", "The version to yank or un-yank")
+            opt("version", "The version to yank or un-yank")
+                .alias("vers")
                 .value_name("VERSION")
                 .required(true),
         )
@@ -30,7 +31,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     ops::yank(
         config,
         args.value_of("crate").map(|s| s.to_string()),
-        args.value_of("vers").map(|s| s.to_string()),
+        args.value_of("version").map(|s| s.to_string()),
         args.value_of("token").map(|s| s.to_string()),
         args.value_of("index").map(|s| s.to_string()),
         args.is_present("undo"),

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -771,14 +771,14 @@ fn parse_semver_flag(v: &str) -> CargoResult<VersionReq> {
     let first = v
         .chars()
         .next()
-        .ok_or_else(|| format_err!("no version provided for the `--vers` flag"))?;
+        .ok_or_else(|| format_err!("no version provided for the `--version` flag"))?;
 
     let is_req = "<>=^~".contains(first) || v.contains('*');
     if is_req {
         match v.parse::<VersionReq>() {
             Ok(v) => Ok(v),
             Err(_) => bail!(
-                "the `--vers` provided, `{}`, is \
+                "the `--version` provided, `{}`, is \
                      not a valid semver version requirement\n\n\
                      Please have a look at \
                      https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html \
@@ -791,7 +791,7 @@ fn parse_semver_flag(v: &str) -> CargoResult<VersionReq> {
             Ok(v) => Ok(VersionReq::exact(&v)),
             Err(e) => {
                 let mut msg = format!(
-                    "the `--vers` provided, `{}`, is \
+                    "the `--version` provided, `{}`, is \
                          not a valid semver version: {}\n",
                     v, e
                 );

--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -6,7 +6,7 @@ cargo-yank - Remove a pushed crate from the index
 
 ## SYNOPSIS
 
-`cargo yank` [_options_] `--vers` _version_ [_crate_]
+`cargo yank` [_options_] `--version` _version_ [_crate_]
 
 ## DESCRIPTION
 
@@ -30,7 +30,7 @@ current directory.
 
 {{#options}}
 
-{{#option "`--vers` _version_" }}
+{{#option "`--vers` _version_" "`--version` _version_" }}
 The version to yank or un-yank.
 {{/option}}
 
@@ -64,7 +64,7 @@ Undo a yank, putting a version back into the index.
 
 1. Yank a crate from the index:
 
-       cargo yank --vers 1.0.7 foo
+       cargo yank --version 1.0.7 foo
 
 ## SEE ALSO
 {{man "cargo" 1}}, {{man "cargo-login" 1}}, {{man "cargo-publish" 1}}

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -4,7 +4,7 @@ NAME
        cargo-yank - Remove a pushed crate from the index
 
 SYNOPSIS
-       cargo yank [options] --vers version [crate]
+       cargo yank [options] --version version [crate]
 
 DESCRIPTION
        The yank command removes a previously published crate's version from the
@@ -23,7 +23,7 @@ DESCRIPTION
 
 OPTIONS
    Yank Options
-       --vers version
+       --vers version, --version version
            The version to yank or un-yank.
 
        --undo
@@ -104,7 +104,7 @@ EXIT STATUS
 EXAMPLES
        1. Yank a crate from the index:
 
-              cargo yank --vers 1.0.7 foo
+              cargo yank --version 1.0.7 foo
 
 SEE ALSO
        cargo(1), cargo-login(1), cargo-publish(1)

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -6,7 +6,7 @@ cargo-yank - Remove a pushed crate from the index
 
 ## SYNOPSIS
 
-`cargo yank` [_options_] `--vers` _version_ [_crate_]
+`cargo yank` [_options_] `--version` _version_ [_crate_]
 
 ## DESCRIPTION
 
@@ -31,6 +31,7 @@ current directory.
 <dl>
 
 <dt class="option-term" id="option-cargo-yank---vers"><a class="option-anchor" href="#option-cargo-yank---vers"></a><code>--vers</code> <em>version</em></dt>
+<dt class="option-term" id="option-cargo-yank---version"><a class="option-anchor" href="#option-cargo-yank---version"></a><code>--version</code> <em>version</em></dt>
 <dd class="option-desc">The version to yank or un-yank.</dd>
 
 
@@ -139,7 +140,7 @@ details on environment variables that Cargo reads.
 
 1. Yank a crate from the index:
 
-       cargo yank --vers 1.0.7 foo
+       cargo yank --version 1.0.7 foo
 
 ## SEE ALSO
 [cargo(1)](cargo.html), [cargo-login(1)](cargo-login.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -142,8 +142,8 @@ etc.). For situations such as this, Cargo supports a “yank” of a version of 
 crate.
 
 ```console
-$ cargo yank --vers 1.0.1
-$ cargo yank --vers 1.0.1 --undo
+$ cargo yank --version 1.0.1
+$ cargo yank --version 1.0.1 --undo
 ```
 
 A yank **does not** delete any code. This feature is not intended for deleting

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -175,7 +175,7 @@ _cargo() {
                         '--rev=[specific commit to use when installing from git]:commit' \
                         '--root=[directory to install packages into]: :_directories' \
                         '--tag=[tag to use when installing from git]:tag' \
-                        '--vers=[version to install from crates.io]:version' \
+                        '--version='[version to install from crates.io]:version' \
                         '--list[list all installed packages and their versions]' \
                         '*: :_guard "^-*" "crate"'
                         ;;
@@ -332,7 +332,7 @@ _cargo() {
 
                 yank)
                     _arguments -s -S $common $registry \
-                        '--vers=[specify yank version]:version' \
+                        '--version=[specify yank version]:version' \
                         '--undo[undo a yank, putting a version back into the index]' \
                         '--index=[specify registry index to yank from]:registry index' \
                         '--token=[specify API token to use when authenticating]:token' \

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -88,7 +88,7 @@ _cargo()
 	local opt__vendor="$opt_common $opt_mani $opt_lock $opt_sync --no-delete --respect-source-config --versioned-dirs"
 	local opt__verify_project="$opt_common $opt_mani $opt_lock"
 	local opt__version="$opt_common $opt_lock"
-	local opt__yank="$opt_common $opt_lock --vers --undo --index --token --registry"
+	local opt__yank="$opt_common $opt_lock --version --undo --index --token --registry"
 	local opt__libtest="--help --include-ignored --ignored --test --bench --list --logfile --nocapture --test-threads --skip -q --quiet --exact --color --format"
 
 	if [[ $cword -gt $dd_i ]]; then

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -6,7 +6,7 @@
 .SH "NAME"
 cargo\-yank \- Remove a pushed crate from the index
 .SH "SYNOPSIS"
-\fBcargo yank\fR [\fIoptions\fR] \fB\-\-vers\fR \fIversion\fR [\fIcrate\fR]
+\fBcargo yank\fR [\fIoptions\fR] \fB\-\-version\fR \fIversion\fR [\fIcrate\fR]
 .SH "DESCRIPTION"
 The yank command removes a previously published crate's version from the
 server's index. This command does not delete any data, and the crate will
@@ -24,7 +24,8 @@ current directory.
 .SH "OPTIONS"
 .SS "Yank Options"
 .sp
-\fB\-\-vers\fR \fIversion\fR
+\fB\-\-vers\fR \fIversion\fR, 
+\fB\-\-version\fR \fIversion\fR
 .RS 4
 The version to yank or un\-yank.
 .RE
@@ -138,7 +139,7 @@ details on environment variables that Cargo reads.
 .sp
 .RS 4
 .nf
-cargo yank \-\-vers 1.0.7 foo
+cargo yank \-\-version 1.0.7 foo
 .fi
 .RE
 .RE

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -647,7 +647,7 @@ Caused by:
         "owner",
         "publish",
         "search",
-        "yank --vers 0.0.1",
+        "yank --version 0.0.1",
     ] {
         p.cargo(cmd)
             .arg("--registry")
@@ -726,12 +726,12 @@ fn no_api() {
         .with_stderr_contains(&err)
         .run();
 
-    p.cargo("yank --registry alternative --vers=0.0.1 bar")
+    p.cargo("yank --registry alternative --version=0.0.1 bar")
         .with_status(101)
         .with_stderr_contains(&err)
         .run();
 
-    p.cargo("yank --registry alternative --vers=0.0.1 bar")
+    p.cargo("yank --registry alternative --version=0.0.1 bar")
         .with_stderr_contains(&err)
         .with_status(101)
         .run();
@@ -1311,7 +1311,7 @@ Caused by:
 #[cargo_test]
 fn both_index_and_registry() {
     let p = project().file("src/lib.rs", "").build();
-    for cmd in &["publish", "owner", "search", "yank --vers 1.0.0"] {
+    for cmd in &["publish", "owner", "search", "yank --version 1.0.0"] {
         p.cargo(cmd)
             .arg("--registry=foo")
             .arg("--index=foo")

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -356,7 +356,7 @@ token for `crates-io` has been erased!
 fn yank() {
     let (p, t) = get_token_test();
 
-    p.cargo("yank --vers 0.1.0 --registry alternative -Z credential-process")
+    p.cargo("yank --version 0.1.0 --registry alternative -Z credential-process")
         .masquerade_as_nightly_cargo()
         .with_stderr(
             "\

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -338,7 +338,7 @@ want to simply build the package.
 #[cargo_test]
 fn bad_version() {
     pkg("foo", "0.0.1");
-    cargo_process("install foo --vers=0.2.0")
+    cargo_process("install foo --version=0.2.0")
         .with_status(101)
         .with_stderr(
             "\
@@ -942,7 +942,7 @@ fn list() {
 
     cargo_process("install --list").with_stdout("").run();
 
-    cargo_process("install bar --vers =0.2.1").run();
+    cargo_process("install bar --version =0.2.1").run();
     cargo_process("install foo").run();
     cargo_process("install --list")
         .with_stdout(

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -231,7 +231,7 @@ fn ambiguous_version_no_longer_allowed() {
     cargo_process("install foo --version=1.0")
         .with_stderr(
             "\
-[ERROR] the `--vers` provided, `1.0`, is not a valid semver version: cannot parse '1.0' as a semver
+[ERROR] the `--version` provided, `1.0`, is not a valid semver version: cannot parse '1.0' as a semver
 
 if you want to specify semver range, add an explicit qualifier, like ^1.0
 ",

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -32,9 +32,9 @@ fn simple() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank --vers 0.0.1 --token sekrit").run();
+    p.cargo("yank --version 0.0.1 --token sekrit").run();
 
-    p.cargo("yank --undo --vers 0.0.1 --token sekrit")
+    p.cargo("yank --undo --version 0.0.1 --token sekrit")
         .with_status(101)
         .with_stderr(
             "    Updating `[..]` index


### PR DESCRIPTION
### What does this PR try to resolve?

During the design conversations on cargo-add, we noticed:
- `cargo-install` has a public flag `--version` and an invisible alias `--vers`
- `cargo-yank` has a public flag `--vers`

This switches `cargo-yank` to publicly use `--version` and have an invisible alias
`--vers`, making it consistent with `cargo-install`.

### How should we test and review this PR?

This updated all tests to use the "recommended" flag.