### PR TITLE
refactor(test): Clarify asserts are for UI

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -70,7 +70,7 @@ use url::Url;
 ///   Other heuristics are applied to try to ensure Windows-style paths aren't
 ///   a problem.
 /// - Carriage returns are removed, which can help when running on Windows.
-pub fn assert() -> snapbox::Assert {
+pub fn assert_ui() -> snapbox::Assert {
     let root = paths::root();
     // Use `from_file_path` instead of `from_dir_path` so the trailing slash is
     // put in the users output, rather than hidden in the variable

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1262,13 +1262,13 @@ impl TestEnv for snapbox::cmd::Command {
 
 /// Test the cargo command
 pub trait CargoCommand {
-    fn cargo() -> Self;
+    fn cargo_ui() -> Self;
 }
 
 impl CargoCommand for snapbox::cmd::Command {
-    fn cargo() -> Self {
+    fn cargo_ui() -> Self {
         Self::new(cargo_exe())
-            .with_assert(compare::assert())
+            .with_assert(compare::assert_ui())
             .test_env()
     }
 }

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -129,7 +129,7 @@ mod <case>;
 `tests/testsuite/<command>/<case>/mod.rs`:
 ```rust,ignore
 use cargo_test_support::prelude::*;
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
@@ -139,7 +139,7 @@ fn <name>() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("run")
         .arg_line("--bin foo")
         .current_dir(cwd)
@@ -148,7 +148,7 @@ fn <name>() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }
 ```
 
@@ -170,13 +170,13 @@ Then populate
 - The project is copied from a directory in the repo
 - Each project is in a separate directory in the sandbox
 
-[`Command`] via `Command::cargo()`:
+[`Command`] via `Command::cargo_ui()`:
 - Set up and run a command.
 
 [`OutputAssert`] via `Command::assert()`:
 - Perform assertions on the result of the [`Command`]
 
-[`Assert`] via `assert()`:
+[`Assert`] via `assert_ui()`:
 - Verify the command modified the file system as expected
 
 #### Updating Snapshots

--- a/tests/testsuite/cargo_add/add_basic/mod.rs
+++ b/tests/testsuite/cargo_add/add_basic/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn add_basic() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn add_basic() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/add_multiple/mod.rs
+++ b/tests/testsuite/cargo_add/add_multiple/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn add_multiple() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn add_multiple() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/add_normalized_name_external/mod.rs
+++ b/tests/testsuite/cargo_add/add_normalized_name_external/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn add_normalized_name_external() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("linked_hash_map Inflector")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn add_normalized_name_external() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/build/mod.rs
+++ b/tests/testsuite/cargo_add/build/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn build() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("--build my-build-package1 my-build-package2")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn build() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/build_prefer_existing_version/mod.rs
+++ b/tests/testsuite/cargo_add/build_prefer_existing_version/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn build_prefer_existing_version() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --build")
         .current_dir(cwd)
@@ -21,7 +21,7 @@ fn build_prefer_existing_version() {
         .stdout_matches_path("tests/testsuite/cargo_add/build_prefer_existing_version/stdout.log")
         .stderr_matches_path("tests/testsuite/cargo_add/build_prefer_existing_version/stderr.log");
 
-    assert().subset_matches(
+    assert_ui().subset_matches(
         "tests/testsuite/cargo_add/build_prefer_existing_version/out",
         &project_root,
     );

--- a/tests/testsuite/cargo_add/change_rename_target/mod.rs
+++ b/tests/testsuite/cargo_add/change_rename_target/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn change_rename_target() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package2 --rename some-package")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn change_rename_target() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/default_features/mod.rs
+++ b/tests/testsuite/cargo_add/default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --default-features")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/deprecated_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/deprecated_default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn deprecated_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn deprecated_default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/deprecated_section/mod.rs
+++ b/tests/testsuite/cargo_add/deprecated_section/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn deprecated_section() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn deprecated_section() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/detect_workspace_inherit/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn detect_workspace_inherit() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -22,5 +22,5 @@ fn detect_workspace_inherit() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_features/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn detect_workspace_inherit_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar", "--features", "test"])
@@ -22,5 +22,5 @@ fn detect_workspace_inherit_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_optional/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn detect_workspace_inherit_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar", "--optional"])
@@ -22,5 +22,5 @@ fn detect_workspace_inherit_optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/dev/mod.rs
+++ b/tests/testsuite/cargo_add/dev/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn dev() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("--dev my-dev-package1 my-dev-package2")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn dev() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/dev_build_conflict/mod.rs
+++ b/tests/testsuite/cargo_add/dev_build_conflict/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn dev_build_conflict() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package --dev --build")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn dev_build_conflict() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/dev_prefer_existing_version/mod.rs
+++ b/tests/testsuite/cargo_add/dev_prefer_existing_version/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn dev_prefer_existing_version() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --dev")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn dev_prefer_existing_version() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/dry_run/mod.rs
+++ b/tests/testsuite/cargo_add/dry_run/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn dry_run() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package --dry-run")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn dry_run() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/features/mod.rs
+++ b/tests/testsuite/cargo_add/features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --features eyes")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/features_empty/mod.rs
+++ b/tests/testsuite/cargo_add/features_empty/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn features_empty() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --features ''")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn features_empty() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/features_multiple_occurrences/mod.rs
+++ b/tests/testsuite/cargo_add/features_multiple_occurrences/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn features_multiple_occurrences() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --features eyes --features nose")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn features_multiple_occurrences() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/features_preserve/mod.rs
+++ b/tests/testsuite/cargo_add/features_preserve/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn features_preserve() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn features_preserve() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/features_spaced_values/mod.rs
+++ b/tests/testsuite/cargo_add/features_spaced_values/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn features_spaced_values() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --features eyes,nose")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn features_spaced_values() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/features_unknown/mod.rs
+++ b/tests/testsuite/cargo_add/features_unknown/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn features_unknown() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --features noze")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn features_unknown() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git/mod.rs
+++ b/tests/testsuite/cargo_add/git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn git() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["git-package", "--git", &git_url])
         .current_dir(cwd)
@@ -30,5 +30,5 @@ fn git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_branch/mod.rs
+++ b/tests/testsuite/cargo_add/git_branch/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -24,7 +24,7 @@ fn git_branch() {
     git_repo.branch(branch, &find_head(), false).unwrap();
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--branch", branch])
         .current_dir(cwd)
@@ -33,5 +33,5 @@ fn git_branch() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_conflicts_namever/mod.rs
+++ b/tests/testsuite/cargo_add/git_conflicts_namever/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn git_conflicts_namever() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args([
             "my-package@0.4.3",
@@ -25,5 +25,5 @@ fn git_conflicts_namever() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_dev/mod.rs
+++ b/tests/testsuite/cargo_add/git_dev/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn git_dev() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--dev"])
         .current_dir(cwd)
@@ -30,5 +30,5 @@ fn git_dev() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_inferred_name/mod.rs
+++ b/tests/testsuite/cargo_add/git_inferred_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn git_inferred_name() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["--git", &git_url])
         .current_dir(cwd)
@@ -30,5 +30,5 @@ fn git_inferred_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_inferred_name_multiple/mod.rs
+++ b/tests/testsuite/cargo_add/git_inferred_name_multiple/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -26,7 +26,7 @@ fn git_inferred_name_multiple() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["--git", &git_url])
         .current_dir(cwd)
@@ -35,5 +35,5 @@ fn git_inferred_name_multiple() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_multiple_names/mod.rs
+++ b/tests/testsuite/cargo_add/git_multiple_names/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -26,7 +26,7 @@ fn git_multiple_names() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["my-package1", "my-package2", "--git", &git_url])
         .current_dir(cwd)
@@ -35,5 +35,5 @@ fn git_multiple_names() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_normalized_name/mod.rs
+++ b/tests/testsuite/cargo_add/git_normalized_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn git_normalized_name() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["git_package", "--git", &git_url])
         .current_dir(cwd)
@@ -30,5 +30,5 @@ fn git_normalized_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_registry/mod.rs
+++ b/tests/testsuite/cargo_add/git_registry/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn git_registry() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args([
             "versioned-package",
@@ -36,5 +36,5 @@ fn git_registry() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_rev/mod.rs
+++ b/tests/testsuite/cargo_add/git_rev/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -23,7 +23,7 @@ fn git_rev() {
     let head = find_head().id().to_string();
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--rev", &head])
         .current_dir(cwd)
@@ -32,5 +32,5 @@ fn git_rev() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/git_tag/mod.rs
+++ b/tests/testsuite/cargo_add/git_tag/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -23,7 +23,7 @@ fn git_tag() {
     cargo_test_support::git::tag(&git_repo, tag);
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["git-package", "--git", &git_url, "--tag", tag])
         .current_dir(cwd)
@@ -32,5 +32,5 @@ fn git_tag() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/infer_prerelease/mod.rs
+++ b/tests/testsuite/cargo_add/infer_prerelease/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn infer_prerelease() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("prerelease_only")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn infer_prerelease() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_arg/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_arg/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_arg() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package --flag")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_arg() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_git_external/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_git_external/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -15,7 +15,7 @@ fn invalid_git_external() {
         .unwrap()
         .to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["fake-git", "--git", &git_url])
         .current_dir(cwd)
@@ -24,5 +24,5 @@ fn invalid_git_external() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_git_name/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_git_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn invalid_git_name() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["not-in-git", "--git", &git_url])
         .current_dir(cwd)
@@ -30,5 +30,5 @@ fn invalid_git_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -10,7 +10,7 @@ fn invalid_key_inherit_dependency() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--default-features", "-p", "bar"])
@@ -20,5 +20,5 @@ fn invalid_key_inherit_dependency() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -10,7 +10,7 @@ fn invalid_key_overwrite_inherit_dependency() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--default-features", "-p", "bar"])
@@ -20,5 +20,5 @@ fn invalid_key_overwrite_inherit_dependency() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -10,7 +10,7 @@ fn invalid_key_rename_inherit_dependency() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["--rename", "foo", "foo-alt", "-p", "bar"])
@@ -20,5 +20,5 @@ fn invalid_key_rename_inherit_dependency() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_manifest/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_manifest/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_manifest() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_manifest() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_name_external/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_name_external/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_name_external() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("lets_hope_nobody_ever_publishes_this_crate")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_name_external() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_path/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_path/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_path() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture --path ./tests/fixtures/local")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_path() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_path_name/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_path_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_path_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("not-at-path --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn invalid_path_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_path_self/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_path_self/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_path_self() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture --path .")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_path_self() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_target_empty/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_target_empty/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_target_empty() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package --target ''")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_target_empty() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/invalid_vers/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_vers/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn invalid_vers() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package@invalid-version-string")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn invalid_vers() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/list_features/mod.rs
+++ b/tests/testsuite/cargo_add/list_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn list_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["your-face"])
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn list_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/list_features_path/mod.rs
+++ b/tests/testsuite/cargo_add/list_features_path/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn list_features_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn list_features_path() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/list_features_path_no_default/mod.rs
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn list_features_path_no_default() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args([
             "your-face",
@@ -26,5 +26,5 @@ fn list_features_path_no_default() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/manifest_path_package/mod.rs
+++ b/tests/testsuite/cargo_add/manifest_path_package/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn manifest_path_package() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args([
             "--manifest-path",
@@ -27,5 +27,5 @@ fn manifest_path_package() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/merge_activated_features/mod.rs
+++ b/tests/testsuite/cargo_add/merge_activated_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -10,7 +10,7 @@ fn merge_activated_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -20,5 +20,5 @@ fn merge_activated_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_features/mod.rs
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn multiple_conflicts_with_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 your-face --features nose")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn multiple_conflicts_with_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_rename/mod.rs
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_rename/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn multiple_conflicts_with_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2 --rename renamed")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn multiple_conflicts_with_rename() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/namever/mod.rs
+++ b/tests/testsuite/cargo_add/namever/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn namever() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1@>=0.1.1 my-package2@0.2.3 my-package")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn namever() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/no_args/mod.rs
+++ b/tests/testsuite/cargo_add/no_args/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn no_args() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .current_dir(cwd)
         .assert()
@@ -20,5 +20,5 @@ fn no_args() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/no_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/no_default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn no_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --no-default-features")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn no_default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/no_optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn no_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --no-optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn no_optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/optional/mod.rs
+++ b/tests/testsuite/cargo_add/optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --default-features")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_default_features_with_no_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --no-default-features")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_default_features_with_no_default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --features nose")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_git_with_path/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_git_with_path/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_git_with_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn overwrite_git_with_path() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_inherit_features_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_features_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -10,7 +10,7 @@ fn overwrite_inherit_features_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -20,5 +20,5 @@ fn overwrite_inherit_features_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_inherit_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_inherit_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -22,5 +22,5 @@ fn overwrite_inherit_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_inherit_optional_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -22,5 +22,5 @@ fn overwrite_inherit_optional_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_inline_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_inline_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line(
             "unrelateed-crate your-face --features your-face/nose,your-face/mouth -Fyour-face/ears",
@@ -23,5 +23,5 @@ fn overwrite_inline_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_name_dev_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --dev")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_name_dev_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_name_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_name_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_name_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_no_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --no-default-features")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_no_default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_no_default_features_with_default_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --default-features")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_no_default_features_with_default_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_no_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --no-optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_no_optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_no_optional_with_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_no_optional_with_optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_optional_with_no_optional() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2@0.4.1 --no-optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_optional_with_no_optional() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_path_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_path_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --path ./dependency")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_path_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_path_with_version() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency@20.0")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn overwrite_path_with_version() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_rename_with_no_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("versioned-package")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_rename_with_no_rename() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_rename_with_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("versioned-package --rename a2")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_rename_with_rename() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_rename_with_rename_noop() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("versioned-package --rename a1")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_rename_with_rename_noop() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -21,7 +21,7 @@ fn overwrite_version_with_git() {
     });
     let git_url = git_dep.url().to_string();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .args(["versioned-package", "--git", &git_url])
         .current_dir(cwd)
@@ -30,5 +30,5 @@ fn overwrite_version_with_git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_version_with_path/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_version_with_path/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_version_with_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn overwrite_version_with_path() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_with_rename/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_with_rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("versioned-package --rename renamed")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn overwrite_with_rename() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_workspace_dep() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--path", "./dependency", "-p", "bar"])
@@ -22,5 +22,5 @@ fn overwrite_workspace_dep() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep_features/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn overwrite_workspace_dep_features() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "--path", "./dependency", "-p", "bar"])
@@ -22,5 +22,5 @@ fn overwrite_workspace_dep_features() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/path/mod.rs
+++ b/tests/testsuite/cargo_add/path/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn path() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/path_dev/mod.rs
+++ b/tests/testsuite/cargo_add/path_dev/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn path_dev() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency --dev")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn path_dev() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/path_inferred_name/mod.rs
+++ b/tests/testsuite/cargo_add/path_inferred_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn path_inferred_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn path_inferred_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/mod.rs
+++ b/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn path_inferred_name_conflicts_full_feature() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("--path ../dependency --features your-face/nose")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn path_inferred_name_conflicts_full_feature() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/path_normalized_name/mod.rs
+++ b/tests/testsuite/cargo_add/path_normalized_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn path_normalized_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo_list_test_fixture_dependency --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn path_normalized_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/preserve_sorted/mod.rs
+++ b/tests/testsuite/cargo_add/preserve_sorted/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn preserve_sorted() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("toml")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn preserve_sorted() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/preserve_unsorted/mod.rs
+++ b/tests/testsuite/cargo_add/preserve_unsorted/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn preserve_unsorted() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("toml")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn preserve_unsorted() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/quiet/mod.rs
+++ b/tests/testsuite/cargo_add/quiet/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn quiet() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("--quiet your-face")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn quiet() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/registry/mod.rs
+++ b/tests/testsuite/cargo_add/registry/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn registry() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2 --registry alternative")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn registry() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/rename/mod.rs
+++ b/tests/testsuite/cargo_add/rename/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn rename() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package --rename renamed")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn rename() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/require_weak/mod.rs
+++ b/tests/testsuite/cargo_add/require_weak/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn require_weak() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("your-face --no-optional")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn require_weak() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/target/mod.rs
+++ b/tests/testsuite/cargo_add/target/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn target() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2 --target i686-unknown-linux-gnu")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn target() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/target_cfg/mod.rs
+++ b/tests/testsuite/cargo_add/target_cfg/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn target_cfg() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package1 my-package2 --target cfg(unix)")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn target_cfg() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -10,7 +10,7 @@ fn unknown_inherited_feature() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .masquerade_as_nightly_cargo()
         .arg("add")
         .args(["foo", "-p", "bar"])
