### PR TITLE
Stabilize `--crate-type` flag for `cargo rustc`

### DIFF
--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -39,7 +39,7 @@ pub fn cli() -> App {
         .arg(multi_opt(
             CRATE_TYPE_ARG_NAME,
             "CRATE-TYPE",
-            "Comma separated list of types of crates for the compiler to emit (unstable)",
+            "Comma separated list of types of crates for the compiler to emit",
         ))
         .arg_target_dir()
         .arg_manifest_path()
@@ -88,9 +88,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     compile_opts.target_rustc_crate_types = if crate_types.is_empty() {
         None
     } else {
-        config
-            .cli_unstable()
-            .fail_if_stable_opt(CRATE_TYPE_ARG_NAME, 10083)?;
         Some(crate_types)
     };
     ops::compile(&ws, &compile_opts)?;

--- a/src/doc/man/cargo-rustc.md
+++ b/src/doc/man/cargo-rustc.md
@@ -70,6 +70,19 @@ See the [the reference](../reference/profiles.html) for more details on profiles
 
 {{> options-timings }}
 
+{{#option "`--crate-type` _crate-type_"}}
+Build for the given crate type. This flag accepts a comma-separated list of
+1 or more crate types, of which the allowed values are the same as `crate-type`
+field in the manifest for configurating a Cargo target. See
+[`crate-type` field](../reference/cargo-targets.html#the-crate-type-field)
+for possible values.
+
+If the manifest contains a list, and `--crate-type` is provided,
+the command-line argument value will override what is in the manifest.
+
+This flag only works when building a `lib` or `example` library target.
+{{/option}}
+
 {{/options}}
 
 ### Output Options
@@ -122,6 +135,10 @@ See the [the reference](../reference/profiles.html) for more details on profiles
    the size of every type:
 
        cargo rustc --lib -- -Z print-type-sizes
+
+3. Override `crate-type` field in Cargo.toml with command-line option:
+
+       cargo rustc --lib --crate-type lib,cdylib
 
 ## SEE ALSO
 {{man "cargo" 1}}, {{man "cargo-build" 1}}, {{man "rustc" 1}}

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -191,6 +191,19 @@ OPTIONS
            o  json (unstable, requires -Zunstable-options): Emit
               machine-readable JSON information about timing information.
 
+       --crate-type crate-type
+           Build for the given crate type. This flag accepts a comma-separated
+           list of 1 or more crate types, of which the allowed values are the
+           same as crate-type field in the manifest for configurating a Cargo
+           target. See crate-type field
+           <https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field>
+           for possible values.
+
+           If the manifest contains a list, and --crate-type is provided, the
+           command-line argument value will override what is in the manifest.
+
+           This flag only works when building a lib or example library target.
+
    Output Options
        --target-dir directory
            Directory for all generated artifacts and intermediate files. May
@@ -338,6 +351,10 @@ EXAMPLES
           prints the size of every type:
 
               cargo rustc --lib -- -Z print-type-sizes
+
+       3. Override crate-type field in Cargo.toml with command-line option:
+
+              cargo rustc --lib --crate-type lib,cdylib
 
 SEE ALSO
        cargo(1), cargo-build(1), rustc(1)

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -226,6 +226,17 @@ information about timing information.</li>
 
 
 
+<dt class="option-term" id="option-cargo-rustc---crate-type"><a class="option-anchor" href="#option-cargo-rustc---crate-type"></a><code>--crate-type</code> <em>crate-type</em></dt>
+<dd class="option-desc">Build for the given crate type. This flag accepts a comma-separated list of
+1 or more crate types, of which the allowed values are the same as <code>crate-type</code>
+field in the manifest for configurating a Cargo target. See
+<a href="../reference/cargo-targets.html#the-crate-type-field"><code>crate-type</code> field</a>
+for possible values.</p>
+<p>If the manifest contains a list, and <code>--crate-type</code> is provided,
+the command-line argument value will override what is in the manifest.</p>
+<p>This flag only works when building a <code>lib</code> or <code>example</code> library target.</dd>
+
+
 </dl>
 
 ### Output Options
@@ -409,6 +420,10 @@ details on environment variables that Cargo reads.
    the size of every type:
 
        cargo rustc --lib -- -Z print-type-sizes
+
+3. Override `crate-type` field in Cargo.toml with command-line option:
+
+       cargo rustc --lib --crate-type lib,cdylib
 
 ## SEE ALSO
 [cargo(1)](cargo.html), [cargo-build(1)](cargo-build.html), [rustc(1)](https://doc.rust-lang.org/rustc/index.html)

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -437,23 +437,6 @@ like to stabilize it somehow!
 
 [rust-lang/rust#64158]: https://github.com/rust-lang/rust/pull/64158
 
-### crate-type
-* Tracking Issue: [#10083](https://github.com/rust-lang/cargo/issues/10083)
-* RFC: [#3180](https://github.com/rust-lang/rfcs/pull/3180)
-* Original Pull Request: [#10093](https://github.com/rust-lang/cargo/pull/10093)
-
-`cargo rustc --crate-type=lib,cdylib` forwards the `--crate-type` flag to `rustc`.
-This runs `rustc` with the corresponding
-[`--crate-type`](https://doc.rust-lang.org/rustc/command-line-arguments.html#--crate-type-a-list-of-types-of-crates-for-the-compiler-to-emit)
-flag, and compiling.
-
-When using it, it requires the `-Z unstable-options`
-command-line option:
-
-```console
-cargo rustc --crate-type lib,cdylib -Z unstable-options
-```
-
 ### keep-going
 * Tracking Issue: [#0](https://github.com/rust-lang/cargo/issues/10496)
 
@@ -1569,3 +1552,9 @@ unstable and require `-Zunstable-options`.)
 The `--config` CLI option has been stabilized in the 1.63 release. See
 the [config documentation](config.html#command-line-overrides) for more
 information.
+
+### crate-type
+
+The `--crate-type` flag for `cargo rustc` has been stabilized in the 1.64
+release. See the [`cargo rustc` documentation](../commands/cargo-rustc.md)
+for more information.

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -224,6 +224,20 @@ and does not provide machine\-readable timing data.
 information about timing information.
 .RE
 .RE
+.sp
+\fB\-\-crate\-type\fR \fIcrate\-type\fR
+.RS 4
+Build for the given crate type. This flag accepts a comma\-separated list of
+1 or more crate types, of which the allowed values are the same as \fBcrate\-type\fR
+field in the manifest for configurating a Cargo target. See
+\fI\f(BIcrate\-type\fI field\fR <https://doc.rust\-lang.org/cargo/reference/cargo\-targets.html#the\-crate\-type\-field>
+for possible values.
+.sp
+If the manifest contains a list, and \fB\-\-crate\-type\fR is provided,
+the command\-line argument value will override what is in the manifest.
+.sp
+This flag only works when building a \fBlib\fR or \fBexample\fR library target.
+.RE
 .SS "Output Options"
 .sp
 \fB\-\-target\-dir\fR \fIdirectory\fR
@@ -429,6 +443,16 @@ the size of every type:
 .RS 4
 .nf
 cargo rustc \-\-lib \-\- \-Z print\-type\-sizes
+.fi
+.RE
+.RE
+.sp
+.RS 4
+\h'-04' 3.\h'+01'Override \fBcrate\-type\fR field in Cargo.toml with command\-line option:
+.sp
+.RS 4
+.nf
+cargo rustc \-\-lib \-\-crate\-type lib,cdylib
 .fi
 .RE
 .RE

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -135,20 +135,6 @@ fn fails_with_args_to_all_binaries() {
 }
 
 #[cargo_test]
-fn fails_with_crate_type_and_without_unstable_options() {
-    let p = project().file("src/lib.rs", r#" "#).build();
-
-    p.cargo("rustc --crate-type lib")
-        .masquerade_as_nightly_cargo(&["crate-type"])
-        .with_status(101)
-        .with_stderr(
-            "[ERROR] the `crate-type` flag is unstable, pass `-Z unstable-options` to enable it
-See https://github.com/rust-lang/cargo/issues/10083 for more information about the `crate-type` flag.",
-        )
-        .run();
-}
-
-#[cargo_test]
 fn fails_with_crate_type_to_multi_binaries() {
     let p = project()
         .file("src/bin/foo.rs", "fn main() {}")
@@ -157,8 +143,7 @@ fn fails_with_crate_type_to_multi_binaries() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    p.cargo("rustc --crate-type lib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc --crate-type lib")
         .with_status(101)
         .with_stderr(
             "[ERROR] crate types to rustc can only be passed to one target, consider filtering
@@ -191,8 +176,7 @@ fn fails_with_crate_type_to_multi_examples() {
         .file("examples/ex2.rs", "")
         .build();
 
-    p.cargo("rustc -v --example ex1 --example ex2 --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --example ex1 --example ex2 --crate-type lib,cdylib")
         .with_status(101)
         .with_stderr(
             "[ERROR] crate types to rustc can only be passed to one target, consider filtering
@@ -205,8 +189,7 @@ the package by passing, e.g., `--lib` or `--example` to specify a single target"
 fn fails_with_crate_type_to_binary() {
     let p = project().file("src/bin/foo.rs", "fn main() {}").build();
 
-    p.cargo("rustc --crate-type lib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc --crate-type lib")
         .with_status(101)
         .with_stderr(
             "[ERROR] crate types can only be specified for libraries and example libraries.
@@ -219,8 +202,7 @@ Binaries, tests, and benchmarks are always the `bin` crate type",
 fn build_with_crate_type_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustc -v --crate-type cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --crate-type cdylib")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -257,8 +239,7 @@ fn build_with_crate_type_for_foo_with_deps() {
         .file("a/src/lib.rs", "pub fn hello() {}")
         .build();
 
-    p.cargo("rustc -v --crate-type cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --crate-type cdylib")
         .with_stderr(
             "\
 [COMPILING] a v0.1.0 ([CWD]/a)
@@ -275,8 +256,7 @@ fn build_with_crate_type_for_foo_with_deps() {
 fn build_with_crate_types_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("rustc -v --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --crate-type lib,cdylib")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -307,8 +287,7 @@ fn build_with_crate_type_to_example() {
         .file("examples/ex.rs", "")
         .build();
 
-    p.cargo("rustc -v --example ex --crate-type cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --example ex --crate-type cdylib")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -340,8 +319,7 @@ fn build_with_crate_types_to_example() {
         .file("examples/ex.rs", "")
         .build();
 
-    p.cargo("rustc -v --example ex --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --example ex --crate-type lib,cdylib")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -377,8 +355,7 @@ fn build_with_crate_types_to_one_of_multi_examples() {
         .file("examples/ex2.rs", "")
         .build();
 
-    p.cargo("rustc -v --example ex1 --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["crate-type"])
+    p.cargo("rustc -v --example ex1 --crate-type lib,cdylib")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Stabilize `--crate-type` flag for `cargo rustc`, as https://github.com/rust-lang/cargo/issues/10083#issuecomment-1175333482 concluded.

Don't merge until FCP ends.

Close #10083

<!-- homu-ignore:end -->
