### PR TITLE
add validation for string "true"/"false" in lto profile

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -655,6 +655,16 @@ impl TomlProfile {
             }
         }
 
+        if let Some(StringOrBool::String(arg)) = &self.lto {
+            if arg == "true" || arg == "false" {
+                bail!(
+                    "`lto` setting of string `\"{arg}\"` for `{name}` profile is not \
+                     a valid setting, must be a boolean (`true`/`false`) or a string \
+                    (`\"thin\"`/`\"fat\"`/`\"off\"`) or omitted.",
+                );
+            }
+        }
+
         Ok(())
     }
 

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -324,6 +324,37 @@ fn profile_in_virtual_manifest_works() {
 }
 
 #[cargo_test]
+fn profile_lto_string_bool_dev() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [profile.dev]
+                lto = "true"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  `lto` setting of string `\"true\"` for `dev` profile is not a valid setting, \
+must be a boolean (`true`/`false`) or a string (`\"thin\"`/`\"fat\"`/`\"off\"`) or omitted.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn profile_panic_test_bench() {
     let p = project()
         .file(


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->
<!-- homu-ignore:end -->

### What does this PR try to resolve?
Adds a special-cased error message for when `lto` is set to the _string_ `"true"`/`"false"` which is surprisingly (I was surprised anyway) not allowed and the error message is ambiguous. The new error message makes it clear what values are accepted. 
Fixes https://github.com/rust-lang/cargo/issues/10572

### How should we test and review this PR?

 <!-- Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests -->

Uh I've not actually tested yet that's the WIP part. But put 
```
[profile.dev]
lto="false"
```
in your TOML and run `cargo build`, check that you get the new error message and that it makes sense and is helpful.

### Additional information

It's worth noting that as per https://github.com/rust-lang/rust/pull/97051 this doesn't fix the _real_ problem here IMO which is that [rust's `opt_parse_bool` cli parsing](https://github.com/rust-lang/rust/blob/491f619f564a4ff9ae4cc837e27bb919d04c31be/compiler/rustc_session/src/options.rs#L456) doesn't accept true/false which certainly seems an ad-hoc historical choice to me on first glance but also it's a much bigger change to change those semantics than this error message.