@@ -20,5 +20,5 @@ fn unknown_inherited_feature() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/vers/mod.rs
+++ b/tests/testsuite/cargo_add/vers/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn vers() {
     let project_root = project.root();
     let cwd = &project_root;
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("my-package@>=0.1.1")
         .current_dir(cwd)
@@ -21,5 +21,5 @@ fn vers() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/workspace_name/mod.rs
+++ b/tests/testsuite/cargo_add/workspace_name/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn workspace_name() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn workspace_name() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/workspace_path/mod.rs
+++ b/tests/testsuite/cargo_add/workspace_path/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn workspace_path() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn workspace_path() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/cargo_add/workspace_path_dev/mod.rs
+++ b/tests/testsuite/cargo_add/workspace_path_dev/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -12,7 +12,7 @@ fn workspace_path_dev() {
     let project_root = project.root();
     let cwd = project_root.join("primary");
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg("add")
         .arg_line("cargo-list-test-fixture-dependency --path ../dependency --dev")
         .current_dir(&cwd)
@@ -21,5 +21,5 @@ fn workspace_path_dev() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
 }

--- a/tests/testsuite/init/auto_git/mod.rs
+++ b/tests/testsuite/init/auto_git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn auto_git() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn auto_git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), &project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
     assert!(project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/bin_already_exists_explicit/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_explicit/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn bin_already_exists_explicit() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --bin --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn bin_already_exists_explicit() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/bin_already_exists_explicit_nosrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_explicit_nosrc/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn bin_already_exists_explicit_nosrc() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --bin --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn bin_already_exists_explicit_nosrc() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("src").is_dir());
 }

