### PR TITLE
fix WorkspaceSource's issues with rename and default-features

### DIFF
--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -284,6 +284,7 @@ fn resolve_dependency(
         // Checking for a workspace dependency happens first since a member could be specified
         // in the workspace dependencies table as a dependency
         if let Some(_dep) = find_workspace_dep(dependency.toml_key(), ws.root_manifest()).ok() {
+            check_invalid_ws_keys(dependency.toml_key(), arg)?;
             dependency = dependency.set_source(WorkspaceSource::new());
         } else if let Some(package) = ws.members().find(|p| p.name().as_str() == dependency.name) {
             // Only special-case workspaces when the user doesn't provide any extra
@@ -565,7 +566,7 @@ fn populate_dependency(mut dependency: Dependency, arg: &DepOp) -> Dependency {
     }
 
     if let Some(rename) = &arg.rename {
-        dependency = dependency.set_rename(rename);
+        dependency = dependency.set_rename(rename).unwrap();
     }
 
     dependency


### PR DESCRIPTION
### Motivations and Context

As talked about in #10685, there were some issues with the `cargo_add::Dependency` methods. They revolved around setting a source to a `WorkspaceSource` from another `Source`. They would leave remnants of the other source that conflicts with a `WorkspaceSource` (`rename` and `default-features`). This fixes that issue by making sure you cannot set `rename` or `default-features` if the source is a `WorkspaceSource`. Additionally, it clears the conflicting fields in a `Dependency` so they cannot show up even if you switched the `Source`.

### Changes
- Made `set_rename` and `set_default_features` return a `CargoResult`
  - They also return an error if the method is called on a `WorkspaceSource` 
- Made `set_source` clear conflicting fields when called with a `WorkspaceSource` 


r? @epage