### PR TITLE
Enforce to use tar v0.4.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
 shell-escape = "0.1.4"
 strip-ansi-escapes = "0.1.0"
-tar = { version = "0.4.36", default-features = false }
+tar = { version = "0.4.38", default-features = false }
 tempfile = "3.0"
 termcolor = "1.1"
 toml_edit =  { version = "0.14.3", features = ["serde", "easy", "perf"] }
@@ -104,7 +104,7 @@ snapbox = { version = "0.2.8", features = ["diff", "path"] }
 
 [build-dependencies]
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-tar = { version = "0.4.26", default-features = false }
+tar = { version = "0.4.38", default-features = false }
 
 [[bin]]
 name = "cargo"

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -13,7 +13,7 @@ cargo = { path = "../.." }
 # Consider removing html_reports in 0.4 and switching to `cargo criterion`.
 criterion = { version = "0.3.5", features = ["html_reports"] }
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-tar = { version = "0.4.35", default-features = false }
+tar = { version = "0.4.38", default-features = false }
 url = "2.2.2"
 
 [[bench]]

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -8,5 +8,5 @@ description = "Tool for capturing a real-world workspace for benchmarking."
 [dependencies]
 cargo_metadata = "0.14.0"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-tar = { version = "0.4.35", default-features = false }
+tar = { version = "0.4.38", default-features = false }
 toml_edit = { version = "0.14.3", features = ["serde", "easy", "perf"] }

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -20,7 +20,7 @@ itertools = "0.10.0"
 lazy_static = "1.0"
 remove_dir_all = "0.5"
 serde_json = "1.0"
-tar = { version = "0.4.18", default-features = false }
+tar = { version = "0.4.38", default-features = false }
 termcolor = "1.1.2"
 toml_edit = { version = "0.14.3", features = ["serde", "easy", "perf"] }
 url = "2.2.2"


### PR DESCRIPTION
The latest version of `tar` crate includes https://github.com/alexcrichton/tar-rs/pull/262, which uses a bit recent timestamp when archiving.
However, [it seems rust-lang/rust uses v0.4.37](https://github.com/rust-lang/rust/blob/e0944922007e1bb4fe59809293acf4364410cccc/Cargo.lock#L5124-L5132). This PR enforces to use v0.4.38 and it would _fix_ https://github.com/rust-lang/crates.io/issues/3859 eventually.