### PR TITLE
Change precedence of `build-override`

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -423,9 +423,9 @@ The precedence for which value is used is done in the following order (first
 match wins):
 
 1. `[profile.dev.package.name]` — A named package.
-2. `[profile.dev.package."*"]` — For any non-workspace member.
-3. `[profile.dev.build-override]` — Only for build scripts, proc macros, and
+2. `[profile.dev.build-override]` — Only for build scripts, proc macros, and
    their dependencies.
+3. `[profile.dev.package."*"]` — For any non-workspace member.
 4. `[profile.dev]` — Settings in `Cargo.toml`.
 5. Default values built-in to Cargo.
 

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -207,6 +207,7 @@ fn profile_override_hierarchy() {
     // m3: 4 (as build.rs dependency)
     // m3: 1 (as [profile.dev] as workspace member)
     // dep: 3 (as [profile.dev.package."*"] as non-workspace member)
+    // dep: 4 (as [profile.dev.build-override])
     // m1 build.rs: 4 (as [profile.dev.build-override])
     // m2 build.rs: 2 (as [profile.dev.package.m2])
     // m2: 2 (as [profile.dev.package.m2])
@@ -217,6 +218,7 @@ fn profile_override_hierarchy() {
 [COMPILING] dep [..]
 [RUNNING] `rustc --crate-name m3 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]
 [RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=3 [..]
+[RUNNING] `rustc --crate-name dep [..]dep/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]
 [RUNNING] `rustc --crate-name m3 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=1 [..]
 [RUNNING] `rustc --crate-name build_script_build m1/build.rs [..] --crate-type bin --emit=[..]link[..]-C codegen-units=4 [..]
 [COMPILING] m2 [..]


### PR DESCRIPTION
See the original PR here <https://github.com/rust-lang/cargo/pull/9382>

> If you specify both `build-override` and `package."*"` then the glob profile has higher precedence than the `build-override` one which is much more specific. In practice this means that very often the `build-override` is just completely ignored and all the proc macro crates get compiled without the `build-override` actually doing anything. This usually results in `debug` builds taking much longer than they should, often even longer than `release` builds. This Pull Request fixes this precedence issue.

This includes those changes along with the necessary documentation changes. Additionally, the `build-override` defaults (and not just overrides supplied by the user) are now applied before `package."*"` overrides.

Fixes #9351

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
