### PR TITLE
fix(add): Don't panic with `--offline`

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -81,9 +81,6 @@ Example uses:
                 .takes_value(true)
                 .value_name("SPEC")
                 .help("Package to modify"),
-            clap::Arg::new("offline")
-                .long("offline")
-                .help("Run without accessing the network")
         ])
         .arg_quiet()
         .arg_dry_run("Don't actually write the manifest")

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -56,6 +56,7 @@ mod namever;
 mod no_args;
 mod no_default_features;
 mod no_optional;
+mod offline_empty_cache;
 mod optional;
 mod overwrite_default_features;
 mod overwrite_default_features_with_no_default_features;

--- a/tests/testsuite/cargo_add/offline_empty_cache/in
+++ b/tests/testsuite/cargo_add/offline_empty_cache/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/offline_empty_cache/mod.rs
+++ b/tests/testsuite/cargo_add/offline_empty_cache/mod.rs
@@ -1,0 +1,25 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::Project;
+
+use crate::cargo_add::init_registry;
+use cargo_test_support::curr_dir;
+
+#[cargo_test]
+fn offline_empty_cache() {
+    init_registry();
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .arg_line("--offline my-package")
+        .current_dir(cwd)
+        .assert()
+        .code(101)
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/offline_empty_cache/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/offline_empty_cache/out/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"

--- a/tests/testsuite/cargo_add/offline_empty_cache/stderr.log
+++ b/tests/testsuite/cargo_add/offline_empty_cache/stderr.log
@@ -1,0 +1,1 @@
+error: the crate `my-package` could not be found in registry index.


### PR DESCRIPTION
For some reason, I defined my own `--offline` flag and it didn't get
updated with the global `--offline` flag, so it started failing.

The new test previously paniced and now it doesn't.

Fixes #10814

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
