### PR TITLE
Fix zsh completions for add and locate-project

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -68,16 +68,16 @@ _cargo() {
             case ${words[1]} in
                 add)
                     _arguments -s -A "^--" $common $manifest $registry \
-                        {-F+,--features=}'[specify features to activate]:feature'
-                        "--default-features[enable the default features]"
-                        "--no-default-features[don't enable the default features]"
-                        "--optional[mark the dependency as optional]"
-                        "--no-optional[mark the dependency as required]"
-                        "--dev[add as a dev dependency]"
-                        "--build[add as a build dependency]"
-                        "--target=[add as a dependency to the given target platform]"
-                        "--rename=[rename the dependency]"
-                        "--dry-run[don't actually write the manifest]"
+                        {-F+,--features=}'[specify features to activate]:feature' \
+                        "--default-features[enable the default features]" \
+                        "--no-default-features[don't enable the default features]" \
+                        "--optional[mark the dependency as optional]" \
+                        "--no-optional[mark the dependency as required]" \
+                        "--dev[add as a dev dependency]" \
+                        "--build[add as a build dependency]" \
+                        "--target=[add as a dependency to the given target platform]" \
+                        "--rename=[rename the dependency]" \
+                        "--dry-run[don't actually write the manifest]" \
                         '--branch=[branch to use when adding from git]:branch' \
                         '--git=[specify URL from which to add the crate]:url:_urls' \
                         '--path=[local filesystem path to crate to add]: :_directories' \
@@ -182,7 +182,7 @@ _cargo() {
 
                 locate-project)
                     _arguments -s -S $common $manifest \
-                        '--message-format=[specify output representation]:output representation [json]:(json plain)'
+                        '--message-format=[specify output representation]:output representation [json]:(json plain)' \
                         '--workspace[locate Cargo.toml of the workspace root]'
                         ;;
 


### PR DESCRIPTION
Currently, trying to tab-complete either the `cargo add` or `cargo locate-project` subcommands results in output such as this:
```
cargo add _cargo:67: command not found: --default-features[enable the default features]
_cargo:68: command not found: --no-default-features[don't enable the default features]
_cargo:69: command not found: --optional[mark the dependency as optional]
```

This is because some line continuations are missing from `src/etc/_cargo`. This PR adds these line continuations.

This file gets packaged for Rust releases by https://github.com/rust-lang/rust/blob/acdcdfb61b7b472bfacbb8bb889bdf3204827f2e/src/bootstrap/dist.rs#L956 and Rustup ultimately places it in `~/.rustup/toolchains/*/share/zsh/site-functions/_cargo`. `rustup completions zsh cargo` outputs a script which sources this filepath.

The easier approach to testing this is probably to manually copy `_cargo` to its proper location under `~/.rustup`, assuming Rust is already installed via Rustup and Zsh completions for Cargo are already installed, but however you choose to install this, testing is as simple as observing that Zsh can correctly tab complete `cargo add` and `cargo locate-project`.