### PR TITLE
fix bugs with `workspace` key and `update_toml`

### DIFF
--- a/src/cargo/ops/cargo_add/dependency.rs
+++ b/src/cargo/ops/cargo_add/dependency.rs
@@ -539,7 +539,9 @@ impl Dependency {
                     }
                 }
                 Some(Source::Workspace(_)) => {
+                    table.insert("workspace", toml_edit::value(true));
                     table.set_dotted(true);
+                    key.fmt();
                     for key in [
                         "version",
                         "registry",

--- a/src/cargo/ops/cargo_add/dependency.rs
+++ b/src/cargo/ops/cargo_add/dependency.rs
@@ -552,6 +552,7 @@ impl Dependency {
                         "tag",
                         "rev",
                         "package",
+                        "default-features",
                     ] {
                         table.remove(key);
                     }


### PR DESCRIPTION
### Motivations and Context

When working on an external subcommand to help with the switch to workspace inheritance, I found issues with the output `Cargo.toml` it was creating. When a `cargo_add::Dependency` would change its source to a `WorkspsaceSource`, `workspace = true` would not show up. This lead me to discover that the `default-features` key was not being removed when the `workspace` key was set. 

This fixes those issues but brought up questions about how to deal with removing keys and clearing conflicting fields in a `Dependency`. After talking with @epage, it was decided that this was the minimal set of changes to make while the changes to fix the other issues is workshopped.

### Changes
- add `default-features` to the list of keys to remove when the source is a `WorkspaceSource`
- insert a `workspace` key when the source is a `WorkspaceSource`
