### PR TITLE
Fix publishing to crates.io with -Z sparse-registry

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -196,10 +196,6 @@ fn verify_dependencies(
         if super::check_dep_has_version(dep, true)? {
             continue;
         }
-        // Allow publishing to crates.io with index.crates.io as a source replacement.
-        if registry_src.is_default_registry() && dep.source_id().is_default_registry() {
-            continue;
-        }
         // TomlManifest::prepare_for_publish will rewrite the dependency
         // to be just the `version` field.
         if dep.source_id() != registry_src {
@@ -535,6 +531,13 @@ fn registry(
         None
     };
     let handle = http_handle(config)?;
+    // Workaround for the sparse+https://index.crates.io replacement index. Use the non-replaced
+    // source_id so that the original (github) url is used when publishing a crate.
+    let sid = if sid.is_default_registry() {
+        SourceId::crates_io(config)?
+    } else {
+        sid
+    };
     Ok((Registry::new_handle(api_host, token, handle), reg_cfg, sid))
 }
 


### PR DESCRIPTION
Attempting to publish a crate to crates.io with `-Z sparse-registry` failed with the following error:

```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error: Dependency `serde` is hosted on another registry. Cross-registry dependencies are not permitted on crates.io.
```

The check in `registry.rs` `dep_registry_id != registry_id` caused the `publish` operation include the crates.io index url in the HTTP request because the id was replaced. The crates.io API seems to require that the `registry` field is not present.

This change fixes the issue by making the `registry` function return the non-replaced crates.io `source_id` only for this case. Other replacement indices of crates.io continue to include the registry URL when publishing.

Tested manually by publishing `arlosi-cargo-test` to crates.io with `-Z sparse-registry`

Fixes #10828
r? @Eh2406 