### PR TITLE
Add fallible units for scrape-examples feature

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -77,6 +77,13 @@ pub struct Context<'a, 'cfg> {
     /// Map of Doc/Docscrape units to metadata for their -Cmetadata flag.
     /// See Context::find_metadata_units for more details.
     pub metadata_for_doc_units: HashMap<Unit, Metadata>,
+
+    /// Map that tracks whether a unit completed successfully. Used in conjuction
+    /// with the `Unit::can_fail` flag, so jobs can dynamically track at runtime
+    /// whether their dependencies succeeded or failed. Currently used for
+    /// the Rustdoc scrape-examples feature to allow Rustdoc to proceed even if
+    /// examples fail to compile.
+    pub completed_units: Arc<Mutex<HashMap<Metadata, bool>>>,
 }
 
 impl<'a, 'cfg> Context<'a, 'cfg> {
@@ -115,6 +122,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             rustc_clients: HashMap::new(),
             lto: HashMap::new(),
             metadata_for_doc_units: HashMap::new(),
+            completed_units: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -22,7 +22,7 @@ mod unit;
 pub mod unit_dependencies;
 pub mod unit_graph;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File};
@@ -639,9 +639,9 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
     let metadata = cx.metadata_for_doc_units[unit];
     rustdoc.arg("-C").arg(format!("metadata={}", metadata));
 
-    let scrape_output_path = |unit: &Unit| -> CargoResult<PathBuf> {
+    let scrape_output_path = |unit: &Unit| -> PathBuf {
         let output_dir = cx.files().deps_dir(unit);
-        Ok(output_dir.join(format!("{}.examples", unit.buildkey())))
+        output_dir.join(format!("{}.examples", unit.buildkey()))
     };
 
     if unit.mode.is_doc_scrape() {
@@ -651,7 +651,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
 
         rustdoc
             .arg("--scrape-examples-output-path")
-            .arg(scrape_output_path(unit)?);
+            .arg(scrape_output_path(unit));
 
         // Only scrape example for items from crates in the workspace, to reduce generated file size
         for pkg in cx.bcx.ws.members() {
@@ -664,18 +664,18 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
                 rustdoc.arg("--scrape-examples-target-crate").arg(name);
             }
         }
-    } else if cx.bcx.scrape_units.len() > 0 && cx.bcx.ws.unit_needs_doc_scrape(unit) {
-        // We only pass scraped examples to packages in the workspace
-        // since examples are only coming from reverse-dependencies of workspace packages
-
-        rustdoc.arg("-Zunstable-options");
-
-        for scrape_unit in &cx.bcx.scrape_units {
-            rustdoc
-                .arg("--with-examples")
-                .arg(scrape_output_path(scrape_unit)?);
-        }
     }
+
+    let should_include_scrape_units =
+        cx.bcx.scrape_units.len() > 0 && cx.bcx.ws.unit_needs_doc_scrape(unit);
+    let scrape_outputs = should_include_scrape_units.then(|| {
+        rustdoc.arg("-Zunstable-options");
+        cx.bcx
+            .scrape_units
+            .iter()
+            .map(|unit| (cx.files().metadata(unit), scrape_output_path(unit)))
+            .collect::<HashMap<_, _>>()
+    });
 
     build_deps_args(&mut rustdoc, cx, unit)?;
     rustdoc::add_root_urls(cx, unit, &mut rustdoc)?;
@@ -693,12 +693,27 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
     let target = Target::clone(&unit.target);
     let mut output_options = OutputOptions::new(cx, unit);
     let script_metadata = cx.find_build_script_metadata(unit);
