### PR TITLE
move workspace inheritance unstable docs to the correct place

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1202,6 +1202,68 @@ For instance:
 cargo check -Z unstable-options -Z check-cfg-features
 ```
 
+### workspace-inheritance
+
+* RFC: [#2906](https://github.com/rust-lang/rfcs/blob/master/text/2906-cargo-workspace-deduplicate.md)
+* Tracking Issue: [#8415](https://github.com/rust-lang/cargo/issues/8415)
+
+The `workspace-inheritance` feature allows workspace members to inherit fields
+and dependencies from a workspace.
+
+Example 1:
+
+```toml
+# in workspace's Cargo.toml
+[workspace.dependencies]
+log = "0.3.1"
+log2 = { version = "2.0.0", package = "log" }
+serde = { git = 'https://github.com/serde-rs/serde' }
+wasm-bindgen-cli = { path = "crates/cli" }
+```
+
+```toml
+# in a workspace member's Cargo.toml
+[dependencies]
+log.workspace = true
+log2.workspace = true
+```
+
+Example 2:
+```toml
+# in workspace's Cargo.toml
+[workspace.package]
+version = "1.2.3"
+authors = ["Nice Folks"]
+description = "..."
+documentation = "https://example.github.io/example"
+readme = "README.md"
+homepage = "https://example.com"
+repository = "https://github.com/example/example"
+license = "MIT"
+license-file = "./LICENSE"
+keywords = ["cli"]
+categories = ["development-tools"]
+publish = false
+edition = "2018"
+```
+
+```toml
+# in a workspace member's Cargo.toml
+[package]
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+license-file.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish.workspace = true
+```
+
 ## Stabilized and removed features
 
 ### Compile progress
@@ -1383,65 +1445,3 @@ See the [Features chapter](features.md#dependency-features) for more information
 The `-Ztimings` option has been stabilized as `--timings` in the 1.60 release.
 (`--timings=html` and the machine-readable `--timings=json` output remain
 unstable and require `-Zunstable-options`.)
-
-### workspace-inheritance
-
-* RFC: [#2906](https://github.com/rust-lang/rfcs/blob/master/text/2906-cargo-workspace-deduplicate.md)
-* Tracking Issue: [#8415](https://github.com/rust-lang/cargo/issues/8415)
-
-The `workspace-inheritance` feature allows workspace members to inherit fields
-and dependencies from a workspace.
-
-Example 1: 
-
-```toml
-# in workspace's Cargo.toml
-[workspace.dependencies]
-log = "0.3.1"
-log2 = { version = "2.0.0", package = "log" }
-serde = { git = 'https://github.com/serde-rs/serde' }
-wasm-bindgen-cli = { path = "crates/cli" }
-```
-
-```toml
-# in a workspace member's Cargo.toml
-[dependencies]
-log = { workspace = true }
-log2 = { workspace = true }
-```
-
-Example 2: 
-```toml
-# in workspace's Cargo.toml
-[workspace]
-version = "1.2.3"
-authors = ["Nice Folks"]
-description = "..."
-documentation = "https://example.github.io/example"
-readme = "README.md"
-homepage = "https://example.com"
-repository = "https://github.com/example/example"
-license = "MIT"
-license-file = "./LICENSE"
-keywords = ["cli"]
-categories = ["development-tools"]
-publish = false
-edition = "2018"
-```
-
-```toml
-# in a workspace member's Cargo.toml
-[package]
-version = { workspace = true }
-authors = { workspace = true }
-description = { workspace = true }
-documentation = { workspace = true }
-readme = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
-license = { workspace = true }
-license-file = { workspace = true }
-keywords = { workspace = true }
-categories = { workspace = true }
-publish = { workspace = true }
-```


### PR DESCRIPTION
While finalizing everything for workspace inheritance it was noticed that the unstable docs for workspace inheritance were in the wrong area. They were moved to the correct place [in this PR](https://github.com/rust-lang/cargo/pull/10609), but it looks like the docs will be in the wrong place for 1.61.0. This should backport the change to 1.61.0
