### PR TITLE
Fix tests due to change in dead_code diagnostic.

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -647,7 +647,7 @@ fn cargo_compile_with_warnings_in_the_root_package() {
         .build();
 
     p.cargo("build")
-        .with_stderr_contains("[..]function is never used: `dead`[..]")
+        .with_stderr_contains("[WARNING] [..]dead[..]")
         .run();
 }
 
@@ -686,7 +686,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         .build();
 
     p.cargo("build")
-        .with_stderr_contains("[..]function is never used: `dead`[..]")
+        .with_stderr_contains("[WARNING] [..]dead[..]")
         .run();
 
     assert!(p.bin("foo").is_file());

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1923,7 +1923,7 @@ fn upstream_warnings_on_extra_verbose(cargo: fn(&Project, &str) -> Execs) {
         .publish();
 
     cargo(&p, "build -vv")
-        .with_stderr_contains("[..]warning: function is never used[..]")
+        .with_stderr_contains("[WARNING] [..]unused[..]")
         .run();
 }
 

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -316,7 +316,7 @@ fn check_core() {
     p.cargo("check -v")
         .build_std_arg(&setup, "core")
         .target_host()
-        .with_stderr_contains("[WARNING] [..]unused_fn[..]`")
+        .with_stderr_contains("[WARNING] [..]unused_fn[..]")
         .run();
 }
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/97853 changed some diagnostics which is causing some tests to fail on the latest nightly.  This updates the tests to work on both stable and nightly.