### PR TITLE
Update libcurl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.1.3" }
 crates-io = { path = "crates/crates-io", version = "0.34.0" }
 crossbeam-utils = "0.8"
-curl = { version = "0.4.41", features = ["http2"] }
-curl-sys = "0.4.50"
+curl = { version = "0.4.43", features = ["http2"] }
+curl-sys = "0.4.55"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"


### PR DESCRIPTION
This updates to the latest libcurl.

Changes in curl:
* 0.4.42: https://github.com/alexcrichton/curl-rust/releases/tag/0.4.42
* 0.4.43: https://github.com/alexcrichton/curl-rust/releases/tag/0.4.43

Changes in libcurl:
* From 7.80.0 to 7.83.1: https://curl.se/changes.html

There were several security issues addressed recently (https://curl.se/docs/security.html), however, I don't think any of them are particularly concerning for us.
