### PR TITLE
Clear disk space on CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,8 @@ jobs:
           other: i686-pc-windows-gnu
     steps:
     - uses: actions/checkout@v3
+    - name: Dump Environment
+      run: ci/dump-environment.sh
     - name: Update Rustup (temporary workaround)
       run: rustup self update
       shell: bash
@@ -97,6 +99,13 @@ jobs:
         # download all workspaces.
         cargo test --manifest-path benches/benchsuite/Cargo.toml --all-targets -- cargo
         cargo check --manifest-path benches/capture/Cargo.toml
+    # The testsuite generates a huge amount of data, and fetch-smoke-test was
+    # running out of disk space.
+    - name: Clear test output
+      run: |
+        df -h
+        rm -rf target/tmp
+        df -h
     - name: Fetch smoke test
       run: ci/fetch-smoke-test.sh
 

--- a/ci/dump-environment.sh
+++ b/ci/dump-environment.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This script dumps information about the build environment to stdout.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+echo "environment variables:"
+printenv | sort
+echo
+
+echo "disk usage:"
+df -h
+echo


### PR DESCRIPTION
Cargo's testsuite uses a considerable amount of disk space. On windows-gnu, the target directory can get over 12GB, and there is only 13GB free.  We're starting to run out of disk space, so this is a stop-gap that clears out the test data before running the smoke test which uses a fair bit of space itself.

We will probably need to think about addressing #9701 somehow, otherwise we will start running out of space as we add more tests. See the linked issues in https://github.com/rust-lang/cargo/pull/9701#issuecomment-881765517 for additional context.
