### PR TITLE
Make -Z http-registry use index.crates.io when accessing crates-io

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -196,6 +196,10 @@ fn verify_dependencies(
         if super::check_dep_has_version(dep, true)? {
             continue;
         }
+        // Allow publishing to crates.io with index.crates.io as a source replacement.
+        if registry_src.is_default_registry() && dep.source_id().is_default_registry() {
+            continue;
+        }
         // TomlManifest::prepare_for_publish will rewrite the dependency
         // to be just the `version` field.
         if dep.source_id() != registry_src {

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -91,6 +91,15 @@ impl<'cfg> SourceConfigMap<'cfg> {
                 replace_with: None,
             },
         )?;
+        if config.cli_unstable().http_registry {
+            base.add(
+                CRATES_IO_REGISTRY,
+                SourceConfig {
+                    id: SourceId::crates_io_maybe_http(config)?,
+                    replace_with: None,
+                },
+            )?;
+        }
         Ok(base)
     }
 
@@ -248,7 +257,7 @@ restore the source replacement configuration to continue the build
             check_not_set("rev", def.rev)?;
         }
         if name == CRATES_IO_REGISTRY && srcs.is_empty() {
-            srcs.push(SourceId::crates_io(self.config)?);
+            srcs.push(SourceId::crates_io_maybe_http(self.config)?);
         }
 
         match srcs.len() {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -186,6 +186,7 @@ use crate::util::{restricted_names, CargoResult, Config, Filesystem, OptVersionR
 
 const PACKAGE_SOURCE_LOCK: &str = ".cargo-ok";
 pub const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
+pub const CRATES_IO_HTTP_INDEX: &str = "sparse+https://index.crates.io/";
 pub const CRATES_IO_REGISTRY: &str = "crates-io";
 pub const CRATES_IO_DOMAIN: &str = "crates.io";
 const CRATE_TEMPLATE: &str = "{crate}";


### PR DESCRIPTION
Use `sparse+https://index.crates.io/` to access crates.io when `-Z http-registry` is set.

* `Cargo.lock` files still emit the github URL `https://github.com/rust-lang/crates.io-index`.
* Allows publishing to a source-replaced `crates-io` only for `index.crates.io`. Other source-replacements of `crates-io` are still blocked.

Fixes #10722
r? @Eh2406 
