### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -4,8 +4,13 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   # Check Code style quickly by running `rustfmt` over all code
   rustfmt:
@@ -149,6 +152,8 @@ jobs:
         sh linkcheck.sh --all cargo
 
   success:
+    permissions:
+      contents: none
     name: bors build finished
     needs: [docs, rustfmt, test, resolver, build_std]
     runs-on: ubuntu-latest
@@ -156,6 +161,8 @@ jobs:
     steps:
     - run: echo ok
   failure:
+    permissions:
+      contents: none
     name: bors build finished
     needs: [docs, rustfmt, test, resolver, build_std]
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
