### PR TITLE
refactor(source): Open query API for adding more types of queries

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -128,8 +128,8 @@ pub fn resolve_with_config_raw(
         fn query(
             &mut self,
             dep: &Dependency,
-            f: &mut dyn FnMut(Summary),
             fuzzy: bool,
+            f: &mut dyn FnMut(Summary),
         ) -> Poll<CargoResult<()>> {
             for summary in self.list.iter() {
                 if fuzzy || dep.matches(summary) {

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -293,7 +293,7 @@ fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<
                 Ok(dep) => dep,
                 Err(_) => return false,
             };
-            match source.query_vec(&dep) {
+            match source.query_vec(&dep, false) {
                 Poll::Ready(Ok(sum)) => {
                     summaries.push((pkg_id, sum));
                     false

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -1,7 +1,7 @@
 //! Support for future-incompatible warning reporting.
 
 use crate::core::compiler::BuildContext;
-use crate::core::{Dependency, PackageId, Workspace};
+use crate::core::{Dependency, PackageId, QueryKind, Workspace};
 use crate::sources::SourceConfigMap;
 use crate::util::{iter_join, CargoResult, Config};
 use anyhow::{bail, format_err, Context};
@@ -293,7 +293,7 @@ fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<
                 Ok(dep) => dep,
                 Err(_) => return false,
             };
-            match source.query_vec(&dep, false) {
+            match source.query_vec(&dep, QueryKind::Exact) {
                 Poll::Ready(Ok(sum)) => {
                     summaries.push((pkg_id, sum));
                     false

--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -8,7 +8,7 @@ pub use self::package_id_spec::PackageIdSpec;
 pub use self::registry::Registry;
 pub use self::resolver::{Resolve, ResolveVersion};
 pub use self::shell::{Shell, Verbosity};
-pub use self::source::{GitReference, Source, SourceId, SourceMap};
+pub use self::source::{GitReference, QueryKind, Source, SourceId, SourceMap};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};
 pub use self::workspace::{
     find_workspace_root, resolve_relative_path, MaybePackage, Workspace, WorkspaceConfig,

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -327,7 +327,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                     .get_mut(dep.source_id())
                     .expect("loaded source not present");
 
-                let summaries = match source.query_vec(dep)? {
+                let summaries = match source.query_vec(dep, false)? {
                     Poll::Ready(deps) => deps,
                     Poll::Pending => {
                         deps_pending.push(dep_remaining);
@@ -483,7 +483,7 @@ impl<'cfg> PackageRegistry<'cfg> {
         for &s in self.overrides.iter() {
             let src = self.sources.get_mut(s).unwrap();
             let dep = Dependency::new_override(dep.package_name(), s);
-            let mut results = match src.query_vec(&dep) {
+            let mut results = match src.query_vec(&dep, false) {
                 Poll::Ready(results) => results?,
                 Poll::Pending => return Poll::Pending,
             };
@@ -881,7 +881,7 @@ fn summary_for_patch(
     // No summaries found, try to help the user figure out what is wrong.
     if let Some(locked) = locked {
         // Since the locked patch did not match anything, try the unlocked one.
-        let orig_matches = match source.query_vec(orig_patch) {
+        let orig_matches = match source.query_vec(orig_patch, false) {
             Poll::Pending => return Poll::Pending,
             Poll::Ready(deps) => deps,
         }
@@ -906,7 +906,7 @@ fn summary_for_patch(
     // Try checking if there are *any* packages that match this by name.
     let name_only_dep = Dependency::new_override(orig_patch.package_name(), orig_patch.source_id());
 
-    let name_summaries = match source.query_vec(&name_only_dep) {
+    let name_summaries = match source.query_vec(&name_only_dep, false) {
         Poll::Pending => return Poll::Pending,
         Poll::Ready(deps) => deps,
     }

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -19,13 +19,13 @@ pub trait Registry {
     fn query(
         &mut self,
         dep: &Dependency,
-        f: &mut dyn FnMut(Summary),
         fuzzy: bool,
+        f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>>;
 
     fn query_vec(&mut self, dep: &Dependency, fuzzy: bool) -> Poll<CargoResult<Vec<Summary>>> {
         let mut ret = Vec::new();
-        self.query(dep, &mut |s| ret.push(s), fuzzy)
+        self.query(dep, fuzzy, &mut |s| ret.push(s))
             .map_ok(|()| ret)
     }
 
@@ -575,8 +575,8 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
     fn query(
         &mut self,
         dep: &Dependency,
-        f: &mut dyn FnMut(Summary),
         fuzzy: bool,
+        f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         assert!(self.patches_locked);
         let (override_summary, n, to_warn) = {

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -671,11 +671,7 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
                             }
                             f(lock(locked, all_patches, summary))
                         };
-                        return if fuzzy {
-                            source.fuzzy_query(dep, callback)
-                        } else {
-                            source.query(dep, callback)
-                        };
+                        return source.query(dep, fuzzy, callback);
                     }
 
                     // If we have an override summary then we query the source
@@ -694,11 +690,7 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
                                 n += 1;
                                 to_warn = Some(summary);
                             };
-                            let pend = if fuzzy {
-                                source.fuzzy_query(dep, callback)?
-                            } else {
-                                source.query(dep, callback)?
-                            };
+                            let pend = source.query(dep, fuzzy, callback);
                             if pend.is_pending() {
                                 return Poll::Pending;
                             }

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -100,13 +100,9 @@ impl<'a> RegistryQueryer<'a> {
         }
 
         let mut ret = Vec::new();
-        let ready = self.registry.query(
-            dep,
-            &mut |s| {
-                ret.push(s);
-            },
-            false,
-        )?;
+        let ready = self.registry.query(dep, false, &mut |s| {
+            ret.push(s);
+        })?;
         if ready.is_pending() {
             self.registry_cache.insert(dep.clone(), Poll::Pending);
             return Poll::Pending;

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -16,7 +16,9 @@ use crate::core::resolver::{
     ActivateError, ActivateResult, CliFeatures, RequestedFeatures, ResolveOpts, VersionOrdering,
     VersionPreferences,
 };
-use crate::core::{Dependency, FeatureValue, PackageId, PackageIdSpec, Registry, Summary};
+use crate::core::{
+    Dependency, FeatureValue, PackageId, PackageIdSpec, QueryKind, Registry, Summary,
+};
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 
@@ -100,7 +102,7 @@ impl<'a> RegistryQueryer<'a> {
         }
 
         let mut ret = Vec::new();
-        let ready = self.registry.query(dep, false, &mut |s| {
+        let ready = self.registry.query(dep, QueryKind::Exact, &mut |s| {
             ret.push(s);
         })?;
         if ready.is_pending() {
@@ -123,7 +125,7 @@ impl<'a> RegistryQueryer<'a> {
                 dep.version_req()
             );
 
-            let mut summaries = match self.registry.query_vec(dep, false)? {
+            let mut summaries = match self.registry.query_vec(dep, QueryKind::Exact)? {
                 Poll::Ready(s) => s.into_iter(),
                 Poll::Pending => {
                     self.registry_cache.insert(dep.clone(), Poll::Pending);

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::task::Poll;
 
-use crate::core::{Dependency, PackageId, Registry, Summary};
+use crate::core::{Dependency, PackageId, QueryKind, Registry, Summary};
 use crate::util::lev_distance::lev_distance;
 use crate::util::{Config, VersionExt};
 use anyhow::Error;
@@ -228,7 +228,7 @@ pub(super) fn activation_error(
     new_dep.set_version_req(all_req);
 
     let mut candidates = loop {
-        match registry.query_vec(&new_dep, false) {
+        match registry.query_vec(&new_dep, QueryKind::Exact) {
             Poll::Ready(Ok(candidates)) => break candidates,
             Poll::Ready(Err(e)) => return to_resolve_err(e),
             Poll::Pending => match registry.block_until_ready() {
@@ -294,7 +294,7 @@ pub(super) fn activation_error(
             // Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
             // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
             let mut candidates = loop {
-                match registry.query_vec(&new_dep, true) {
+                match registry.query_vec(&new_dep, QueryKind::Fuzzy) {
                     Poll::Ready(Ok(candidates)) => break candidates,
                     Poll::Ready(Err(e)) => return to_resolve_err(e),
                     Poll::Pending => match registry.block_until_ready() {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -40,9 +40,9 @@ pub trait Source {
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>>;
 
-    fn query_vec(&mut self, dep: &Dependency) -> Poll<CargoResult<Vec<Summary>>> {
+    fn query_vec(&mut self, dep: &Dependency, fuzzy: bool) -> Poll<CargoResult<Vec<Summary>>> {
         let mut ret = Vec::new();
-        self.query(dep, false, &mut |s| ret.push(s)).map_ok(|_| ret)
+        self.query(dep, fuzzy, &mut |s| ret.push(s)).map_ok(|_| ret)
     }
 
     /// Ensure that the source is fully up-to-date for the current session on the next query.

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -19,6 +19,7 @@ use toml_edit::Item as TomlItem;
 use crate::core::dependency::DepKind;
 use crate::core::registry::PackageRegistry;
 use crate::core::Package;
+use crate::core::QueryKind;
 use crate::core::Registry;
 use crate::core::Shell;
 use crate::core::Workspace;
@@ -443,8 +444,7 @@ fn get_latest_dependency(
         }
         MaybeWorkspace::Other(query) => {
             let possibilities = loop {
-                let fuzzy = true;
-                match registry.query_vec(&query, fuzzy) {
+                match registry.query_vec(&query, QueryKind::Fuzzy) {
                     std::task::Poll::Ready(res) => {
                         break res?;
                     }
@@ -485,8 +485,8 @@ fn select_package(
         }
         MaybeWorkspace::Other(query) => {
             let possibilities = loop {
-                let fuzzy = false; // Returns all for path/git
-                match registry.query_vec(&query, fuzzy) {
+                // Exact to avoid returning all for path/git
+                match registry.query_vec(&query, QueryKind::Exact) {
                     std::task::Poll::Ready(res) => {
                         break res?;
                     }
@@ -600,7 +600,7 @@ fn populate_available_features(
         MaybeWorkspace::Other(query) => query,
     };
     let possibilities = loop {
-        match registry.query_vec(&query, true) {
+        match registry.query_vec(&query, QueryKind::Fuzzy) {
             std::task::Poll::Ready(res) => {
                 break res?;
             }

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -540,7 +540,7 @@ where
     }
 
     let deps = loop {
-        match source.query_vec(&dep)? {
+        match source.query_vec(&dep, false)? {
             Poll::Ready(deps) => break deps,
             Poll::Pending => source.block_until_ready()?,
         }

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use toml_edit::easy as toml;
 
 use crate::core::compiler::Freshness;
-use crate::core::{Dependency, FeatureValue, Package, PackageId, Source, SourceId};
+use crate::core::{Dependency, FeatureValue, Package, PackageId, QueryKind, Source, SourceId};
 use crate::ops::{self, CompileFilter, CompileOptions};
 use crate::sources::PathSource;
 use crate::util::errors::CargoResult;
@@ -540,7 +540,7 @@ where
     }
 
     let deps = loop {
-        match source.query_vec(&dep, false)? {
+        match source.query_vec(&dep, QueryKind::Exact)? {
             Poll::Ready(deps) => break deps,
             Poll::Pending => source.block_until_ready()?,
         }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -46,28 +46,18 @@ impl<'cfg> Debug for DirectorySource<'cfg> {
 }
 
 impl<'cfg> Source for DirectorySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
-        if !self.updated {
-            return Poll::Pending;
-        }
-        let packages = self.packages.values().map(|p| &p.0);
-        let matches = packages.filter(|pkg| dep.matches(pkg.summary()));
-        for summary in matches.map(|pkg| pkg.summary().clone()) {
-            f(summary);
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    fn fuzzy_query(
+    fn query(
         &mut self,
-        _dep: &Dependency,
+        dep: &Dependency,
+        fuzzy: bool,
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         if !self.updated {
             return Poll::Pending;
         }
         let packages = self.packages.values().map(|p| &p.0);
-        for summary in packages.map(|pkg| pkg.summary().clone()) {
+        let matches = packages.filter(|pkg| fuzzy || dep.matches(pkg.summary()));
+        for summary in matches.map(|pkg| pkg.summary().clone()) {
             f(summary);
         }
         Poll::Ready(Ok(()))

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -1,4 +1,4 @@
-use crate::core::source::{MaybePackage, Source, SourceId};
+use crate::core::source::{MaybePackage, QueryKind, Source, SourceId};
 use crate::core::GitReference;
 use crate::core::{Dependency, Package, PackageId, Summary};
 use crate::sources::git::utils::GitRemote;
@@ -89,11 +89,11 @@ impl<'cfg> Source for GitSource<'cfg> {
     fn query(
         &mut self,
         dep: &Dependency,
-        fuzzy: bool,
+        kind: QueryKind,
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         if let Some(src) = self.path_source.as_mut() {
-            src.query(dep, fuzzy, f)
+            src.query(dep, kind, f)
         } else {
             Poll::Pending
         }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -86,21 +86,14 @@ impl<'cfg> Debug for GitSource<'cfg> {
 }
 
 impl<'cfg> Source for GitSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
-        if let Some(src) = self.path_source.as_mut() {
-            src.query(dep, f)
-        } else {
-            Poll::Pending
-        }
-    }
-
-    fn fuzzy_query(
+    fn query(
         &mut self,
         dep: &Dependency,
+        fuzzy: bool,
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         if let Some(src) = self.path_source.as_mut() {
-            src.fuzzy_query(dep, f)
+            src.query(dep, fuzzy, f)
         } else {
             Poll::Pending
         }

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -497,24 +497,17 @@ impl<'cfg> Debug for PathSource<'cfg> {
 }
 
 impl<'cfg> Source for PathSource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
-        self.update()?;
-        for s in self.packages.iter().map(|p| p.summary()) {
-            if dep.matches(s) {
-                f(s.clone())
-            }
-        }
-        Poll::Ready(Ok(()))
-    }
-
-    fn fuzzy_query(
+    fn query(
         &mut self,
-        _dep: &Dependency,
+        dep: &Dependency,
+        fuzzy: bool,
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         self.update()?;
         for s in self.packages.iter().map(|p| p.summary()) {
-            f(s.clone())
+            if fuzzy || dep.matches(s) {
+                f(s.clone())
+            }
         }
         Poll::Ready(Ok(()))
     }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -701,49 +701,50 @@ impl<'cfg> RegistrySource<'cfg> {
 }
 
 impl<'cfg> Source for RegistrySource<'cfg> {
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
-        // If this is a precise dependency, then it came from a lock file and in
-        // theory the registry is known to contain this version. If, however, we
-        // come back with no summaries, then our registry may need to be
-        // updated, so we fall back to performing a lazy update.
-        if dep.source_id().precise().is_some() && !self.ops.is_updated() {
-            debug!("attempting query without update");
-            let mut called = false;
-            let pend =
-                self.index
-                    .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
+    fn query(
+        &mut self,
+        dep: &Dependency,
+        fuzzy: bool,
+        f: &mut dyn FnMut(Summary),
+    ) -> Poll<CargoResult<()>> {
+        if !fuzzy {
+            // If this is a precise dependency, then it came from a lock file and in
+            // theory the registry is known to contain this version. If, however, we
+            // come back with no summaries, then our registry may need to be
+            // updated, so we fall back to performing a lazy update.
+            if dep.source_id().precise().is_some() && !self.ops.is_updated() {
+                debug!("attempting query without update");
+                let mut called = false;
+                let pend = self.index.query_inner(
+                    dep,
+                    &mut *self.ops,
+                    &self.yanked_whitelist,
+                    &mut |s| {
                         if dep.matches(&s) {
                             called = true;
                             f(s);
                         }
-                    })?;
-            if pend.is_pending() {
-                return Poll::Pending;
-            }
-            if called {
-                return Poll::Ready(Ok(()));
-            } else {
-                debug!("falling back to an update");
-                self.invalidate_cache();
-                return Poll::Pending;
+                    },
+                )?;
+                if pend.is_pending() {
+                    return Poll::Pending;
+                }
+                if called {
+                    return Poll::Ready(Ok(()));
+                } else {
+                    debug!("falling back to an update");
+                    self.invalidate_cache();
+                    return Poll::Pending;
+                }
             }
         }
 
         self.index
             .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
-                if dep.matches(&s) {
+                if fuzzy || dep.matches(&s) {
                     f(s);
                 }
             })
-    }
-
-    fn fuzzy_query(
-        &mut self,
-        dep: &Dependency,
-        f: &mut dyn FnMut(Summary),
-    ) -> Poll<CargoResult<()>> {
-        self.index
-            .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, f)
     }
 
     fn supports_checksums(&self) -> bool {

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -42,32 +42,17 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         self.inner.requires_precise()
     }
 
-    fn query(&mut self, dep: &Dependency, f: &mut dyn FnMut(Summary)) -> Poll<CargoResult<()>> {
-        let (replace_with, to_replace) = (self.replace_with, self.to_replace);
-        let dep = dep.clone().map_source(to_replace, replace_with);
-
-        self.inner
-            .query(&dep, &mut |summary| {
-                f(summary.map_source(replace_with, to_replace))
-            })
-            .map_err(|e| {
-                e.context(format!(
-                    "failed to query replaced source {}",
-                    self.to_replace
-                ))
-            })
-    }
-
-    fn fuzzy_query(
+    fn query(
         &mut self,
         dep: &Dependency,
+        fuzzy: bool,
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         let (replace_with, to_replace) = (self.replace_with, self.to_replace);
         let dep = dep.clone().map_source(to_replace, replace_with);
 
         self.inner
-            .fuzzy_query(&dep, &mut |summary| {
+            .query(&dep, fuzzy, &mut |summary| {
                 f(summary.map_source(replace_with, to_replace))
             })
             .map_err(|e| {

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -1,5 +1,5 @@
 use crate::core::source::MaybePackage;
-use crate::core::{Dependency, Package, PackageId, Source, SourceId, Summary};
+use crate::core::{Dependency, Package, PackageId, QueryKind, Source, SourceId, Summary};
 use crate::util::errors::CargoResult;
 use std::task::Poll;
 
@@ -45,14 +45,14 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
     fn query(
         &mut self,
         dep: &Dependency,
-        fuzzy: bool,
+        kind: QueryKind,
         f: &mut dyn FnMut(Summary),
     ) -> Poll<CargoResult<()>> {
         let (replace_with, to_replace) = (self.replace_with, self.to_replace);
         let dep = dep.clone().map_source(to_replace, replace_with);
 
         self.inner
-            .query(&dep, fuzzy, &mut |summary| {
+            .query(&dep, kind, &mut |summary| {
                 f(summary.map_source(replace_with, to_replace))
             })
             .map_err(|e| {


### PR DESCRIPTION
### What does this PR try to resolve?

This refactors the Source/Registry traits from accepting a `fuzzy: bool` to accepting an enum so we can add alternative query styles in the future, as discussed in the Cargo team meeting for fixing #10729

The expected fix for `cargo add` at this point would be
- Add `QueryKind::Normalized`
  - Initially, we can make it like Exact for path sources and like Fuzzy for registry sources
- Switch cargo-add to using that kind everywhere (both where `Exact` and `Fuzzy` are used)
- A test to ensure this fixed it
- Rename `Fuzzy` to `Alternatives` or something to clarify its actual intent

### How should we test and review this PR?

The refactor is broken down into multiple commits, so ideally review a commit at a time to more easily see how it evolved.

### Additional information

Future possibilities
- Supporting normalized search on all sources
- Doing version / source matching for normalized results (probably not needed for cargo-add but will make the API less surprising for future users)