### PR TITLE
add a reason to `masquerade_as_nightly_cargo` so it is searchable

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -806,9 +806,14 @@ impl Execs {
         p.build_command()
     }
 
-    pub fn masquerade_as_nightly_cargo(&mut self) -> &mut Self {
+    /// Enables nightly features for testing
+    ///
+    /// The list of reasons should be why nightly cargo is needed. If it is
+    /// becuase of an unstable feature put the name of the feature as the reason,
+    /// e.g. `&["print-im-a-teapot"]`
+    pub fn masquerade_as_nightly_cargo(&mut self, reasons: &[&str]) -> &mut Self {
         if let Some(ref mut p) = self.process_builder {
-            p.masquerade_as_nightly_cargo();
+            p.masquerade_as_nightly_cargo(reasons);
         }
         self
     }
@@ -1139,17 +1144,20 @@ fn _process(t: &OsStr) -> ProcessBuilder {
 
 /// Enable nightly features for testing
 pub trait ChannelChanger {
-    fn masquerade_as_nightly_cargo(self) -> Self;
+    /// The list of reasons should be why nightly cargo is needed. If it is
+    /// becuase of an unstable feature put the name of the feature as the reason,
+    /// e.g. `&["print-im-a-teapot"]`.
+    fn masquerade_as_nightly_cargo(self, _reasons: &[&str]) -> Self;
 }
 
 impl ChannelChanger for &mut ProcessBuilder {
-    fn masquerade_as_nightly_cargo(self) -> Self {
+    fn masquerade_as_nightly_cargo(self, _reasons: &[&str]) -> Self {
         self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
     }
 }
 
 impl ChannelChanger for snapbox::cmd::Command {
-    fn masquerade_as_nightly_cargo(self) -> Self {
+    fn masquerade_as_nightly_cargo(self, _reasons: &[&str]) -> Self {
         self.env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "nightly")
     }
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -86,7 +86,9 @@
 //!      `CliUnstable. Remove the `(unstable)` note in the clap help text if
 //!      necessary.
 //! 2. Remove `masquerade_as_nightly_cargo` from any tests, and remove
-//!    `cargo-features` from `Cargo.toml` test files if any.
+//!    `cargo-features` from `Cargo.toml` test files if any. You can
+//!     quickly find what needs to be removed by searching for the name
+//!     of the feature, e.g. `print_im_a_teapot`
 //! 3. Update the docs in unstable.md to move the section to the bottom
 //!    and summarize it similar to the other entries. Update the rest of the
 //!    documentation to add the new feature.

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -71,11 +71,11 @@ fn <description>() {
 #### Testing Nightly Features
 
 If you are testing a Cargo feature that only works on "nightly" Cargo, then
-you need to call `masquerade_as_nightly_cargo` on the process builder like
-this:
+you need to call `masquerade_as_nightly_cargo` on the process builder and pass 
+the name of the feature as the reason, like this:
 
 ```rust,ignore
-p.cargo("build").masquerade_as_nightly_cargo()
+p.cargo("build").masquerade_as_nightly_cargo(&["print-im-a-teapot"])
 ```
 
 If you are testing a feature that only works on *nightly rustc* (such as
@@ -192,12 +192,12 @@ Be sure to check the snapshots to make sure they make sense.
 #### Testing Nightly Features
 
 If you are testing a Cargo feature that only works on "nightly" Cargo, then
-you need to call `masquerade_as_nightly_cargo` on the process builder like
-this:
+you need to call `masquerade_as_nightly_cargo` on the process builder and pass
+the name of the feature as the reason, like this:
 
 ```rust,ignore
     snapbox::cmd::Command::cargo()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["print-im-a-teapot"])
 ```
 
 If you are testing a feature that only works on *nightly rustc* (such as

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -32,7 +32,7 @@ fn enable_build_std(e: &mut Execs, arg: Option<&str>) {
         None => "-Zbuild-std".to_string(),
     };
     e.arg(arg);
-    e.masquerade_as_nightly_cargo();
+    e.masquerade_as_nightly_cargo(&["build-std"]);
 }
 
 // Helper methods used in the tests below

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -31,7 +31,7 @@ fn source_config_env() {
     let path = paths::root().join("registry");
 
     p.cargo("check -Zadvanced-env")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["advanced-env"])
         .env("CARGO_SOURCE_crates-io_REPLACE_WITH", "my-local-source")
         .env("CARGO_SOURCE_my-local-source_LOCAL_REGISTRY", path)
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -30,7 +30,7 @@ fn check_with_invalid_artifact_dependency() {
         .file("bar/src/lib.rs", "")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [ERROR] failed to parse manifest at `[..]/Cargo.toml`
@@ -49,7 +49,7 @@ Caused by:
     ) {
         assert(
             p.cargo(&format!("{} -Z bindeps", cmd))
-                .masquerade_as_nightly_cargo(),
+                .masquerade_as_nightly_cargo(&["bindeps"]),
         );
         assert(&mut p.cargo(cmd));
     }
@@ -141,7 +141,7 @@ fn check_with_invalid_target_triple() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(
             r#"[..]Could not find specification for target "unknown-target-triple"[..]"#,
         )
@@ -204,7 +204,7 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr("\
 [WARNING] foo v0.0.0 ([CWD]) ignoring invalid dependency `bar_stable` which is missing a lib target
@@ -310,7 +310,7 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
         .build();
 
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] d2 v0.0.1 ([CWD]/d2)
@@ -417,7 +417,7 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
         .build();
 
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_contains(
             "error[E0425]: cannot find function `f2` in crate `d2`\n --> d1/src/main.rs:6:17",
@@ -499,7 +499,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .build();
 
     p.cargo("test -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
 
@@ -565,7 +565,7 @@ fn build_script_with_bin_artifacts() {
         .file("bar/src/lib.rs", "")
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[COMPILING] foo [..]")
         .with_stderr_contains("[COMPILING] bar v0.5.0 ([CWD]/bar)")
         .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
@@ -648,7 +648,7 @@ fn build_script_with_bin_artifact_and_lib_false() {
         )
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_does_not_contain("[..]sentinel[..]")
         .run();
@@ -689,7 +689,7 @@ fn lib_with_bin_artifact_and_lib_false() {
         )
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_does_not_contain("[..]sentinel[..]")
         .run();
@@ -747,7 +747,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         "#)
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] bar-baz v0.5.0 ([CWD]/bar)
@@ -844,7 +844,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
         .file("bar/src/lib.rs", "pub fn exists() {}")
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] bar-baz v0.5.0 ([CWD]/bar)
@@ -893,7 +893,7 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
         .file("bar/src/lib.rs", "")
         .build();
     p.cargo("test -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[COMPILING] bar v0.5.0 ([CWD]/bar)")
         .with_stderr_contains("[FINISHED] test [unoptimized + debuginfo] target(s) in [..]")
         .run();
@@ -932,7 +932,7 @@ fn normal_build_deps_are_picked_up_in_presence_of_an_artifact_build_dep_to_the_s
         .file("bar/src/lib.rs", "pub fn f() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
 
@@ -958,7 +958,7 @@ fn disallow_using_example_binaries_as_artifacts() {
         .file("bar/examples/one-example.rs", "fn main() {}")
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr(r#"[ERROR] dependency `bar` in package `foo` requires a `bin:one-example` artifact to be present."#)
         .run();
@@ -1007,7 +1007,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate() {
         .build();
 
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[COMPILING] bar [..]")
         .with_stderr_contains("[COMPILING] foo [..]")
         .run();
@@ -1051,7 +1051,7 @@ fn build_script_deps_adopt_specified_target_unconditionally() {
         .build();
 
     p.cargo("check -v -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_does_not_contain(format!(
             "[RUNNING] `rustc --crate-name build_script_build build.rs [..]--target {} [..]",
             target
@@ -1122,7 +1122,7 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
         .build();
 
     p.cargo("check -v -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr(format!(
             "error: the crate `foo v0.0.0 ([CWD])` depends on crate `bar v0.5.0 ([CWD]/bar)` multiple times with different names",
@@ -1166,7 +1166,7 @@ fn non_build_script_deps_adopt_specified_target_unconditionally() {
         .build();
 
     p.cargo("check -v -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(format!(
             "[RUNNING] `rustc --crate-name bar bar/src/lib.rs [..]--target {} [..]",
             target
@@ -1224,7 +1224,7 @@ fn no_cross_doctests_works_with_artifacts() {
     let target = rustc_host();
     p.cargo("test -Z bindeps --target")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(&format!(
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
@@ -1244,7 +1244,7 @@ fn no_cross_doctests_works_with_artifacts() {
     // This should probably be a warning or error.
     p.cargo("test -Z bindeps -v --doc --target")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(format!(
             "[COMPILING] bar v0.5.0 ([CWD]/bar)
 [RUNNING] `rustc --crate-name bar bar/src/lib.rs [..]--target {triple} [..]
@@ -1263,7 +1263,7 @@ fn no_cross_doctests_works_with_artifacts() {
     // This tests the library, but does not run the doc tests.
     p.cargo("test -Z bindeps -v --target")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(&format!(
             "[FRESH] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -1309,7 +1309,7 @@ fn build_script_deps_adopts_target_platform_if_target_equals_target() {
     let alternate_target = cross_compile::alternate();
     p.cargo("check -v -Z bindeps --target")
         .arg(alternate_target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_does_not_contain(format!(
             "[RUNNING] `rustc --crate-name build_script_build build.rs [..]--target {} [..]",
             alternate_target
@@ -1363,7 +1363,7 @@ fn profile_override_basic() {
         .build();
 
     p.cargo("build -v -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(
             "[RUNNING] `rustc --crate-name build_script_build [..] -C opt-level=1 [..]`",
         )
@@ -1428,12 +1428,12 @@ fn dependencies_of_dependencies_work_in_artifacts() {
         .file("bar/src/main.rs", r#"fn main() {bar::bar()}"#)
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 
     // cargo tree sees artifacts as the dependency kind they are in and doesn't do anything special with it.
     p.cargo("tree -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stdout(
             "\
 foo v0.0.0 ([CWD])
@@ -1490,7 +1490,7 @@ fn targets_are_picked_up_from_non_workspace_artifact_deps() {
         .build();
 
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
 
@@ -1529,7 +1529,7 @@ fn allow_dep_renames_with_multiple_versions() {
         .file("bar/src/main.rs", r#"fn main() {println!("0.5.0")}"#)
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[COMPILING] bar [..]")
         .with_stderr_contains("[COMPILING] foo [..]")
         .run();
@@ -1580,7 +1580,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate_if_these_are_not_the
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("build -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] bar [..]
@@ -1615,7 +1615,7 @@ fn prevent_no_lib_warning_with_artifact_dependencies() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
@@ -1650,7 +1650,7 @@ fn show_no_lib_warning_with_artifact_dependencies_that_have_no_lib_but_lib_true(
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[WARNING] foo v0.0.0 ([CWD]) ignoring invalid dependency `bar` which is missing a lib target")
         .with_stderr_contains("[COMPILING] bar v0.5.0 ([CWD]/bar)")
         .with_stderr_contains("[CHECKING] foo [..]")
@@ -1684,7 +1684,7 @@ fn resolver_2_build_dep_without_lib() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
 
@@ -1712,7 +1712,7 @@ fn check_missing_crate_type_in_package_fails() {
             .file("bar/src/lib.rs", "")
             .build();
         p.cargo("check -Z bindeps")
-            .masquerade_as_nightly_cargo()
+            .masquerade_as_nightly_cargo(&["bindeps"])
             .with_status(101)
             .with_stderr(
                 "[ERROR] dependency `bar` in package `foo` requires a `[..]` artifact to be present.",
@@ -1742,7 +1742,7 @@ fn check_target_equals_target_in_non_build_dependency_errors() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("check -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr_contains(
             "  `target = \"target\"` in normal- or dev-dependencies has no effect (bar)",
@@ -1855,7 +1855,7 @@ fn env_vars_and_build_products_for_various_build_targets() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
     p.cargo("test -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] bar [..]
@@ -1901,7 +1901,7 @@ fn publish_artifact_dep() {
         .build();
 
     p.cargo("publish -Z bindeps --no-verify --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -2014,7 +2014,7 @@ fn doc_lib_true() {
         .build();
 
     p.cargo("doc -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
@@ -2034,7 +2034,7 @@ fn doc_lib_true() {
     assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 2);
 
     p.cargo("doc -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .env("CARGO_LOG", "cargo::ops::cargo_rustc::fingerprint")
         .with_stdout("")
         .run();
@@ -2090,7 +2090,7 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
         .build();
 
     p.cargo("doc -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
@@ -2260,6 +2260,6 @@ fn build_script_features_for_shared_dependency() {
         .build();
 
     p.cargo("build -Z bindeps -v")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -24,7 +24,7 @@ fn gated() {
 
     // Run cargo build.
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_status(101)
         .with_stderr_contains("[..]feature `different-binary-name` is required")
         .run();
@@ -58,7 +58,9 @@ fn binary_name1() {
         .build();
 
     // Run cargo build.
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
+        .run();
 
     // Check the name of the binary that cargo has generated.
     // A binary with the name of the crate should NOT be created.
@@ -90,7 +92,7 @@ fn binary_name1() {
 
     // Run cargo second time, to verify fingerprint.
     p.cargo("build -p foo -v")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_stderr(
             "\
 [FRESH] foo [..]
@@ -100,7 +102,9 @@ fn binary_name1() {
         .run();
 
     // Run cargo clean.
-    p.cargo("clean -p foo").masquerade_as_nightly_cargo().run();
+    p.cargo("clean -p foo")
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
+        .run();
 
     // Check if the appropriate file was removed.
     assert!(
@@ -156,7 +160,9 @@ fn binary_name2() {
         .build();
 
     // Run cargo build.
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
+        .run();
 
     // Check the name of the binary that cargo has generated.
     // A binary with the name of the crate should NOT be created.
@@ -168,7 +174,7 @@ fn binary_name2() {
 
     // Check if `cargo test` works
     p.cargo("test")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -180,17 +186,19 @@ fn binary_name2() {
 
     // Check if `cargo run` is able to execute the binary
     p.cargo("run")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_stdout("Hello, crabs!")
         .run();
 
-    p.cargo("install").masquerade_as_nightly_cargo().run();
+    p.cargo("install")
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
+        .run();
 
     assert_has_installed_exe(cargo_home(), "007bar");
 
     p.cargo("uninstall")
         .with_stderr("[REMOVING] [ROOT]/home/.cargo/bin/007bar[EXE]")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .run();
 
     assert_has_not_installed_exe(cargo_home(), "007bar");
@@ -234,13 +242,15 @@ fn check_env_vars() {
         .build();
 
     // Run cargo build.
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
+        .run();
     p.cargo("run")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_stdout("007bar")
         .run();
     p.cargo("test")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_status(0)
         .run();
 }
@@ -285,7 +295,7 @@ fn check_msg_format_json() {
 
     // Run cargo build.
     p.cargo("build --message-format=json")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_json(output)
         .run();
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5382,7 +5382,7 @@ required by package `bar v0.1.0 ([..]/foo)`
         )
         .run();
     p.cargo("build -Zavoid-dev-deps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["avoid-dev-deps"])
         .run();
 }
 
@@ -6122,7 +6122,7 @@ fn simple_terminal_width() {
         .build();
 
     p.cargo("build -Zterminal-width=20")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["terminal-width"])
         .with_status(101)
         .with_stderr_contains("3 | ..._: () = 42;")
         .run();

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -11,7 +11,7 @@ fn cargo_build_plan_simple() {
         .build();
 
     p.cargo("build --build-plan -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["build-plan"])
         .with_json(
             r#"
             {
@@ -70,7 +70,7 @@ fn cargo_build_plan_single_dep() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
     p.cargo("build --build-plan -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["build-plan"])
         .with_json(
             r#"
             {
@@ -139,7 +139,7 @@ fn cargo_build_plan_build_script() {
         .build();
 
     p.cargo("build --build-plan -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["build-plan"])
         .with_json(
             r#"
             {
@@ -217,6 +217,6 @@ fn build_plan_with_dev_dep() {
         .build();
 
     p.cargo("build --build-plan -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["build-plan"])
         .run();
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -404,7 +404,7 @@ fn custom_build_env_var_rustc_linker_host_target() {
     // only if build.rs succeeds, despite linker binary not existing.
     p.cargo("build -Z target-applies-to-host --target")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .run();
 }
 
@@ -440,7 +440,7 @@ fn custom_build_env_var_rustc_linker_host_target_env() {
     p.cargo("build -Z target-applies-to-host --target")
         .env("CARGO_TARGET_APPLIES_TO_HOST", "false")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .run();
 }
 
@@ -465,7 +465,7 @@ fn custom_build_invalid_host_config_feature_flag() {
     // build.rs should fail due to -Zhost-config being set without -Ztarget-applies-to-host
     p.cargo("build -Z host-config --target")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["host-config"])
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -498,7 +498,7 @@ fn custom_build_linker_host_target_with_bad_host_config() {
     // build.rs should fail due to bad host linker being set
     p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
-            .masquerade_as_nightly_cargo()
+            .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
             .with_status(101)
             .with_stderr_contains(
                 "\
@@ -533,7 +533,7 @@ fn custom_build_linker_bad_host() {
     // build.rs should fail due to bad host linker being set
     p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
-            .masquerade_as_nightly_cargo()
+            .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
             .with_status(101)
             .with_stderr_contains(
                 "\
@@ -570,7 +570,7 @@ fn custom_build_linker_bad_host_with_arch() {
     // build.rs should fail due to bad host linker being set
     p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
-            .masquerade_as_nightly_cargo()
+            .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
             .with_status(101)
             .with_stderr_contains(
                 "\
@@ -616,7 +616,7 @@ fn custom_build_env_var_rustc_linker_cross_arch_host() {
     // assertion should succeed since it's still passed the target linker
     p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
         .arg(&target)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .run();
 }
 
@@ -646,7 +646,7 @@ fn custom_build_linker_bad_cross_arch_host() {
     // build.rs should fail due to bad host linker being set
     p.cargo("build -Z target-applies-to-host -Z host-config --verbose --target")
             .arg(&target)
-            .masquerade_as_nightly_cargo()
+            .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
             .with_status(101)
             .with_stderr_contains(
                 "\
@@ -4870,7 +4870,7 @@ fn duplicate_script_with_extra_env() {
     if cargo_test_support::is_nightly() {
         p.cargo("test --workspace -Z doctest-xcompile --doc --target")
             .arg(&target)
-            .masquerade_as_nightly_cargo()
+            .masquerade_as_nightly_cargo(&["doctest-xcompile"])
             .with_stdout_contains("test src/lib.rs - (line 2) ... ok")
             .run();
     }

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -130,7 +130,7 @@ fn rustc_bootstrap() {
         .run();
     // nightly should warn whether or not RUSTC_BOOTSTRAP is set
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["RUSTC_BOOTSTRAP"])
         // NOTE: uses RUSTC_BOOTSTRAP so it will be propagated to rustc
         // (this matters when tests are being run with a beta or stable cargo)
         .env("RUSTC_BOOTSTRAP", "1")
@@ -159,7 +159,7 @@ fn rustc_bootstrap() {
         .build();
     // nightly should warn when there's no library whether or not RUSTC_BOOTSTRAP is set
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["RUSTC_BOOTSTRAP"])
         // NOTE: uses RUSTC_BOOTSTRAP so it will be propagated to rustc
         // (this matters when tests are being run with a beta or stable cargo)
         .env("RUSTC_BOOTSTRAP", "1")

--- a/tests/testsuite/cargo_add/detect_workspace_inherit/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit/mod.rs
@@ -13,7 +13,7 @@ fn detect_workspace_inherit() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_features/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_features/mod.rs
@@ -13,7 +13,7 @@ fn detect_workspace_inherit_features() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar", "--features", "test"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_optional/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_optional/mod.rs
@@ -13,7 +13,7 @@ fn detect_workspace_inherit_optional() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar", "--optional"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
@@ -11,7 +11,7 @@ fn invalid_key_inherit_dependency() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "--default-features", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
@@ -11,7 +11,7 @@ fn invalid_key_overwrite_inherit_dependency() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "--default-features", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
@@ -11,7 +11,7 @@ fn invalid_key_rename_inherit_dependency() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["--rename", "foo", "foo-alt", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/merge_activated_features/mod.rs
+++ b/tests/testsuite/cargo_add/merge_activated_features/mod.rs
@@ -11,7 +11,7 @@ fn merge_activated_features() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["zworkspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/overwrite_inherit_features_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_features_noop/mod.rs
@@ -11,7 +11,7 @@ fn overwrite_inherit_features_noop() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/overwrite_inherit_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_noop/mod.rs
@@ -13,7 +13,7 @@ fn overwrite_inherit_noop() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/mod.rs
@@ -13,7 +13,7 @@ fn overwrite_inherit_optional_noop() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep/mod.rs
@@ -13,7 +13,7 @@ fn overwrite_workspace_dep() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["zworkspace-inheritance"])
         .arg("add")
         .args(["foo", "--path", "./dependency", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep_features/mod.rs
@@ -13,7 +13,7 @@ fn overwrite_workspace_dep_features() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "--path", "./dependency", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
@@ -11,7 +11,7 @@ fn unknown_inherited_feature() {
     let cwd = &project_root;
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .arg("add")
         .args(["foo", "-p", "bar"])
         .current_dir(cwd)

--- a/tests/testsuite/cargo_config.rs
+++ b/tests/testsuite/cargo_config.rs
@@ -20,7 +20,7 @@ fn cargo_process(s: &str) -> cargo_test_support::Execs {
 #[cargo_test]
 fn gated() {
     cargo_process("config get")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_status(101)
         .with_stderr("\
 error: the `cargo config` command is unstable, pass `-Z unstable-options` to enable it
@@ -73,7 +73,7 @@ fn get_toml() {
     let sub_folder = common_setup();
     cargo_process("config get -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_ALIAS_BAR", "cat dog")
         .env("CARGO_BUILD_JOBS", "100")
         // The weird forward slash in the linux line is due to testsuite normalization.
@@ -99,7 +99,7 @@ target.\"cfg(target_os = \\\"linux\\\")\".runner = \"runme\"
     // Env keys work if they are specific.
     cargo_process("config get build.jobs -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_BUILD_JOBS", "100")
         .with_stdout("build.jobs = 100")
         .with_stderr("")
@@ -108,7 +108,7 @@ target.\"cfg(target_os = \\\"linux\\\")\".runner = \"runme\"
     // Array value.
     cargo_process("config get build.rustflags -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_stdout("build.rustflags = [\"--flag-directory\", \"--flag-global\"]")
         .with_stderr("")
         .run();
@@ -116,7 +116,7 @@ target.\"cfg(target_os = \\\"linux\\\")\".runner = \"runme\"
     // Sub-table
     cargo_process("config get profile -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_stdout(
             "\
 profile.dev.opt-level = 3
@@ -129,7 +129,7 @@ profile.dev.package.foo.opt-level = 1
     // Specific profile entry.
     cargo_process("config get profile.dev.opt-level -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_stdout("profile.dev.opt-level = 3")
         .with_stderr("")
         .run();
@@ -137,7 +137,7 @@ profile.dev.package.foo.opt-level = 1
     // A key that isn't set.
     cargo_process("config get build.rustc -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_status(101)
         .with_stdout("")
         .with_stderr("error: config value `build.rustc` is not set")
@@ -146,7 +146,7 @@ profile.dev.package.foo.opt-level = 1
     // A key that is not part of Cargo's config schema.
     cargo_process("config get not.set -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_status(101)
         .with_stdout("")
         .with_stderr("error: config value `not.set` is not set")
@@ -196,7 +196,7 @@ fn get_json() {
     let sub_folder = common_setup();
     cargo_process("config get --format=json -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_ALIAS_BAR", "cat dog")
         .env("CARGO_BUILD_JOBS", "100")
         .with_json(all_json)
@@ -213,7 +213,7 @@ CARGO_HOME=[ROOT]/home/.cargo
     // json-value is the same for the entire root table
     cargo_process("config get --format=json-value -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_json(all_json)
         .with_stderr(
             "\
@@ -225,7 +225,7 @@ CARGO_HOME=[ROOT]/home/.cargo
 
     cargo_process("config get --format=json build.jobs -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_json(
             r#"
             {"build": {"jobs": 99}}
@@ -236,7 +236,7 @@ CARGO_HOME=[ROOT]/home/.cargo
 
     cargo_process("config get --format=json-value build.jobs -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_stdout("99")
         .with_stderr("")
         .run();
@@ -247,7 +247,7 @@ fn show_origin_toml() {
     let sub_folder = common_setup();
     cargo_process("config get --show-origin -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_stdout(
             "\
 alias.foo = \"abc --xyz\" # [ROOT]/home/.cargo/config.toml
@@ -273,7 +273,7 @@ target.\"cfg(target_os = \\\"linux\\\")\".runner = \"runme\" # [ROOT]/home/.carg
 
     cargo_process("config get --show-origin build.rustflags -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
         .with_stdout(
             "\
@@ -294,7 +294,7 @@ fn show_origin_toml_cli() {
     let sub_folder = common_setup();
     cargo_process("config get --show-origin build.jobs -Zunstable-options --config build.jobs=123")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_BUILD_JOBS", "1")
         .with_stdout("build.jobs = 123 # --config cli option")
         .with_stderr("")
@@ -303,7 +303,7 @@ fn show_origin_toml_cli() {
     cargo_process("config get --show-origin build.rustflags -Zunstable-options --config")
         .arg("build.rustflags=[\"cli1\",\"cli2\"]")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
         .with_stdout(
             "\
@@ -326,7 +326,7 @@ fn show_origin_json() {
     let sub_folder = common_setup();
     cargo_process("config get --show-origin --format=json -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_status(101)
         .with_stderr("error: the `json` format does not support --show-origin, try the `toml` format instead")
         .run();
@@ -337,7 +337,7 @@ fn unmerged_toml() {
     let sub_folder = common_setup();
     cargo_process("config get --merged=no -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_ALIAS_BAR", "cat dog")
         .env("CARGO_BUILD_JOBS", "100")
         .with_stdout(
@@ -368,7 +368,7 @@ target.\"cfg(target_os = \\\"linux\\\")\".runner = \"runme\"
 
     cargo_process("config get --merged=no build.rustflags -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
         .with_stdout(
             "\
@@ -388,14 +388,14 @@ build.rustflags = [\"--flag-global\"]
 
     cargo_process("config get --merged=no does.not.exist -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_stderr("")
         .with_stderr("")
         .run();
 
     cargo_process("config get --merged=no build.rustflags.extra -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_status(101)
         .with_stderr(
             "error: expected table for configuration key `build.rustflags`, \
@@ -410,7 +410,7 @@ fn unmerged_toml_cli() {
     cargo_process("config get --merged=no build.rustflags -Zunstable-options --config")
         .arg("build.rustflags=[\"cli1\",\"cli2\"]")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .env("CARGO_BUILD_RUSTFLAGS", "env1 env2")
         .with_stdout(
             "\
@@ -437,7 +437,7 @@ fn unmerged_json() {
     let sub_folder = common_setup();
     cargo_process("config get --merged=no --format=json -Zunstable-options")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config"])
         .with_status(101)
         .with_stderr(
             "error: the `json` format does not support --merged=no, try the `toml` format instead",
@@ -468,14 +468,14 @@ fn includes() {
 
     cargo_process("config get build.rustflags -Zunstable-options -Zconfig-include")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config", "config-include"])
         .with_stdout(r#"build.rustflags = ["--flag-other", "--flag-directory", "--flag-global"]"#)
         .with_stderr("")
         .run();
 
     cargo_process("config get build.rustflags --show-origin -Zunstable-options -Zconfig-include")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config", "config-include"])
         .with_stdout(
             "\
 build.rustflags = [
@@ -490,7 +490,7 @@ build.rustflags = [
 
     cargo_process("config get --merged=no -Zunstable-options -Zconfig-include")
         .cwd(&sub_folder.parent().unwrap())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-config", "config-include"])
         .with_stdout(
             "\
 # Environment variables

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -19,7 +19,7 @@ fn feature_required() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
             "\
@@ -98,7 +98,7 @@ fn feature_required_dependency() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
             "\
@@ -240,7 +240,7 @@ fn allow_features() {
         .build();
 
     p.cargo("-Zallow-features=test-dummy-unstable build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["allow-features", "test-dummy-unstable"])
         .with_stderr(
             "\
 [COMPILING] a [..]
@@ -250,12 +250,20 @@ fn allow_features() {
         .run();
 
     p.cargo("-Zallow-features=test-dummy-unstable,print-im-a-teapot -Zprint-im-a-teapot build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&[
+            "allow-features",
+            "test-dummy-unstable",
+            "print-im-a-teapot",
+        ])
         .with_stdout("im-a-teapot = true")
         .run();
 
     p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&[
+            "allow-features",
+            "test-dummy-unstable",
+            "print-im-a-teapot",
+        ])
         .with_status(101)
         .with_stderr(
             "\
@@ -265,7 +273,7 @@ error: the feature `print-im-a-teapot` is not in the list of allowed features: [
         .run();
 
     p.cargo("-Zallow-features= build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["allow-features", "test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
             "\
@@ -305,13 +313,13 @@ fn allow_features_to_rustc() {
         .build();
 
     p.cargo("-Zallow-features= build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["allow-features"])
         .with_status(101)
         .with_stderr_contains("[..]E0725[..]")
         .run();
 
     p.cargo("-Zallow-features=test_2018_feature build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["allow-features"])
         .with_stderr(
             "\
 [COMPILING] a [..]
@@ -353,7 +361,11 @@ fn allow_features_in_cfg() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&[
+            "allow-features",
+            "test-dummy-unstable",
+            "print-im-a-teapot",
+        ])
         .with_stderr(
             "\
 [COMPILING] a [..]
@@ -363,13 +375,17 @@ fn allow_features_in_cfg() {
         .run();
 
     p.cargo("-Zprint-im-a-teapot build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&[
+            "allow-features",
+            "test-dummy-unstable",
+            "print-im-a-teapot",
+        ])
         .with_stdout("im-a-teapot = true")
         .with_stderr("[FINISHED] [..]")
         .run();
 
     p.cargo("-Zunstable-options build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["allow-features", "test-dummy-unstable", "print-im-a-teapot"])
         .with_status(101)
         .with_stderr(
             "\
@@ -380,7 +396,11 @@ error: the feature `unstable-options` is not in the list of allowed features: [p
 
     // -Zallow-features overrides .cargo/config
     p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&[
+            "allow-features",
+            "test-dummy-unstable",
+            "print-im-a-teapot",
+        ])
         .with_status(101)
         .with_stderr(
             "\
@@ -390,7 +410,11 @@ error: the feature `print-im-a-teapot` is not in the list of allowed features: [
         .run();
 
     p.cargo("-Zallow-features= build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&[
+            "allow-features",
+            "test-dummy-unstable",
+            "print-im-a-teapot",
+        ])
         .with_status(101)
         .with_stderr(
             "\
@@ -421,7 +445,7 @@ fn nightly_feature_requires_nightly() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
 [COMPILING] a [..]
@@ -478,7 +502,7 @@ fn nightly_feature_requires_nightly_in_dep() {
         .file("a/src/lib.rs", "")
         .build();
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
 [COMPILING] a [..]
@@ -532,7 +556,7 @@ fn cant_publish() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
 [COMPILING] a [..]
@@ -585,13 +609,13 @@ fn z_flags_rejected() {
         .run();
 
     p.cargo("build -Zarg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr("error: unknown `-Z` flag specified: arg")
         .run();
 
     p.cargo("build -Zprint-im-a-teapot")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stdout("im-a-teapot = true\n")
         .with_stderr(
             "\
@@ -621,7 +645,7 @@ fn publish_allowed() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("publish --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .run();
 }
 
@@ -640,7 +664,7 @@ fn wrong_position() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("check")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
             "\
@@ -659,7 +683,7 @@ fn z_stabilized() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("check -Z cache-messages")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
         .with_stderr(
             "\
 warning: flag `-Z cache-messages` has been stabilized in the 1.40 release, \
@@ -673,7 +697,7 @@ warning: flag `-Z cache-messages` has been stabilized in the 1.40 release, \
         .run();
 
     p.cargo("check -Z offline")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -861,7 +861,7 @@ fn check_keep_going() {
 
     // Due to -j1, without --keep-going only one of the two bins would be built.
     foo.cargo("check -j1 --keep-going -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["keep-going"])
         .with_status(101)
         .with_stderr_contains("error: ONE")
         .with_stderr_contains("error: TWO")

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -53,7 +53,7 @@ fn features() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
 }
@@ -87,7 +87,7 @@ fn features_with_deps() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature"))
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
@@ -123,7 +123,7 @@ fn features_with_opt_deps() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature"))
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "bar" "default" "f_a" "f_b"))
         .run();
@@ -158,7 +158,7 @@ fn features_with_namespaced_features() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
 }
@@ -176,7 +176,7 @@ fn well_known_names() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=names")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .run();
 }
@@ -194,7 +194,7 @@ fn well_known_values() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=values")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values"))
         .run();
 }
@@ -223,7 +223,7 @@ fn cli_all_options() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=features,names,values")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .with_stderr_contains(x!("rustc" => "values"))
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
@@ -254,7 +254,7 @@ fn features_with_cargo_check() {
         .build();
 
     p.cargo("check -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
 }
@@ -272,7 +272,7 @@ fn well_known_names_with_check() {
         .build();
 
     p.cargo("check -v -Zcheck-cfg=names")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .run();
 }
@@ -290,7 +290,7 @@ fn well_known_values_with_check() {
         .build();
 
     p.cargo("check -v -Zcheck-cfg=values")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values"))
         .run();
 }
@@ -319,7 +319,7 @@ fn features_test() {
         .build();
 
     p.cargo("test -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
 }
@@ -349,7 +349,7 @@ fn features_doctest() {
         .build();
 
     p.cargo("test -v --doc -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "default" "f_a" "f_b"))
         .with_stderr_contains(x!("rustdoc" => "values" of "feature" with "default" "f_a" "f_b"))
         .run();
@@ -368,7 +368,7 @@ fn well_known_names_test() {
         .build();
 
     p.cargo("test -v -Zcheck-cfg=names")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .run();
 }
@@ -386,7 +386,7 @@ fn well_known_values_test() {
         .build();
 
     p.cargo("test -v -Zcheck-cfg=values")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values"))
         .run();
 }
@@ -404,7 +404,7 @@ fn well_known_names_doctest() {
         .build();
 
     p.cargo("test -v --doc -Zcheck-cfg=names")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .with_stderr_contains(x!("rustdoc" => "names"))
         .run();
@@ -423,7 +423,7 @@ fn well_known_values_doctest() {
         .build();
 
     p.cargo("test -v --doc -Zcheck-cfg=values")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values"))
         .with_stderr_contains(x!("rustdoc" => "values"))
         .run();
@@ -454,7 +454,7 @@ fn features_doc() {
         .build();
 
     p.cargo("doc -v -Zcheck-cfg=features")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustdoc" => "values" of "feature" with "default" "f_a" "f_b"))
         .run();
 }
@@ -485,7 +485,7 @@ fn build_script_feedback() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=output")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names" of "foo"))
         .run();
 }
@@ -526,7 +526,7 @@ fn build_script_doc() {
 [RUNNING] `rustdoc [..] src/main.rs [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
         )
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .run();
 }
 
@@ -566,7 +566,7 @@ fn build_script_override() {
 
     p.cargo("build -v -Zcheck-cfg=output")
         .with_stderr_contains(x!("rustc" => "names" of "foo"))
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .run();
 }
 
@@ -626,7 +626,7 @@ fn build_script_test() {
         .with_stdout_contains("test test_foo ... ok")
         .with_stdout_contains("test test_bar ... ok")
         .with_stdout_contains_n("test [..] ... ok", 3)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .run();
 }
 
@@ -661,7 +661,7 @@ fn config_valid() {
         .build();
 
     p.cargo("build -v -Zcheck-cfg=features,names,values")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .with_stderr_contains(x!("rustc" => "values"))
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
@@ -695,7 +695,7 @@ fn config_invalid() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains("error: unstable check-cfg only takes `features`, `names`, `values` or `output` as valid inputs")
         .with_status(101)
         .run();

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -105,7 +105,7 @@ fn collision_export() {
     // -j1 to avoid issues with two processes writing to the same file at the
     // same time.
     p.cargo("build -j1 --out-dir=out -Z unstable-options --bins --examples")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .with_stderr_contains("\
 [WARNING] `--out-dir` filename collision.
 The example target `foo` in package `foo v1.0.0 ([..]/foo)` has the same output filename as the bin target `foo` in package `foo v1.0.0 ([..]/foo)`.

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -71,7 +71,7 @@ fn works_with_cli() {
         )
         .run();
     p.cargo("build -v -Z config-include")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["config-include"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 [..]

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -32,7 +32,7 @@ fn gated() {
         .build();
 
     p.cargo("publish --no-verify")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_status(101)
         .with_stderr(
             "\
@@ -51,7 +51,7 @@ fn gated() {
     );
 
     p.cargo("publish --no-verify --registry alternative")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_status(101)
         .with_stderr(
             "\
@@ -94,7 +94,7 @@ fn warn_both_token_and_process() {
         .build();
 
     p.cargo("publish --no-verify --registry alternative -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_status(101)
         .with_stderr(
             "\
@@ -118,7 +118,7 @@ Only one of these values may be set, remove one or the other to proceed.
         "#,
     );
     p.cargo("publish --no-verify --registry alternative -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -192,7 +192,7 @@ fn publish() {
     let (p, _t) = get_token_test();
 
     p.cargo("publish --no-verify --registry alternative -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -219,7 +219,7 @@ fn basic_unsupported() {
     .unwrap();
 
     cargo_process("login -Z credential-process abcdefg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_status(101)
         .with_stderr(
             "\
@@ -232,7 +232,7 @@ the credential-process configuration value must pass the \
         .run();
 
     cargo_process("logout -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process", "cargo-logout"])
         .with_status(101)
         .with_stderr(
             "\
@@ -287,7 +287,7 @@ fn login() {
     .unwrap();
 
     cargo_process("login -Z credential-process abcdefg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -341,7 +341,7 @@ fn logout() {
     .unwrap();
 
     cargo_process("logout -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process", "cargo-logout"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -361,7 +361,7 @@ fn yank() {
     let (p, _t) = get_token_test();
 
     p.cargo("yank --version 0.1.0 --registry alternative -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -376,7 +376,7 @@ fn owner() {
     let (p, _t) = get_token_test();
 
     p.cargo("owner --add username --registry alternative -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -402,7 +402,7 @@ fn libexec_path() {
     .unwrap();
 
     cargo_process("login -Z credential-process abcdefg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_status(101)
         .with_stderr(
             // FIXME: Update "Caused by" error message once rust/pull/87704 is merged.
@@ -452,7 +452,7 @@ fn invalid_token_output() {
         .build();
 
     p.cargo("publish --no-verify --registry alternative -Z credential-process")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["credential-process"])
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -216,7 +216,8 @@ fn per_crate_target_test(
     if let Some(t) = arg_target {
         cmd.arg("--target").arg(&t);
     }
-    cmd.masquerade_as_nightly_cargo().run();
+    cmd.masquerade_as_nightly_cargo(&["per-package-target"])
+        .run();
     assert!(p.target_bin(cross_compile::alternate(), "foo").is_file());
 
     if cross_compile::can_run_on_host() {
@@ -344,7 +345,8 @@ fn workspace_with_multiple_targets() {
         .build();
 
     let mut cmd = p.cargo("build -v");
-    cmd.masquerade_as_nightly_cargo().run();
+    cmd.masquerade_as_nightly_cargo(&["per-package-target"])
+        .run();
 
     assert!(p.bin("native").is_file());
     assert!(p.target_bin(cross_compile::alternate(), "cross").is_file());
@@ -1334,7 +1336,7 @@ fn doctest_xcompile_linker() {
     p.cargo("test --doc -v -Zdoctest-xcompile --target")
         .arg(&target)
         .with_status(101)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["doctest-xcompile"])
         .with_stderr_contains(&format!(
             "\
 [RUNNING] `rustdoc --crate-type lib --crate-name foo --test [..]\

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -61,7 +61,7 @@ fn custom_target_minimal() {
 
     // Ensure that the correct style of flag is passed to --target with doc tests.
     p.cargo("test --doc --target src/../custom-target.json -v -Zdoctest-xcompile")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["doctest-xcompile", "no_core", "lang_items"])
         .with_stderr_contains("[RUNNING] `rustdoc [..]--target [..]foo/custom-target.json[..]")
         .run();
 }

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -324,7 +324,7 @@ fn relative_depinfo_paths_ws() {
     let host = rustc_host();
     p.cargo("build -Z binary-dep-depinfo --target")
         .arg(&host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr_contains("[COMPILING] foo [..]")
         .run();
 
@@ -361,7 +361,7 @@ fn relative_depinfo_paths_ws() {
     // Make sure it stays fresh.
     p.cargo("build -Z binary-dep-depinfo --target")
         .arg(&host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr("[FINISHED] dev [..]")
         .run();
 }
@@ -452,7 +452,7 @@ fn relative_depinfo_paths_no_ws() {
         .build();
 
     p.cargo("build -Z binary-dep-depinfo")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr_contains("[COMPILING] foo [..]")
         .run();
 
@@ -488,7 +488,7 @@ fn relative_depinfo_paths_no_ws() {
 
     // Make sure it stays fresh.
     p.cargo("build -Z binary-dep-depinfo")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .with_stderr("[FINISHED] dev [..]")
         .run();
 }
@@ -566,7 +566,7 @@ fn canonical_path() {
     p.symlink(real, "target");
 
     p.cargo("build -Z binary-dep-depinfo")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .run();
 
     assert_deps_contains(

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1332,7 +1332,7 @@ fn doc_extern_map_local() {
 
     p.cargo("doc -v --no-deps -Zrustdoc-map --open")
         .env("BROWSER", tools::echo())
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.1.0 [..]
@@ -2102,7 +2102,7 @@ fn doc_test_in_workspace() {
         )
         .build();
     p.cargo("test -Zdoctest-in-workspace --doc -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["doctest-in-workspace"])
         .with_stderr_contains("[DOCTEST] crate-a")
         .with_stdout_contains(
             "
@@ -2346,7 +2346,7 @@ fn doc_fingerprint_unusual_behavior() {
     p.change_file("src/lib.rs", "// changed2");
     fs::write(real_doc.join("somefile"), "test").unwrap();
     p.cargo("doc -Z skip-rustdoc-fingerprint")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["skip-rustdoc-fingerprint"])
         .with_stderr(
             "[DOCUMENTING] foo [..]\n\
              [FINISHED] [..]",
@@ -2379,7 +2379,7 @@ fn scrape_examples_basic() {
         .build();
 
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr(
             "\
 [..] foo v0.0.1 ([CWD])
@@ -2440,7 +2440,7 @@ fn scrape_examples_avoid_build_script_cycle() {
         .build();
 
     p.cargo("doc --all -Zunstable-options -Z rustdoc-scrape-examples=all")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }
 
@@ -2502,7 +2502,7 @@ fn scrape_examples_complex_reverse_dependencies() {
         .build();
 
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }
 
@@ -2528,7 +2528,7 @@ fn scrape_examples_crate_with_dash() {
         .build();
 
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 
     let doc_html = p.read_file("target/doc/da_sh/fn.foo.html");
@@ -2554,7 +2554,7 @@ fn scrape_examples_missing_flag() {
         .file("src/lib.rs", "//! These are the docs!")
         .build();
     p.cargo("doc -Zrustdoc-scrape-examples")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_status(101)
         .with_stderr("error: -Z rustdoc-scrape-examples must take [..] an argument")
         .run();
@@ -2585,7 +2585,7 @@ fn scrape_examples_configure_profile() {
         .build();
 
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 
     let doc_html = p.read_file("target/doc/foo/fn.foo.html");
@@ -2641,7 +2641,7 @@ fn scrape_examples_issue_10545() {
         .build();
 
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples=all")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .run();
 }
 

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -117,7 +117,7 @@ fn edition_unstable() {
         .build();
 
     p.cargo("check")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
         .with_stderr(
             "\
 [CHECKING] foo [..]

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2012,7 +2012,7 @@ fn minimal_download() {
     // none
     // Should be the same as `-Zfeatures=all`
     p.cargo("check -Zfeatures=compare")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["features=compare"])
         .with_stderr_unordered(
             "\
 [UPDATING] [..]

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -861,7 +861,7 @@ https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-proje
     }
 
     p.cargo("fix --edition --allow-no-vcs")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
         .with_stderr(&format!(
             "\
 [CHECKING] foo [..]
@@ -942,7 +942,7 @@ fn prepare_for_already_on_latest_unstable() {
         .build();
 
     p.cargo("fix --edition --allow-no-vcs")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
         .with_stderr_contains("[CHECKING] foo [..]")
         .with_stderr_contains(&format!(
             "\

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1225,7 +1225,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .build();
 
     p.cargo("build -Z mtime-on-use")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr(
             "\
@@ -1236,13 +1236,13 @@ fn update_dependency_mtime_does_not_rebuild() {
         .run();
     // This does not make new files, but it does update the mtime of the dependency.
     p.cargo("build -p bar -Z mtime-on-use")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
     // This should not recompile!
     p.cargo("build -Z mtime-on-use")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
@@ -1303,10 +1303,10 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .build();
 
     p.cargo("build -Z mtime-on-use")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .run();
     p.cargo("build -Z mtime-on-use --features a")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
@@ -1322,18 +1322,18 @@ fn fingerprint_cleaner_does_not_rebuild() {
     }
     // This does not make new files, but it does update the mtime.
     p.cargo("build -Z mtime-on-use --features a")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
     fingerprint_cleaner(p.target_debug_dir(), timestamp);
     // This should not recompile!
     p.cargo("build -Z mtime-on-use --features a")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
     // But this should be cleaned and so need a rebuild
     p.cargo("build -Z mtime-on-use")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -278,7 +278,7 @@ fn color() {
 
     p.cargo("check")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["future-incompat-test"])
         .run();
 
     p.cargo("report future-incompatibilities")
@@ -307,7 +307,7 @@ fn bad_ids() {
 
     p.cargo("check")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["future-incompat-test"])
         .run();
 
     p.cargo("report future-incompatibilities --id foo")
@@ -393,7 +393,7 @@ with_updates v1.0.0 has the following newer versions available: 1.0.1, 1.0.2, 3.
 ";
 
     p.cargo("check --future-incompat-report")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["future-incompat-test"])
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr_contains(update_message)
         .run();

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -81,7 +81,7 @@ fn no_index_update() {
         .run();
 
     p.cargo("generate-lockfile -Zno-index-update")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["no-index-update"])
         .with_stdout("")
         .with_stderr("")
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -104,7 +104,7 @@ Caused by:
   dep1 is optional, but workspace dependencies cannot be optional
 ",
         )
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .run();
 }
 
@@ -165,7 +165,7 @@ fn inherit_own_workspace_fields() {
         .build();
 
     p.cargo("publish --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .run();
     publish::validate_upload_with_contents(
         r#"
@@ -276,7 +276,7 @@ fn inherit_own_dependencies() {
     Package::new("dep-dev", "0.5.2").publish();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -290,13 +290,15 @@ fn inherit_own_dependencies() {
         )
         .run();
 
-    p.cargo("check").masquerade_as_nightly_cargo().run();
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
+        .run();
     let lockfile = p.read_lockfile();
     assert!(lockfile.contains("dep"));
     assert!(lockfile.contains("dep-dev"));
     assert!(lockfile.contains("dep-build"));
     p.cargo("publish --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .run();
     publish::validate_upload_with_contents(
         r#"
@@ -410,7 +412,7 @@ fn inherit_own_detailed_dependencies() {
         .publish();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -423,11 +425,13 @@ fn inherit_own_detailed_dependencies() {
         )
         .run();
 
-    p.cargo("check").masquerade_as_nightly_cargo().run();
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
+        .run();
     let lockfile = p.read_lockfile();
     assert!(lockfile.contains("dep"));
     p.cargo("publish --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .run();
     publish::validate_upload_with_contents(
         r#"
@@ -511,7 +515,7 @@ fn inherit_from_own_undefined_field() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_status(101)
         .with_stderr(
             "\
@@ -563,7 +567,7 @@ fn inherited_dependencies_union_features() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -654,7 +658,7 @@ fn inherit_workspace_fields() {
         .build();
 
     p.cargo("publish --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .cwd("bar")
         .run();
     publish::validate_upload_with_contents(
@@ -773,8 +777,7 @@ fn inherit_dependencies() {
     Package::new("dep-dev", "0.5.2").publish();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -788,13 +791,15 @@ fn inherit_dependencies() {
         )
         .run();
 
-    p.cargo("check").masquerade_as_nightly_cargo().run();
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
+        .run();
     let lockfile = p.read_lockfile();
     assert!(lockfile.contains("dep"));
     assert!(lockfile.contains("dep-dev"));
     assert!(lockfile.contains("dep-build"));
     p.cargo("publish --token sekrit")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .cwd("bar")
         .run();
     publish::validate_upload_with_contents(
@@ -912,7 +917,7 @@ fn inherit_target_dependencies() {
     Package::new("dep", "0.1.2").publish();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -961,7 +966,7 @@ fn inherit_dependency_override_optional() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -1006,7 +1011,7 @@ fn inherit_dependency_features() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -1080,7 +1085,7 @@ fn inherit_detailed_dependencies() {
     let git_root = git_project.root();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`\n\
@@ -1125,7 +1130,7 @@ fn inherit_path_dependencies() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_stderr(
             "\
 [COMPILING] dep v0.9.0 ([CWD]/dep)
@@ -1169,7 +1174,7 @@ fn error_workspace_false() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1214,7 +1219,7 @@ fn error_workspace_dependency_looked_for_workspace_itself() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_status(101)
         .with_stderr(
             "\
@@ -1259,7 +1264,7 @@ fn error_malformed_workspace_root() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1306,7 +1311,7 @@ fn error_no_root_workspace() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1354,7 +1359,7 @@ fn error_inherit_unspecified_dependency() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1395,7 +1400,7 @@ fn workspace_inheritance_not_enabled() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["workspace-inheritance"])
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1755,7 +1755,9 @@ fn install_ignores_unstable_table_in_local_cargo_config() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("install bar").masquerade_as_nightly_cargo().run();
+    p.cargo("install bar")
+        .masquerade_as_nightly_cargo(&["build-std"])
+        .run();
     assert_has_installed_exe(cargo_home(), "bar");
 }
 

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -9,7 +9,7 @@ use toml_edit::easy as toml;
 fn gated() {
     registry::init();
     cargo_process("logout")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-logout"])
         .with_status(101)
         .with_stderr(
             "\
@@ -48,7 +48,7 @@ fn simple_logout_test(reg: Option<&str>, flag: &str) {
     let msg = reg.unwrap_or("crates.io");
     check_config_token(reg, true);
     cargo_process(&format!("logout -Z unstable-options {}", flag))
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-logout"])
         .with_stderr(&format!(
             "\
 [UPDATING] [..]
@@ -60,7 +60,7 @@ fn simple_logout_test(reg: Option<&str>, flag: &str) {
     check_config_token(reg, false);
 
     cargo_process(&format!("logout -Z unstable-options {}", flag))
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["cargo-logout"])
         .with_stderr(&format!(
             "\
 [LOGOUT] not currently logged in to `{}`

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -23,7 +23,7 @@ fn metabuild_gated() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_stderr(
             "\
@@ -84,7 +84,7 @@ fn basic_project() -> Project {
 fn metabuild_basic() {
     let p = basic_project();
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .with_stdout_contains("[foo 0.0.1] Hello mb-other")
         .run();
@@ -116,7 +116,7 @@ fn metabuild_error_both() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -146,7 +146,7 @@ fn metabuild_missing_dep() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -183,12 +183,12 @@ fn metabuild_optional_dep() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_does_not_contain("[foo 0.0.1] Hello mb")
         .run();
 
     p.cargo("build -vv --features mb")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 }
@@ -228,7 +228,7 @@ fn metabuild_lib_name() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 }
@@ -267,12 +267,12 @@ fn metabuild_fresh() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_does_not_contain("[foo 0.0.1] Hello mb")
         .with_stderr(
             "\
@@ -316,7 +316,7 @@ fn metabuild_links() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 }
@@ -356,7 +356,9 @@ fn metabuild_override() {
         )
         .build();
 
-    p.cargo("build -vv").masquerade_as_nightly_cargo().run();
+    p.cargo("build -vv")
+        .masquerade_as_nightly_cargo(&["metabuild"])
+        .run();
 }
 
 #[cargo_test]
@@ -419,7 +421,7 @@ fn metabuild_workspace() {
         .build();
 
     p.cargo("build -vv --workspace")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
         .with_stdout_contains("[member1 0.0.1] Hello mb2 [..]member1")
         .with_stdout_contains("[member2 0.0.1] Hello mb1 [..]member2")
@@ -434,7 +436,7 @@ fn metabuild_metadata() {
 
     let meta = p
         .cargo("metadata --format-version=1")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .run_json();
     let mb_info: Vec<&str> = meta["packages"]
         .as_array()
@@ -455,7 +457,7 @@ fn metabuild_build_plan() {
     let p = basic_project();
 
     p.cargo("build --build-plan -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild", "build-plan"])
         .with_json(
             r#"
             {
@@ -620,7 +622,7 @@ fn metabuild_two_versions() {
         .build();
 
     p.cargo("build -vv --workspace")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
         .with_stdout_contains("[member2 0.0.1] Hello mb2 [..]member2")
         .run();
@@ -673,7 +675,7 @@ fn metabuild_external_dependency() {
         .build();
 
     p.cargo("build -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[dep 1.0.0] Hello mb")
         .run();
 
@@ -684,7 +686,7 @@ fn metabuild_external_dependency() {
 fn metabuild_json_artifact() {
     let p = basic_project();
     p.cargo("build --message-format=json")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_json_contains_unordered(
             r#"
             {
@@ -732,7 +734,7 @@ fn metabuild_failed_build_json() {
     // Modify the metabuild dep so that it fails to compile.
     p.change_file("mb/src/lib.rs", "");
     p.cargo("build --message-format=json")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_json_contains_unordered(
             r#"

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -957,7 +957,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
         .build();
 
     p.cargo("metadata --no-deps -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_json(
             r#"
     {
@@ -1220,7 +1220,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
         .build();
 
     p.cargo("metadata -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_json(
             r#"
             {
@@ -3786,7 +3786,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
         .build();
 
     p.cargo("metadata --no-deps -Z bindeps")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["bindeps"])
         .with_json(
             r#"
             {

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -29,7 +29,7 @@ fn minimal_version_cli() {
         .build();
 
     p.cargo("generate-lockfile -Zminimal-versions")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["minimal-versions"])
         .run();
 
     let lock = p.read_lockfile();

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -69,7 +69,7 @@ fn simple_build() {
         .arg(&t1)
         .arg("--target")
         .arg(&t2)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["multitarget"])
         .run();
 
     assert!(p.target_bin(t1, "foo").is_file());
@@ -99,7 +99,9 @@ fn simple_build_with_config() {
         )
         .build();
 
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["multitarget"])
+        .run();
 
     assert!(p.target_bin(t1, "foo").is_file());
     assert!(p.target_bin(t2, "foo").is_file());
@@ -122,7 +124,7 @@ fn simple_test() {
         .arg(&t1)
         .arg("--target")
         .arg(&t2)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["multitarget"])
         .with_stderr_contains(&format!("[RUNNING] [..]{}[..]", t1))
         .with_stderr_contains(&format!("[RUNNING] [..]{}[..]", t2))
         .run();
@@ -138,7 +140,7 @@ fn simple_run() {
     p.cargo("run -Z multitarget --target a --target b")
         .with_stderr("[ERROR] only one `--target` argument is supported")
         .with_status(101)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["multitarget"])
         .run();
 }
 
@@ -159,7 +161,7 @@ fn simple_doc() {
         .arg(&t1)
         .arg("--target")
         .arg(&t2)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["multitarget"])
         .run();
 
     assert!(p.build_dir().join(&t1).join("doc/foo/index.html").is_file());
@@ -183,7 +185,7 @@ fn simple_check() {
         .arg(&t1)
         .arg("--target")
         .arg(&t2)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["multitarget"])
         .run();
 }
 
@@ -203,7 +205,7 @@ fn same_value_twice() {
         .arg(&t)
         .arg("--target")
         .arg(&t)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["multitarget"])
         .run();
 
     assert!(p.target_bin(t, "foo").is_file());
@@ -231,7 +233,9 @@ fn same_value_twice_with_config() {
         )
         .build();
 
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["multitarget"])
+        .run();
 
     assert!(p.target_bin(t, "foo").is_file());
 }
@@ -258,7 +262,9 @@ fn works_with_config_in_both_string_or_list() {
         )
         .build();
 
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["multitarget"])
+        .run();
 
     assert!(p.target_bin(t, "foo").is_file());
 
@@ -276,7 +282,9 @@ fn works_with_config_in_both_string_or_list() {
         ),
     );
 
-    p.cargo("build").masquerade_as_nightly_cargo().run();
+    p.cargo("build")
+        .masquerade_as_nightly_cargo(&["multitarget"])
+        .run();
 
     assert!(p.target_bin(t, "foo").is_file());
 }

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -13,7 +13,7 @@ fn binary_with_debug() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .enable_mac_dsym()
         .run();
     check_dir_contents(
@@ -50,7 +50,7 @@ fn static_library_with_debug() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .run();
     check_dir_contents(
         &p.root().join("out"),
@@ -86,7 +86,7 @@ fn dynamic_library_with_debug() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .enable_mac_dsym()
         .run();
     check_dir_contents(
@@ -122,7 +122,7 @@ fn rlib_with_debug() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .run();
     check_dir_contents(
         &p.root().join("out"),
@@ -166,7 +166,7 @@ fn include_only_the_binary_from_the_current_package() {
         .build();
 
     p.cargo("build -Z unstable-options --bin foo --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .enable_mac_dsym()
         .run();
     check_dir_contents(
@@ -186,7 +186,7 @@ fn out_dir_is_a_file() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .with_status(101)
         .with_stderr_contains("[ERROR] failed to create directory [..]")
         .run();
@@ -199,7 +199,7 @@ fn replaces_artifacts() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .run();
     p.process(
         &p.root()
@@ -212,7 +212,7 @@ fn replaces_artifacts() {
     p.change_file("src/main.rs", r#"fn main() { println!("bar") }"#);
 
     p.cargo("build -Z unstable-options --out-dir out")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .run();
     p.process(
         &p.root()
@@ -241,7 +241,7 @@ fn avoid_build_scripts() {
         .build();
 
     p.cargo("build -Z unstable-options --out-dir out -vv")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .enable_mac_dsym()
         .with_stdout_contains("[a 0.0.1] hello-build-a")
         .with_stdout_contains("[b 0.0.1] hello-build-b")
@@ -269,7 +269,7 @@ fn cargo_build_out_dir() {
         .build();
 
     p.cargo("build -Z unstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["out-dir"])
         .enable_mac_dsym()
         .run();
     check_dir_contents(

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -631,7 +631,7 @@ fn rustflags_works() {
         .build();
 
     p.cargo("build -v")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["profile-rustflags"])
         .with_stderr(
             "\
 [COMPILING] foo [..]
@@ -660,7 +660,7 @@ fn rustflags_works_with_env() {
 
     p.cargo("build -v")
         .env("CARGO_PROFILE_DEV_RUSTFLAGS", "-C link-dead-code=yes")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["profile-rustflags"])
         .with_stderr(
             "\
 [COMPILING] foo [..]
@@ -689,7 +689,7 @@ fn rustflags_requires_cargo_feature() {
         .build();
 
     p.cargo("build -v")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["profile-rustflags"])
         .with_status(101)
         .with_stderr(
             "\
@@ -724,7 +724,7 @@ Caused by:
         "#,
     );
     p.cargo("check")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["profile-rustflags"])
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -37,7 +37,7 @@ fn exported_priv_warning() {
         .build();
 
     p.cargo("build --message-format=short")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_contains(
             "\
 src/lib.rs:3:13: warning: type `[..]FromPriv` from private dependency 'priv_dep' in public interface
@@ -80,7 +80,7 @@ fn exported_pub_dep() {
         .build();
 
     p.cargo("build --message-format=short")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -143,7 +143,7 @@ fn requires_feature() {
         .build();
 
     p.cargo("build --message-format=short")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_status(101)
         .with_stderr(
             "\
@@ -193,7 +193,7 @@ fn pub_dev_dependency() {
         .build();
 
     p.cargo("build --message-format=short")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -47,7 +47,7 @@ fn removed() {
         .file("src/lib.rs", "")
         .build();
     p.cargo("package")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["publish-lockfile"])
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -14,7 +14,8 @@ use std::path::Path;
 
 fn cargo_http(p: &Project, s: &str) -> Execs {
     let mut e = p.cargo(s);
-    e.arg("-Zsparse-registry").masquerade_as_nightly_cargo();
+    e.arg("-Zsparse-registry")
+        .masquerade_as_nightly_cargo(&["sparse-registry"]);
     e
 }
 
@@ -2650,7 +2651,7 @@ fn http_requires_z_flag() {
 #[cargo_test]
 fn http_requires_trailing_slash() {
     cargo_process("-Z sparse-registry install bar --index sparse+https://index.crates.io")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["sparse-registry"])
         .with_status(101)
         .with_stderr("[ERROR] registry url must end in a slash `/`: sparse+https://index.crates.io")
         .run()

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -139,7 +139,7 @@ fn fails_with_crate_type_and_without_unstable_options() {
     let p = project().file("src/lib.rs", r#" "#).build();
 
     p.cargo("rustc --crate-type lib")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_status(101)
         .with_stderr(
             "[ERROR] the `crate-type` flag is unstable, pass `-Z unstable-options` to enable it
@@ -158,7 +158,7 @@ fn fails_with_crate_type_to_multi_binaries() {
         .build();
 
     p.cargo("rustc --crate-type lib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_status(101)
         .with_stderr(
             "[ERROR] crate types to rustc can only be passed to one target, consider filtering
@@ -192,7 +192,7 @@ fn fails_with_crate_type_to_multi_examples() {
         .build();
 
     p.cargo("rustc -v --example ex1 --example ex2 --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_status(101)
         .with_stderr(
             "[ERROR] crate types to rustc can only be passed to one target, consider filtering
@@ -206,7 +206,7 @@ fn fails_with_crate_type_to_binary() {
     let p = project().file("src/bin/foo.rs", "fn main() {}").build();
 
     p.cargo("rustc --crate-type lib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_status(101)
         .with_stderr(
             "[ERROR] crate types can only be specified for libraries and example libraries.
@@ -220,7 +220,7 @@ fn build_with_crate_type_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("rustc -v --crate-type cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -258,7 +258,7 @@ fn build_with_crate_type_for_foo_with_deps() {
         .build();
 
     p.cargo("rustc -v --crate-type cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_stderr(
             "\
 [COMPILING] a v0.1.0 ([CWD]/a)
@@ -276,7 +276,7 @@ fn build_with_crate_types_for_foo() {
     let p = project().file("src/lib.rs", "").build();
 
     p.cargo("rustc -v --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -308,7 +308,7 @@ fn build_with_crate_type_to_example() {
         .build();
 
     p.cargo("rustc -v --example ex --crate-type cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -341,7 +341,7 @@ fn build_with_crate_types_to_example() {
         .build();
 
     p.cargo("rustc -v --example ex --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -378,7 +378,7 @@ fn build_with_crate_types_to_one_of_multi_examples() {
         .build();
 
     p.cargo("rustc -v --example ex1 --crate-type lib,cdylib -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["crate-type"])
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
@@ -723,7 +723,7 @@ fn rustc_with_print_cfg_single_target() {
         .build();
 
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["print"])
         .with_stdout_contains("debug_assertions")
         .with_stdout_contains("target_arch=\"x86_64\"")
         .with_stdout_contains("target_endian=\"little\"")
@@ -744,7 +744,7 @@ fn rustc_with_print_cfg_multiple_targets() {
         .build();
 
     p.cargo("rustc -Z unstable-options -Z multitarget --target x86_64-pc-windows-msvc --target i686-unknown-linux-gnu --print cfg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["print", "multitarget"])
         .with_stdout_contains("debug_assertions")
         .with_stdout_contains("target_arch=\"x86_64\"")
         .with_stdout_contains("target_endian=\"little\"")
@@ -771,7 +771,7 @@ fn rustc_with_print_cfg_rustflags_env_var() {
         .build();
 
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["print"])
         .env("RUSTFLAGS", "-C target-feature=+crt-static")
         .with_stdout_contains("debug_assertions")
         .with_stdout_contains("target_arch=\"x86_64\"")
@@ -801,7 +801,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
         .build();
 
     p.cargo("rustc -Z unstable-options --target x86_64-pc-windows-msvc --print cfg")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["print"])
         .env("RUSTFLAGS", "-C target-feature=+crt-static")
         .with_stdout_contains("debug_assertions")
         .with_stdout_contains("target_arch=\"x86_64\"")

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -50,7 +50,7 @@ fn simple() {
     }
     let p = basic_project();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo [..]bar=https://docs.rs/bar/1.0.0/[..]",
         )
@@ -91,7 +91,7 @@ fn std_docs() {
         "#,
     );
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains("[RUNNING] `rustdoc [..]--crate-name foo [..]std=file://[..]")
         .run();
     let myfun = p.read_file("target/doc/foo/fn.myfun.html");
@@ -105,7 +105,7 @@ fn std_docs() {
         "#,
     );
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo [..]std=https://example.com/rust/[..]",
         )
@@ -148,7 +148,7 @@ fn renamed_dep() {
         )
         .build();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo [..]bar=https://docs.rs/bar/1.0.0/[..]",
         )
@@ -201,7 +201,7 @@ fn lib_name() {
         )
         .build();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo [..]rumpelstiltskin=https://docs.rs/bar/1.0.0/[..]",
         )
@@ -270,7 +270,7 @@ fn alt_registry() {
         )
         .build();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo \
             [..]bar=https://example.com/bar/1.0.0/[..]grimm=https://docs.rs/grimm/1.0.0/[..]",
@@ -328,7 +328,7 @@ fn multiple_versions() {
         )
         .build();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo \
             [..]bar=https://docs.rs/bar/1.0.0/[..]bar=https://docs.rs/bar/2.0.0/[..]",
@@ -351,7 +351,7 @@ fn rebuilds_when_changing() {
     }
     let p = basic_project();
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains("[..]--extern-html-root-url[..]")
         .run();
 
@@ -364,7 +364,7 @@ fn rebuilds_when_changing() {
         "#,
     );
     p.cargo("doc -v --no-deps -Zrustdoc-map")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--extern-html-root-url [..]bar=https://example.com/bar/1.0.0/[..]",
         )

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -297,7 +297,7 @@ fn env_rustflags_build_script_with_target_doesnt_apply_to_host_kind() {
 
     let host = rustc_host();
     p.cargo("build --target")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg(host)
         .arg("-Ztarget-applies-to-host")
         .env("RUSTFLAGS", "--cfg foo")
@@ -1072,7 +1072,7 @@ fn target_rustflags_not_for_build_scripts_with_target() {
     // Enabling -Ztarget-applies-to-host should not make a difference without the config setting
     p.cargo("build --target")
         .arg(host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .run();
 
@@ -1092,7 +1092,7 @@ fn target_rustflags_not_for_build_scripts_with_target() {
     );
     p.cargo("build --target")
         .arg(host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .run();
 }
@@ -1129,12 +1129,12 @@ fn build_rustflags_for_build_scripts() {
 
     // Enabling -Ztarget-applies-to-host should not make a difference without the config setting
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .run();
     p.cargo("build --target")
         .arg(host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
         .with_stderr_contains("[..]assertion failed[..]")
@@ -1152,14 +1152,14 @@ fn build_rustflags_for_build_scripts() {
         ",
     );
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
         .with_stderr_contains("[..]assertion failed[..]")
         .run();
     p.cargo("build --target")
         .arg(host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
         .with_stderr_contains("[..]assertion failed[..]")
@@ -1194,7 +1194,7 @@ fn host_rustflags_for_build_scripts() {
 
     p.cargo("build --target")
         .arg(host)
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .arg("-Ztarget-applies-to-host")
         .arg("-Zhost-config")
         .run();
@@ -1663,7 +1663,7 @@ fn host_config_rustflags_with_target() {
         .build();
 
     p.cargo("build")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .arg("-Zhost-config")
         .arg("-Ztarget-applies-to-host")
         .arg("-Zunstable-options")

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -134,7 +134,7 @@ fn enable_build_std(e: &mut Execs, setup: &Setup) {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/testsuite/mock-std");
     e.env("__CARGO_TESTS_ONLY_SRC_ROOT", &root);
 
-    e.masquerade_as_nightly_cargo();
+    e.masquerade_as_nightly_cargo(&["build-std"]);
 
     // We do various shenanigans to ensure our "mock sysroot" actually links
     // with the real sysroot, so we don't have to actually recompile std for

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4023,7 +4023,7 @@ fn cargo_test_doctest_xcompile_ignores() {
 
     #[cfg(not(target_arch = "x86_64"))]
     p.cargo("test -Zdoctest-xcompile")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["doctest-xcompile"])
         .with_stdout_contains(
             "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]",
         )
@@ -4031,7 +4031,7 @@ fn cargo_test_doctest_xcompile_ignores() {
 
     #[cfg(target_arch = "x86_64")]
     p.cargo("test -Zdoctest-xcompile")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["doctest-xcompile"])
         .with_stdout_contains(
             "test result: ok. 0 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out[..]",
         )
@@ -4071,7 +4071,7 @@ fn cargo_test_doctest_xcompile() {
         "test --target {} -Zdoctest-xcompile",
         cross_compile::alternate()
     ))
-    .masquerade_as_nightly_cargo()
+    .masquerade_as_nightly_cargo(&["doctest-xcompile"])
     .with_stdout_contains(
         "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]",
     )
@@ -4151,7 +4151,7 @@ fn cargo_test_doctest_xcompile_runner() {
         "test --target {} -Zdoctest-xcompile",
         cross_compile::alternate()
     ))
-    .masquerade_as_nightly_cargo()
+    .masquerade_as_nightly_cargo(&["doctest-xcompile"])
     .with_stdout_contains(
         "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]",
     )
@@ -4195,7 +4195,7 @@ fn cargo_test_doctest_xcompile_no_runner() {
         "test --target {} -Zdoctest-xcompile",
         cross_compile::alternate()
     ))
-    .masquerade_as_nightly_cargo()
+    .masquerade_as_nightly_cargo(&["doctest-xcompile"])
     .with_stdout_contains(
         "test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]",
     )
@@ -4243,7 +4243,7 @@ fn panic_abort_tests() {
         .with_stderr_contains("[..]--crate-name a [..]-C panic=abort[..]")
         .with_stderr_contains("[..]--crate-name foo [..]-C panic=abort[..]")
         .with_stderr_contains("[..]--crate-name foo [..]-C panic=abort[..]--test[..]")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .run();
 }
 
@@ -4284,7 +4284,7 @@ fn panic_abort_only_test() {
 
     p.cargo("test -Z panic-abort-tests -v")
         .with_stderr_contains("warning: `panic` setting is ignored for `test` profile")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .run();
 }
 
@@ -4324,7 +4324,7 @@ fn panic_abort_test_profile_inherits() {
         .build();
 
     p.cargo("test -Z panic-abort-tests -v")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["panic-abort-tests"])
         .with_status(0)
         .run();
 }

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -46,7 +46,7 @@ fn simple() {
         .build();
 
     p.cargo("build --features a/feata --unit-graph -Zunstable-options")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["unit-graph"])
         .with_json(
             r#"{
               "roots": [

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -62,7 +62,7 @@ fn cargo_verify_project_honours_unstable_features() {
         .build();
 
     p.cargo("verify-project")
-        .masquerade_as_nightly_cargo()
+        .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stdout(verify_project_success_output())
         .run();
 


### PR DESCRIPTION
When I was working on the stabilization for workspace inheritance, it was very tedious to find all of the places to remove `.masquerade_as_nightly_cargo()`. I [suggested](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/problems.20finding.20.60.2Emasquerade_as_nightly_cargo.28.29.60) to add a reason to `.masquerade_as_nightly_cargo()` so that it would be easier to find all of the places to remove it. By adding the reason it makes it easy to search for all places with the features name. This PR adds the reason(s) to all of the places `.masquerade_as_nightly_cargo()` is called, as well as updates the documentation so it talks about adding a reason when making the call.
