### PR TITLE
add `cargo-features` to unstable docs for workspace inheritance

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1256,6 +1256,8 @@ documentation = "https://example.github.io/example"
 
 ```toml
 # [PROGECT_DIR]/bar/Cargo.toml
+cargo-features = ["workspace-inheritance"]
+
 [package]
 name = "bar"
 version.workspace = true
@@ -1290,6 +1292,8 @@ dep-dev = "0.5.2"
 
 ```toml
 # [PROGECT_DIR]/bar/Cargo.toml
+cargo-features = ["workspace-inheritance"]
+
 [project]
 name = "bar"
 version = "0.2.0"


### PR DESCRIPTION
The unstable docs for workspace inheritance did not include `cargo-features = ["workspace-inheritance"]`. If a user were to follow the docs cargo would throw an error saying to `feature `workspace-inheritance` is required`. It would be better to explicitly add this to the unstable docs and remove it during stabilization.

r? @epage