--- a/tests/testsuite/init/bin_already_exists_implicit/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn bin_already_exists_implicit() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn bin_already_exists_implicit() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/bin_already_exists_implicit_namenosrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit_namenosrc/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn bin_already_exists_implicit_namenosrc() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn bin_already_exists_implicit_namenosrc() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("src").is_dir());
 }

--- a/tests/testsuite/init/bin_already_exists_implicit_namesrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit_namesrc/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn bin_already_exists_implicit_namesrc() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn bin_already_exists_implicit_namesrc() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("src/main.rs").is_file());
 }

--- a/tests/testsuite/init/bin_already_exists_implicit_nosrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit_nosrc/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn bin_already_exists_implicit_nosrc() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn bin_already_exists_implicit_nosrc() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("src").is_dir());
 }

--- a/tests/testsuite/init/both_lib_and_bin/mod.rs
+++ b/tests/testsuite/init/both_lib_and_bin/mod.rs
@@ -7,7 +7,7 @@ use cargo_test_support::curr_dir;
 fn both_lib_and_bin() {
     let cwd = paths::root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --bin")
         .current_dir(&cwd)
         .assert()

--- a/tests/testsuite/init/cant_create_library_when_both_binlib_present/mod.rs
+++ b/tests/testsuite/init/cant_create_library_when_both_binlib_present/mod.rs
@@ -8,7 +8,7 @@ fn cant_create_library_when_both_binlib_present() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()

--- a/tests/testsuite/init/confused_by_multiple_lib_files/mod.rs
+++ b/tests/testsuite/init/confused_by_multiple_lib_files/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn confused_by_multiple_lib_files() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn confused_by_multiple_lib_files() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("Cargo.toml").is_file());
 }

