### PR TITLE
Update terminal-width flag.

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -793,11 +793,11 @@ fn add_error_format_and_color(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder) {
         ) {
             // Terminal width explicitly provided - only useful for testing.
             (Some(Some(width)), _) => {
-                cmd.arg(format!("-Zterminal-width={}", width));
+                cmd.arg(format!("--diagnostic-width={}", width));
             }
             // Terminal width was not explicitly provided but flag was provided - common case.
             (Some(None), Some(width)) => {
-                cmd.arg(format!("-Zterminal-width={}", width));
+                cmd.arg(format!("--diagnostic-width={}", width));
             }
             // User didn't opt-in.
             _ => (),

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6107,7 +6107,7 @@ fn target_directory_backup_exclusion() {
 #[cargo_test]
 fn simple_terminal_width() {
     if !is_nightly() {
-        // --terminal-width is unstable
+        // --diagnostic-width is stabilized in 1.64
         return;
     }
     let p = project()


### PR DESCRIPTION
The rustc flag `-Zterminal-width` has been stabilized as `--terminal-width` in https://github.com/rust-lang/rust/pull/95635. This updates cargo to use the new flag so that tests will pass.

Tests won't pass until the next nightly is published in about 10 hours from now. I just wanted to post this to get ahead of the breaking change. 

This doesn't stabilize in cargo because that will take more time, and this is needed to prevent CI from failing. Will continue the stabilization discussion at https://github.com/rust-lang/rust/issues/84673.