### PR TITLE
Require http-registry URLs to end with a '/'

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -546,10 +546,7 @@ impl<'cfg> RegistrySource<'cfg> {
     ) -> CargoResult<RegistrySource<'cfg>> {
         let name = short_name(source_id);
         let ops = if source_id.url().scheme().starts_with("sparse+") {
-            if !config.cli_unstable().http_registry {
-                anyhow::bail!("Usage of HTTP-based registries requires `-Z http-registry`");
-            }
-            Box::new(http_remote::HttpRegistry::new(source_id, config, &name)) as Box<_>
+            Box::new(http_remote::HttpRegistry::new(source_id, config, &name)?) as Box<_>
         } else {
             Box::new(remote::RemoteRegistry::new(source_id, config, &name)) as Box<_>
         };

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -41,7 +41,7 @@ fn configure_source_replacement_for_http(addr: &str) {
             replace-with = 'dummy-registry'
 
             [source.dummy-registry]
-            registry = 'sparse+http://{}'
+            registry = 'sparse+http://{}/'
         ",
             addr
         )
@@ -2680,6 +2680,15 @@ fn http_requires_z_flag() {
 
     p.cargo("build")
         .with_status(101)
-        .with_stderr_contains("  Usage of HTTP-based registries requires `-Z http-registry`")
+        .with_stderr_contains("  usage of HTTP-based registries requires `-Z http-registry`")
         .run();
+}
+
+#[cargo_test]
+fn http_requires_trailing_slash() {
+    cargo_process("-Z http-registry install bar --index sparse+https://index.crates.io")
+        .masquerade_as_nightly_cargo()
+        .with_status(101)
+        .with_stderr("[ERROR] registry url must end in a slash `/`: sparse+https://index.crates.io")
+        .run()
 }


### PR DESCRIPTION
The `url` crate normalizes URLs with no path component to end in a trailing slash. This causes the current implementation to use urls containing two slashes for registries without a path component (such as `https://index.crates.io//config.json`).

This PR resolves the issue by requiring http registry URLs to end in a slash and generating paths by concatenating. A new error message is emitted for http registry URLs that do not end in a slash.

r? @Eh2406