### PR TITLE
chore: Upgrade toml_edit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ strip-ansi-escapes = "0.1.0"
 tar = { version = "0.4.36", default-features = false }
 tempfile = "3.0"
 termcolor = "1.1"
-toml_edit =  { version = "0.13.4", features = ["serde", "easy"] }
+toml_edit =  { version = "0.14.3", features = ["serde", "easy", "perf"] }
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -36,6 +36,9 @@ use crate::util::{
 mod targets;
 use self::targets::targets;
 
+pub use toml_edit::de::Error as TomlDeError;
+pub use toml_edit::TomlError as TomlEditError;
+
 /// Loads a `Cargo.toml` from a file on disk.
 ///
 /// This could result in a real or virtual manifest being returned.


### PR DESCRIPTION
### What does this PR try to resolve?

This upgrades toml_edit and tries to make future upgrades easier.  To do this, it officially adds `toml_edit` to the public API but this will let RLS use these errors and stay up-to-date without manual intervention.

### How should we test and review this PR?

The main question is if we should have toml_edit in the API

### Additional information

See https://github.com/rust-lang/rls/pull/1764