### PR TITLE
List C compiler as a build dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Cargo requires the following tools and packages to build:
 * `curl` (on Unix)
 * `pkg-config` (on Unix, used to figure out the `libssl` headers/libraries)
 * OpenSSL headers (only for Unix, this is the `libssl-dev` package on ubuntu)
+* A C compiler [for your platform](https://github.com/rust-lang/cc-rs#compile-time-requirements)
 * `cargo` and `rustc`
 
 First, you'll want to check out this repository


### PR DESCRIPTION
Cargo requires a C compiler to build, this should be specified in README
```
$ cargo tree --invert cc
cc v1.0.73
[build-dependencies]
├── curl-sys v0.4.55+curl-7.83.1
│   ├── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
│   └── curl v0.4.43
│       ├── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
│       ├── crates-io v0.34.0 (C:\Users\IEUser\Documents\cargo\crates\crates-io)
│       │   └── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
│       └── git2-curl v0.15.0
│           └── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
├── libgit2-sys v0.13.4+1.4.2
│   ├── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
│   └── git2 v0.14.4
│       ├── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
│       ├── cargo-test-support v0.1.0 (C:\Users\IEUser\Documents\cargo\crates\cargo-test-support)
│       │   [dev-dependencies]
│       │   └── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
│       └── git2-curl v0.15.0 (*)
├── libnghttp2-sys v0.1.7+1.45.0
│   └── curl-sys v0.4.55+curl-7.83.1 (*)
├── libssh2-sys v0.2.23
│   └── libgit2-sys v0.13.4+1.4.2 (*)
└── libz-sys v1.1.6
    ├── curl-sys v0.4.55+curl-7.83.1 (*)
    ├── flate2 v1.0.23
    │   ├── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
    │   └── cargo-test-support v0.1.0 (C:\Users\IEUser\Documents\cargo\crates\cargo-test-support) (*)
    │   [build-dependencies]
    │   └── cargo v0.63.0 (C:\Users\IEUser\Documents\cargo)
    ├── libgit2-sys v0.13.4+1.4.2 (*)
    └── libssh2-sys v0.2.23 (*)
```