### PR TITLE
doc: Improve example of using the links field

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -364,7 +364,8 @@ script guide.
 ```toml
 [package]
 # ...
-links = "foo"
+# this package links with a native library called "git2", e.g. "libgit2.a" on Linux
+links = "git2"
 ```
 
 <a id="the-exclude-and-include-fields-optional"></a>

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -361,10 +361,12 @@ script guide.
 
 [links]: build-scripts.md#the-links-manifest-key
 
+For example, a crate that links a native library called "git2" (e.g. `libgit2.a`
+on Linux) may specify:
+
 ```toml
 [package]
 # ...
-# this package links with a native library called "git2", e.g. "libgit2.a" on Linux
 links = "git2"
 ```
 


### PR DESCRIPTION
`"foo"` doesn't really help say what this is. 