### PR TITLE
Reduce warning strictness

### DIFF
--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,7 +1,7 @@
 // For various reasons, some idioms are still allow'ed, but we would like to
 // test and enforce them.
 #![warn(rust_2018_idioms)]
-#![cfg_attr(test, deny(warnings))]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -2,6 +2,7 @@
 // test and enforce them.
 #![warn(rust_2018_idioms)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
+#![cfg_attr(feature = "deny-warnings", allow(deprecated))]
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]


### PR DESCRIPTION
### What does this PR try to resolve?

This solves two use cases
- When developing a feature, I might be experimenting with some sloppy, intermediate states and warnings shouldn't prevent me from running tests
- A new dependency being released should not block people from running tests (also solved by the above) or cause CI (for PRs or Bors) to fail, blocking them on something unrelated to their work

### How should we test and review this PR?

I didn't see any pertinent history for why `cargo` conditions `deny(warnings)` on `cfg(test)` while other parts of cargo use `feature = "deny-warnings"`, so I just went forward with this consolidation.  It does mean some targets that we test without the feature might have warnings slip through though the risk is low.

I tested this against clap `master` which adds more deprecations.  

### Additional information

This does raise the risk of deprecations not being addressed but that is a question of contributor culture.  I know I would look into it if I saw deprecation warnings go by and I would hope others would too.