### PR TITLE
Completion support for `cargo-add`

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -66,6 +66,26 @@ _cargo() {
         args)
             curcontext="${curcontext%:*}-${words[1]}:"
             case ${words[1]} in
+                add)
+                    _arguments -s -A "^--" $common $manifest $registry \
+                        {-F+,--features=}'[specify features to activate]:feature'
+                        "--default-features[enable the default features]"
+                        "--no-default-features[don't enable the default features]"
+                        "--optional[mark the dependency as optional]"
+                        "--no-optional[mark the dependency as required]"
+                        "--dev[add as a dev dependency]"
+                        "--build[add as a build dependency]"
+                        "--target=[add as a dependency to the given target platform]"
+                        "--rename=[rename the dependency]"
+                        "--dry-run[don't actually write the manifest]"
+                        '--branch=[branch to use when adding from git]:branch' \
+                        '--git=[specify URL from which to add the crate]:url:_urls' \
+                        '--path=[local filesystem path to crate to add]: :_directories' \
+                        '--rev=[specific commit to use when adding from git]:commit' \
+                        '--tag=[tag to use when adding from git]:tag' \
+                        '1: :_guard "^-*" "crate name"' \
+                        '*:args:_default'
+                        ;;
                 bench)
                     _arguments -s -A "^--" $common $parallel $features $msgfmt $triple $target $manifest \
                         "${command_scope_spec[@]}" \

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -48,6 +48,7 @@ _cargo()
 	local opt_targets="--lib --bin --bins --example --examples --test --tests --bench --benches --all-targets"
 
 	local opt___nocmd="$opt_common -V --version --list --explain"
+	local opt__add="$opt_common -p --package --features --default-features --no-default-features $opt_mani --optional --no-optional --rename --dry-run --path --git --branch --tag --rev --registry --dev --build --target"
 	local opt__bench="$opt_common $opt_pkg_spec $opt_feat $opt_mani $opt_lock $opt_parallel $opt_targets --message-format --target --no-run --no-fail-fast --target-dir"
 	local opt__build="$opt_common $opt_pkg_spec $opt_feat $opt_mani $opt_lock $opt_parallel $opt_targets --message-format --target --release --profile --target-dir"
 	local opt__b="$opt__build"


### PR DESCRIPTION
### What does this PR try to resolve?

cargo-add's PR was minimal to ensure we had settled on the CLI before
adding references to the CLI and have cascading churn.  This updates
bash and zsh completion to include cargo-add.

### How should we test and review this PR?

I am unsure how to handle testing of completions, so this is a
best-effort from looking at other completions and the docs.

### Additional information

To keep the PRs focused, I am submitting completions separate from documentation updates so one does not get blocked on the other and its easier to see all relevant parts and sign off on them.