### PR TITLE
fix(publish): add more check when use `publish -p <SPEC>` 

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1449,6 +1449,7 @@ impl<'cfg> Workspace<'cfg> {
 
         let ms: Vec<_> = self
             .members()
+            .filter(|m| specs.iter().any(|spec| spec.matches(m.package_id())))
             .filter_map(|member| {
                 let member_id = member.package_id();
                 match self.current_opt() {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1449,7 +1449,6 @@ impl<'cfg> Workspace<'cfg> {
 
         let ms: Vec<_> = self
             .members()
-            .filter(|m| specs.iter().any(|spec| spec.matches(m.package_id())))
             .filter_map(|member| {
                 let member_id = member.package_id();
                 match self.current_opt() {

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -146,15 +146,10 @@ impl Packages {
                 emit_pattern_not_found(ws, patterns, true).or_else(warn)?;
                 specs
             }
+            Packages::Packages(packages) if packages.is_empty() => {
+                vec![PackageIdSpec::from_package_id(ws.current()?.package_id())]
+            }
             Packages::Packages(opt_in) => {
-                if ws.is_virtual() {
-                    bail!("can't use \"--package <SPEC>\" in virtual manifest")
-                }
-                if opt_in.is_empty() {
-                    return Ok(vec![PackageIdSpec::from_package_id(
-                        ws.current()?.package_id(),
-                    )]);
-                }
                 let (mut patterns, packages) = opt_patterns_and_names(opt_in)?;
                 let mut specs = packages
                     .iter()
@@ -169,25 +164,6 @@ impl Packages {
                     specs.extend(matched_pkgs);
                 }
                 emit_pattern_not_found(ws, patterns, false)?;
-                let matched_packages = ws
-                    .members()
-                    .filter(|m| specs.iter().any(|spec| spec.matches(m.package_id())))
-                    .collect::<Vec<_>>();
-                if matched_packages.is_empty() {
-                    bail!(
-                        "not found `{}` in manifest members. Check in manifest path `{}`",
-                        opt_in.get(0).unwrap(),
-                        ws.root().display()
-                    )
-                }
-                if matched_packages.len() > 1 {
-                    bail!(
-                        "found mutilate `{}` in manifest members. Check in manifest path `{}`",
-                        opt_in.get(0).unwrap(),
-                        ws.root().display()
-                    )
-                }
-
                 specs
             }
             Packages::Default => ws

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -146,10 +146,15 @@ impl Packages {
                 emit_pattern_not_found(ws, patterns, true).or_else(warn)?;
                 specs
             }
-            Packages::Packages(packages) if packages.is_empty() => {
-                vec![PackageIdSpec::from_package_id(ws.current()?.package_id())]
-            }
             Packages::Packages(opt_in) => {
+                if ws.is_virtual() {
+                    bail!("can't use \"--package <SPEC>\" in virtual manifest")
+                }
+                if opt_in.is_empty() {
+                    return Ok(vec![PackageIdSpec::from_package_id(
+                        ws.current()?.package_id(),
+                    )]);
+                }
                 let (mut patterns, packages) = opt_patterns_and_names(opt_in)?;
                 let mut specs = packages
                     .iter()
@@ -164,6 +169,25 @@ impl Packages {
                     specs.extend(matched_pkgs);
                 }
                 emit_pattern_not_found(ws, patterns, false)?;
+                let matched_packages = ws
+                    .members()
+                    .filter(|m| specs.iter().any(|spec| spec.matches(m.package_id())))
+                    .collect::<Vec<_>>();
+                if matched_packages.is_empty() {
+                    bail!(
+                        "not found `{}` in manifest members. Check in manifest path `{}`",
+                        opt_in.get(0).unwrap(),
+                        ws.root().display()
+                    )
+                }
+                if matched_packages.len() > 1 {
+                    bail!(
+                        "found mutilate `{}` in manifest members. Check in manifest path `{}`",
+                        opt_in.get(0).unwrap(),
+                        ws.root().display()
+                    )
+                }
+
                 specs
             }
             Packages::Default => ws
@@ -174,13 +198,13 @@ impl Packages {
         };
         if specs.is_empty() {
             if ws.is_virtual() {
-                anyhow::bail!(
+                bail!(
                     "manifest path `{}` contains no package: The manifest is virtual, \
                      and the workspace has no members.",
                     ws.root().display()
                 )
             }
-            anyhow::bail!("no packages to compile")
+            bail!("no packages to compile")
         }
         Ok(specs)
     }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -23,7 +23,7 @@ use crate::core::resolver::CliFeatures;
 use crate::core::source::Source;
 use crate::core::{Package, SourceId, Workspace};
 use crate::ops;
-use crate::ops::Packages::Packages;
+use crate::ops::Packages;
 use crate::sources::{RegistrySource, SourceConfigMap, CRATES_IO_DOMAIN, CRATES_IO_REGISTRY};
 use crate::util::config::{self, Config, SslVersionConfig, SslVersionConfigRange};
 use crate::util::errors::CargoResult;
@@ -91,21 +91,31 @@ pub struct PublishOpts<'cfg> {
 
 pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
     let specs = opts.to_publish.to_package_id_specs(ws)?;
-
-    if let Packages(_) = &opts.to_publish {
-        if specs.len() > 1 {
-            bail!("the `-p` argument must be specified to select a single package to publish");
+    if specs.len() > 1 {
+        match opts.to_publish {
+            Packages::Default => {
+                bail!("must be specified to select a single package to publish. Check `default-members` or using `-p` argument")
+            }
+            Packages::Packages(_) => {
+                bail!("the `-p` argument must be specified to select a single package to publish")
+            }
+            _ => {}
         }
-    } else {
-        if ws.is_virtual() {
-            bail!("the `-p` argument must be specified in the root of a virtual workspace")
-        }
+    }
+    if Packages::Packages(vec![]) != opts.to_publish && ws.is_virtual() {
+        bail!("the `-p` argument must be specified in the root of a virtual workspace")
     }
     let member_ids = ws.members().map(|p| p.package_id());
     // Check that the spec matches exactly one member.
     specs[0].query(member_ids)?;
     let mut pkgs = ws.members_with_features(&specs, &opts.cli_features)?;
-    // Double check
+    // In `members_with_features_old`, it will add "current" package(determined by the cwd). Line:1455 in workspace.rs.
+    // So we need filter
+    pkgs = pkgs
+        .into_iter()
+        .filter(|(m, _)| specs.iter().any(|spec| spec.matches(m.package_id())))
+        .collect();
+    // Double check. It is safe theoretically, unless logic has updated.
     assert_eq!(pkgs.len(), 1);
 
     let (pkg, cli_features) = pkgs.pop().unwrap();

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -98,7 +98,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         }
     } else {
         if ws.is_virtual() {
-            bail!("must use `-p` argument in virtual manifest")
+            bail!("the `-p` argument must be specified in the root of a virtual workspace")
         }
     }
     let member_ids = ws.members().map(|p| p.package_id());

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -109,7 +109,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         }
         if matched_packages.len() > 1 {
             bail!(
-                "found mutilate `{}` in manifest members. Check in manifest path `{}`",
+                "found multiple `{}` in manifest members. Check in manifest path `{}`",
                 opt_in.get(0).unwrap(),
                 ws.root().display()
             )

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -168,7 +168,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
             cli_features: cli_features,
         },
     )?
-        .unwrap();
+    .unwrap();
 
     opts.config
         .shell()
@@ -262,7 +262,7 @@ fn transmit(
                     DepKind::Build => "build",
                     DepKind::Development => "dev",
                 }
-                    .to_string(),
+                .to_string(),
                 registry: dep_registry,
                 explicit_name_in_toml: dep.explicit_name_in_toml().map(|s| s.to_string()),
             })

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -92,24 +92,16 @@ pub struct PublishOpts<'cfg> {
 pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
     let specs = opts.to_publish.to_package_id_specs(ws)?;
     if specs.len() > 1 {
-        match opts.to_publish {
-            Packages::Default => {
-                bail!("must be specified to select a single package to publish. Check `default-members` or using `-p` argument")
-            }
-            Packages::Packages(_) => {
-                bail!("the `-p` argument must be specified to select a single package to publish")
-            }
-            _ => {}
-        }
+        bail!("the `-p` argument must be specified to select a single package to publish")
     }
-    if Packages::Packages(vec![]) != opts.to_publish && ws.is_virtual() {
+    if Packages::Default == opts.to_publish && ws.is_virtual() {
         bail!("the `-p` argument must be specified in the root of a virtual workspace")
     }
     let member_ids = ws.members().map(|p| p.package_id());
     // Check that the spec matches exactly one member.
     specs[0].query(member_ids)?;
     let mut pkgs = ws.members_with_features(&specs, &opts.cli_features)?;
-    // In `members_with_features_old`, it will add "current" package(determined by the cwd). Line:1455 in workspace.rs.
+    // In `members_with_features_old`, it will add "current" package (determined by the cwd)
     // So we need filter
     pkgs = pkgs
         .into_iter()

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -168,7 +168,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
             cli_features: cli_features,
         },
     )?
-    .unwrap();
+        .unwrap();
 
     opts.config
         .shell()
@@ -262,7 +262,7 @@ fn transmit(
                     DepKind::Build => "build",
                     DepKind::Development => "dev",
                 }
-                .to_string(),
+                    .to_string(),
                 registry: dep_registry,
                 explicit_name_in_toml: dep.explicit_name_in_toml().map(|s| s.to_string()),
             })

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1839,7 +1839,6 @@ error: the `-p` argument must be specified to select a single package to publish
         .run();
 }
 
