### PR TITLE
Make the `rust-version` error recommend `cargo update --precise -p crate@ver`

### DIFF
--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -661,12 +661,32 @@ pub fn create_bcx<'a, 'cfg>(
                 continue;
             }
 
+            let guidance = if ws.is_ephemeral() {
+                if ws.ignore_lock() {
+                    "Try re-running cargo install with `--locked`".to_string()
+                } else {
+                    String::new()
+                }
+            } else {
+                format!(
+                    "Either upgrade to rustc {} or newer, or use\n\
+                     cargo update -p {}@{} --precise ver\n\
+                     where `ver` is the latest version of `{}` supporting rustc {}",
+                    version,
+                    unit.pkg.name(),
+                    unit.pkg.version(),
+                    unit.pkg.name(),
+                    current_version,
+                )
+            };
+
             anyhow::bail!(
                 "package `{}` cannot be built because it requires rustc {} or newer, \
-                 while the currently active rustc version is {}",
+                 while the currently active rustc version is {}\n{}",
                 unit.pkg,
                 version,
                 current_version,
+                guidance,
             );
         }
     }

--- a/src/cargo/ops/cargo_compile.rs
+++ b/src/cargo/ops/cargo_compile.rs
@@ -667,7 +667,7 @@ pub fn create_bcx<'a, 'cfg>(
                 } else {
                     String::new()
                 }
-            } else {
+            } else if !unit.is_local() {
                 format!(
                     "Either upgrade to rustc {} or newer, or use\n\
                      cargo update -p {}@{} --precise ver\n\
@@ -678,6 +678,8 @@ pub fn create_bcx<'a, 'cfg>(
                     unit.pkg.name(),
                     current_version,
                 )
+            } else {
+                String::new()
             };
 
             anyhow::bail!(

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -124,10 +124,7 @@ fn rust_version_too_high() {
         .with_status(101)
         .with_stderr(
             "error: package `foo v0.0.1 ([..])` cannot be built because it requires \
-             rustc 1.9876.0 or newer, while the currently active rustc version is [..]\n\
-             Either upgrade to rustc 1.9876.0 or newer, or use\n\
-             cargo update -p foo@0.0.1 --precise ver\n\
-             where `ver` is the latest version of `foo` supporting rustc [..]",
+             rustc 1.9876.0 or newer, while the currently active rustc version is [..]\n\n",
         )
         .run();
     p.cargo("build --ignore-rust-version").run();

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -124,7 +124,10 @@ fn rust_version_too_high() {
         .with_status(101)
         .with_stderr(
             "error: package `foo v0.0.1 ([..])` cannot be built because it requires \
-             rustc 1.9876.0 or newer, while the currently active rustc version is [..]",
+             rustc 1.9876.0 or newer, while the currently active rustc version is [..]\n\
+             Either upgrade to rustc 1.9876.0 or newer, or use\n\
+             cargo update -p foo@0.0.1 --precise ver\n\
+             where `ver` is the latest version of `foo` supporting rustc [..]",
         )
         .run();
     p.cargo("build --ignore-rust-version").run();
@@ -159,7 +162,10 @@ fn rust_version_dependency_fails() {
              Downloading crates ...\n  \
              Downloaded bar v0.0.1 (registry `[..]`)\n\
              error: package `bar v0.0.1` cannot be built because it requires \
-             rustc 1.2345.0 or newer, while the currently active rustc version is [..]",
+             rustc 1.2345.0 or newer, while the currently active rustc version is [..]\n\
+             Either upgrade to rustc 1.2345.0 or newer, or use\n\
+             cargo update -p bar@0.0.1 --precise ver\n\
+             where `ver` is the latest version of `bar` supporting rustc [..]",
         )
         .run();
     p.cargo("build --ignore-rust-version").run();


### PR DESCRIPTION
People encountering a dependency with a newer `rust-version` requirement
may not know about `cargo update --precise`, or may consider alternate
approaches that may be harmful (such as pinning with a `=` dependency).

Provide specific guidance in the error message.
