### PR TITLE
Integrate snapbox in with cargo-test-support

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 anyhow = "1.0.34"
 cargo-test-macro = { path = "../cargo-test-macro" }
 cargo-util = { path = "../cargo-util" }
+snapbox = { version = "0.2.8", features = ["diff", "path"] }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 git2 = "0.14.2"

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -60,6 +60,7 @@ pub mod registry;
 pub mod tools;
 
 pub mod prelude {
+    pub use crate::CargoCommand;
     pub use crate::ChannelChanger;
     pub use crate::TestEnv;
 }
@@ -1226,6 +1227,19 @@ impl TestEnv for snapbox::cmd::Command {
     }
     fn env_remove(self, key: &str) -> Self {
         self.env_remove(key)
+    }
+}
+
+/// Test the cargo command
+pub trait CargoCommand {
+    fn cargo() -> Self;
+}
+
+impl CargoCommand for snapbox::cmd::Command {
+    fn cargo() -> Self {
+        Self::new(cargo_exe())
+            .with_assert(compare::assert())
+            .test_env()
     }
 }
 

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -61,6 +61,7 @@ pub mod tools;
 
 pub mod prelude {
     pub use crate::ChannelChanger;
+    pub use crate::TestEnv;
 }
 
 /*
@@ -1101,75 +1102,7 @@ pub fn process<T: AsRef<OsStr>>(t: T) -> ProcessBuilder {
 
 fn _process(t: &OsStr) -> ProcessBuilder {
     let mut p = ProcessBuilder::new(t);
-
-    // In general just clear out all cargo-specific configuration already in the
-    // environment. Our tests all assume a "default configuration" unless
-    // specified otherwise.
-    for (k, _v) in env::vars() {
-        if k.starts_with("CARGO_") {
-            p.env_remove(&k);
-        }
-    }
-    if env::var_os("RUSTUP_TOOLCHAIN").is_some() {
-        // Override the PATH to avoid executing the rustup wrapper thousands
-        // of times. This makes the testsuite run substantially faster.
-        lazy_static::lazy_static! {
-            static ref RUSTC_DIR: PathBuf = {
-                match ProcessBuilder::new("rustup")
-                    .args(&["which", "rustc"])
-                    .exec_with_output()
-                {
-                    Ok(output) => {
-                        let s = str::from_utf8(&output.stdout).expect("utf8").trim();
-                        let mut p = PathBuf::from(s);
-                        p.pop();
-                        p
-                    }
-                    Err(e) => {
-                        panic!("RUSTUP_TOOLCHAIN was set, but could not run rustup: {}", e);
-                    }
-                }
-            };
-        }
-        let path = env::var_os("PATH").unwrap_or_default();
-        let paths = env::split_paths(&path);
-        let new_path = env::join_paths(std::iter::once(RUSTC_DIR.clone()).chain(paths)).unwrap();
-        p.env("PATH", new_path);
-    }
-
-    p.cwd(&paths::root())
-        .env("HOME", paths::home())
-        .env("CARGO_HOME", paths::home().join(".cargo"))
-        .env("__CARGO_TEST_ROOT", paths::root())
-        // Force Cargo to think it's on the stable channel for all tests, this
-        // should hopefully not surprise us as we add cargo features over time and
-        // cargo rides the trains.
-        .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "stable")
-        // For now disable incremental by default as support hasn't ridden to the
-        // stable channel yet. Once incremental support hits the stable compiler we
-        // can switch this to one and then fix the tests.
-        .env("CARGO_INCREMENTAL", "0")
-        .env_remove("__CARGO_DEFAULT_LIB_METADATA")
-        .env_remove("RUSTC")
-        .env_remove("RUSTDOC")
-        .env_remove("RUSTC_WRAPPER")
-        .env_remove("RUSTFLAGS")
-        .env_remove("RUSTDOCFLAGS")
-        .env_remove("XDG_CONFIG_HOME") // see #2345
-        .env("GIT_CONFIG_NOSYSTEM", "1") // keep trying to sandbox ourselves
-        .env_remove("EMAIL")
-        .env_remove("USER") // not set on some rust-lang docker images
-        .env_remove("MFLAGS")
-        .env_remove("MAKEFLAGS")
-        .env_remove("GIT_AUTHOR_NAME")
-        .env_remove("GIT_AUTHOR_EMAIL")
-        .env_remove("GIT_COMMITTER_NAME")
-        .env_remove("GIT_COMMITTER_EMAIL")
-        .env_remove("MSYSTEM"); // assume cmd.exe everywhere on windows
-    if cfg!(target_os = "macos") {
-        // Work-around a bug in macOS 10.15, see `link_or_copy` for details.
-        p.env("__CARGO_COPY_DONT_LINK_DO_NOT_USE_THIS", "1");
-    }
+    p.cwd(&paths::root()).test_env();
     p
 }
 
@@ -1187,6 +1120,103 @@ impl ChannelChanger for &mut ProcessBuilder {
 impl ChannelChanger for snapbox::cmd::Command {
     fn masquerade_as_nightly_cargo(self) -> Self {
         self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
+    }
+}
+
+/// Establish a process's test environment
+pub trait TestEnv: Sized {
+    fn test_env(mut self) -> Self {
+        // In general just clear out all cargo-specific configuration already in the
+        // environment. Our tests all assume a "default configuration" unless
+        // specified otherwise.
+        for (k, _v) in env::vars() {
+            if k.starts_with("CARGO_") {
+                self = self.env_remove(&k);
+            }
+        }
+        if env::var_os("RUSTUP_TOOLCHAIN").is_some() {
+            // Override the PATH to avoid executing the rustup wrapper thousands
+            // of times. This makes the testsuite run substantially faster.
+            lazy_static::lazy_static! {
+                static ref RUSTC_DIR: PathBuf = {
+                    match ProcessBuilder::new("rustup")
+                        .args(&["which", "rustc"])
+                        .exec_with_output()
+                    {
+                        Ok(output) => {
+                            let s = str::from_utf8(&output.stdout).expect("utf8").trim();
+                            let mut p = PathBuf::from(s);
+                            p.pop();
+                            p
+                        }
+                        Err(e) => {
+                            panic!("RUSTUP_TOOLCHAIN was set, but could not run rustup: {}", e);
+                        }
+                    }
+                };
+            }
+            let path = env::var_os("PATH").unwrap_or_default();
+            let paths = env::split_paths(&path);
+            let new_path =
+                env::join_paths(std::iter::once(RUSTC_DIR.clone()).chain(paths)).unwrap();
+            self = self.env("PATH", new_path);
+        }
+
+        self = self
+            .env("HOME", paths::home())
+            .env("CARGO_HOME", paths::home().join(".cargo"))
+            .env("__CARGO_TEST_ROOT", paths::root())
+            // Force Cargo to think it's on the stable channel for all tests, this
+            // should hopefully not surprise us as we add cargo features over time and
+            // cargo rides the trains.
+            .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "stable")
+            // For now disable incremental by default as support hasn't ridden to the
+            // stable channel yet. Once incremental support hits the stable compiler we
+            // can switch this to one and then fix the tests.
+            .env("CARGO_INCREMENTAL", "0")
+            .env_remove("__CARGO_DEFAULT_LIB_METADATA")
+            .env_remove("RUSTC")
+            .env_remove("RUSTDOC")
+            .env_remove("RUSTC_WRAPPER")
+            .env_remove("RUSTFLAGS")
+            .env_remove("RUSTDOCFLAGS")
+            .env_remove("XDG_CONFIG_HOME") // see #2345
+            .env("GIT_CONFIG_NOSYSTEM", "1") // keep trying to sandbox ourselves
+            .env_remove("EMAIL")
+            .env_remove("USER") // not set on some rust-lang docker images
+            .env_remove("MFLAGS")
+            .env_remove("MAKEFLAGS")
+            .env_remove("GIT_AUTHOR_NAME")
+            .env_remove("GIT_AUTHOR_EMAIL")
+            .env_remove("GIT_COMMITTER_NAME")
+            .env_remove("GIT_COMMITTER_EMAIL")
+            .env_remove("MSYSTEM"); // assume cmd.exe everywhere on windows
+        if cfg!(target_os = "macos") {
+            // Work-around a bug in macOS 10.15, see `link_or_copy` for details.
+            self = self.env("__CARGO_COPY_DONT_LINK_DO_NOT_USE_THIS", "1");
+        }
+        self
+    }
+
+    fn env<S: AsRef<std::ffi::OsStr>>(self, key: &str, value: S) -> Self;
+    fn env_remove(self, key: &str) -> Self;
+}
+
+impl TestEnv for &mut ProcessBuilder {
+    fn env<S: AsRef<std::ffi::OsStr>>(self, key: &str, value: S) -> Self {
+        self.env(key, value)
+    }
+    fn env_remove(self, key: &str) -> Self {
+        self.env_remove(key)
+    }
+}
+
+impl TestEnv for snapbox::cmd::Command {
+    fn env<S: AsRef<std::ffi::OsStr>>(self, key: &str, value: S) -> Self {
+        self.env(key, value)
+    }
+    fn env_remove(self, key: &str) -> Self {
+        self.env_remove(key)
     }
 }
 

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -156,10 +156,16 @@ impl SymlinkBuilder {
     }
 }
 
+/// A cargo project to run tests against.
+///
+/// See [`ProjectBuilder`] or [`Project::from_template`] to get started.
 pub struct Project {
     root: PathBuf,
 }
 
+/// Create a project to run tests against
+///
+/// The project can be constructed programmatically or from the filesystem with [`Project::from_template`]
 #[must_use]
 pub struct ProjectBuilder {
     root: Project,
@@ -284,6 +290,14 @@ impl ProjectBuilder {
 }
 
 impl Project {
+    /// Copy the test project from a fixed state
+    pub fn from_template(template_path: impl AsRef<std::path::Path>) -> Self {
+        let root = paths::root();
+        let project_root = root.join("case");
+        snapbox::path::copy_template(template_path.as_ref(), &project_root).unwrap();
+        Self { root: project_root }
+    }
+
     /// Root of the project, ex: `/path/to/cargo/target/cit/t0/foo`
     pub fn root(&self) -> PathBuf {
         self.root.clone()

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -470,24 +470,8 @@ pub fn main_file(println: &str, deps: &[&str]) -> String {
     buf
 }
 
-// Path to cargo executables
-pub fn cargo_dir() -> PathBuf {
-    env::var_os("CARGO_BIN_PATH")
-        .map(PathBuf::from)
-        .or_else(|| {
-            env::current_exe().ok().map(|mut path| {
-                path.pop();
-                if path.ends_with("deps") {
-                    path.pop();
-                }
-                path
-            })
-        })
-        .unwrap_or_else(|| panic!("CARGO_BIN_PATH wasn't set. Cannot continue running test"))
-}
-
 pub fn cargo_exe() -> PathBuf {
-    cargo_dir().join(format!("cargo{}", env::consts::EXE_SUFFIX))
+    snapbox::cmd::cargo_bin("cargo")
 }
 
 /// This is the raw output from the process.

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1163,6 +1163,7 @@ pub trait TestEnv: Sized {
         }
 
         self = self
+            .current_dir(&paths::root())
             .env("HOME", paths::home())
             .env("CARGO_HOME", paths::home().join(".cargo"))
             .env("__CARGO_TEST_ROOT", paths::root())
@@ -1198,11 +1199,16 @@ pub trait TestEnv: Sized {
         self
     }
 
+    fn current_dir<S: AsRef<std::path::Path>>(self, path: S) -> Self;
     fn env<S: AsRef<std::ffi::OsStr>>(self, key: &str, value: S) -> Self;
     fn env_remove(self, key: &str) -> Self;
 }
 
 impl TestEnv for &mut ProcessBuilder {
+    fn current_dir<S: AsRef<std::path::Path>>(self, path: S) -> Self {
+        let path = path.as_ref();
+        self.cwd(path)
+    }
     fn env<S: AsRef<std::ffi::OsStr>>(self, key: &str, value: S) -> Self {
         self.env(key, value)
     }
@@ -1212,6 +1218,9 @@ impl TestEnv for &mut ProcessBuilder {
 }
 
 impl TestEnv for snapbox::cmd::Command {
+    fn current_dir<S: AsRef<std::path::Path>>(self, path: S) -> Self {
+        self.current_dir(path)
+    }
     fn env<S: AsRef<std::ffi::OsStr>>(self, key: &str, value: S) -> Self {
         self.env(key, value)
     }

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -59,6 +59,10 @@ pub mod publish;
 pub mod registry;
 pub mod tools;
 
+pub mod prelude {
+    pub use crate::ChannelChanger;
+}
+
 /*
  *
  * ===== Builders =====
@@ -1169,12 +1173,19 @@ fn _process(t: &OsStr) -> ProcessBuilder {
     p
 }
 
-pub trait ChannelChanger: Sized {
-    fn masquerade_as_nightly_cargo(&mut self) -> &mut Self;
+/// Enable nightly features for testing
+pub trait ChannelChanger {
+    fn masquerade_as_nightly_cargo(self) -> Self;
 }
 
-impl ChannelChanger for ProcessBuilder {
-    fn masquerade_as_nightly_cargo(&mut self) -> &mut Self {
+impl ChannelChanger for &mut ProcessBuilder {
+    fn masquerade_as_nightly_cargo(self) -> Self {
+        self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
+    }
+}
+
+impl ChannelChanger for snapbox::cmd::Command {
+    fn masquerade_as_nightly_cargo(self) -> Self {
         self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
     }
 }

--- a/tests/snapshots/add/invalid_vers.stderr
+++ b/tests/snapshots/add/invalid_vers.stderr
@@ -1,4 +1,4 @@
-error: invalid version requirement `invalid version string`
+error: invalid version requirement `invalid-version-string`
 
 Caused by:
   unexpected character 'i' while parsing major version number

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -1,6 +1,4 @@
-pub fn cargo_exe() -> &'static std::path::Path {
-    snapbox::cmd::cargo_bin!("cargo")
-}
+use cargo_test_support::cargo_exe;
 
 pub fn cargo_command() -> snapbox::cmd::Command {
     let mut cmd = snapbox::cmd::Command::new(cargo_exe()).with_assert(assert());

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -4,51 +4,9 @@ use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
 pub fn cargo_command() -> snapbox::cmd::Command {
-    let mut cmd = snapbox::cmd::Command::new(cargo_exe()).with_assert(assert());
-
-    // In general just clear out all cargo-specific configuration already in the
-    // environment. Our tests all assume a "default configuration" unless
-    // specified otherwise.
-    for (k, _v) in std::env::vars() {
-        if k.starts_with("CARGO_") {
-            cmd = cmd.env_remove(&k);
-        }
-    }
-
-    cmd = cmd
-        .env("HOME", cargo_test_support::paths::home())
-        .env(
-            "CARGO_HOME",
-            cargo_test_support::paths::home().join(".cargo"),
-        )
-        .env("__CARGO_TEST_ROOT", cargo_test_support::paths::root())
-        // Force Cargo to think it's on the stable channel for all tests, this
-        // should hopefully not surprise us as we add cargo features over time and
-        // cargo rides the trains.
-        .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "stable")
-        // For now disable incremental by default as support hasn't ridden to the
-        // stable channel yet. Once incremental support hits the stable compiler we
-        // can switch this to one and then fix the tests.
-        .env("CARGO_INCREMENTAL", "0")
-        .env_remove("__CARGO_DEFAULT_LIB_METADATA")
-        .env_remove("RUSTC")
-        .env_remove("RUSTDOC")
-        .env_remove("RUSTC_WRAPPER")
-        .env_remove("RUSTFLAGS")
-        .env_remove("RUSTDOCFLAGS")
-        .env_remove("XDG_CONFIG_HOME") // see #2345
-        .env("GIT_CONFIG_NOSYSTEM", "1") // keep trying to sandbox ourselves
-        .env_remove("EMAIL")
-        .env_remove("USER") // not set on some rust-lang docker images
-        .env_remove("MFLAGS")
-        .env_remove("MAKEFLAGS")
-        .env_remove("GIT_AUTHOR_NAME")
-        .env_remove("GIT_AUTHOR_EMAIL")
-        .env_remove("GIT_COMMITTER_NAME")
-        .env_remove("GIT_COMMITTER_EMAIL")
-        .env_remove("MSYSTEM"); // assume cmd.exe everywhere on windows
-
-    cmd
+    snapbox::cmd::Command::new(cargo_exe())
+        .with_assert(assert())
+        .test_env()
 }
 
 fn init_registry() {

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -1,5 +1,6 @@
 use cargo_test_support::cargo_exe;
 use cargo_test_support::compare::assert;
+use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
 pub fn cargo_command() -> snapbox::cmd::Command {
@@ -48,16 +49,6 @@ pub fn cargo_command() -> snapbox::cmd::Command {
         .env_remove("MSYSTEM"); // assume cmd.exe everywhere on windows
 
     cmd
-}
-
-pub trait CommandExt {
-    fn masquerade_as_nightly_cargo(self) -> Self;
-}
-
-impl CommandExt for snapbox::cmd::Command {
-    fn masquerade_as_nightly_cargo(self) -> Self {
-        self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
-    }
 }
 
 fn init_registry() {

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -1,5 +1,6 @@
 use cargo_test_support::cargo_exe;
 use cargo_test_support::compare::assert;
+use cargo_test_support::Project;
 
 pub fn cargo_command() -> snapbox::cmd::Command {
     let mut cmd = snapbox::cmd::Command::new(cargo_exe()).with_assert(assert());
@@ -57,13 +58,6 @@ impl CommandExt for snapbox::cmd::Command {
     fn masquerade_as_nightly_cargo(self) -> Self {
         self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
     }
-}
-
-pub fn project_from_template(template_path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
-    let root = cargo_test_support::paths::root();
-    let project_root = root.join("case");
-    snapbox::path::copy_template(template_path.as_ref(), &project_root).unwrap();
-    project_root
 }
 
 fn init_registry() {
@@ -152,7 +146,8 @@ fn add_registry_packages(alt: bool) {
 #[cargo_test]
 fn add_basic() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/add_basic.in");
+    let project = Project::from_template("tests/snapshots/add/add_basic.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -170,7 +165,8 @@ fn add_basic() {
 #[cargo_test]
 fn add_multiple() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/add_multiple.in");
+    let project = Project::from_template("tests/snapshots/add/add_multiple.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -188,7 +184,8 @@ fn add_multiple() {
 #[cargo_test]
 fn quiet() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/quiet.in");
+    let project = Project::from_template("tests/snapshots/add/quiet.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -206,7 +203,8 @@ fn quiet() {
 #[cargo_test]
 fn add_normalized_name_external() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/add_normalized_name_external.in");
+    let project = Project::from_template("tests/snapshots/add/add_normalized_name_external.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -227,7 +225,8 @@ fn add_normalized_name_external() {
 #[cargo_test]
 fn infer_prerelease() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/infer_prerelease.in");
+    let project = Project::from_template("tests/snapshots/add/infer_prerelease.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -245,7 +244,8 @@ fn infer_prerelease() {
 #[cargo_test]
 fn build() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/build.in");
+    let project = Project::from_template("tests/snapshots/add/build.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -263,8 +263,8 @@ fn build() {
 #[cargo_test]
 fn build_prefer_existing_version() {
     init_alt_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/build_prefer_existing_version.in");
+    let project = Project::from_template("tests/snapshots/add/build_prefer_existing_version.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -285,7 +285,8 @@ fn build_prefer_existing_version() {
 #[cargo_test]
 fn default_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/default_features.in");
+    let project = Project::from_template("tests/snapshots/add/default_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -303,7 +304,8 @@ fn default_features() {
 #[cargo_test]
 fn require_weak() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/require_weak.in");
+    let project = Project::from_template("tests/snapshots/add/require_weak.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -321,7 +323,8 @@ fn require_weak() {
 #[cargo_test]
 fn detect_workspace_inherit() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/detect_workspace_inherit.in");
+    let project = Project::from_template("tests/snapshots/add/detect_workspace_inherit.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -343,8 +346,9 @@ fn detect_workspace_inherit() {
 #[cargo_test]
 fn detect_workspace_inherit_features() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/detect_workspace_inherit_features.in");
+    let project =
+        Project::from_template("tests/snapshots/add/detect_workspace_inherit_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -366,8 +370,9 @@ fn detect_workspace_inherit_features() {
 #[cargo_test]
 fn detect_workspace_inherit_optional() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/detect_workspace_inherit_optional.in");
+    let project =
+        Project::from_template("tests/snapshots/add/detect_workspace_inherit_optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -389,7 +394,8 @@ fn detect_workspace_inherit_optional() {
 #[cargo_test]
 fn dev() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/dev.in");
+    let project = Project::from_template("tests/snapshots/add/dev.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -407,7 +413,8 @@ fn dev() {
 #[cargo_test]
 fn dev_build_conflict() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/dev_build_conflict.in");
+    let project = Project::from_template("tests/snapshots/add/dev_build_conflict.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -425,7 +432,8 @@ fn dev_build_conflict() {
 #[cargo_test]
 fn dev_prefer_existing_version() {
     init_alt_registry();
-    let project_root = project_from_template("tests/snapshots/add/dev_prefer_existing_version.in");
+    let project = Project::from_template("tests/snapshots/add/dev_prefer_existing_version.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -446,7 +454,8 @@ fn dev_prefer_existing_version() {
 #[cargo_test]
 fn dry_run() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/dry_run.in");
+    let project = Project::from_template("tests/snapshots/add/dry_run.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -464,7 +473,8 @@ fn dry_run() {
 #[cargo_test]
 fn features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/features.in");
+    let project = Project::from_template("tests/snapshots/add/features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -482,7 +492,8 @@ fn features() {
 #[cargo_test]
 fn features_empty() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/features_empty.in");
+    let project = Project::from_template("tests/snapshots/add/features_empty.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -500,8 +511,8 @@ fn features_empty() {
 #[cargo_test]
 fn features_multiple_occurrences() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/features_multiple_occurrences.in");
+    let project = Project::from_template("tests/snapshots/add/features_multiple_occurrences.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -522,7 +533,8 @@ fn features_multiple_occurrences() {
 #[cargo_test]
 fn features_preserve() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/features_preserve.in");
+    let project = Project::from_template("tests/snapshots/add/features_preserve.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -540,7 +552,8 @@ fn features_preserve() {
 #[cargo_test]
 fn features_spaced_values() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/features_spaced_values.in");
+    let project = Project::from_template("tests/snapshots/add/features_spaced_values.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -561,7 +574,8 @@ fn features_spaced_values() {
 #[cargo_test]
 fn features_unknown() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/features_unknown.in");
+    let project = Project::from_template("tests/snapshots/add/features_unknown.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -579,7 +593,8 @@ fn features_unknown() {
 #[cargo_test]
 fn git() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git.in");
+    let project = Project::from_template("tests/snapshots/add/git.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -606,7 +621,8 @@ fn git() {
 #[cargo_test]
 fn git_inferred_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_inferred_name.in");
+    let project = Project::from_template("tests/snapshots/add/git_inferred_name.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -633,7 +649,8 @@ fn git_inferred_name() {
 #[cargo_test]
 fn git_inferred_name_multiple() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_inferred_name_multiple.in");
+    let project = Project::from_template("tests/snapshots/add/git_inferred_name_multiple.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -668,7 +685,8 @@ fn git_inferred_name_multiple() {
 #[cargo_test]
 fn git_normalized_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_normalized_name.in");
+    let project = Project::from_template("tests/snapshots/add/git_normalized_name.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -695,7 +713,8 @@ fn git_normalized_name() {
 #[cargo_test]
 fn invalid_git_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_git_name.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_git_name.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -722,7 +741,8 @@ fn invalid_git_name() {
 #[cargo_test]
 fn git_branch() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_branch.in");
+    let project = Project::from_template("tests/snapshots/add/git_branch.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let (git_dep, git_repo) = cargo_test_support::git::new_repo("git-package", |project| {
         project
@@ -752,7 +772,8 @@ fn git_branch() {
 #[cargo_test]
 fn git_conflicts_namever() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_conflicts_namever.in");
+    let project = Project::from_template("tests/snapshots/add/git_conflicts_namever.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -777,7 +798,8 @@ fn git_conflicts_namever() {
 #[cargo_test]
 fn git_registry() {
     init_alt_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_registry.in");
+    let project = Project::from_template("tests/snapshots/add/git_registry.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("versioned-package", |project| {
         project
@@ -810,7 +832,8 @@ fn git_registry() {
 #[cargo_test]
 fn git_dev() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_dev.in");
+    let project = Project::from_template("tests/snapshots/add/git_dev.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -837,7 +860,8 @@ fn git_dev() {
 #[cargo_test]
 fn git_rev() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_rev.in");
+    let project = Project::from_template("tests/snapshots/add/git_rev.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let (git_dep, git_repo) = cargo_test_support::git::new_repo("git-package", |project| {
         project
@@ -866,7 +890,8 @@ fn git_rev() {
 #[cargo_test]
 fn git_tag() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_tag.in");
+    let project = Project::from_template("tests/snapshots/add/git_tag.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let (git_dep, git_repo) = cargo_test_support::git::new_repo("git-package", |project| {
         project
@@ -895,7 +920,8 @@ fn git_tag() {
 #[cargo_test]
 fn path() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/path.in");
+    let project = Project::from_template("tests/snapshots/add/path.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -917,7 +943,8 @@ fn path() {
 #[cargo_test]
 fn path_inferred_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/path_inferred_name.in");
+    let project = Project::from_template("tests/snapshots/add/path_inferred_name.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -939,8 +966,9 @@ fn path_inferred_name() {
 #[cargo_test]
 fn path_inferred_name_conflicts_full_feature() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/path_inferred_name_conflicts_full_feature.in");
+    let project =
+        Project::from_template("tests/snapshots/add/path_inferred_name_conflicts_full_feature.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -963,7 +991,8 @@ fn path_inferred_name_conflicts_full_feature() {
 #[cargo_test]
 fn path_normalized_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/path_normalized_name.in");
+    let project = Project::from_template("tests/snapshots/add/path_normalized_name.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -988,7 +1017,8 @@ fn path_normalized_name() {
 #[cargo_test]
 fn invalid_path_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_path_name.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_path_name.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -1006,7 +1036,8 @@ fn invalid_path_name() {
 #[cargo_test]
 fn path_dev() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/path_dev.in");
+    let project = Project::from_template("tests/snapshots/add/path_dev.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -1029,7 +1060,8 @@ fn path_dev() {
 #[cargo_test]
 fn invalid_arg() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_arg.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_arg.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1047,7 +1079,8 @@ fn invalid_arg() {
 #[cargo_test]
 fn invalid_git_external() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_git_external.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_git_external.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_url = url::Url::from_directory_path(cwd.join("does-not-exist"))
         .unwrap()
@@ -1070,8 +1103,8 @@ fn invalid_git_external() {
 
 #[cargo_test]
 fn invalid_key_inherit_dependency() {
-    let project_root =
-        project_from_template("tests/snapshots/add/invalid_key_inherit_dependency.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_key_inherit_dependency.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1092,8 +1125,9 @@ fn invalid_key_inherit_dependency() {
 
 #[cargo_test]
 fn invalid_key_rename_inherit_dependency() {
-    let project_root =
-        project_from_template("tests/snapshots/add/invalid_key_rename_inherit_dependency.in");
+    let project =
+        Project::from_template("tests/snapshots/add/invalid_key_rename_inherit_dependency.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1114,8 +1148,9 @@ fn invalid_key_rename_inherit_dependency() {
 
 #[cargo_test]
 fn invalid_key_overwrite_inherit_dependency() {
-    let project_root =
-        project_from_template("tests/snapshots/add/invalid_key_overwrite_inherit_dependency.in");
+    let project =
+        Project::from_template("tests/snapshots/add/invalid_key_overwrite_inherit_dependency.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1137,7 +1172,8 @@ fn invalid_key_overwrite_inherit_dependency() {
 #[cargo_test]
 fn invalid_path() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_path.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_path.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1159,7 +1195,8 @@ fn invalid_path() {
 #[cargo_test]
 fn invalid_path_self() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_path_self.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_path_self.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1177,7 +1214,8 @@ fn invalid_path_self() {
 #[cargo_test]
 fn invalid_manifest() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_manifest.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_manifest.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1195,7 +1233,8 @@ fn invalid_manifest() {
 #[cargo_test]
 fn invalid_name_external() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_name_external.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_name_external.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1216,7 +1255,8 @@ fn invalid_name_external() {
 #[cargo_test]
 fn invalid_target_empty() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_target_empty.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_target_empty.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1237,7 +1277,8 @@ fn invalid_target_empty() {
 #[cargo_test]
 fn invalid_vers() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/invalid_vers.in");
+    let project = Project::from_template("tests/snapshots/add/invalid_vers.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1255,7 +1296,8 @@ fn invalid_vers() {
 #[cargo_test]
 fn list_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/list_features.in");
+    let project = Project::from_template("tests/snapshots/add/list_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1273,7 +1315,8 @@ fn list_features() {
 #[cargo_test]
 fn list_features_path() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/list_features_path.in");
+    let project = Project::from_template("tests/snapshots/add/list_features_path.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -1291,8 +1334,8 @@ fn list_features_path() {
 #[cargo_test]
 fn list_features_path_no_default() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/list_features_path_no_default.in");
+    let project = Project::from_template("tests/snapshots/add/list_features_path_no_default.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -1318,7 +1361,8 @@ fn list_features_path_no_default() {
 #[cargo_test]
 fn manifest_path_package() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/manifest_path_package.in");
+    let project = Project::from_template("tests/snapshots/add/manifest_path_package.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1344,7 +1388,8 @@ fn manifest_path_package() {
 
 #[cargo_test]
 fn merge_activated_features() {
-    let project_root = project_from_template("tests/snapshots/add/merge_activated_features.in");
+    let project = Project::from_template("tests/snapshots/add/merge_activated_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1366,8 +1411,8 @@ fn merge_activated_features() {
 #[cargo_test]
 fn multiple_conflicts_with_features() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/multiple_conflicts_with_features.in");
+    let project = Project::from_template("tests/snapshots/add/multiple_conflicts_with_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1388,7 +1433,8 @@ fn multiple_conflicts_with_features() {
 #[cargo_test]
 fn git_multiple_names() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/git_multiple_names.in");
+    let project = Project::from_template("tests/snapshots/add/git_multiple_names.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("git-package", |project| {
         project
@@ -1420,8 +1466,8 @@ fn git_multiple_names() {
 #[cargo_test]
 fn multiple_conflicts_with_rename() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/multiple_conflicts_with_rename.in");
+    let project = Project::from_template("tests/snapshots/add/multiple_conflicts_with_rename.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1442,7 +1488,8 @@ fn multiple_conflicts_with_rename() {
 #[cargo_test]
 fn namever() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/namever.in");
+    let project = Project::from_template("tests/snapshots/add/namever.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1460,7 +1507,8 @@ fn namever() {
 #[cargo_test]
 fn no_args() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/no_args.in");
+    let project = Project::from_template("tests/snapshots/add/no_args.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1477,7 +1525,8 @@ fn no_args() {
 #[cargo_test]
 fn no_default_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/no_default_features.in");
+    let project = Project::from_template("tests/snapshots/add/no_default_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1495,7 +1544,8 @@ fn no_default_features() {
 #[cargo_test]
 fn no_optional() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/no_optional.in");
+    let project = Project::from_template("tests/snapshots/add/no_optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1513,7 +1563,8 @@ fn no_optional() {
 #[cargo_test]
 fn optional() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/optional.in");
+    let project = Project::from_template("tests/snapshots/add/optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1531,7 +1582,8 @@ fn optional() {
 #[cargo_test]
 fn overwrite_default_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_default_features.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_default_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1552,9 +1604,10 @@ fn overwrite_default_features() {
 #[cargo_test]
 fn overwrite_default_features_with_no_default_features() {
     init_registry();
-    let project_root = project_from_template(
+    let project = Project::from_template(
         "tests/snapshots/add/overwrite_default_features_with_no_default_features.in",
     );
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1579,7 +1632,8 @@ fn overwrite_default_features_with_no_default_features() {
 #[cargo_test]
 fn overwrite_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_features.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1597,7 +1651,8 @@ fn overwrite_features() {
 #[cargo_test]
 fn overwrite_git_with_path() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_git_with_path.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_git_with_path.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -1622,7 +1677,8 @@ fn overwrite_git_with_path() {
 #[cargo_test]
 fn overwrite_inline_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_inline_features.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_inline_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1648,8 +1704,8 @@ fn overwrite_inline_features() {
 
 #[cargo_test]
 fn overwrite_inherit_features_noop() {
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_inherit_features_noop.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_inherit_features_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1671,7 +1727,8 @@ fn overwrite_inherit_features_noop() {
 #[cargo_test]
 fn overwrite_inherit_noop() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_inherit_noop.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_inherit_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1693,8 +1750,8 @@ fn overwrite_inherit_noop() {
 #[cargo_test]
 fn overwrite_inherit_optional_noop() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_inherit_optional_noop.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_inherit_optional_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1716,7 +1773,8 @@ fn overwrite_inherit_optional_noop() {
 #[cargo_test]
 fn overwrite_name_dev_noop() {
     init_alt_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_name_dev_noop.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_name_dev_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1737,7 +1795,8 @@ fn overwrite_name_dev_noop() {
 #[cargo_test]
 fn overwrite_name_noop() {
     init_alt_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_name_noop.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_name_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1755,8 +1814,8 @@ fn overwrite_name_noop() {
 #[cargo_test]
 fn overwrite_no_default_features() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_no_default_features.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_no_default_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1777,9 +1836,10 @@ fn overwrite_no_default_features() {
 #[cargo_test]
 fn overwrite_no_default_features_with_default_features() {
     init_registry();
-    let project_root = project_from_template(
+    let project = Project::from_template(
         "tests/snapshots/add/overwrite_no_default_features_with_default_features.in",
     );
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1804,7 +1864,8 @@ fn overwrite_no_default_features_with_default_features() {
 #[cargo_test]
 fn overwrite_no_optional() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_no_optional.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_no_optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1825,8 +1886,9 @@ fn overwrite_no_optional() {
 #[cargo_test]
 fn overwrite_no_optional_with_optional() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_no_optional_with_optional.in");
+    let project =
+        Project::from_template("tests/snapshots/add/overwrite_no_optional_with_optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1847,7 +1909,8 @@ fn overwrite_no_optional_with_optional() {
 #[cargo_test]
 fn overwrite_optional() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_optional.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1865,8 +1928,9 @@ fn overwrite_optional() {
 #[cargo_test]
 fn overwrite_optional_with_no_optional() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_optional_with_no_optional.in");
+    let project =
+        Project::from_template("tests/snapshots/add/overwrite_optional_with_no_optional.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1887,7 +1951,8 @@ fn overwrite_optional_with_no_optional() {
 #[cargo_test]
 fn overwrite_path_noop() {
     init_alt_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_path_noop.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_path_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1905,7 +1970,8 @@ fn overwrite_path_noop() {
 #[cargo_test]
 fn overwrite_path_with_version() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_path_with_version.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_path_with_version.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -1926,8 +1992,8 @@ fn overwrite_path_with_version() {
 #[cargo_test]
 fn overwrite_rename_with_no_rename() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_rename_with_no_rename.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_rename_with_no_rename.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1948,7 +2014,8 @@ fn overwrite_rename_with_no_rename() {
 #[cargo_test]
 fn overwrite_rename_with_rename() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_rename_with_rename.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_rename_with_rename.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1969,7 +2036,8 @@ fn overwrite_rename_with_rename() {
 #[cargo_test]
 fn change_rename_target() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/change_rename_target.in");
+    let project = Project::from_template("tests/snapshots/add/change_rename_target.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -1990,8 +2058,9 @@ fn change_rename_target() {
 #[cargo_test]
 fn overwrite_rename_with_rename_noop() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_rename_with_rename_noop.in");
+    let project =
+        Project::from_template("tests/snapshots/add/overwrite_rename_with_rename_noop.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2012,7 +2081,8 @@ fn overwrite_rename_with_rename_noop() {
 #[cargo_test]
 fn overwrite_version_with_git() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_version_with_git.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_version_with_git.in");
+    let project_root = project.root();
     let cwd = &project_root;
     let git_dep = cargo_test_support::git::new("versioned-package", |project| {
         project
@@ -2042,7 +2112,8 @@ fn overwrite_version_with_git() {
 #[cargo_test]
 fn overwrite_version_with_path() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_version_with_path.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_version_with_path.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -2067,7 +2138,8 @@ fn overwrite_version_with_path() {
 #[cargo_test]
 fn overwrite_with_rename() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_with_rename.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_with_rename.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2088,7 +2160,8 @@ fn overwrite_with_rename() {
 #[cargo_test]
 fn overwrite_workspace_dep() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/overwrite_workspace_dep.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_workspace_dep.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2110,8 +2183,8 @@ fn overwrite_workspace_dep() {
 #[cargo_test]
 fn overwrite_workspace_dep_features() {
     init_registry();
-    let project_root =
-        project_from_template("tests/snapshots/add/overwrite_workspace_dep_features.in");
+    let project = Project::from_template("tests/snapshots/add/overwrite_workspace_dep_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2133,7 +2206,8 @@ fn overwrite_workspace_dep_features() {
 #[cargo_test]
 fn preserve_sorted() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/preserve_sorted.in");
+    let project = Project::from_template("tests/snapshots/add/preserve_sorted.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2151,7 +2225,8 @@ fn preserve_sorted() {
 #[cargo_test]
 fn preserve_unsorted() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/preserve_unsorted.in");
+    let project = Project::from_template("tests/snapshots/add/preserve_unsorted.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2169,7 +2244,8 @@ fn preserve_unsorted() {
 #[cargo_test]
 fn registry() {
     init_alt_registry();
-    let project_root = project_from_template("tests/snapshots/add/registry.in");
+    let project = Project::from_template("tests/snapshots/add/registry.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2187,7 +2263,8 @@ fn registry() {
 #[cargo_test]
 fn rename() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/rename.in");
+    let project = Project::from_template("tests/snapshots/add/rename.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2205,7 +2282,8 @@ fn rename() {
 #[cargo_test]
 fn target() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/target.in");
+    let project = Project::from_template("tests/snapshots/add/target.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2228,7 +2306,8 @@ fn target() {
 #[cargo_test]
 fn target_cfg() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/target_cfg.in");
+    let project = Project::from_template("tests/snapshots/add/target_cfg.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2245,7 +2324,8 @@ fn target_cfg() {
 
 #[cargo_test]
 fn unknown_inherited_feature() {
-    let project_root = project_from_template("tests/snapshots/add/unknown_inherited_feature.in");
+    let project = Project::from_template("tests/snapshots/add/unknown_inherited_feature.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2267,7 +2347,8 @@ fn unknown_inherited_feature() {
 #[cargo_test]
 fn vers() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/vers.in");
+    let project = Project::from_template("tests/snapshots/add/vers.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2285,7 +2366,8 @@ fn vers() {
 #[cargo_test]
 fn workspace_path() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/workspace_path.in");
+    let project = Project::from_template("tests/snapshots/add/workspace_path.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -2307,7 +2389,8 @@ fn workspace_path() {
 #[cargo_test]
 fn workspace_path_dev() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/workspace_path_dev.in");
+    let project = Project::from_template("tests/snapshots/add/workspace_path_dev.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -2330,7 +2413,8 @@ fn workspace_path_dev() {
 #[cargo_test]
 fn workspace_name() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/workspace_name.in");
+    let project = Project::from_template("tests/snapshots/add/workspace_name.in");
+    let project_root = project.root();
     let cwd = project_root.join("primary");
 
     cargo_command()
@@ -2348,7 +2432,8 @@ fn workspace_name() {
 #[cargo_test]
 fn deprecated_default_features() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/deprecated_default_features.in");
+    let project = Project::from_template("tests/snapshots/add/deprecated_default_features.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()
@@ -2369,7 +2454,8 @@ fn deprecated_default_features() {
 #[cargo_test]
 fn deprecated_section() {
     init_registry();
-    let project_root = project_from_template("tests/snapshots/add/deprecated_section.in");
+    let project = Project::from_template("tests/snapshots/add/deprecated_section.in");
+    let project_root = project.root();
     let cwd = &project_root;
 
     cargo_command()

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -1,4 +1,5 @@
 use cargo_test_support::cargo_exe;
+use cargo_test_support::compare::assert;
 
 pub fn cargo_command() -> snapbox::cmd::Command {
     let mut cmd = snapbox::cmd::Command::new(cargo_exe()).with_assert(assert());
@@ -63,28 +64,6 @@ pub fn project_from_template(template_path: impl AsRef<std::path::Path>) -> std:
     let project_root = root.join("case");
     snapbox::path::copy_template(template_path.as_ref(), &project_root).unwrap();
     project_root
-}
-
-pub fn assert() -> snapbox::Assert {
-    let root = cargo_test_support::paths::root();
-    // Use `from_file_path` instead of `from_dir_path` so the trailing slash is
-    // put in the users output, rather than hidden in the variable
-    let root_url = url::Url::from_file_path(&root).unwrap().to_string();
-    let root = root.display().to_string();
-
-    let mut subs = snapbox::Substitutions::new();
-    subs.extend([
-        (
-            "[EXE]",
-            std::borrow::Cow::Borrowed(std::env::consts::EXE_SUFFIX),
-        ),
-        ("[ROOT]", std::borrow::Cow::Owned(root)),
-        ("[ROOTURL]", std::borrow::Cow::Owned(root_url)),
-    ])
-    .unwrap();
-    snapbox::Assert::new()
-        .action_env(snapbox::DEFAULT_ACTION_ENV)
-        .substitutions(subs)
 }
 
 fn init_registry() {

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -94,7 +94,7 @@ fn add_basic() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package"])
+        .arg_line("my-package")
         .current_dir(cwd)
         .assert()
         .success()
@@ -113,7 +113,7 @@ fn add_multiple() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2"])
+        .arg_line("my-package1 my-package2")
         .current_dir(cwd)
         .assert()
         .success()
@@ -132,7 +132,7 @@ fn quiet() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["--quiet", "your-face"])
+        .arg_line("--quiet your-face")
         .current_dir(cwd)
         .assert()
         .success()
@@ -151,7 +151,7 @@ fn add_normalized_name_external() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["linked_hash_map", "Inflector"])
+        .arg_line("linked_hash_map Inflector")
         .current_dir(cwd)
         .assert()
         .success()
@@ -173,7 +173,7 @@ fn infer_prerelease() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["prerelease_only"])
+        .arg_line("prerelease_only")
         .current_dir(cwd)
         .assert()
         .success()
@@ -192,7 +192,7 @@ fn build() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["--build", "my-build-package1", "my-build-package2"])
+        .arg_line("--build my-build-package1 my-build-package2")
         .current_dir(cwd)
         .assert()
         .success()
@@ -211,7 +211,7 @@ fn build_prefer_existing_version() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["cargo-list-test-fixture-dependency", "--build"])
+        .arg_line("cargo-list-test-fixture-dependency --build")
         .current_dir(cwd)
         .assert()
         .success()
@@ -233,7 +233,7 @@ fn default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--default-features"])
+        .arg_line("my-package1 my-package2@0.4.1 --default-features")
         .current_dir(cwd)
         .assert()
         .success()
@@ -252,7 +252,7 @@ fn require_weak() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--no-optional"])
+        .arg_line("your-face --no-optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -342,7 +342,7 @@ fn dev() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["--dev", "my-dev-package1", "my-dev-package2"])
+        .arg_line("--dev my-dev-package1 my-dev-package2")
         .current_dir(cwd)
         .assert()
         .success()
@@ -361,7 +361,7 @@ fn dev_build_conflict() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package", "--dev", "--build"])
+        .arg_line("my-package --dev --build")
         .current_dir(cwd)
         .assert()
         .code(1)
@@ -380,7 +380,7 @@ fn dev_prefer_existing_version() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["cargo-list-test-fixture-dependency", "--dev"])
+        .arg_line("cargo-list-test-fixture-dependency --dev")
         .current_dir(cwd)
         .assert()
         .success()
@@ -402,7 +402,7 @@ fn dry_run() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package", "--dry-run"])
+        .arg_line("my-package --dry-run")
         .current_dir(cwd)
         .assert()
         .success()
@@ -421,7 +421,7 @@ fn features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--features", "eyes"])
+        .arg_line("your-face --features eyes")
         .current_dir(cwd)
         .assert()
         .success()
@@ -440,7 +440,7 @@ fn features_empty() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--features", ""])
+        .arg_line("your-face --features ''")
         .current_dir(cwd)
         .assert()
         .success()
@@ -459,7 +459,7 @@ fn features_multiple_occurrences() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--features", "eyes", "--features", "nose"])
+        .arg_line("your-face --features eyes --features nose")
         .current_dir(cwd)
         .assert()
         .success()
@@ -481,7 +481,7 @@ fn features_preserve() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face"])
+        .arg_line("your-face")
         .current_dir(cwd)
         .assert()
         .success()
@@ -500,7 +500,7 @@ fn features_spaced_values() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--features", "eyes nose"])
+        .arg_line("your-face --features eyes,nose")
         .current_dir(cwd)
         .assert()
         .success()
@@ -522,7 +522,7 @@ fn features_unknown() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--features", "noze"])
+        .arg_line("your-face --features noze")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -868,11 +868,7 @@ fn path() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -891,11 +887,7 @@ fn path_inferred_name() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -915,7 +907,7 @@ fn path_inferred_name_conflicts_full_feature() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["--path", "../dependency", "--features", "your-face/nose"])
+        .arg_line("--path ../dependency --features your-face/nose")
         .current_dir(&cwd)
         .assert()
         .code(101)
@@ -939,11 +931,7 @@ fn path_normalized_name() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo_list_test_fixture_dependency",
-            "--path",
-            "../dependency",
-        ])
+        .arg_line("cargo_list_test_fixture_dependency --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .failure() // Fuzzy searching for paths isn't supported at this time
@@ -965,7 +953,7 @@ fn invalid_path_name() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["not-at-path", "--path", "../dependency"])
+        .arg_line("not-at-path --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .code(101)
@@ -984,12 +972,7 @@ fn path_dev() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-            "--dev",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency --dev")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -1008,7 +991,7 @@ fn invalid_arg() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package", "--flag"])
+        .arg_line("my-package --flag")
         .current_dir(cwd)
         .assert()
         .code(1)
@@ -1120,11 +1103,7 @@ fn invalid_path() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture",
-            "--path",
-            "./tests/fixtures/local",
-        ])
+        .arg_line("cargo-list-test-fixture --path ./tests/fixtures/local")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1143,7 +1122,7 @@ fn invalid_path_self() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["cargo-list-test-fixture", "--path", "."])
+        .arg_line("cargo-list-test-fixture --path .")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1162,7 +1141,7 @@ fn invalid_manifest() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package"])
+        .arg_line("my-package")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1181,7 +1160,7 @@ fn invalid_name_external() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["lets_hope_nobody_ever_publishes_this_crate"])
+        .arg_line("lets_hope_nobody_ever_publishes_this_crate")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1203,7 +1182,7 @@ fn invalid_target_empty() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package", "--target", ""])
+        .arg_line("my-package --target ''")
         .current_dir(cwd)
         .assert()
         .code(1)
@@ -1225,7 +1204,7 @@ fn invalid_vers() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package@invalid version string"])
+        .arg_line("my-package@invalid-version-string")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1263,7 +1242,7 @@ fn list_features_path() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--path", "../dependency"])
+        .arg_line("your-face --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -1359,7 +1338,7 @@ fn multiple_conflicts_with_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "your-face", "--features", "nose"])
+        .arg_line("my-package1 your-face --features nose")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1414,7 +1393,7 @@ fn multiple_conflicts_with_rename() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2", "--rename", "renamed"])
+        .arg_line("my-package1 my-package2 --rename renamed")
         .current_dir(cwd)
         .assert()
         .code(101)
@@ -1436,7 +1415,7 @@ fn namever() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1@>=0.1.1", "my-package2@0.2.3", "my-package"])
+        .arg_line("my-package1@>=0.1.1 my-package2@0.2.3 my-package")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1473,7 +1452,7 @@ fn no_default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--no-default-features"])
+        .arg_line("my-package1 my-package2@0.4.1 --no-default-features")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1492,7 +1471,7 @@ fn no_optional() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--no-optional"])
+        .arg_line("my-package1 my-package2@0.4.1 --no-optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1511,7 +1490,7 @@ fn optional() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--optional"])
+        .arg_line("my-package1 my-package2@0.4.1 --optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1530,7 +1509,7 @@ fn overwrite_default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--default-features"])
+        .arg_line("my-package1 my-package2@0.4.1 --default-features")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1554,7 +1533,7 @@ fn overwrite_default_features_with_no_default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--no-default-features"])
+        .arg_line("my-package1 my-package2@0.4.1 --no-default-features")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1580,7 +1559,7 @@ fn overwrite_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--features", "nose"])
+        .arg_line("your-face --features nose")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1599,11 +1578,7 @@ fn overwrite_git_with_path() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -1625,13 +1600,9 @@ fn overwrite_inline_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "unrelateed-crate",
-            "your-face",
-            "--features",
-            "your-face/nose,your-face/mouth",
-            "-Fyour-face/ears",
-        ])
+        .arg_line(
+            "unrelateed-crate your-face --features your-face/nose,your-face/mouth -Fyour-face/ears",
+        )
         .current_dir(cwd)
         .assert()
         .success()
@@ -1721,7 +1692,7 @@ fn overwrite_name_dev_noop() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--dev"])
+        .arg_line("your-face --dev")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1743,7 +1714,7 @@ fn overwrite_name_noop() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face"])
+        .arg_line("your-face")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1762,7 +1733,7 @@ fn overwrite_no_default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--no-default-features"])
+        .arg_line("my-package1 my-package2@0.4.1 --no-default-features")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1786,7 +1757,7 @@ fn overwrite_no_default_features_with_default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--default-features"])
+        .arg_line("my-package1 my-package2@0.4.1 --default-features")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1812,7 +1783,7 @@ fn overwrite_no_optional() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--no-optional"])
+        .arg_line("my-package1 my-package2@0.4.1 --no-optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1835,7 +1806,7 @@ fn overwrite_no_optional_with_optional() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--optional"])
+        .arg_line("my-package1 my-package2@0.4.1 --optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1857,7 +1828,7 @@ fn overwrite_optional() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--optional"])
+        .arg_line("my-package1 my-package2@0.4.1 --optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1877,7 +1848,7 @@ fn overwrite_optional_with_no_optional() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2@0.4.1", "--no-optional"])
+        .arg_line("my-package1 my-package2@0.4.1 --no-optional")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1899,7 +1870,7 @@ fn overwrite_path_noop() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["your-face", "--path", "./dependency"])
+        .arg_line("your-face --path ./dependency")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1918,7 +1889,7 @@ fn overwrite_path_with_version() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["cargo-list-test-fixture-dependency@20.0"])
+        .arg_line("cargo-list-test-fixture-dependency@20.0")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -1940,7 +1911,7 @@ fn overwrite_rename_with_no_rename() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["versioned-package"])
+        .arg_line("versioned-package")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1962,7 +1933,7 @@ fn overwrite_rename_with_rename() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["versioned-package", "--rename", "a2"])
+        .arg_line("versioned-package --rename a2")
         .current_dir(cwd)
         .assert()
         .success()
@@ -1984,7 +1955,7 @@ fn change_rename_target() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package2", "--rename", "some-package"])
+        .arg_line("my-package2 --rename some-package")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2007,7 +1978,7 @@ fn overwrite_rename_with_rename_noop() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["versioned-package", "--rename", "a1"])
+        .arg_line("versioned-package --rename a1")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2060,11 +2031,7 @@ fn overwrite_version_with_path() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -2086,7 +2053,7 @@ fn overwrite_with_rename() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["versioned-package", "--rename", "renamed"])
+        .arg_line("versioned-package --rename renamed")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2154,7 +2121,7 @@ fn preserve_sorted() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["toml"])
+        .arg_line("toml")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2173,7 +2140,7 @@ fn preserve_unsorted() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["toml"])
+        .arg_line("toml")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2192,7 +2159,7 @@ fn registry() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2", "--registry", "alternative"])
+        .arg_line("my-package1 my-package2 --registry alternative")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2211,7 +2178,7 @@ fn rename() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package", "--rename", "renamed"])
+        .arg_line("my-package --rename renamed")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2230,12 +2197,7 @@ fn target() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "my-package1",
-            "my-package2",
-            "--target",
-            "i686-unknown-linux-gnu",
-        ])
+        .arg_line("my-package1 my-package2 --target i686-unknown-linux-gnu")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2254,7 +2216,7 @@ fn target_cfg() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package1", "my-package2", "--target", "cfg(unix)"])
+        .arg_line("my-package1 my-package2 --target cfg(unix)")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2295,7 +2257,7 @@ fn vers() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package@>=0.1.1"])
+        .arg_line("my-package@>=0.1.1")
         .current_dir(cwd)
         .assert()
         .success()
@@ -2314,11 +2276,7 @@ fn workspace_path() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -2337,12 +2295,7 @@ fn workspace_path_dev() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args([
-            "cargo-list-test-fixture-dependency",
-            "--path",
-            "../dependency",
-            "--dev",
-        ])
+        .arg_line("cargo-list-test-fixture-dependency --path ../dependency --dev")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -2361,7 +2314,7 @@ fn workspace_name() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["cargo-list-test-fixture-dependency"])
+        .arg_line("cargo-list-test-fixture-dependency")
         .current_dir(&cwd)
         .assert()
         .success()
@@ -2380,7 +2333,7 @@ fn deprecated_default_features() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package"])
+        .arg_line("my-package")
         .current_dir(&cwd)
         .assert()
         .failure()
@@ -2402,7 +2355,7 @@ fn deprecated_section() {
 
     snapbox::cmd::Command::cargo()
         .arg("add")
-        .args(["my-package"])
+        .arg_line("my-package")
         .current_dir(&cwd)
         .assert()
         .failure()

--- a/tests/testsuite/cargo_add.rs
+++ b/tests/testsuite/cargo_add.rs
@@ -1,13 +1,6 @@
-use cargo_test_support::cargo_exe;
 use cargo_test_support::compare::assert;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
-
-pub fn cargo_command() -> snapbox::cmd::Command {
-    snapbox::cmd::Command::new(cargo_exe())
-        .with_assert(assert())
-        .test_env()
-}
 
 fn init_registry() {
     cargo_test_support::registry::init();
@@ -99,7 +92,7 @@ fn add_basic() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package"])
         .current_dir(cwd)
@@ -118,7 +111,7 @@ fn add_multiple() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2"])
         .current_dir(cwd)
@@ -137,7 +130,7 @@ fn quiet() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["--quiet", "your-face"])
         .current_dir(cwd)
@@ -156,7 +149,7 @@ fn add_normalized_name_external() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["linked_hash_map", "Inflector"])
         .current_dir(cwd)
@@ -178,7 +171,7 @@ fn infer_prerelease() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["prerelease_only"])
         .current_dir(cwd)
@@ -197,7 +190,7 @@ fn build() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["--build", "my-build-package1", "my-build-package2"])
         .current_dir(cwd)
@@ -216,7 +209,7 @@ fn build_prefer_existing_version() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["cargo-list-test-fixture-dependency", "--build"])
         .current_dir(cwd)
@@ -238,7 +231,7 @@ fn default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--default-features"])
         .current_dir(cwd)
@@ -257,7 +250,7 @@ fn require_weak() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--no-optional"])
         .current_dir(cwd)
@@ -276,7 +269,7 @@ fn detect_workspace_inherit() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -300,7 +293,7 @@ fn detect_workspace_inherit_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar", "--features", "test"])
@@ -324,7 +317,7 @@ fn detect_workspace_inherit_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar", "--optional"])
@@ -347,7 +340,7 @@ fn dev() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["--dev", "my-dev-package1", "my-dev-package2"])
         .current_dir(cwd)
@@ -366,7 +359,7 @@ fn dev_build_conflict() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package", "--dev", "--build"])
         .current_dir(cwd)
@@ -385,7 +378,7 @@ fn dev_prefer_existing_version() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["cargo-list-test-fixture-dependency", "--dev"])
         .current_dir(cwd)
@@ -407,7 +400,7 @@ fn dry_run() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package", "--dry-run"])
         .current_dir(cwd)
@@ -426,7 +419,7 @@ fn features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--features", "eyes"])
         .current_dir(cwd)
@@ -445,7 +438,7 @@ fn features_empty() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--features", ""])
         .current_dir(cwd)
@@ -464,7 +457,7 @@ fn features_multiple_occurrences() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--features", "eyes", "--features", "nose"])
         .current_dir(cwd)
@@ -486,7 +479,7 @@ fn features_preserve() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face"])
         .current_dir(cwd)
@@ -505,7 +498,7 @@ fn features_spaced_values() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--features", "eyes nose"])
         .current_dir(cwd)
@@ -527,7 +520,7 @@ fn features_unknown() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--features", "noze"])
         .current_dir(cwd)
@@ -555,7 +548,7 @@ fn git() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["git-package", "--git", &git_url])
         .current_dir(cwd)
@@ -583,7 +576,7 @@ fn git_inferred_name() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["--git", &git_url])
         .current_dir(cwd)
@@ -616,7 +609,7 @@ fn git_inferred_name_multiple() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["--git", &git_url])
         .current_dir(cwd)
@@ -647,7 +640,7 @@ fn git_normalized_name() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["git_package", "--git", &git_url])
         .current_dir(cwd)
@@ -675,7 +668,7 @@ fn invalid_git_name() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["not-in-git", "--git", &git_url])
         .current_dir(cwd)
@@ -706,7 +699,7 @@ fn git_branch() {
     git_repo.branch(branch, &find_head(), false).unwrap();
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--branch", branch])
         .current_dir(cwd)
@@ -725,7 +718,7 @@ fn git_conflicts_namever() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "my-package@0.4.3",
@@ -760,7 +753,7 @@ fn git_registry() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "versioned-package",
@@ -794,7 +787,7 @@ fn git_dev() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--dev"])
         .current_dir(cwd)
@@ -824,7 +817,7 @@ fn git_rev() {
     let head = find_head().id().to_string();
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--rev", &head])
         .current_dir(cwd)
@@ -854,7 +847,7 @@ fn git_tag() {
     cargo_test_support::git::tag(&git_repo, tag);
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--tag", tag])
         .current_dir(cwd)
@@ -873,7 +866,7 @@ fn path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -896,7 +889,7 @@ fn path_inferred_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -920,7 +913,7 @@ fn path_inferred_name_conflicts_full_feature() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["--path", "../dependency", "--features", "your-face/nose"])
         .current_dir(&cwd)
@@ -944,7 +937,7 @@ fn path_normalized_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo_list_test_fixture_dependency",
@@ -970,7 +963,7 @@ fn invalid_path_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["not-at-path", "--path", "../dependency"])
         .current_dir(&cwd)
@@ -989,7 +982,7 @@ fn path_dev() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -1013,7 +1006,7 @@ fn invalid_arg() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package", "--flag"])
         .current_dir(cwd)
@@ -1035,7 +1028,7 @@ fn invalid_git_external() {
         .unwrap()
         .to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["fake-git", "--git", &git_url])
         .current_dir(cwd)
@@ -1056,7 +1049,7 @@ fn invalid_key_inherit_dependency() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--default-features", "-p", "bar"])
@@ -1079,7 +1072,7 @@ fn invalid_key_rename_inherit_dependency() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["--rename", "foo", "foo-alt", "-p", "bar"])
@@ -1102,7 +1095,7 @@ fn invalid_key_overwrite_inherit_dependency() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--default-features", "-p", "bar"])
@@ -1125,7 +1118,7 @@ fn invalid_path() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture",
@@ -1148,7 +1141,7 @@ fn invalid_path_self() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["cargo-list-test-fixture", "--path", "."])
         .current_dir(cwd)
@@ -1167,7 +1160,7 @@ fn invalid_manifest() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package"])
         .current_dir(cwd)
@@ -1186,7 +1179,7 @@ fn invalid_name_external() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["lets_hope_nobody_ever_publishes_this_crate"])
         .current_dir(cwd)
@@ -1208,7 +1201,7 @@ fn invalid_target_empty() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package", "--target", ""])
         .current_dir(cwd)
@@ -1230,7 +1223,7 @@ fn invalid_vers() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package@invalid version string"])
         .current_dir(cwd)
@@ -1249,7 +1242,7 @@ fn list_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face"])
         .current_dir(cwd)
@@ -1268,7 +1261,7 @@ fn list_features_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--path", "../dependency"])
         .current_dir(&cwd)
@@ -1287,7 +1280,7 @@ fn list_features_path_no_default() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "your-face",
@@ -1314,7 +1307,7 @@ fn manifest_path_package() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "--manifest-path",
@@ -1341,7 +1334,7 @@ fn merge_activated_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -1364,7 +1357,7 @@ fn multiple_conflicts_with_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "your-face", "--features", "nose"])
         .current_dir(cwd)
@@ -1400,7 +1393,7 @@ fn git_multiple_names() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2", "--git", &git_url])
         .current_dir(cwd)
@@ -1419,7 +1412,7 @@ fn multiple_conflicts_with_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2", "--rename", "renamed"])
         .current_dir(cwd)
@@ -1441,7 +1434,7 @@ fn namever() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1@>=0.1.1", "my-package2@0.2.3", "my-package"])
         .current_dir(cwd)
@@ -1460,7 +1453,7 @@ fn no_args() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .current_dir(cwd)
         .assert()
@@ -1478,7 +1471,7 @@ fn no_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--no-default-features"])
         .current_dir(cwd)
@@ -1497,7 +1490,7 @@ fn no_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--no-optional"])
         .current_dir(cwd)
@@ -1516,7 +1509,7 @@ fn optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--optional"])
         .current_dir(cwd)
@@ -1535,7 +1528,7 @@ fn overwrite_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--default-features"])
         .current_dir(cwd)
@@ -1559,7 +1552,7 @@ fn overwrite_default_features_with_no_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--no-default-features"])
         .current_dir(cwd)
@@ -1585,7 +1578,7 @@ fn overwrite_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--features", "nose"])
         .current_dir(cwd)
@@ -1604,7 +1597,7 @@ fn overwrite_git_with_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -1630,7 +1623,7 @@ fn overwrite_inline_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "unrelateed-crate",
@@ -1657,7 +1650,7 @@ fn overwrite_inherit_features_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -1680,7 +1673,7 @@ fn overwrite_inherit_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -1703,7 +1696,7 @@ fn overwrite_inherit_optional_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -1726,7 +1719,7 @@ fn overwrite_name_dev_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--dev"])
         .current_dir(cwd)
@@ -1748,7 +1741,7 @@ fn overwrite_name_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face"])
         .current_dir(cwd)
@@ -1767,7 +1760,7 @@ fn overwrite_no_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--no-default-features"])
         .current_dir(cwd)
@@ -1791,7 +1784,7 @@ fn overwrite_no_default_features_with_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--default-features"])
         .current_dir(cwd)
@@ -1817,7 +1810,7 @@ fn overwrite_no_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--no-optional"])
         .current_dir(cwd)
@@ -1840,7 +1833,7 @@ fn overwrite_no_optional_with_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--optional"])
         .current_dir(cwd)
@@ -1862,7 +1855,7 @@ fn overwrite_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--optional"])
         .current_dir(cwd)
@@ -1882,7 +1875,7 @@ fn overwrite_optional_with_no_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2@0.4.1", "--no-optional"])
         .current_dir(cwd)
@@ -1904,7 +1897,7 @@ fn overwrite_path_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["your-face", "--path", "./dependency"])
         .current_dir(cwd)
@@ -1923,7 +1916,7 @@ fn overwrite_path_with_version() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["cargo-list-test-fixture-dependency@20.0"])
         .current_dir(&cwd)
@@ -1945,7 +1938,7 @@ fn overwrite_rename_with_no_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["versioned-package"])
         .current_dir(cwd)
@@ -1967,7 +1960,7 @@ fn overwrite_rename_with_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["versioned-package", "--rename", "a2"])
         .current_dir(cwd)
@@ -1989,7 +1982,7 @@ fn change_rename_target() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package2", "--rename", "some-package"])
         .current_dir(cwd)
@@ -2012,7 +2005,7 @@ fn overwrite_rename_with_rename_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["versioned-package", "--rename", "a1"])
         .current_dir(cwd)
@@ -2043,7 +2036,7 @@ fn overwrite_version_with_git() {
     });
     let git_url = git_dep.url().to_string();
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["versioned-package", "--git", &git_url])
         .current_dir(cwd)
@@ -2065,7 +2058,7 @@ fn overwrite_version_with_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -2091,7 +2084,7 @@ fn overwrite_with_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["versioned-package", "--rename", "renamed"])
         .current_dir(cwd)
@@ -2113,7 +2106,7 @@ fn overwrite_workspace_dep() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--path", "./dependency", "-p", "bar"])
@@ -2136,7 +2129,7 @@ fn overwrite_workspace_dep_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--path", "./dependency", "-p", "bar"])
@@ -2159,7 +2152,7 @@ fn preserve_sorted() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["toml"])
         .current_dir(cwd)
@@ -2178,7 +2171,7 @@ fn preserve_unsorted() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["toml"])
         .current_dir(cwd)
@@ -2197,7 +2190,7 @@ fn registry() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2", "--registry", "alternative"])
         .current_dir(cwd)
@@ -2216,7 +2209,7 @@ fn rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package", "--rename", "renamed"])
         .current_dir(cwd)
@@ -2235,7 +2228,7 @@ fn target() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "my-package1",
@@ -2259,7 +2252,7 @@ fn target_cfg() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package1", "my-package2", "--target", "cfg(unix)"])
         .current_dir(cwd)
@@ -2277,7 +2270,7 @@ fn unknown_inherited_feature() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -2300,7 +2293,7 @@ fn vers() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package@>=0.1.1"])
         .current_dir(cwd)
@@ -2319,7 +2312,7 @@ fn workspace_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -2342,7 +2335,7 @@ fn workspace_path_dev() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args([
             "cargo-list-test-fixture-dependency",
@@ -2366,7 +2359,7 @@ fn workspace_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["cargo-list-test-fixture-dependency"])
         .current_dir(&cwd)
@@ -2385,7 +2378,7 @@ fn deprecated_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package"])
         .current_dir(&cwd)
@@ -2407,7 +2400,7 @@ fn deprecated_section() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    cargo_command()
+    snapbox::cmd::Command::cargo()
         .arg("add")
         .args(["my-package"])
         .current_dir(&cwd)


### PR DESCRIPTION
### What does this PR try to resolve?

#10472 introduced snapbox to cargo's tests in the least intrusive manner by copying some cargo-test-support code.  Primarily, this PR works to de-duplicate that code.  Secondarily, it makes it possible for snapbox to be used by other cargo tests that can work with its more limited functionality compared to cargo-test-support.

### How should we test and review this PR?

This is broken down by commits for smaller chunks to look over with some extra details in some of the commit messages.

As this is effectively refactoring existing tests, them passing is sufficient for testing.  The main focus would be on any API design including if there are any practices that we used to do that this continues forward to snapbox that we shouldn't.

### Additional information

The cargo contributing guide also needs to be updated but I'm leaving that off for another PR once this is merged so we have a clearer idea of what the API will look like (less churn) and so we can focus the conversation for each PR.