--- a/tests/testsuite/init/creates_binary_when_both_binlib_present/mod.rs
+++ b/tests/testsuite/init/creates_binary_when_both_binlib_present/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn creates_binary_when_both_binlib_present() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --bin --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn creates_binary_when_both_binlib_present() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/creates_binary_when_instructed_and_has_lib_file/mod.rs
+++ b/tests/testsuite/init/creates_binary_when_instructed_and_has_lib_file/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn creates_binary_when_instructed_and_has_lib_file() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --bin --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn creates_binary_when_instructed_and_has_lib_file() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/creates_library_when_instructed_and_has_bin_file/mod.rs
+++ b/tests/testsuite/init/creates_library_when_instructed_and_has_bin_file/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn creates_library_when_instructed_and_has_bin_file() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn creates_library_when_instructed_and_has_bin_file() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/empty_dir/mod.rs
+++ b/tests/testsuite/init/empty_dir/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::{command_is_available, paths, Project};
 use std::fs;

--- a/tests/testsuite/init/explicit_bin_with_git/mod.rs
+++ b/tests/testsuite/init/explicit_bin_with_git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn explicit_bin_with_git() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs git --bin")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn explicit_bin_with_git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/formats_source/mod.rs
+++ b/tests/testsuite/init/formats_source/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::{command_is_available, Project};
 
