### PR TITLE
Prefer `key.workspace = true` to `key = { workspace = true }`

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -130,8 +130,9 @@ pub fn read_manifest_from_str(
             }
             if let TomlDependency::Workspace(_) = dep {
                 bail!(
-                    "`workspace.dependencies.{}` specified `{{ workspace = true }}`, but \
-                    workspace dependencies cannot do this",
+                    "{} was specified as `workspace.dependencies.{}.workspace = true`, but \
+                    workspace dependencies cannot specify `workspace = true`",
+                    name,
                     name
                 );
             }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -225,7 +225,7 @@ pub enum TomlDependency<P: Clone = String> {
     /// In the simple format, only a version is specified, eg.
     /// `package = "<version>"`
     Simple(String),
-    /// `package = { workspace = true }`
+    /// `package.workspace = true`
     Workspace(TomlWorkspaceDependency),
     /// The simple format is equivalent to a detailed dependency
     /// specifying only a version, eg.
@@ -990,7 +990,7 @@ where
     deserializer.deserialize_any(Visitor)
 }
 
-/// Enum that allows for the parsing of { workspace = true } in a Cargo.toml
+/// Enum that allows for the parsing of `field.workspace = true` in a Cargo.toml
 ///
 /// It allows for things to be inherited from a workspace or defined as needed
 #[derive(Deserialize, Serialize, Clone, Debug)]

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1432,8 +1432,8 @@ wasm-bindgen-cli = { path = "crates/cli" }
 ```toml
 # in a workspace member's Cargo.toml
 [dependencies]
-log = { workspace = true }
-log2 = { workspace = true }
+log.workspace = true
+log2.workspace = true
 ```
 
 Example 2: 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1458,16 +1458,16 @@ edition = "2018"
 ```toml
 # in a workspace member's Cargo.toml
 [package]
-version = { workspace = true }
-authors = { workspace = true }
-description = { workspace = true }
-documentation = { workspace = true }
-readme = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
-license-file = { workspace = true }
-keywords = { workspace = true }
-categories = { workspace = true }
-publish = { workspace = true }
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
 ```

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -251,13 +251,13 @@ fn inherit_own_dependencies() {
             authors = []
 
             [dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
 
             [build-dependencies]
-            dep-build = { workspace = true }
+            dep-build.workspace = true
 
             [dev-dependencies]
-            dep-dev = { workspace = true }
+            dep-dev.workspace = true
 
             [workspace]
             members = []
@@ -393,7 +393,7 @@ fn inherit_own_detailed_dependencies() {
             authors = []
 
             [dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
 
             [workspace]
             members = []
@@ -758,11 +758,11 @@ fn inherit_dependencies() {
             version = "0.2.0"
             authors = []
             [dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
             [build-dependencies]
-            dep-build = { workspace = true }
+            dep-build.workspace = true
             [dev-dependencies]
-            dep-dev = { workspace = true }
+            dep-dev.workspace = true
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -901,9 +901,9 @@ fn inherit_target_dependencies() {
             version = "0.2.0"
             authors = []
             [target.'cfg(unix)'.dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
             [target.'cfg(windows)'.dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1071,7 +1071,7 @@ fn inherit_detailed_dependencies() {
             version = "0.2.0"
             authors = []
             [dependencies]
-            detailed = { workspace = true }
+            detailed.workspace = true
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1116,7 +1116,7 @@ fn inherit_path_dependencies() {
             version = "0.2.0"
             authors = []
             [dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")
@@ -1200,13 +1200,13 @@ fn error_workspace_dependency_looked_for_workspace_itself() {
             workspace = ".."
 
             [dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
 
             [workspace]
             members = ["bar"]
 
             [workspace.dependencies]
-            dep = { workspace = true }
+            dep.workspace = true
 
             "#,
         )
@@ -1221,8 +1221,8 @@ fn error_workspace_dependency_looked_for_workspace_itself() {
 [ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
-  `workspace.dependencies.dep` specified `{ workspace = true }`, but workspace dependencies \
-  cannot do this
+  dep was specified as `workspace.dependencies.dep.workspace = true`, but \
+  workspace dependencies cannot specify `workspace = true`
 ",
         )
         .run();
@@ -1347,7 +1347,7 @@ fn error_inherit_unspecified_dependency() {
             version = "1.2.3"
             authors = ["rustaceans"]
             [dependencies]
-            foo = { workspace = true }
+            foo.workspace = true
         "#,
         )
         .file("bar/src/main.rs", "fn main() {}")

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1,4 +1,4 @@
-//! Tests for inheriting Cargo.toml fields with { workspace = true }
+//! Tests for inheriting Cargo.toml fields with field.workspace = true
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::{
     basic_lib_manifest, basic_manifest, git, path2url, paths, project, publish, registry,
@@ -119,24 +119,24 @@ fn inherit_own_workspace_fields() {
             "Cargo.toml",
             r#"
             cargo-features = ["workspace-inheritance"]
-            badges = { workspace = true }
+            badges.workspace = true
 
             [package]
             name = "foo"
-            version = { workspace = true }
-            authors = { workspace = true }
-            description = { workspace = true }
-            documentation = { workspace = true }
-            homepage = { workspace = true }
-            repository = { workspace = true }
-            license = { workspace = true }
-            keywords = { workspace = true }
-            categories = { workspace = true }
-            publish = { workspace = true }
-            edition = { workspace = true }
-            rust-version = { workspace = true }
-            exclude = { workspace = true }
-            include = { workspace = true }
+            version.workspace = true
+            authors.workspace = true
+            description.workspace = true
+            documentation.workspace = true
+            homepage.workspace = true
+            repository.workspace = true
+            license.workspace = true
+            keywords.workspace = true
+            categories.workspace = true
+            publish.workspace = true
+            edition.workspace = true
+            rust-version.workspace = true
+            exclude.workspace = true
+            include.workspace = true
 
             [workspace]
             members = []
@@ -501,7 +501,7 @@ fn inherit_from_own_undefined_field() {
             name = "foo"
             version = "1.2.5"
             authors = ["rustaceans"]
-            description = { workspace = true }
+            description.workspace = true
 
             [workspace]
             members = []
@@ -623,27 +623,27 @@ fn inherit_workspace_fields() {
         .file(
             "bar/Cargo.toml",
             r#"
-            badges = { workspace = true }
+            badges.workspace = true
             cargo-features = ["workspace-inheritance"]
             [package]
             name = "bar"
             workspace = ".."
-            version = { workspace = true }
-            authors = { workspace = true }
-            description = { workspace = true }
-            documentation = { workspace = true }
-            readme = { workspace = true }
-            homepage = { workspace = true }
-            repository = { workspace = true }
-            license = { workspace = true }
-            license-file = { workspace = true }
-            keywords = { workspace = true }
-            categories = { workspace = true }
-            publish = { workspace = true }
-            edition = { workspace = true }
-            rust-version = { workspace = true }
-            exclude = { workspace = true }
-            include = { workspace = true }
+            version.workspace = true
+            authors.workspace = true
+            description.workspace = true
+            documentation.workspace = true
+            readme.workspace = true
+            homepage.workspace = true
+            repository.workspace = true
+            license.workspace = true
+            license-file.workspace = true
+            keywords.workspace = true
+            categories.workspace = true
+            publish.workspace = true
+            edition.workspace = true
+            rust-version.workspace = true
+            exclude.workspace = true
+            include.workspace = true
         "#,
         )
         .file("LICENSE", "license")
@@ -1298,7 +1298,7 @@ fn error_no_root_workspace() {
             workspace = ".."
             version = "1.2.3"
             authors = ["rustaceans"]
-            description = { workspace = true }
+            description.workspace = true
         "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -1385,7 +1385,7 @@ fn workspace_inheritance_not_enabled() {
             name = "foo"
             version = "1.2.5"
             authors = ["rustaceans"]
-            description = { workspace = true }
+            description.workspace = true
 
             [workspace]
             members = []
@@ -1431,7 +1431,7 @@ fn nightly_required() {
             name = "foo"
             version = "1.2.5"
             authors = ["rustaceans"]
-            description = { workspace = true }
+            description.workspace = true
 
             [workspace]
             members = []


### PR DESCRIPTION
Tracking issue: #8415
RFC: rust-lang/rfcs#2906

Part 1: #10497
Part 2: #10517
Part 3: #10538
Part 4: #10548
Part 5: #10563
Part 6: #10564
Part 7: #10565
Part 8: #10568

This PR fell out of [this discussion](https://github.com/rust-lang/cargo/pull/10497#discussion_r833636010) regarding if `key.workspace = true` is better than `key = { workspace = true }`. 

Changes:
- Made all fields into `field.workspace = true`
- Made dependencies into `dep.workspace = true` when a they only specify `{ workspace = true }`

Remaining implementation work for the RFC
- `cargo-add` support, see [epage's comment](https://github.com/rust-lang/cargo/issues/8415#issuecomment-1075544790)
- Optimizations as needed
