### PR TITLE
Normalize path for `cargo vendor` output

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -298,6 +298,9 @@ fn sync(
         config.insert(
             merged_source_name.to_string(),
             VendorSource::Directory {
+                // Windows-flavour paths are valid here on Windows but Unix.
+                // This backslash normalization is for making output paths more
+                // cross-platform compatible.
                 directory: opts.destination.to_string_lossy().replace("\\", "/"),
             },
         );

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -60,7 +60,7 @@ struct VendorConfig {
 #[serde(rename_all = "lowercase", untagged)]
 enum VendorSource {
     Directory {
-        directory: PathBuf,
+        directory: String,
     },
     Registry {
         registry: Option<String>,
@@ -298,7 +298,7 @@ fn sync(
         config.insert(
             merged_source_name.to_string(),
             VendorSource::Directory {
-                directory: opts.destination.to_path_buf(),
+                directory: opts.destination.to_string_lossy().replace("\\", "/"),
             },
         );
     } else if !dest_dir_already_exists {

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -117,7 +117,7 @@ fn package_exclude() {
         .publish();
 
     p.cargo("vendor --respect-source-config").run();
-    let csum = dbg!(p.read_file("vendor/bar/.cargo-checksum.json"));
+    let csum = p.read_file("vendor/bar/.cargo-checksum.json");
     assert!(csum.contains(".include"));
     assert!(!csum.contains(".exclude"));
     assert!(!csum.contains(".dotdir/exclude"));


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Normalize path for `cargo vendor` output

fixes #10652

### How should we test and review this PR?

A new test `vendor::vendor_path_specified` is added. Please run under Windows to verify the behaviour.

### Additional information

There are already three places [^1][^2][^3] using the same trick. I guess we are happy to adopt it here.

[^1]: [ops/cargo_add/dependency.rs](https://github.com/rust-lang/cargo/blob/6d6dd9d9be9c91390da620adf43581619c2fa90e/src/cargo/ops/cargo_add/dependency.rs#L662)
[^2]: [ops/vendor.rs](https://github.com/rust-lang/cargo/blob/6d6dd9d9be9c91390da620adf43581619c2fa90e/src/cargo/ops/vendor.rs#L354)
[^3]: [ops/cargo_package.rs](https://github.com/rust-lang/cargo/blob/6d6dd9d9be9c91390da620adf43581619c2fa90e/src/cargo/ops/cargo_package.rs#L447)

<!-- homu-ignore:end -->