@@ -13,7 +13,7 @@ fn formats_source() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs none")
         .current_dir(project_root)
         .assert()
@@ -21,5 +21,5 @@ fn formats_source() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/fossil_autodetect/mod.rs
+++ b/tests/testsuite/init/fossil_autodetect/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn fossil_autodetect() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn fossil_autodetect() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/git_autodetect/mod.rs
+++ b/tests/testsuite/init/git_autodetect/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::paths;
 use cargo_test_support::prelude::*;
 use std::fs;
@@ -11,7 +11,7 @@ fn git_autodetect() {
     // Need to create `.git` dir manually because it cannot be tracked under a git repo
     fs::create_dir_all(project_root.join(".git")).unwrap();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()
@@ -19,6 +19,6 @@ fn git_autodetect() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/mod.rs
+++ b/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn git_ignore_exists_no_conflicting_entries() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --edition 2015")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn git_ignore_exists_no_conflicting_entries() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/ignores_failure_to_format_source/mod.rs
+++ b/tests/testsuite/init/ignores_failure_to_format_source/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn ignores_failure_to_format_source() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs none")
         .env("PATH", "") // pretend that `rustfmt` is missing
         .current_dir(project_root)
@@ -18,5 +18,5 @@ fn ignores_failure_to_format_source() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/inferred_bin_with_git/mod.rs
+++ b/tests/testsuite/init/inferred_bin_with_git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn inferred_bin_with_git() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs git")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn inferred_bin_with_git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/inferred_lib_with_git/mod.rs
+++ b/tests/testsuite/init/inferred_lib_with_git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn inferred_lib_with_git() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs git")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn inferred_lib_with_git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }

--- a/tests/testsuite/init/invalid_dir_name/mod.rs
+++ b/tests/testsuite/init/invalid_dir_name/mod.rs
@@ -9,7 +9,7 @@ fn invalid_dir_name() {
     let foo = &paths::root().join("foo.bar");
     fs::create_dir_all(foo).unwrap();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init")
         .current_dir(foo)
         .assert()

--- a/tests/testsuite/init/lib_already_exists_nosrc/mod.rs
+++ b/tests/testsuite/init/lib_already_exists_nosrc/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn lib_already_exists_nosrc() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn lib_already_exists_nosrc() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("src/main.rs").is_file());
 }

