### PR TITLE
fix typos found by the `typos-cli` crate

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -250,7 +250,7 @@ pub fn mtime_recursive(path: &Path) -> Result<FileTime> {
                         // race with unlinking?). Regardless, if Cargo can't
                         // read it, the build script probably can't either.
                         log::debug!(
-                            "failed to determine mtime while fetching symlink metdata of {}: {}",
+                            "failed to determine mtime while fetching symlink metadata of {}: {}",
                             e.path().display(),
                             err
                         );
@@ -541,7 +541,7 @@ fn _link_or_copy(src: &Path, dst: &Path) -> Result<()> {
         if cfg!(target_os = "macos") {
             // This is a work-around for a bug on macos. There seems to be a race condition
             // with APFS when hard-linking binaries. Gatekeeper does not have signing or
-            // hash informations stored in kernel when running the process. Therefore killing it.
+            // hash information stored in kernel when running the process. Therefore killing it.
             // This problem does not appear when copying files as kernel has time to process it.
             // Note that: fs::copy on macos is using CopyOnWrite (syscall fclonefileat) which should be
             // as fast as hardlinking.

--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -457,7 +457,7 @@ impl ProcessBuilder {
         Ok((cmd, tmp))
     }
 
-    /// Builds a command from `ProcessBuilder` for everythings but not `args`.
+    /// Builds a command from `ProcessBuilder` for everything but not `args`.
     fn build_command_without_args(&self) -> Command {
         let mut command = {
             let mut iter = self.wrappers.iter().rev().chain(once(&self.program));

--- a/src/bin/cargo/commands/report.rs
+++ b/src/bin/cargo/commands/report.rs
@@ -25,7 +25,7 @@ pub fn cli() -> App {
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     match args.subcommand() {
-        Some(("future-incompatibilities", args)) => report_future_incompatibilies(config, args),
+        Some(("future-incompatibilities", args)) => report_future_incompatibilities(config, args),
         Some((cmd, _)) => {
             unreachable!("unexpected command {}", cmd)
         }
@@ -35,7 +35,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     }
 }
 
-fn report_future_incompatibilies(config: &Config, args: &ArgMatches) -> CliResult {
+fn report_future_incompatibilities(config: &Config, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(config)?;
     let reports = OnDiskReports::load(&ws)?;
     let id = args

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1830,7 +1830,7 @@ pub fn translate_dep_info(
 
     // This is a bit of a tricky statement, but here we're *removing* the
     // dependency on environment variables that were defined specifically for
-    // the command itself. Environment variables returend by `get_envs` includes
+    // the command itself. Environment variables returned by `get_envs` includes
     // environment variables like:
     //
     // * `OUT_DIR` if applicable

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -30,7 +30,7 @@ pub struct Timings<'cfg> {
     start_str: String,
     /// A summary of the root units.
     ///
-    /// Tuples of `(package_description, target_descrptions)`.
+    /// Tuples of `(package_description, target_descriptions)`.
     root_targets: Vec<(String, Vec<String>)>,
     /// The build profile.
     profile: String,

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -802,7 +802,7 @@ impl CompileFilter {
     /// Constructs a filter that includes all test targets.
     ///
     /// Being different from the behavior of [`CompileFilter::Default`], this
-    /// function only recongnizes test targets, which means cargo might compile
+    /// function only recognizes test targets, which means cargo might compile
     /// all targets with `tested` flag on, whereas [`CompileFilter::Default`]
     /// may include additional example targets to ensure they can be compiled.
     ///

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -409,7 +409,7 @@ impl<'cfg> RegistryIndex<'cfg> {
         Poll::Ready(Ok(self.summaries_cache.get_mut(&name).unwrap()))
     }
 
-    /// Clears the in-memory summmaries cache.
+    /// Clears the in-memory summaries cache.
     pub fn clear_summaries_cache(&mut self) {
         self.summaries_cache.clear();
     }

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -18,7 +18,7 @@ use crate::core::Edition;
 use crate::util::errors::CargoResult;
 use crate::util::Config;
 
-const DIAGNOSICS_SERVER_VAR: &str = "__CARGO_FIX_DIAGNOSTICS_SERVER";
+const DIAGNOSTICS_SERVER_VAR: &str = "__CARGO_FIX_DIAGNOSTICS_SERVER";
 const PLEASE_REPORT_THIS_BUG: &str =
     "This likely indicates a bug in either rustc or cargo itself,\n\
      and we would appreciate a bug report! You're likely to see \n\
@@ -63,7 +63,7 @@ pub enum Message {
 impl Message {
     pub fn post(&self) -> Result<(), Error> {
         let addr =
-            env::var(DIAGNOSICS_SERVER_VAR).context("diagnostics collector misconfigured")?;
+            env::var(DIAGNOSTICS_SERVER_VAR).context("diagnostics collector misconfigured")?;
         let mut client =
             TcpStream::connect(&addr).context("failed to connect to parent diagnostics target")?;
 
@@ -240,7 +240,7 @@ impl RustfixDiagnosticServer {
     }
 
     pub fn configure(&self, process: &mut ProcessBuilder) {
-        process.env(DIAGNOSICS_SERVER_VAR, self.addr.to_string());
+        process.env(DIAGNOSTICS_SERVER_VAR, self.addr.to_string());
     }
 
     pub fn start<F>(self, on_message: F) -> Result<StartedServer, Error>

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -84,7 +84,7 @@ supported environment variables are:
 * `CARGO_BUILD_INCREMENTAL` — Incremental compilation, see [`build.incremental`].
 * `CARGO_BUILD_DEP_INFO_BASEDIR` — Dep-info relative directory, see [`build.dep-info-basedir`].
 * `CARGO_CARGO_NEW_VCS` — The default source control system with [`cargo new`], see [`cargo-new.vcs`].
-* `CARGO_FUTURE_INCOMPAT_REPORT_FREQUENCY` - How often we should generate a future incompat report notifcation, see [`future-incompat-report.frequency`].
+* `CARGO_FUTURE_INCOMPAT_REPORT_FREQUENCY` - How often we should generate a future incompat report notification, see [`future-incompat-report.frequency`].
 * `CARGO_HTTP_DEBUG` — Enables HTTP debugging, see [`http.debug`].
 * `CARGO_HTTP_PROXY` — Enables HTTP proxy, see [`http.proxy`].
 * `CARGO_HTTP_TIMEOUT` — The HTTP timeout, see [`http.timeout`].

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1243,9 +1243,9 @@ Keys that are supported:
 
 Example:
 ```toml
-# [PROGECT_DIR]/Cargo.toml
+# [PROJECT_DIR]/Cargo.toml
 [workspace]
-memebers = ["bar"]
+members = ["bar"]
 
 [workspace.package]
 version = "1.2.3"
@@ -1255,7 +1255,7 @@ documentation = "https://example.github.io/example"
 ```
 
 ```toml
-# [PROGECT_DIR]/bar/Cargo.toml
+# [PROGJCT_DIR]/bar/Cargo.toml
 cargo-features = ["workspace-inheritance"]
 
 [package]
@@ -1280,9 +1280,9 @@ You can then [inherit the workspace dependency as a package dependency][inheriti
 
 Example:
 ```toml
-# [PROGECT_DIR]/Cargo.toml
+# [PROJECT_DIR]/Cargo.toml
 [workspace]
-memebers = ["bar"]
+members = ["bar"]
 
 [workspace.dependencies]
 dep = { version = "0.1", features = ["fancy"] }
@@ -1291,7 +1291,7 @@ dep-dev = "0.5.2"
 ```
 
 ```toml
-# [PROGECT_DIR]/bar/Cargo.toml
+# [PROJECT_DIR]/bar/Cargo.toml
 cargo-features = ["workspace-inheritance"]
 
 [project]

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2397,7 +2397,7 @@ fn found_multiple_target_files() {
 
     p.cargo("build -v")
         .with_status(101)
-        // Don't assert the inferred pathes since the order is non-deterministic.
+        // Don't assert the inferred paths since the order is non-deterministic.
         .with_stderr(
             "\
 [ERROR] failed to parse manifest at `[..]`
@@ -5088,7 +5088,7 @@ fn same_metadata_different_directory() {
 }
 
 #[cargo_test]
-fn building_a_dependent_crate_witout_bin_should_fail() {
+fn building_a_dependent_crate_without_bin_should_fail() {
     Package::new("testless", "0.1.0")
         .file(
             "Cargo.toml",

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1256,7 +1256,7 @@ fn fingerprint_cleaner(mut dir: PathBuf, timestamp: filetime::FileTime) {
     // So a cleaner can remove files associated with a fingerprint
     // if all the files in the fingerprint's folder are older then a time stamp without
     // effecting any builds that happened since that time stamp.
-    let mut cleand = false;
+    let mut cleaned = false;
     dir.push(".fingerprint");
     for fing in fs::read_dir(&dir).unwrap() {
         let fing = fing.unwrap();
@@ -1270,12 +1270,12 @@ fn fingerprint_cleaner(mut dir: PathBuf, timestamp: filetime::FileTime) {
             println!("remove: {:?}", fing.path());
             // a real cleaner would remove the big files in deps and build as well
             // but fingerprint is sufficient for our tests
-            cleand = true;
+            cleaned = true;
         } else {
         }
     }
     assert!(
-        cleand,
+        cleaned,
         "called fingerprint_cleaner, but there was nothing to remove"
     );
 }

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -1,4 +1,4 @@
-//! Tests for target filter flags rith glob patterns.
+//! Tests for target filter flags with glob patterns.
 
 use cargo_test_support::{project, Project};
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1428,7 +1428,7 @@ fn uninstall_multiple_and_specifying_bin() {
 }
 
 #[cargo_test]
-fn uninstall_with_empty_pakcage_option() {
+fn uninstall_with_empty_package_option() {
     cargo_process("uninstall -p")
         .with_status(101)
         .with_stderr(

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -578,7 +578,7 @@ fn profile_selection_check_all_targets_test() {
     //   Pkg  Target  Profile    Action   Reason
     //   ---  ------  -------    ------   ------
     //   bar  lib     test*       link     For bdep
-    //   bar  lib     test-panic  metdata  For tests/benches
+    //   bar  lib     test-panic  metadata  For tests/benches
     //   bdep lib     test*       link     For foo build.rs
     //   foo  custom  test*       link     For build.rs
     //

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -186,7 +186,7 @@ fn lock_file_and_workspace() {
 #[cargo_test]
 fn note_resolve_changes() {
     // `multi` has multiple sources (path and registry).
-    Package::new("mutli", "0.1.0").publish();
+    Package::new("multi", "0.1.0").publish();
     // `updated` is always from registry, but should not change.
     Package::new("updated", "1.0.0").publish();
     // `patched` is [patch]ed.
@@ -200,7 +200,7 @@ fn note_resolve_changes() {
                 "0.0.1",
                 r#"
                 [dependencies]
-                mutli = { path = "mutli", version = "0.1" }
+                multi = { path = "multi", version = "0.1" }
                 updated = "1.0"
                 patched = "1.0"
 
@@ -210,8 +210,8 @@ fn note_resolve_changes() {
             ),
         )
         .file("src/main.rs", "fn main() {}")
-        .file("mutli/Cargo.toml", &basic_manifest("mutli", "0.1.0"))
-        .file("mutli/src/lib.rs", "")
+        .file("multi/Cargo.toml", &basic_manifest("multi", "0.1.0"))
+        .file("multi/src/lib.rs", "")
         .file("patched/Cargo.toml", &basic_manifest("patched", "1.0.0"))
         .file("patched/src/lib.rs", "")
         .build();
@@ -230,7 +230,7 @@ fn note_resolve_changes() {
 [ARCHIVING] Cargo.toml.orig
 [ARCHIVING] src/main.rs
 [UPDATING] `[..]` index
-[NOTE] package `mutli v0.1.0` added to the packaged Cargo.lock file, was originally sourced from `[..]/foo/mutli`
+[NOTE] package `multi v0.1.0` added to the packaged Cargo.lock file, was originally sourced from `[..]/foo/multi`
 [NOTE] package `patched v1.0.0` added to the packaged Cargo.lock file, was originally sourced from `[..]/foo/patched`
 ",
         )

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1221,7 +1221,7 @@ fn workspace_in_git() {
 }
 
 #[cargo_test]
-fn lockfile_can_specify_nonexistant_members() {
+fn lockfile_can_specify_nonexistent_members() {
     let p = project()
         .file(
             "Cargo.toml",


### PR DESCRIPTION
This fixes various typos inside `cargo`. They were found by [`typos-cli`](https://crates.io/crates/typos-cli). A few different typos were left out as they seemed either intentional or were needed. Typos found in `LICENSE-THIRD-PARTY` were left alone as well.

r? @epage