### PR TITLE
clarify profile used for 'cargo install --debug'

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -55,7 +55,10 @@ pub fn cli() -> App {
         .arg(flag("no-track", "Do not save tracking information"))
         .arg_features()
         .arg_profile("Install artifacts with the specified profile")
-        .arg(flag("debug", "Build in debug mode instead of release mode"))
+        .arg(flag(
+            "debug",
+            "Build in debug mode (with the 'dev' profile) instead of release mode",
+        ))
         .arg_targets_bins_examples(
             "Install only the specified binary",
             "Install all binaries",

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -246,7 +246,7 @@ whether or not [`rpath`] is enabled.
 #### dev
 
 The `dev` profile is used for normal development and debugging. It is the
-default for build commands like [`cargo build`].
+default for build commands like [`cargo build`], and is used for `cargo install --debug`.
 
 The default settings for the `dev` profile are:
 

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -168,7 +168,7 @@ _cargo() {
                         '(-f --force)'{-f,--force}'[force overwriting of existing crates or binaries]' \
                         '--bin=[only install the specified binary]:binary' \
                         '--branch=[branch to use when installing from git]:branch' \
-                        '--debug[build in debug mode instead of release mode]' \
+                        '--debug[Build in debug mode (with the "dev" profile) instead of release mode]' \
                         '--example=[install the specified example instead of binaries]:example:_cargo_example_names' \
                         '--git=[specify URL from which to install the crate]:url:_urls' \
                         '--path=[local filesystem path to crate to install]: :_directories' \


### PR DESCRIPTION
TIL that the profile used by `cargo build` is called `dev`, not `debug`. That made me wonder, is that profile also used by `cargo install --debug` (despite the name of the flag being `--debug`, not `--dev`)? Turns out the answer is yes, but the first 2 places where I looked for help did not say that. So this PR changes those two places to be explicit about this.