### PR TITLE
Make the empty rustc-wrapper test more explicit.

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -870,7 +870,18 @@ fn check_keep_going() {
 
 #[cargo_test]
 fn does_not_use_empty_rustc_wrapper() {
-    let p = project().file("src/lib.rs", "").build();
+    // An empty RUSTC_WRAPPER environment variable won't be used.
+    // The env var will also override the config, essentially unsetting it.
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [build]
+                rustc-wrapper = "do-not-execute-me"
+            "#,
+        )
+        .build();
     p.cargo("check").env("RUSTC_WRAPPER", "").run();
 }
 


### PR DESCRIPTION
This changes the test for an empty RUSTC_WRAPPER environment variable to make it explicit that it doesn't just ignore the environment variable, but that it also essentially unsets any config-loaded value.  It's not clear if this implication was known at the time it was added in #5985, but I don't think we can change it, and it can be useful.