### PR TITLE
Improve testing framework for http registries

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -569,6 +569,12 @@ impl Execs {
         self
     }
 
+    /// Writes the given lines to stdin.
+    pub fn with_stdin<S: ToString>(&mut self, expected: S) -> &mut Self {
+        self.expect_stdin = Some(expected.to_string());
+        self
+    }
+
     /// Verifies the exit code from the process.
     ///
     /// This is not necessary if the expected exit code is `0`.
@@ -820,7 +826,10 @@ impl Execs {
     #[track_caller]
     pub fn run(&mut self) {
         self.ran = true;
-        let p = (&self.process_builder).clone().unwrap();
+        let mut p = (&self.process_builder).clone().unwrap();
+        if let Some(stdin) = self.expect_stdin.take() {
+            p.stdin(stdin);
+        }
         if let Err(e) = self.match_process(&p) {
             panic_error(&format!("test failed running {}", p), e);
         }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -2,7 +2,7 @@
 
 use cargo::util::IntoUrl;
 use cargo_test_support::publish::validate_alt_upload;
-use cargo_test_support::registry::{self, Package};
+use cargo_test_support::registry::{self, Package, RegistryBuilder};
 use cargo_test_support::{basic_manifest, git, paths, project};
 use std::fs;
 
@@ -660,18 +660,8 @@ Caused by:
 
 #[cargo_test]
 fn no_api() {
-    registry::alt_init();
+    let _registry = RegistryBuilder::new().alternative().no_api().build();
     Package::new("bar", "0.0.1").alternative(true).publish();
-    // Configure without `api`.
-    let repo = git2::Repository::open(registry::alt_registry_path()).unwrap();
-    let cfg_path = registry::alt_registry_path().join("config.json");
-    fs::write(
-        cfg_path,
-        format!(r#"{{"dl": "{}"}}"#, registry::alt_dl_url()),
-    )
-    .unwrap();
-    git::add(&repo);
-    git::commit(&repo);
 
     // First check that a dependency works.
     let p = project()
@@ -1221,8 +1211,6 @@ fn registries_index_relative_url() {
     )
     .unwrap();
 
-    registry::init();
-
     let p = project()
         .file(
             "Cargo.toml",
@@ -1269,8 +1257,6 @@ fn registries_index_relative_path_not_allowed() {
         "#,
     )
     .unwrap();
-
-    registry::init();
 
     let p = project()
         .file(

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -1,8 +1,8 @@
 //! Tests for credential-process.
 
+use cargo_test_support::registry::TestRegistry;
 use cargo_test_support::{basic_manifest, cargo_process, paths, project, registry, Project};
 use std::fs;
-use std::thread;
 
 fn toml_bin(proj: &Project, name: &str) -> String {
     proj.bin(name).display().to_string().replace('\\', "\\\\")
@@ -10,9 +10,13 @@ fn toml_bin(proj: &Project, name: &str) -> String {
 
 #[cargo_test]
 fn gated() {
-    registry::RegistryBuilder::new()
-        .alternative(true)
-        .add_tokens(false)
+    let _alternative = registry::RegistryBuilder::new()
+        .alternative()
+        .no_configure_token()
+        .build();
+
+    let _cratesio = registry::RegistryBuilder::new()
+        .no_configure_token()
         .build();
 
     let p = project()
@@ -61,9 +65,9 @@ fn gated() {
 #[cargo_test]
 fn warn_both_token_and_process() {
     // Specifying both credential-process and a token in config should issue a warning.
-    registry::RegistryBuilder::new()
-        .alternative(true)
-        .add_tokens(false)
+    let _server = registry::RegistryBuilder::new()
+        .alternative()
+        .no_configure_token()
         .build();
     let p = project()
         .file(
@@ -134,19 +138,15 @@ Only one of these values may be set, remove one or the other to proceed.
 /// * Create a simple `foo` project to run the test against.
 /// * Configure the credential-process config.
 ///
-/// Returns a thread handle for the API server, the test should join it when
-/// finished. Also returns the simple `foo` project to test against.
-fn get_token_test() -> (Project, thread::JoinHandle<()>) {
+/// Returns returns the simple `foo` project to test against and the API server handle.
+fn get_token_test() -> (Project, TestRegistry) {
     // API server that checks that the token is included correctly.
     let server = registry::RegistryBuilder::new()
-        .add_tokens(false)
-        .build_api_server(&|headers| {
-            assert!(headers
-                .iter()
-                .any(|header| header == "Authorization: sekrit"));
-
-            (200, &r#"{"ok": true, "msg": "completed!"}"#)
-        });
+        .no_configure_token()
+        .token("sekrit")
+        .alternative()
+        .http_api()
+        .build();
 
     // The credential process to use.
     let cred_proj = project()
@@ -165,7 +165,7 @@ fn get_token_test() -> (Project, thread::JoinHandle<()>) {
                     index = "{}"
                     credential-process = ["{}"]
                 "#,
-                registry::alt_registry_url(),
+                server.index_url(),
                 toml_bin(&cred_proj, "test-cred")
             ),
         )
@@ -189,7 +189,7 @@ fn get_token_test() -> (Project, thread::JoinHandle<()>) {
 #[cargo_test]
 fn publish() {
     // Checks that credential-process is used for `cargo publish`.
-    let (p, t) = get_token_test();
+    let (p, _t) = get_token_test();
 
     p.cargo("publish --no-verify --registry alternative -Z credential-process")
         .masquerade_as_nightly_cargo()
@@ -201,14 +201,14 @@ fn publish() {
 ",
         )
         .run();
-
-    t.join().ok().unwrap();
 }
 
 #[cargo_test]
 fn basic_unsupported() {
     // Non-action commands don't support login/logout.
-    registry::RegistryBuilder::new().add_tokens(false).build();
+    let _server = registry::RegistryBuilder::new()
+        .no_configure_token()
+        .build();
     cargo_util::paths::append(
         &paths::home().join(".cargo/config"),
         br#"
@@ -246,7 +246,9 @@ the credential-process configuration value must pass the \
 
 #[cargo_test]
 fn login() {
-    registry::init();
+    let server = registry::RegistryBuilder::new()
+        .no_configure_token()
+        .build();
     // The credential process to use.
     let cred_proj = project()
         .at("cred_proj")
@@ -266,7 +268,7 @@ fn login() {
                     std::fs::write("token-store", buffer).unwrap();
                 }
             "#
-            .replace("__API__", &registry::api_url().to_string()),
+            .replace("__API__", server.api_url().as_str()),
         )
         .build();
     cred_proj.cargo("build").run();
@@ -301,7 +303,9 @@ fn login() {
 
 #[cargo_test]
 fn logout() {
-    registry::RegistryBuilder::new().add_tokens(false).build();
+    let _server = registry::RegistryBuilder::new()
+        .no_configure_token()
+        .build();
     // The credential process to use.
     let cred_proj = project()
         .at("cred_proj")
@@ -354,7 +358,7 @@ token for `crates-io` has been erased!
 
 #[cargo_test]
 fn yank() {
-    let (p, t) = get_token_test();
+    let (p, _t) = get_token_test();
 
     p.cargo("yank --version 0.1.0 --registry alternative -Z credential-process")
         .masquerade_as_nightly_cargo()
@@ -365,13 +369,11 @@ fn yank() {
 ",
         )
         .run();
-
-    t.join().ok().unwrap();
 }
 
 #[cargo_test]
 fn owner() {
-    let (p, t) = get_token_test();
+    let (p, _t) = get_token_test();
 
     p.cargo("owner --add username --registry alternative -Z credential-process")
         .masquerade_as_nightly_cargo()
@@ -382,14 +384,14 @@ fn owner() {
 ",
         )
         .run();
-
-    t.join().ok().unwrap();
 }
 
 #[cargo_test]
 fn libexec_path() {
     // cargo: prefixed names use the sysroot
-    registry::RegistryBuilder::new().add_tokens(false).build();
+    let _server = registry::RegistryBuilder::new()
+        .no_configure_token()
+        .build();
     cargo_util::paths::append(
         &paths::home().join(".cargo/config"),
         br#"
@@ -420,9 +422,9 @@ Caused by:
 #[cargo_test]
 fn invalid_token_output() {
     // Error when credential process does not output the expected format for a token.
-    registry::RegistryBuilder::new()
-        .alternative(true)
-        .add_tokens(false)
+    let _server = registry::RegistryBuilder::new()
+        .alternative()
+        .no_configure_token()
         .build();
     let cred_proj = project()
         .at("cred_proj")

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 
 use cargo_test_support::cross_compile;
 use cargo_test_support::git;
-use cargo_test_support::registry::{self, registry_path, registry_url, Package};
+use cargo_test_support::registry::{self, registry_path, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, no_such_file_err_msg, project, project_in, symlink_supported, t,
 };
@@ -133,10 +133,11 @@ fn simple_with_message_format() {
 
 #[cargo_test]
 fn with_index() {
+    let registry = registry::init();
     pkg("foo", "0.0.1");
 
     cargo_process("install foo --index")
-        .arg(registry_url().to_string())
+        .arg(registry.index_url().as_str())
         .with_stderr(&format!(
             "\
 [UPDATING] `{reg}` index

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -1,10 +1,9 @@
 //! Tests for the `cargo login` command.
 
 use cargo_test_support::install::cargo_home;
-use cargo_test_support::registry;
-use cargo_test_support::{cargo_process, paths, t};
-use std::fs::{self, OpenOptions};
-use std::io::prelude::*;
+use cargo_test_support::registry::RegistryBuilder;
+use cargo_test_support::{cargo_process, t};
+use std::fs::{self};
 use std::path::PathBuf;
 use toml_edit::easy as toml;
 
@@ -62,27 +61,11 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
 
 #[cargo_test]
 fn registry_credentials() {
-    registry::alt_init();
+    let _alternative = RegistryBuilder::new().alternative().build();
+    let _alternative2 = RegistryBuilder::new()
+        .alternative_named("alternative2")
+        .build();
 
-    let config = paths::home().join(".cargo/config");
-    let mut f = OpenOptions::new().append(true).open(config).unwrap();
-    t!(f.write_all(
-        format!(
-            r#"
-                [registries.alternative2]
-                index = '{}'
-            "#,
-            registry::generate_url("alternative2-registry")
-        )
-        .as_bytes(),
-    ));
-
-    registry::init_registry(
-        registry::generate_path("alternative2-registry"),
-        registry::generate_alt_dl_url("alt2_dl"),
-        registry::generate_url("alt2_api"),
-        registry::generate_path("alt2_api"),
-    );
     setup_new_credentials();
 
     let reg = "alternative";

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -45,7 +45,6 @@ fn check_config_token(registry: Option<&str>, should_be_set: bool) {
 }
 
 fn simple_logout_test(reg: Option<&str>, flag: &str) {
-    registry::init();
     let msg = reg.unwrap_or("crates.io");
     check_config_token(reg, true);
     cargo_process(&format!("logout -Z unstable-options {}", flag))
@@ -74,6 +73,7 @@ fn simple_logout_test(reg: Option<&str>, flag: &str) {
 
 #[cargo_test]
 fn default_registry() {
+    registry::init();
     simple_logout_test(None, "");
 }
 

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -113,6 +113,7 @@ fn default_toolchain_is_stable() -> bool {
 #[ignore]
 #[cargo_test]
 fn new_features() {
+    let registry = registry::init();
     if std::process::Command::new("rustup").output().is_err() {
         panic!("old_cargos requires rustup to be installed");
     }
@@ -153,7 +154,7 @@ fn new_features() {
 
     let lock_bar_to = |toolchain_version: &Version, bar_version| {
         let lock = if toolchain_version < &Version::new(1, 12, 0) {
-            let url = registry::registry_url();
+            let url = registry.index_url();
             match bar_version {
                 100 => format!(
                     r#"
@@ -314,7 +315,7 @@ fn new_features() {
                         [registry]
                         index = "{}"
                     "#,
-                    registry::registry_url()
+                    registry.index_url()
                 ),
             )
             .unwrap();
@@ -330,7 +331,7 @@ fn new_features() {
                         [source.dummy-registry]
                         registry = '{}'
                     ",
-                    registry::registry_url()
+                    registry.index_url()
                 ),
             )
             .unwrap();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1072,7 +1072,7 @@ src/lib.rs
 
 #[cargo_test]
 fn generated_manifest() {
-    registry::alt_init();
+    let registry = registry::alt_init();
     Package::new("abc", "1.0.0").publish();
     Package::new("def", "1.0.0").alternative(true).publish();
     Package::new("ghi", "1.0.0").publish();
@@ -1137,7 +1137,7 @@ registry-index = "{}"
 version = "1.0"
 "#,
         cargo::core::package::MANIFEST_PREAMBLE,
-        registry::alt_registry_url()
+        registry.index_url()
     );
 
     validate_crate_contents(

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -1,149 +1,99 @@
 //! Tests for the `cargo search` command.
 
 use cargo_test_support::cargo_process;
-use cargo_test_support::git::repo;
 use cargo_test_support::paths;
-use cargo_test_support::registry::{api_path, registry_path, registry_url};
+use cargo_test_support::registry::{RegistryBuilder, Response};
 use std::collections::HashSet;
-use std::fs;
-use std::path::Path;
-use url::Url;
 
-fn api() -> Url {
-    Url::from_file_path(&*api_path()).ok().unwrap()
-}
-
-fn write_crates(dest: &Path) {
-    let content = r#"{
-        "crates": [{
-            "created_at": "2014-11-16T20:17:35Z",
-            "description": "Design by contract style assertions for Rust",
-            "documentation": null,
-            "downloads": 2,
-            "homepage": null,
-            "id": "hoare",
-            "keywords": [],
-            "license": null,
-            "links": {
-                "owners": "/api/v1/crates/hoare/owners",
-                "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
-                "version_downloads": "/api/v1/crates/hoare/downloads",
-                "versions": "/api/v1/crates/hoare/versions"
-            },
-            "max_version": "0.1.1",
-            "name": "hoare",
-            "repository": "https://github.com/nick29581/libhoare",
-            "updated_at": "2014-11-20T21:49:21Z",
-            "versions": null
+const SEARCH_API_RESPONSE: &[u8] = br#"
+{
+    "crates": [{
+        "created_at": "2014-11-16T20:17:35Z",
+        "description": "Design by contract style assertions for Rust",
+        "documentation": null,
+        "downloads": 2,
+        "homepage": null,
+        "id": "hoare",
+        "keywords": [],
+        "license": null,
+        "links": {
+            "owners": "/api/v1/crates/hoare/owners",
+            "reverse_dependencies": "/api/v1/crates/hoare/reverse_dependencies",
+            "version_downloads": "/api/v1/crates/hoare/downloads",
+            "versions": "/api/v1/crates/hoare/versions"
         },
-        {
-            "id": "postgres",
-            "name": "postgres",
-            "updated_at": "2020-05-01T23:17:54.335921+00:00",
-            "versions": null,
-            "keywords": null,
-            "categories": null,
-            "badges": [
-                {
-                    "badge_type": "circle-ci",
-                    "attributes": {
-                        "repository": "sfackler/rust-postgres",
-                        "branch": null
-                    }
+        "max_version": "0.1.1",
+        "name": "hoare",
+        "repository": "https://github.com/nick29581/libhoare",
+        "updated_at": "2014-11-20T21:49:21Z",
+        "versions": null
+    },
+    {
+        "id": "postgres",
+        "name": "postgres",
+        "updated_at": "2020-05-01T23:17:54.335921+00:00",
+        "versions": null,
+        "keywords": null,
+        "categories": null,
+        "badges": [
+            {
+                "badge_type": "circle-ci",
+                "attributes": {
+                    "repository": "sfackler/rust-postgres",
+                    "branch": null
                 }
-            ],
-            "created_at": "2014-11-24T02:34:44.756689+00:00",
-            "downloads": 535491,
-            "recent_downloads": 88321,
-            "max_version": "0.17.3",
-            "newest_version": "0.17.3",
-            "description": "A native, synchronous PostgreSQL client",
-            "homepage": null,
-            "documentation": null,
-            "repository": "https://github.com/sfackler/rust-postgres",
-            "links": {
-                "version_downloads": "/api/v1/crates/postgres/downloads",
-                "versions": "/api/v1/crates/postgres/versions",
-                "owners": "/api/v1/crates/postgres/owners",
-                "owner_team": "/api/v1/crates/postgres/owner_team",
-                "owner_user": "/api/v1/crates/postgres/owner_user",
-                "reverse_dependencies": "/api/v1/crates/postgres/reverse_dependencies"
-            },
-            "exact_match": true
-        }
+            }
         ],
-        "meta": {
-            "total": 2
-        }
-    }"#;
-
-    // Older versions of curl don't peel off query parameters when looking for
-    // filenames, so just make both files.
-    //
-    // On windows, though, `?` is an invalid character, but we always build curl
-    // from source there anyway!
-    fs::write(&dest, content).unwrap();
-    if !cfg!(windows) {
-        fs::write(
-            &dest.with_file_name("crates?q=postgres&per_page=10"),
-            content,
-        )
-        .unwrap();
+        "created_at": "2014-11-24T02:34:44.756689+00:00",
+        "downloads": 535491,
+        "recent_downloads": 88321,
+        "max_version": "0.17.3",
+        "newest_version": "0.17.3",
+        "description": "A native, synchronous PostgreSQL client",
+        "homepage": null,
+        "documentation": null,
+        "repository": "https://github.com/sfackler/rust-postgres",
+        "links": {
+            "version_downloads": "/api/v1/crates/postgres/downloads",
+            "versions": "/api/v1/crates/postgres/versions",
+            "owners": "/api/v1/crates/postgres/owners",
+            "owner_team": "/api/v1/crates/postgres/owner_team",
+            "owner_user": "/api/v1/crates/postgres/owner_user",
+            "reverse_dependencies": "/api/v1/crates/postgres/reverse_dependencies"
+        },
+        "exact_match": true
     }
-}
+    ],
+    "meta": {
+        "total": 2
+    }
+}"#;
 
 const SEARCH_RESULTS: &str = "\
 hoare = \"0.1.1\"        # Design by contract style assertions for Rust
 postgres = \"0.17.3\"    # A native, synchronous PostgreSQL client
 ";
 
-fn setup() {
-    let cargo_home = paths::root().join(".cargo");
-    fs::create_dir_all(cargo_home).unwrap();
-    fs::create_dir_all(&api_path().join("api/v1")).unwrap();
-
-    // Init a new registry
-    let _ = repo(&registry_path())
-        .file(
-            "config.json",
-            &format!(r#"{{"dl":"{0}","api":"{0}"}}"#, api()),
-        )
-        .build();
-
-    let base = api_path().join("api/v1/crates");
-    write_crates(&base);
-}
-
-fn set_cargo_config() {
-    let config = paths::root().join(".cargo/config");
-
-    fs::write(
-        &config,
-        format!(
-            r#"
-            [source.crates-io]
-            registry = 'https://wut'
-            replace-with = 'dummy-registry'
-
-            [source.dummy-registry]
-            registry = '{reg}'
-            "#,
-            reg = registry_url(),
-        ),
-    )
-    .unwrap();
+#[must_use]
+fn setup() -> RegistryBuilder {
+    RegistryBuilder::new()
+        .http_api()
+        .add_responder("/api/v1/crates", |_| Response {
+            code: 200,
+            headers: vec![],
+            body: SEARCH_API_RESPONSE.to_vec(),
+        })
 }
 
 #[cargo_test]
 fn not_update() {
-    setup();
-    set_cargo_config();
+    let registry = setup().build();
 
     use cargo::core::{Shell, Source, SourceId};
     use cargo::sources::RegistrySource;
     use cargo::util::Config;
 
-    let sid = SourceId::for_registry(&registry_url()).unwrap();
+    let sid = SourceId::for_registry(registry.index_url()).unwrap();
     let cfg = Config::new(
         Shell::from_write(Box::new(Vec::new())),
         paths::root(),
@@ -163,8 +113,7 @@ fn not_update() {
 
 #[cargo_test]
 fn replace_default() {
-    setup();
-    set_cargo_config();
+    let _server = setup().build();
 
     cargo_process("search postgres")
         .with_stdout_contains(SEARCH_RESULTS)
@@ -174,28 +123,27 @@ fn replace_default() {
 
 #[cargo_test]
 fn simple() {
-    setup();
+    let registry = setup().build();
 
     cargo_process("search postgres --index")
-        .arg(registry_url().to_string())
+        .arg(registry.index_url().as_str())
         .with_stdout_contains(SEARCH_RESULTS)
         .run();
 }
 
 #[cargo_test]
 fn multiple_query_params() {
-    setup();
+    let registry = setup().build();
 
     cargo_process("search postgres sql --index")
-        .arg(registry_url().to_string())
+        .arg(registry.index_url().as_str())
         .with_stdout_contains(SEARCH_RESULTS)
         .run();
 }
 
 #[cargo_test]
 fn ignore_quiet() {
-    setup();
-    set_cargo_config();
+    let _server = setup().build();
 
     cargo_process("search -q postgres")
         .with_stdout_contains(SEARCH_RESULTS)
@@ -204,8 +152,7 @@ fn ignore_quiet() {
 
 #[cargo_test]
 fn colored_results() {
-    setup();
-    set_cargo_config();
+    let _server = setup().build();
 
     cargo_process("search --color=never postgres")
         .with_stdout_does_not_contain("[..]\x1b[[..]")


### PR DESCRIPTION
Improve integration of the http server introduced by the http-registry feature.

The same HTTP server is used for serving downloads, the index, and the API within the test framework.

This makes it easier to write tests that deal with authentication and http registries.

Most of this change is pulled from #10592. Getting it in separately should make the other change easier to review.

r? @Eh2406 