### PR TITLE
Stabilize `-Zmultitarget`

### DIFF
--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -2,7 +2,7 @@ use crate::core::Target;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{Config, StableHasher};
-use anyhow::{bail, Context as _};
+use anyhow::Context as _;
 use serde::Serialize;
 use std::collections::BTreeSet;
 use std::fs;
@@ -65,9 +65,6 @@ impl CompileKind {
         };
 
         if !targets.is_empty() {
-            if targets.len() > 1 && !config.cli_unstable().multitarget {
-                bail!("specifying multiple `--target` flags requires `-Zmultitarget`")
-            }
             return dedup(targets);
         }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -722,6 +722,8 @@ const STABILISED_NAMESPACED_FEATURES: &str = "Namespaced features are now always
 
 const STABILIZED_TIMINGS: &str = "The -Ztimings option has been stabilized as --timings.";
 
+const STABILISED_MULTITARGET: &str = "Multiple `--target` options are now always available.";
+
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -922,7 +924,7 @@ impl CliUnstable {
                 self.features = Some(feats);
             }
             "separate-nightlies" => self.separate_nightlies = parse_empty(k, v)?,
-            "multitarget" => self.multitarget = parse_empty(k, v)?,
+            "multitarget" => stabilized_warn(k, "1.64", STABILISED_MULTITARGET),
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "terminal-width" => self.terminal_width = Some(parse_usize_opt(v)?),
             "sparse-registry" => self.sparse_registry = parse_empty(k, v)?,

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2248,13 +2248,7 @@ impl BuildTargetConfig {
         };
         let values = match &self.inner.val {
             BuildTargetConfigInner::One(s) => vec![map(s)],
-            BuildTargetConfigInner::Many(v) => {
-                if !config.cli_unstable().multitarget {
-                    bail!("specifying an array in `build.target` config value requires `-Zmultitarget`")
-                } else {
-                    v.iter().map(map).collect()
-                }
-            }
+            BuildTargetConfigInner::Many(v) => v.iter().map(map).collect(),
         };
         Ok(values)
     }

