### PR TITLE
Mention `[patch]` config in "Overriding Dependencies"

### DIFF
--- a/src/doc/src/reference/overriding-dependencies.md
+++ b/src/doc/src/reference/overriding-dependencies.md
@@ -266,6 +266,12 @@ git = 'https://github.com/example/baz'
 baz = { git = 'https://github.com/example/patched-baz', branch = 'my-branch' }
 ```
 
+> **Note**: The `[patch]` table can also be specified as a [configuration
+> option](config.md), such as in a `.cargo/config.toml` file or a CLI option
+> like `--config 'patch.crates-io.rand.path="rand"'`. This can be useful for
+> local-only changes that you don't want to commit, or temporarily testing a
+> patch.
+
 The `[patch]` table is made of dependency-like sub-tables. Each key after
 `[patch]` is a URL of the source that is being patched, or the name of a
 registry. The name `crates-io` may be used to override the default registry


### PR DESCRIPTION
The "Overriding Dependencies" chapter is the primary documentation for the `[patch]` table, but it does not mention that `[patch]` also works in config files. This adds a note to mention this option.

cc https://github.com/rust-lang/cargo/issues/10832#issuecomment-1177647089