### PR TITLE
Disallow setting registry tokens with --config

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1244,9 +1244,27 @@ impl Config {
                     );
                 }
 
-                let toml_v = toml::from_document(doc).with_context(|| {
+                let toml_v: toml::Value = toml::from_document(doc).with_context(|| {
                     format!("failed to parse value from --config argument `{arg}`")
                 })?;
+
+                if toml_v
+                    .get("registry")
+                    .and_then(|v| v.as_table())
+                    .and_then(|t| t.get("token"))
+                    .is_some()
+                {
+                    bail!("registry.token cannot be set through --config for security reasons");
+                } else if let Some((k, _)) = toml_v
+                    .get("registries")
+                    .and_then(|v| v.as_table())
+                    .and_then(|t| t.iter().find(|(_, v)| v.get("token").is_some()))
+                {
+                    bail!(
+                        "registries.{}.token cannot be set through --config for security reasons",
+                        k
+                    );
+                }
 
                 CV::from_toml(Definition::Cli, toml_v)
                     .with_context(|| format!("failed to convert --config argument `{arg}`"))?

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -369,6 +369,24 @@ b=2` was not a TOML dotted key expression (such as `build.jobs = 2`)",
 }
 
 #[cargo_test]
+fn no_disallowed_values() {
+    let config = ConfigBuilder::new()
+        .config_arg("registry.token=\"hello\"")
+        .build_err();
+    assert_error(
+        config.unwrap_err(),
+        "registry.token cannot be set through --config for security reasons",
+    );
+    let config = ConfigBuilder::new()
+        .config_arg("registries.crates-io.token=\"hello\"")
+        .build_err();
+    assert_error(
+        config.unwrap_err(),
+        "registries.crates-io.token cannot be set through --config for security reasons",
+    );
+}
+
+#[cargo_test]
 fn no_inline_table_value() {
     // Disallow inline tables
     let config = ConfigBuilder::new()


### PR DESCRIPTION
As per the concern `restricted-values` in
https://github.com/rust-lang/cargo/issues/7722#issuecomment-1101784126.

r? @ehuss 