### PR TITLE
Don't compile on install without binaries

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -4,6 +4,7 @@ use cargo::core::{GitReference, SourceId, Workspace};
 use cargo::ops;
 use cargo::util::IntoUrl;
 
+use cargo::ops::{CompileFilter, FilterRule, LibRule};
 use cargo_util::paths;
 
 pub fn cli() -> App {
@@ -161,6 +162,17 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     if args.flag("list") {
         ops::install_list(root, config)?;
     } else {
+        if !compile_opts.filter.is_specific() {
+            compile_opts.filter = CompileFilter::Only {
+                all_targets: false,
+                lib: LibRule::False,
+                bins: FilterRule::All,
+                examples: FilterRule::none(),
+                tests: FilterRule::none(),
+                benches: FilterRule::none(),
+            };
+        }
+
         ops::install(
             config,
             root,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -725,12 +725,14 @@ fn no_binaries() {
     cargo_process("install --path")
         .arg(p.root())
         .arg("foo")
-        .with_status(101)
+        .with_status(0)
         .with_stderr(
             "\
-[ERROR] there is nothing to install in `foo v0.0.1 ([..])`, because it has no binaries[..]
-[..]
-[..]",
+[INSTALLING] foo v0.0.1 ([..])
+warning: Target filter `bins` specified, but no targets matched. This is a no-op
+[FINISHED] release [optimized] target(s) in [..]
+warning: none of the package's binaries are available for install using the selected features
+",
         )
         .run();
 }

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -653,6 +653,7 @@ fn install_default_features() {
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
+warning: Target filter `bins` specified, but no targets matched. This is a no-op
 [FINISHED] release [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
 ",
@@ -805,6 +806,7 @@ fn install_multiple_required_features() {
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
+warning: Target filter `bins` specified, but no targets matched. This is a no-op
 [FINISHED] release [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
 ",
@@ -1093,6 +1095,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
+warning: Target filter `bins` specified, but no targets matched. This is a no-op
 [FINISHED] release [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
 ",


### PR DESCRIPTION
Fixes #8970

This PR is trying to revive the effort started in https://github.com/rust-lang/cargo/pull/9576.
We don't want to compile code if there is no viable binary when running `cargo install my-name-here`.

The PR in the current form is not great. Due to the new compile filter, we show ``warning: Target filter `bins` specified, but no targets matched. This is a no-op``, even when the customer did not specify `--bins`.

I think one the way to address this issue would to update `CompileMode::Build` to `CompileMode::Build { install: bool }`, but I am not sure if that change would be welcome.