### PR TITLE
Allow '.' in workspace.default-members in non-virtual workspaces.

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -686,13 +686,13 @@ impl<'cfg> Workspace<'cfg> {
                 })?;
         }
 
+        self.find_path_deps(&root_manifest_path, &root_manifest_path, false)?;
+
         if let Some(default) = default_members_paths {
             for path in default {
                 let normalized_path = paths::normalize_path(&path);
                 let manifest_path = normalized_path.join("Cargo.toml");
-                if !self.members.contains(&manifest_path)
-                    && (self.is_virtual() || manifest_path != root_manifest_path)
-                {
+                if !self.members.contains(&manifest_path) {
                     // default-members are allowed to be excluded, but they
                     // still must be referred to by the original (unfiltered)
                     // members list. Note that we aren't testing against the
@@ -718,7 +718,7 @@ impl<'cfg> Workspace<'cfg> {
             self.default_members.push(self.current_manifest.clone())
         }
 
-        self.find_path_deps(&root_manifest_path, &root_manifest_path, false)
+        Ok(())
     }
 
     fn find_path_deps(

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -690,7 +690,9 @@ impl<'cfg> Workspace<'cfg> {
             for path in default {
                 let normalized_path = paths::normalize_path(&path);
                 let manifest_path = normalized_path.join("Cargo.toml");
-                if !self.members.contains(&manifest_path) {
+                if !self.members.contains(&manifest_path)
+                    && (self.is_virtual() || manifest_path != root_manifest_path)
+                {
                     // default-members are allowed to be excluded, but they
                     // still must be referred to by the original (unfiltered)
                     // members list. Note that we aren't testing against the

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -120,6 +120,35 @@ fn non_virtual_default_members_build_other_member() {
 }
 
 #[cargo_test]
+fn non_virtual_default_members_build_root_project() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                members = ["bar"]
+                default-members = ["."]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
+
+    p.cargo("build")
+        .with_stderr(
+            "[..] Compiling foo v0.1.0 ([..])\n\
+             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn inferred_root() {
     let p = project()
         .file(


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fixes #10783

### How should we test and review this PR?

I've added a test case that I've verified fails without this change and succeeds with it.

I've further switched to using this patched cargo to build another project (where I originally ran into this issue) and everything appeared to work perfectly.

### Additional information

This shouldn't impact any existing cargo users as it only changes an invalid config into a valid one. As long as this new behavior is considered desirable (needs review there), I think this should be safe to merge.

<!-- homu-ignore:end -->
