### PR TITLE
Guide new users to add use `super::*;` to `mod test`

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -809,13 +809,17 @@ fn main() {
 "
         } else {
             b"\
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+    
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -811,6 +811,8 @@ fn main() {
             b"\
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -816,7 +816,7 @@ pub fn add(left: usize, right: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn it_works() {
         let result = add(2, 2);

--- a/tests/testsuite/init/auto_git/out/src/lib.rs
+++ b/tests/testsuite/init/auto_git/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/auto_git/out/src/lib.rs
+++ b/tests/testsuite/init/auto_git/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/formats_source/out/src/lib.rs
+++ b/tests/testsuite/init/formats_source/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+  left + right
+}
+
 #[cfg(test)]
 mod tests {
-  // Uncomment this to use items from the containing module.
-  // use super::*;
+  use super::*;
+
   #[test]
   fn it_works() {
-    let result = 2 + 2;
+    let result = add(2, 2);
     assert_eq!(result, 4);
   }
 }

--- a/tests/testsuite/init/formats_source/out/src/lib.rs
+++ b/tests/testsuite/init/formats_source/out/src/lib.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
-    #[test]
-    fn it_works() {
-        let result = 2 + 2;
-        assert_eq!(result, 4);
-    }
+  // Uncomment this to use items from the containing module.
+  // use super::*;
+  #[test]
+  fn it_works() {
+    let result = 2 + 2;
+    assert_eq!(result, 4);
+  }
 }

--- a/tests/testsuite/init/formats_source/out/src/lib.rs
+++ b/tests/testsuite/init/formats_source/out/src/lib.rs
@@ -1,8 +1,10 @@
 #[cfg(test)]
 mod tests {
-  #[test]
-  fn it_works() {
-    let result = 2 + 2;
-    assert_eq!(result, 4);
-  }
+    // Uncomment this to use items from the containing module.
+    // use super::*;
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
 }

--- a/tests/testsuite/init/fossil_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/fossil_autodetect/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/fossil_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/fossil_autodetect/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/git_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/git_autodetect/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/git_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/git_autodetect/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/out/src/lib.rs
+++ b/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/out/src/lib.rs
+++ b/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
+++ b/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
+++ b/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
@@ -5,7 +5,7 @@ pub fn add(left: usize, right: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    
     #[test]
     fn it_works() {
         let result = add(2, 2);

--- a/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
+++ b/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
@@ -5,7 +5,7 @@ pub fn add(left: usize, right: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn it_works() {
         let result = add(2, 2);

--- a/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
+++ b/tests/testsuite/init/ignores_failure_to_format_source/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/mercurial_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/mercurial_autodetect/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/mercurial_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/mercurial_autodetect/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/pijul_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/pijul_autodetect/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/pijul_autodetect/out/src/lib.rs
+++ b/tests/testsuite/init/pijul_autodetect/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/simple_git/out/src/lib.rs
+++ b/tests/testsuite/init/simple_git/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/simple_git/out/src/lib.rs
+++ b/tests/testsuite/init/simple_git/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/simple_git_ignore_exists/out/src/lib.rs
+++ b/tests/testsuite/init/simple_git_ignore_exists/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/simple_git_ignore_exists/out/src/lib.rs
+++ b/tests/testsuite/init/simple_git_ignore_exists/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/simple_hg/out/src/lib.rs
+++ b/tests/testsuite/init/simple_hg/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/simple_hg/out/src/lib.rs
+++ b/tests/testsuite/init/simple_hg/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/simple_hg_ignore_exists/out/src/lib.rs
+++ b/tests/testsuite/init/simple_hg_ignore_exists/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/simple_hg_ignore_exists/out/src/lib.rs
+++ b/tests/testsuite/init/simple_hg_ignore_exists/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/init/simple_lib/out/src/lib.rs
+++ b/tests/testsuite/init/simple_lib/out/src/lib.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/init/simple_lib/out/src/lib.rs
+++ b/tests/testsuite/init/simple_lib/out/src/lib.rs
@@ -1,10 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
 #[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -41,6 +41,8 @@ fn simple_lib() {
         contents,
         r#"#[cfg(test)]
 mod tests {
+    // Uncomment this to use items from the containing module.
+    // use super::*;
     #[test]
     fn it_works() {
         let result = 2 + 2;

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -39,13 +39,17 @@ fn simple_lib() {
     let contents = fs::read_to_string(&lib).unwrap();
     assert_eq!(
         contents,
-        r#"#[cfg(test)]
+        r#"pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
 mod tests {
-    // Uncomment this to use items from the containing module.
-    // use super::*;
+    use super::*;
+
     #[test]
     fn it_works() {
-        let result = 2 + 2;
+        let result = add(2, 2);
         assert_eq!(result, 4);
     }
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Currently, `cargo init --lib` produces examples for unit tests. However, new users will find that they are unable to use functions they defined above. This should resolve the confusion.

Fixes #10559 

### How should we test and review this PR?

This PR does not create new features. Test this PR using the already-existing tests.

### Additional information

I didn't think this was a major change, so I did not open a RFC for it. Please let me know if I should have!

