### PR TITLE
Set cargo --version git hash length to 9

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -53,6 +53,7 @@ fn commit_info() {
         .arg("-1")
         .arg("--date=short")
         .arg("--format=%H %h %cd")
+        .arg("--abbrev=9")
         .output()
     {
         Ok(output) if output.status.success() => output,


### PR DESCRIPTION
#10323 changed how cargo captures the current git commit hash, which resulted in platform-dependent commit hash lengths.
This change sets the length to 9, which is consistent with rustc and previous releases of cargo.

Fixes #10547