### PR TITLE
Pass `--target` to `rustdoc` for `cargo test` if specified with host target.

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -200,11 +200,12 @@ fn run_doc_tests(
             p.arg(unit.target.src_path().path().unwrap());
         }
 
+        if let CompileKind::Target(target) = unit.kind {
+            // use `rustc_target()` to properly handle JSON target paths
+            p.arg("--target").arg(target.rustc_target());
+        }
+
         if doctest_xcompile {
-            if let CompileKind::Target(target) = unit.kind {
-                // use `rustc_target()` to properly handle JSON target paths
-                p.arg("--target").arg(target.rustc_target());
-            }
             p.arg("-Zunstable-options");
             p.arg("--enable-per-target-ignores");
             if let Some((runtool, runtool_args)) = compilation.target_runner(unit.kind) {

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -592,17 +592,33 @@ fn no_cross_doctests() {
 
     println!("b");
     let target = rustc_host();
-    p.cargo("test --target")
+    p.cargo("test -v --target")
         .arg(&target)
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo [..]
+[RUNNING] `rustc --crate-name foo [..]--test[..]
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..] (target/{triple}/debug/deps/foo-[..][EXE])
+[RUNNING] `[CWD]/target/{target}/debug/deps/foo-[..][EXE]`
 [DOCTEST] foo
+[RUNNING] `rustdoc [..]--target {target}[..]`
 ",
-            triple = target
         ))
+        .with_stdout(
+            "
+running 0 tests
+
+test result: ok. 0 passed[..]
+
+
+running 1 test
+test src/lib.rs - (line 2) ... ok
+
+test result: ok. 1 passed[..]
+
+",
+        )
         .run();
 
     println!("c");


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #10560

### How should we test and review this PR?

Add assertion in `cross_compile::no_cross_doctests` to verify that `rustdoc --target` exists. 

<!-- homu-ignore:end -->