+    let completed_units = Arc::clone(&cx.completed_units);
     Ok(Work::new(move |state| {
         add_custom_flags(
             &mut rustdoc,
             &build_script_outputs.lock().unwrap(),
             script_metadata,
         )?;
+
+        // Add the output of scraped examples to the rustdoc command.
+        // This action must happen after the unit's dependencies have finished,
+        // because some of those deps may be Docscrape units which have failed.
+        // So we dynamically determine which `--with-examples` flags to pass here.
+        if let Some(scrape_outputs) = scrape_outputs {
+            let completed_units = completed_units.lock().unwrap();
+            for (metadata, output_path) in &scrape_outputs {
+                if completed_units[metadata] {
+                    rustdoc.arg("--with-examples").arg(output_path);
+                }
+            }
+        }
+
         let crate_dir = doc_dir.join(&crate_name);
         if crate_dir.exists() {
             // Remove output from a previous build. This ensures that stale
@@ -706,6 +721,7 @@ fn rustdoc(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Work> {
             debug!("removing pre-existing doc directory {:?}", crate_dir);
             paths::remove_dir_all(crate_dir)?;
         }
+
         state.running(&rustdoc);
 
         rustdoc

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -217,6 +217,7 @@ pub fn generate_std_roots(
                 /*is_std*/ true,
                 /*dep_hash*/ 0,
                 IsArtifact::No,
+                false,
             ));
         }
     }

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -72,6 +72,7 @@ pub struct UnitInner {
     /// This value initially starts as 0, and then is filled in via a
     /// second-pass after all the unit dependencies have been computed.
     pub dep_hash: u64,
+    pub can_fail: bool,
 }
 
 impl UnitInner {
@@ -141,6 +142,7 @@ impl fmt::Debug for Unit {
             .field("artifact", &self.artifact.is_true())
             .field("is_std", &self.is_std)
             .field("dep_hash", &self.dep_hash)
+            .field("can_fail", &self.can_fail)
             .finish()
     }
 }
@@ -184,6 +186,7 @@ impl UnitInterner {
         is_std: bool,
         dep_hash: u64,
         artifact: IsArtifact,
+        can_fail: bool,
     ) -> Unit {
         let target = match (is_std, target.kind()) {
             // This is a horrible hack to support build-std. `libstd` declares
@@ -216,6 +219,7 @@ impl UnitInterner {
             is_std,
             dep_hash,
             artifact,
+            can_fail,
         });
         Unit { inner }
     }

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -888,6 +888,7 @@ fn new_unit_dep_with_profile(
         state.is_std,
         /*dep_hash*/ 0,
         artifact.map_or(IsArtifact::No, |_| IsArtifact::Yes),
+        parent.can_fail,
     );
     Ok(UnitDep {
         unit,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -665,6 +665,7 @@ unstable_cli_options!(
     // TODO(wcrichto): move scrape example configuration into Cargo.toml before stabilization
     // See: https://github.com/rust-lang/cargo/pull/9525#discussion_r728470927
     rustdoc_scrape_examples: Option<String> = ("Allow rustdoc to scrape examples from reverse-dependencies for documentation"),
+    ignore_scrape_failures: bool = ("When scraping examples for Rustdoc, don't stop compilation if an example fails"),
     skip_rustdoc_fingerprint: bool = (HIDDEN),
 );
 
@@ -938,6 +939,7 @@ impl CliUnstable {
                     )
                 }
             }
+            "ignore-scrape-failures" => self.ignore_scrape_failures = parse_empty(k, v)?,
             "skip-rustdoc-fingerprint" => self.skip_rustdoc_fingerprint = parse_empty(k, v)?,
             "compile-progress" => stabilized_warn(k, "1.30", STABILIZED_COMPILE_PROGRESS),
             "offline" => stabilized_err(k, "1.36", STABILIZED_OFFLINE)?,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1519,7 +1519,7 @@ impl<'cfg> Workspace<'cfg> {
         // (not documented) or proc macros (have no scrape-able exports). Additionally,
         // naively passing a proc macro's unit_for to new_unit_dep will currently cause
         // Cargo to panic, see issue #10545.
-        self.is_member(&unit.pkg) && !unit.target.for_host()
+        self.is_member(&unit.pkg) && !unit.target.for_host() && unit.mode.is_doc()
     }
 }
 

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -1069,6 +1069,7 @@ fn generate_targets(
                 /*is_std*/ false,
                 /*dep_hash*/ 0,
                 IsArtifact::No,
+                mode.is_doc_scrape() && ws.config().cli_unstable().ignore_scrape_failures,
             );
             units.insert(unit);
         }
@@ -1631,6 +1632,7 @@ fn traverse_and_share(
         unit.is_std,
         new_dep_hash,
         unit.artifact,
+        unit.can_fail,
     );
     assert!(memo.insert(unit.clone(), new_unit.clone()).is_none());
     new_graph.entry(new_unit.clone()).or_insert(new_deps);
@@ -1872,6 +1874,7 @@ fn override_rustc_crate_types(
             unit.is_std,
             unit.dep_hash,
             unit.artifact,
+            unit.can_fail,
         )
     };
     units[0] = match unit.target.kind() {

--- a/src/cargo/util/dependency_queue.rs
+++ b/src/cargo/util/dependency_queue.rs
@@ -170,6 +170,10 @@ impl<N: Hash + Eq + Clone, E: Eq + Hash + Clone, V> DependencyQueue<N, E, V> {
         self.dep_map.len()
     }
 
+    pub fn dep_map(&self) -> &HashMap<N, (HashSet<(N, E)>, V)> {
+        &self.dep_map
+    }
+
     /// Indicate that something has finished.
     ///
     /// Calling this function indicates that the `node` has produced `edge`. All


### PR DESCRIPTION
### What does this PR try to resolve?

As established in rust-lang/rust#73566 and rust-lang/rust#43348, the minimum viable input to Rustdoc only needs to have valid function headers, and not valid function bodies. This is not super common, but must be a valid fallback for some crates.

The scrape examples feature requires checking the bodies of functions in order to find locations of examples. This includes the main library's functions, and functions in any other desired target. Therefore some libraries that are otherwise documentable will fail while scraping.

### How should we test and review this PR?

To address this issue, this PR implements a new concept: fallible units. Units can be marked as `can_fail = true`, and then their failure does not terminate the Cargo session. A new data structure `Context::units_completed` tracks which units have completed and whether they succeeded or failed. If a unit fails, then all of its transitive reverse dependencies that  also have `can_fail = true` will immediately fail as well.

This PR uses this feature to implement the desired behavior for scraping examples. When the user passes `-Z ignore-scrape-failures`, then all `CompileMode::Docscrape` units will have `can_fail = true`, and the `cargo doc` implementation will dynamically check which scraped examples have succeeded to determine which `*.examples` files should be passed to Rustdoc. The idea of the added flag is that it will be used on docs.rs where limiting failure is desirable, while users individually calling `cargo doc` will be presented terminal compilation failures by default since it's more likely a bug than a feature if a crate's examples don't compile. 

The added tests `scrape_examples_no_fail_bad_example` and `scrape_examples_no_fail_bad_dependency` show how this behavior works in practice.

### Additional information

Some questions / todos:
* Right now the user will still see the compiler error when they arise. But they don't see any information about skipped fallible units. How should that be communicated through the CLI?
* When fallible units are skipped, I ensure that `queue.finish` is called to register that the unit is done. Are there other pieces of state that need to get updated in this special case?