--- a/tests/testsuite/init/lib_already_exists_src/mod.rs
+++ b/tests/testsuite/init/lib_already_exists_src/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn lib_already_exists_src() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn lib_already_exists_src() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("src/main.rs").is_file());
 }

--- a/tests/testsuite/init/mercurial_autodetect/mod.rs
+++ b/tests/testsuite/init/mercurial_autodetect/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn mercurial_autodetect() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn mercurial_autodetect() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/multibin_project_name_clash/mod.rs
+++ b/tests/testsuite/init/multibin_project_name_clash/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn multibin_project_name_clash() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn multibin_project_name_clash() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join("Cargo.toml").is_file());
 }

--- a/tests/testsuite/init/no_filename/mod.rs
+++ b/tests/testsuite/init/no_filename/mod.rs
@@ -6,7 +6,7 @@ use cargo_test_support::curr_dir;
 #[cfg(not(windows))]
 #[cargo_test]
 fn no_filename() {
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init /")
         .current_dir(paths::root())
         .assert()

--- a/tests/testsuite/init/pijul_autodetect/mod.rs
+++ b/tests/testsuite/init/pijul_autodetect/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn pijul_autodetect() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn pijul_autodetect() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/reserved_name/mod.rs
+++ b/tests/testsuite/init/reserved_name/mod.rs
@@ -9,7 +9,7 @@ fn reserved_name() {
     let project_root = &paths::root().join("test");
     fs::create_dir_all(project_root).unwrap();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init")
         .current_dir(project_root)
         .assert()

--- a/tests/testsuite/init/simple_bin/mod.rs
+++ b/tests/testsuite/init/simple_bin/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn simple_bin() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --bin --vcs none --edition 2015")
         .current_dir(project_root)
         .assert()
@@ -17,10 +17,10 @@ fn simple_bin() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".gitignore").is_file());
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .current_dir(project_root)
         .arg("build")
         .assert()

