### PR TITLE
remove`.masquerade_as_nightly_cargo()` from various tests the no longer need it

### DIFF
--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -149,8 +149,7 @@ fn env_no_override() {
         )
         .build();
 
-    p.cargo("run -Zconfigurable-env")
-        .masquerade_as_nightly_cargo()
+    p.cargo("run")
         .with_stdout_contains("CARGO_PKG_NAME:unchanged")
         .run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2389,7 +2389,6 @@ foo v0.1.0 [..]
     // Importantly, this does not include `f1` on `common`.
     p.cargo("tree -f")
         .arg("{p} feats:{f}")
-        .masquerade_as_nightly_cargo()
         .with_stdout(
             "\
 foo v0.1.0 [..]

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1563,7 +1563,6 @@ fn fix_edition_2021() {
         )
         .build();
     p.cargo("fix --edition --allow-no-vcs")
-        .masquerade_as_nightly_cargo()
         .with_stderr(
             "\
 [CHECKING] foo v0.1.0 [..]
@@ -1745,7 +1744,6 @@ fn fix_with_run_cargo_in_proc_macros() {
         )
         .build();
     p.cargo("fix --allow-no-vcs")
-        .masquerade_as_nightly_cargo()
         .with_stderr_does_not_contain("error: could not find .rs file in rustc args")
         .run();
 }
@@ -1782,10 +1780,7 @@ fn non_edition_lint_migration() {
         .with_stderr_contains("[..]unused_imports[..]")
         .with_stderr_contains("[..]std::str::from_utf8[..]")
         .run();
-    p.cargo("fix --edition --allow-no-vcs")
-        // Remove once --force-warn is stabilized
-        .masquerade_as_nightly_cargo()
-        .run();
+    p.cargo("fix --edition --allow-no-vcs").run();
     let contents = p.read_file("src/lib.rs");
     // Check it does not remove the "unused" import.
     assert!(contents.contains("use std::str::from_utf8;"));

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -282,12 +282,10 @@ fn color() {
         .run();
 
     p.cargo("report future-incompatibilities")
-        .masquerade_as_nightly_cargo()
         .with_stdout_does_not_contain("[..]\x1b[[..]")
         .run();
 
     p.cargo("report future-incompatibilities")
-        .masquerade_as_nightly_cargo()
         .env("CARGO_TERM_COLOR", "always")
         .with_stdout_contains("[..]\x1b[[..]")
         .run();
@@ -303,7 +301,6 @@ fn bad_ids() {
     let p = simple_project();
 
     p.cargo("report future-incompatibilities --id 1")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr("error: no reports are currently available")
         .run();
@@ -314,13 +311,11 @@ fn bad_ids() {
         .run();
 
     p.cargo("report future-incompatibilities --id foo")
-        .masquerade_as_nightly_cargo()
         .with_status(1)
         .with_stderr("error: Invalid value: could not parse `foo` as a number")
         .run();
 
     p.cargo("report future-incompatibilities --id 7")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr(
             "\
@@ -404,7 +399,6 @@ with_updates v1.0.0 has the following newer versions available: 1.0.1, 1.0.2, 3.
         .run();
 
     p.cargo("report future-incompatibilities")
-        .masquerade_as_nightly_cargo()
         .with_stdout_contains(update_message)
         .run()
 }

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -77,13 +77,11 @@ fn virtual_no_default_features() {
         .run();
 
     p.cargo("check --features a/dep,b/f1,b/f2,f2")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr("[ERROR] none of the selected packages contains these features: a/dep, b/f2, f2, did you mean: a/dep1, f1?")
         .run();
 
     p.cargo("check --features a/dep,a/dep1")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr("[ERROR] none of the selected packages contains these features: a/dep, did you mean: b/f1?")
         .run();
@@ -107,7 +105,6 @@ fn virtual_typo_member_feature() {
         .file("src/lib.rs", "")
         .build()
         .cargo("check --features a/deny-warning")
-        .masquerade_as_nightly_cargo()
         .with_status(101)
         .with_stderr(
             "[ERROR] none of the selected packages contains these features: a/deny-warning, did you mean: a/deny-warnings?",

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -490,7 +490,7 @@ fn clean_custom_dirname() {
         )
         .run();
 
-    p.cargo("clean -p foo").masquerade_as_nightly_cargo().run();
+    p.cargo("clean -p foo").run();
 
     p.cargo("build --release")
         .with_stdout("")


### PR DESCRIPTION
When looking at making [`.masquerade_as_nightly_cargo()` take in a list of reasons](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/problems.20finding.20.60.2Emasquerade_as_nightly_cargo.28.29.60), I found various tests that no longer needed `.masquerade_as_nightly_cargo()`. This removes it from all of the offending tests.

I tried my best to find all tests that no longer need it but I could have missed one or two.