-
 #[cargo_test]
 // https://github.com/rust-lang/cargo/issues/10536
 fn publish_path_dependency_without_workspace() {
@@ -1884,4 +1883,3 @@ error: package ID specification `bar` did not match any packages
         )
         .run();
 }
-

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1831,7 +1831,7 @@ fn in_package_workspace_found_mutilate() {
         .with_status(101)
         .with_stderr(
             "\
-error: found mutilate `li*` in manifest members. Check in manifest path `[CWD]`
+error: found multiple `li*` in manifest members. Check in manifest path `[CWD]`
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1737,7 +1737,7 @@ fn in_virtual_workspace() {
 
     p.cargo("publish --no-verify --token sekrit")
         .with_status(101)
-        .with_stderr("error: must use `-p` argument in virtual manifest")
+        .with_stderr("error: the `-p` argument must be specified in the root of a virtual workspace")
         .run();
 }
 

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1737,7 +1737,9 @@ fn in_virtual_workspace() {
 
     p.cargo("publish --no-verify --token sekrit")
         .with_status(101)
-        .with_stderr("error: the `-p` argument must be specified in the root of a virtual workspace")
+        .with_stderr(
+            "error: the `-p` argument must be specified in the root of a virtual workspace",
+        )
         .run();
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
### Main issue
As issue say #10536 , we need add more check when user use `cargo publish -p <SPEC>`

>@ehuss point outs: 
>From a behavior standpoint, here are some things to check:
> - In the root of a virtual workspace, it should be an error to run without -p.
>- It should be an error to pass -p for a non-workspace member.
>- It should be an error for -p to match multiple packages.
>- When using -p, it should publish that package, not the one in the current directory (which can be different).