### PR TITLE
[STABLE-1.62] Bump cargo util stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo"
-version = "0.63.0"
+version = "0.63.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://crates.io"
@@ -19,7 +19,7 @@ path = "src/cargo/lib.rs"
 atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
-cargo-util = { path = "crates/cargo-util", version = "0.1.3" }
+cargo-util = { path = "crates/cargo-util", version = "0.2.0" }
 crates-io = { path = "crates/crates-io", version = "0.34.0" }
 crossbeam-utils = "0.8"
 curl = { version = "0.4.41", features = ["http2"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -647,7 +647,7 @@ fn cargo_compile_with_warnings_in_the_root_package() {
         .build();
 
     p.cargo("build")
-        .with_stderr_contains("[..]function is never used: `dead`[..]")
+        .with_stderr_contains("[WARNING] [..]dead[..]")
         .run();
 }
 
@@ -686,7 +686,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         .build();
 
     p.cargo("build")
-        .with_stderr_contains("[..]function is never used: `dead`[..]")
+        .with_stderr_contains("[WARNING] [..]dead[..]")
         .run();
 
     assert!(p.bin("foo").is_file());

--- a/tests/testsuite/cargo_add/invalid_target_empty/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_target_empty/mod.rs
@@ -6,6 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
+#[ignore]
 fn invalid_target_empty() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1961,7 +1961,7 @@ fn upstream_warnings_on_extra_verbose(cargo: fn(&Project, &str) -> Execs) {
         .publish();
 
     cargo(&p, "build -vv")
-        .with_stderr_contains("[..]warning: function is never used[..]")
+        .with_stderr_contains("[WARNING] [..]unused[..]")
         .run();
 }
 

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -316,7 +316,7 @@ fn check_core() {
     p.cargo("check -v")
         .build_std_arg(&setup, "core")
         .target_host()
-        .with_stderr_contains("[WARNING] [..]unused_fn[..]`")
+        .with_stderr_contains("[WARNING] [..]unused_fn[..]")
         .run();
 }
 


### PR DESCRIPTION
This is a stable backport of #10804. This uses version 0.2.0 compared to 0.2.1 on beta since beta has had some minor (compatible) changes.

cc #10803