### PR TITLE
Add "unit struct to normal struct" case to semver.md

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -279,7 +279,7 @@ Mitigation strategies:
 
 When constructing a normal struct using [struct literal] syntax, the curly braces
 are required even if the struct has no fields. Changing a unit struct
-to a normal struct will then break any code that attempted to construct 
+to a normal struct will then break any code that attempted to construct
 the unit struct using a [struct literal].
 
 ```rust,ignore
@@ -295,6 +295,8 @@ pub struct Foo {}
 
 ///////////////////////////////////////////////////////////
 // Example usage that will break.
+use updated_crate::Foo;
+
 fn main() {
     let x = Foo; // Error: expected value, found struct `Foo`
     //      ^^^ help: use struct literal syntax instead: `Foo {}`

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -62,6 +62,7 @@ considered incompatible.
     * Structs
         * [Major: adding a private struct field when all current fields are public](#struct-add-private-field-when-public)
         * [Major: adding a public field when no private field exists](#struct-add-public-field-when-no-private)
+        * [Major: going from a unit struct to a normal struct, even if it has no fields](#struct-unit-to-normal)
         * [Minor: adding or removing private fields when at least one already exists](#struct-private-fields-with-private)
         * [Minor: going from a tuple struct with all private fields (with at least one field) to a normal struct, or vice versa](#struct-tuple-normal-with-private)
     * Enums
@@ -272,6 +273,33 @@ Mitigation strategies:
 * Mark structs as [`#[non_exhaustive]`][non_exhaustive] when first introducing
   a struct to prevent users from using struct literal syntax, and instead
   provide a constructor method and/or [Default] implementation.
+
+<a id="#struct-unit-to-normal"></a>
+### Major: going from a unit struct to a normal struct, even if it has no fields
+
+When constructing a normal struct using [struct literal] syntax, the curly braces
+are required even if the struct has no fields. Changing a unit struct
+to a normal struct will then break any code that attempted to construct 
+the unit struct using a [struct literal].
+
+```rust,ignore
+// MAJOR CHANGE
+
+///////////////////////////////////////////////////////////
+// Before
+pub struct Foo;
+
+///////////////////////////////////////////////////////////
+// After
+pub struct Foo {}
+
+///////////////////////////////////////////////////////////
+// Example usage that will break.
+fn main() {
+    let x = Foo; // Error: expected value, found struct `Foo`
+    //      ^^^ help: use struct literal syntax instead: `Foo {}`
+}
+```
 
 <a id="struct-private-fields-with-private"></a>
 ### Minor: adding or removing private fields when at least one already exists

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -277,10 +277,13 @@ Mitigation strategies:
 <a id="#struct-unit-to-normal"></a>
 ### Major: going from a unit struct to a normal struct, even if it has no fields
 
-When constructing a normal struct using [struct literal] syntax, the curly braces
-are required even if the struct has no fields. Changing a unit struct
-to a normal struct will then break any code that attempted to construct
-the unit struct using a [struct literal].
+A unit struct can be constructed using both `Unit` and `Unit {}`
+[struct literal] syntax. However, the curly braces are mandatory for
+normal structs, even ones with no fields.
+
+If the unit struct was not [`#[non_exhaustive]`][non_exhaustive],
+changing it to a normal struct will break any code that constructs
+it using a [struct literal] without the curly braces.
 
 ```rust,ignore
 // MAJOR CHANGE
@@ -302,6 +305,10 @@ fn main() {
     //      ^^^ help: use struct literal syntax instead: `Foo {}`
 }
 ```
+
+Mitigation strategies:
+* Mark the unit struct [`#[non_exhaustive]`][non_exhaustive] when first
+  adding it, to make it impossible to construct outside of its own crate.
 
 <a id="struct-private-fields-with-private"></a>
 ### Minor: adding or removing private fields when at least one already exists


### PR DESCRIPTION
### What does this PR try to resolve?

Changing a public unit struct to a normal struct appears to be a breaking change that should require a major version bump: unit structs are always constructible as `Foo` but normal (i.e. plain) structs are only constructible as `Foo {}`. The curly braces are required by the compiler, and produce a compilation error and suggestion to add them if they are missing.

The semver page in the reference does not mention anything about unit structs, and as far as I could tell, this case does not seem to be covered in any of the existing entries in the `Structs` section of the semver page.

This PR adds a new entry in the `Structs` section of the semver page in the reference, describing this major breaking change and providing an example.