### PR TITLE
fix: bash complete `install --path` with dirs

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -138,7 +138,7 @@ _cargo()
 			--target)
 				COMPREPLY=( $( compgen -W "$(_get_targets)" -- "$cur" ) )
 				;;
-			--target-dir)
+			--target-dir|--path)
 				_filedir -d
 				;;
 			help)


### PR DESCRIPTION
`--path` takes a mandatory dir argument.