--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -1,6 +1,7 @@
 # cargo-bench(1)
 {{*set actionverb="Benchmark"}}
 {{*set nouns="benchmarks"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-build.md
+++ b/src/doc/man/cargo-build.md
@@ -1,5 +1,6 @@
 # cargo-build(1)
 {{*set actionverb="Build"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-check.md
+++ b/src/doc/man/cargo-check.md
@@ -1,5 +1,6 @@
 # cargo-check(1)
 {{*set actionverb="Check"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-clean.md
+++ b/src/doc/man/cargo-clean.md
@@ -1,5 +1,6 @@
 # cargo-clean(1)
 {{*set actionverb="Clean"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -1,5 +1,6 @@
 # cargo-doc(1)
 {{*set actionverb="Document"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-fetch.md
+++ b/src/doc/man/cargo-fetch.md
@@ -1,6 +1,7 @@
 # cargo-fetch(1)
 {{*set actionverb="Fetch"}}
 {{*set target-default-to-all-arch=true}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -1,5 +1,6 @@
 # cargo-fix(1)
 {{*set actionverb="Fix"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -1,6 +1,7 @@
 # cargo-package(1)
 {{*set actionverb="Package"}}
 {{*set noall=true}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -1,5 +1,6 @@
 # cargo-publish(1)
 {{*set actionverb="Publish"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-rustc.md
+++ b/src/doc/man/cargo-rustc.md
@@ -1,5 +1,6 @@
 # cargo-rustc(1)
 {{*set actionverb="Build"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-rustdoc.md
+++ b/src/doc/man/cargo-rustdoc.md
@@ -1,5 +1,6 @@
 # cargo-rustdoc(1)
 {{*set actionverb="Document"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -1,6 +1,7 @@
 # cargo-test(1)
 {{*set actionverb="Test"}}
 {{*set nouns="tests"}}
+{{*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -208,7 +208,8 @@ OPTIONS
            Benchmark for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -140,7 +140,8 @@ OPTIONS
            Build for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -137,7 +137,8 @@ OPTIONS
            Check for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -43,7 +43,8 @@ OPTIONS
            Clean for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -115,7 +115,8 @@ OPTIONS
            Document for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -28,7 +28,8 @@ OPTIONS
            Fetch for the given architecture. The default is all architectures.
            The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -210,7 +210,8 @@ OPTIONS
            Fix for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -112,7 +112,8 @@ OPTIONS
            Package for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -79,7 +79,8 @@ OPTIONS
            Publish for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -131,7 +131,8 @@ OPTIONS
            Build for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -131,7 +131,8 @@ OPTIONS
            Document for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -222,7 +222,8 @@ OPTIONS
            Test for the given architecture. The default is the host
            architecture. The general format of the triple is
            <arch><sub>-<vendor>-<sys>-<abi>. Run rustc --print target-list for
-           a list of supported targets.
+           a list of supported targets. This flag may be specified multiple
+           times.
 
            This may also be specified with the build.target config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.

--- a/src/doc/man/includes/options-target-triple.md
+++ b/src/doc/man/includes/options-target-triple.md
@@ -5,6 +5,7 @@
 {{~/if}} The general format of the triple is
 `<arch><sub>-<vendor>-<sys>-<abi>`. Run `rustc --print target-list` for a
 list of supported targets.
+{{~#if multitarget }} This flag may be specified multiple times. {{~/if}}
 
 This may also be specified with the `build.target`
 [config value](../reference/config.html).

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-bench - Execute benchmarks of a package
@@ -255,7 +256,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-bench---target"><a class="option-anchor" href="#option-cargo-bench---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Benchmark for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -1,6 +1,7 @@
 # cargo-build(1)
 
 
+
 ## NAME
 
 cargo-build - Compile the current package
@@ -182,7 +183,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-build---target"><a class="option-anchor" href="#option-cargo-build---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Build for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -1,6 +1,7 @@
 # cargo-check(1)
 
 
+
 ## NAME
 
 cargo-check - Check the current package
@@ -177,7 +178,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-check---target"><a class="option-anchor" href="#option-cargo-check---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Check for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -1,6 +1,7 @@
 # cargo-clean(1)
 
 
+
 ## NAME
 
 cargo-clean - Remove generated artifacts
@@ -59,7 +60,7 @@ Defaults to <code>target</code> in the root of the workspace.</dd>
 <dt class="option-term" id="option-cargo-clean---target"><a class="option-anchor" href="#option-cargo-clean---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Clean for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -1,6 +1,7 @@
 # cargo-doc(1)
 
 
+
 ## NAME
 
 cargo-doc - Build a package's documentation
@@ -155,7 +156,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-doc---target"><a class="option-anchor" href="#option-cargo-doc---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Document for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-fetch - Fetch dependencies of a package from the network
@@ -34,7 +35,7 @@ you plan to use Cargo without a network with the `--offline` flag.
 <dt class="option-term" id="option-cargo-fetch---target"><a class="option-anchor" href="#option-cargo-fetch---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Fetch for the given architecture. The default is all architectures. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -1,6 +1,7 @@
 # cargo-fix(1)
 
 
+
 ## NAME
 
 cargo-fix - Automatically fix lint warnings reported by rustc
@@ -257,7 +258,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-fix---target"><a class="option-anchor" href="#option-cargo-fix---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Fix for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-package - Assemble the local package into a distributable tarball
@@ -133,7 +134,7 @@ single quotes or double quotes around each pattern.</dd>
 <dt class="option-term" id="option-cargo-package---target"><a class="option-anchor" href="#option-cargo-package---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Package for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -1,6 +1,7 @@
 # cargo-publish(1)
 
 
+
 ## NAME
 
 cargo-publish - Upload a package to the registry
@@ -99,7 +100,7 @@ format.</dd>
 <dt class="option-term" id="option-cargo-publish---target"><a class="option-anchor" href="#option-cargo-publish---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Publish for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -1,6 +1,7 @@
 # cargo-rustc(1)
 
 
+
 ## NAME
 
 cargo-rustc - Compile the current package, and pass extra options to the compiler
@@ -169,7 +170,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-rustc---target"><a class="option-anchor" href="#option-cargo-rustc---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Build for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -1,6 +1,7 @@
 # cargo-rustdoc(1)
 
 
+
 ## NAME
 
 cargo-rustdoc - Build a package's documentation, using specified custom flags
@@ -174,7 +175,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-rustdoc---target"><a class="option-anchor" href="#option-cargo-rustdoc---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Document for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-test - Execute unit and integration tests of a package
@@ -269,7 +270,7 @@ be specified multiple times, which enables all specified features.</dd>
 <dt class="option-term" id="option-cargo-test---target"><a class="option-anchor" href="#option-cargo-test---target"></a><code>--target</code> <em>triple</em></dt>
 <dd class="option-desc">Test for the given architecture. The default is the host architecture. The general format of the triple is
 <code>&lt;arch&gt;&lt;sub&gt;-&lt;vendor&gt;-&lt;sys&gt;-&lt;abi&gt;</code>. Run <code>rustc --print target-list</code> for a
-list of supported targets.</p>
+list of supported targets. This flag may be specified multiple times.</p>
 <p>This may also be specified with the <code>build.target</code>
 <a href="../reference/config.html">config value</a>.</p>
 <p>Note that specifying this flag makes Cargo run in a different mode where the

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -380,15 +380,24 @@ It affects the filename hash so that artifacts produced by the wrapper are cache
 Sets the executable to use for `rustdoc`.
 
 ##### `build.target`
-* Type: string
+* Type: string or array of strings
 * Default: host platform
 * Environment: `CARGO_BUILD_TARGET`
 
-The default target platform triple to compile to.
+The default target platform triples to compile to.
 
-This may also be a relative path to a `.json` target spec file.
+This allows passing either a string or an array of strings. Each string value
+is a target platform triple. The selected build targets will be built for each
+of the selected architectures.
+
+The string value may also be a relative path to a `.json` target spec file.
 
 Can be overridden with the `--target` CLI option.
+
+```toml
+[build]
+target = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
+```
 
 ##### `build.target-dir`
 * Type: string (path)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -48,7 +48,7 @@ how the feature works:
   ```toml
   [unstable]
   mtime-on-use = true
-  multitarget = true
+  build-std = ["core", "alloc"]
   ```
 
 Each new feature described below should explain how to use it.
@@ -76,7 +76,6 @@ Each new feature described below should explain how to use it.
 * Compile behavior
     * [mtime-on-use](#mtime-on-use) — Updates the last-modified timestamp on every dependency every time it is used, to provide a mechanism to delete unused artifacts.
     * [doctest-xcompile](#doctest-xcompile) — Supports running doctests with the `--target` flag.
-    * [multitarget](#multitarget) — Supports building for multiple targets at the same time.
     * [build-std](#build-std) — Builds the standard library instead of using pre-built binaries.
     * [build-std-features](#build-std-features) — Sets features to use with the standard library.
     * [binary-dep-depinfo](#binary-dep-depinfo) — Causes the dep-info file to track binary dependencies.
@@ -216,32 +215,6 @@ information from `.cargo/config.toml`. See the rustc issue for more information.
 
 ```sh
 cargo test --target foo -Zdoctest-xcompile
-```
-
-### multitarget
-* Tracking Issue: [#8176](https://github.com/rust-lang/cargo/issues/8176)
-
-This flag allows passing multiple `--target` flags to the `cargo` subcommand
-selected. When multiple `--target` flags are passed the selected build targets
-will be built for each of the selected architectures.
-
-For example to compile a library for both 32 and 64-bit:
-
-```
-cargo build --target x86_64-unknown-linux-gnu --target i686-unknown-linux-gnu
-```
-
-or running tests for both targets:
-
-```
-cargo test --target x86_64-unknown-linux-gnu --target i686-unknown-linux-gnu
-```
-
-This can also be specified in `.cargo/config.toml` files.
-
-```toml
-[build]
-target = ["x86_64-unknown-linux-gnu", "i686-unknown-linux-gnu"]
 ```
 
 #### New `dir-name` attribute
@@ -1569,3 +1542,9 @@ unstable and require `-Zunstable-options`.)
 The `--config` CLI option has been stabilized in the 1.63 release. See
 the [config documentation](config.html#command-line-overrides) for more
 information.
+
+### multitarget
+
+The `-Z multitarget` option has been stabilized in the 1.64 release.
+See [`build.target`](config.md#buildtarget) for more information about
+setting the default target platform triples.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -257,7 +257,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Benchmark for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -168,7 +168,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Build for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -164,7 +164,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Check for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -53,7 +53,7 @@ Defaults to \fBtarget\fR in the root of the workspace.
 .RS 4
 Clean for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -137,7 +137,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Document for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -27,7 +27,7 @@ you plan to use Cargo without a network with the \fB\-\-offline\fR flag.
 .RS 4
 Fetch for the given architecture. The default is all architectures. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -259,7 +259,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Fix for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -148,7 +148,7 @@ single quotes or double quotes around each pattern.
 .RS 4
 Package for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -98,7 +98,7 @@ format.
 .RS 4
 Publish for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -154,7 +154,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Build for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -156,7 +156,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Document for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -269,7 +269,7 @@ Do not activate the \fBdefault\fR feature of the selected packages.
 .RS 4
 Test for the given architecture. The default is the host architecture. The general format of the triple is
 \fB<arch><sub>\-<vendor>\-<sys>\-<abi>\fR\&. Run \fBrustc \-\-print target\-list\fR for a
-list of supported targets.
+list of supported targets. This flag may be specified multiple times.
 .sp
 This may also be specified with the \fBbuild.target\fR
 \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -743,8 +743,8 @@ fn rustc_with_print_cfg_multiple_targets() {
         .file("src/main.rs", r#"fn main() {} "#)
         .build();
 
-    p.cargo("rustc -Z unstable-options -Z multitarget --target x86_64-pc-windows-msvc --target i686-unknown-linux-gnu --print cfg")
-        .masquerade_as_nightly_cargo(&["print", "multitarget"])
+    p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --target i686-unknown-linux-gnu --print cfg")
+        .masquerade_as_nightly_cargo(&["print"])
         .with_stdout_contains("debug_assertions")
         .with_stdout_contains("target_arch=\"x86_64\"")
         .with_stdout_contains("target_endian=\"little\"")


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Stabilize `-Zmultitarget`. Closes #8176.

`-Zmultitarget` exists on nightly for years (#8167, merged in April 2020). It has already been in the wild for a long time, and is the main code path of cargo compilation since then. It may be the time to push it to stable.

### How should we test and review this PR?

Almost all build commands get this update, only `cargo run` and `cargo install` accept no more than one `--target`. Here is a list of commands that support multiple `--target` options:

- `cargo bench`
- `cargo build`
- `cargo check`
- `cargo clean`
- `cargo doc`
- `cargo fetch`
- `cargo fix`
- `cargo package`
- `cargo publish`
- `cargo rustc`
- `cargo rustdoc`
- `cargo test`

You may want to check if anything weird for them to support multitarget. Also get a glimpse on their docs.

### Additional information

I found that `cargo clean --target` does not work. I'll look into it and post another issue afterward.

<!-- homu-ignore:end -->
