### PR TITLE
remove unused dependency from benchsuite

### DIFF
--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -10,7 +10,6 @@ description = "Benchmarking suite for Cargo."
 
 [dependencies]
 cargo = { path = "../.." }
-cargo-test-support = { path = "../../crates/cargo-test-support" }
 # Consider removing html_reports in 0.4 and switching to `cargo criterion`.
 criterion = { version = "0.3.5", features = ["html_reports"] }
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }


### PR DESCRIPTION
In #10754 I added a new benchmark to the benchsuite. While figuring out the best way to add the new benchmark, I added `cargo-test-support` as a dependency. It appears I missed removing it before making the PR. 

This PR removes `cargo-test-support` since it is not needed