### PR TITLE
test: Make curr_dir work in/out of workspace

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -35,8 +35,21 @@ macro_rules! t {
 #[macro_export]
 macro_rules! curr_dir {
     () => {
-        std::path::Path::new(file!()).parent().unwrap()
+        $crate::_curr_dir(std::path::Path::new(file!()));
     };
+}
+
+#[doc(hidden)]
+pub fn _curr_dir(mut file_path: &'static Path) -> &'static Path {
+    if !file_path.exists() {
+        // HACK: Must be running in the rust-lang/rust workspace, adjust the paths accordingly.
+        let prefix = PathBuf::from("src").join("tools").join("cargo");
+        if let Ok(crate_relative) = file_path.strip_prefix(prefix) {
+            file_path = crate_relative
+        }
+    }
+    assert!(file_path.exists(), "{} does not exist", file_path.display());
+    file_path.parent().unwrap()
 }
 
 #[track_caller]


### PR DESCRIPTION
### What does this PR try to resolve?

Get snapbox tests passing when testing `cargo` as part of the `rust-lang/rust` workspace via a git submodule.
- When running tests in the `rust-lang/cargo` repo, `file!` is relative to
the crate root and tests are run relative to the crate root and
everything is fine.
- When running tests in the `rust-lang/rust` repo, `file!` is relative to
the workspace root and tests are run relative to the crate root and
there is much sadness.

If we are compiling relative to the crate root, we could make the path
absolute and everything would be dandy but this needs to happen at
compile time.  Didn't see a way to do this.

We could stop using `curr_dir` but that makes the tests a bit noisier
with more overhead for creating a new tests from an existing case.

Since we can reasonly know what all roots will be used for `file!`, we
can just hard code-in support for those two roots.  Much happiness
ensues as everything works with this surgical hack.

### How should we test and review this PR?

I ran the tests in both the `cargo` and `rust` repos.  You can as well.

### Additional information
