### PR TITLE
Expose rust-version through env var

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -347,6 +347,10 @@ impl<'cfg> Compilation<'cfg> {
                 metadata.license_file.as_ref().unwrap_or(&String::new()),
             )
             .env("CARGO_PKG_AUTHORS", &pkg.authors().join(":"))
+            .env(
+                "CARGO_PKG_RUST_VERSION",
+                &pkg.rust_version().unwrap_or(&String::new()),
+            )
             .cwd(pkg.root());
 
         // Apply any environment variables from the config

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -214,6 +214,9 @@ corresponding environment variable is set to the empty string, `""`.
 * `CARGO_PKG_REPOSITORY` — The repository from the manifest of your package.
 * `CARGO_PKG_LICENSE` — The license from the manifest of your package.
 * `CARGO_PKG_LICENSE_FILE` — The license file from the manifest of your package.
+* `CARGO_PKG_RUST_VERSION` — The Rust version from the manifest of your package.
+  Note that this is the minimum Rust version supported by the package, not the
+  current Rust version.
 * `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled.
 * `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as `.exe`.
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1314,6 +1314,7 @@ fn crate_env_vars() {
             authors = ["wycats@example.com"]
             license = "MIT OR Apache-2.0"
             license-file = "license.txt"
+            rust-version = "1.61.0"
 
             [[bin]]
             name = "foo-bar"
@@ -1338,6 +1339,7 @@ fn crate_env_vars() {
                 static LICENSE: &'static str = env!("CARGO_PKG_LICENSE");
                 static LICENSE_FILE: &'static str = env!("CARGO_PKG_LICENSE_FILE");
                 static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
+                static RUST_VERSION: &'static str = env!("CARGO_PKG_RUST_VERSION");
                 static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
                 static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
 
@@ -1356,6 +1358,7 @@ fn crate_env_vars() {
                      assert_eq!("MIT OR Apache-2.0", LICENSE);
                      assert_eq!("license.txt", LICENSE_FILE);
                      assert_eq!("This is foo", DESCRIPTION);
+                     assert_eq!("1.61.0", RUST_VERSION);
                     let s = format!("{}.{}.{}-{}", VERSION_MAJOR,
                                     VERSION_MINOR, VERSION_PATCH, VERSION_PRE);
                     assert_eq!(s, VERSION);


### PR DESCRIPTION
This adds another env var that is exposed by cargo. In Clippy we would like to use that in order to efficiently check if a rust-version is set for the current package: https://github.com/rust-lang/rust-clippy/pull/8774

Currently we either have to parse the `Cargo.toml` file ourselves or use the `cargo_metadata` crate which has a notable performance impact when running `clippy-driver` on single files.