--- a/tests/testsuite/init/simple_git/mod.rs
+++ b/tests/testsuite/init/simple_git/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn simple_git() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs git")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn simple_git() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/simple_git_ignore_exists/mod.rs
+++ b/tests/testsuite/init/simple_git_ignore_exists/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn simple_git_ignore_exists() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --edition 2015")
         .current_dir(project_root)
         .assert()
@@ -17,10 +17,10 @@ fn simple_git_ignore_exists() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(project_root.join(".git").is_dir());
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .current_dir(project_root)
         .arg("build")
         .assert()

--- a/tests/testsuite/init/simple_hg/mod.rs
+++ b/tests/testsuite/init/simple_hg/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -14,7 +14,7 @@ fn simple_hg() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs hg")
         .current_dir(project_root)
         .assert()
@@ -22,6 +22,6 @@ fn simple_hg() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/simple_hg_ignore_exists/mod.rs
+++ b/tests/testsuite/init/simple_hg_ignore_exists/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn simple_hg_ignore_exists() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib")
         .current_dir(project_root)
         .assert()
@@ -17,6 +17,6 @@ fn simple_hg_ignore_exists() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".git").is_dir());
 }

--- a/tests/testsuite/init/simple_lib/mod.rs
+++ b/tests/testsuite/init/simple_lib/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn simple_lib() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init --lib --vcs none --edition 2015")
         .current_dir(project_root)
         .assert()
@@ -17,10 +17,10 @@ fn simple_lib() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
     assert!(!project_root.join(".gitignore").is_file());
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .current_dir(project_root)
         .arg("build")
         .assert()

--- a/tests/testsuite/init/unknown_flags/mod.rs
+++ b/tests/testsuite/init/unknown_flags/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::curr_dir;
 
 #[cargo_test]
 fn unknown_flags() {
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init foo --flag")
         .current_dir(paths::root())
         .assert()

--- a/tests/testsuite/init/with_argument/mod.rs
+++ b/tests/testsuite/init/with_argument/mod.rs
@@ -1,4 +1,4 @@
-use cargo_test_support::compare::assert;
+use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
 use cargo_test_support::Project;
 
@@ -9,7 +9,7 @@ fn with_argument() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 
-    snapbox::cmd::Command::cargo()
+    snapbox::cmd::Command::cargo_ui()
         .arg_line("init foo --vcs none")
         .current_dir(project_root)
         .assert()
@@ -17,5 +17,5 @@ fn with_argument() {
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 
-    assert().subset_matches(curr_dir!().join("out"), project_root);
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
 }


### PR DESCRIPTION
In writing the contrib documentation for functional vs ui tests, I
realized that as we work to make snapbox work for the functional tests,
we'll need distinct `Assert` objects since we'll want to elide a lot
more content in functional tests.  I'm making room for this by
qualifying the existing asserts as being for "ui".