### PR TITLE
Implement RFC 3289: source replacement ambiguity

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -818,6 +818,17 @@ impl Execs {
         self
     }
 
+    /// Overrides the crates.io URL for testing.
+    ///
+    /// Can be used for testing crates-io functionality where alt registries
+    /// cannot be used.
+    pub fn replace_crates_io(&mut self, url: &Url) -> &mut Self {
+        if let Some(ref mut p) = self.process_builder {
+            p.env("__CARGO_TEST_CRATES_IO_URL_DO_NOT_USE_THIS", url.as_str());
+        }
+        self
+    }
+
     pub fn enable_mac_dsym(&mut self) -> &mut Self {
         if cfg!(target_os = "macos") {
             self.env("CARGO_PROFILE_DEV_SPLIT_DEBUGINFO", "packed")

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -105,7 +105,7 @@ impl RegistryBuilder {
     pub fn new() -> RegistryBuilder {
         RegistryBuilder {
             alternative: None,
-            token: Some("api-token".to_string()),
+            token: None,
             http_api: false,
             http_index: false,
             api: true,
@@ -197,6 +197,7 @@ impl RegistryBuilder {
         let dl_url = generate_url(&format!("{prefix}dl"));
         let dl_path = generate_path(&format!("{prefix}dl"));
         let api_path = generate_path(&format!("{prefix}api"));
+        let token = Some(self.token.unwrap_or_else(|| format!("{prefix}sekrit")));
 
         let (server, index_url, api_url, dl_url) = if !self.http_index && !self.http_api {
             // No need to start the HTTP server.
@@ -205,7 +206,7 @@ impl RegistryBuilder {
             let server = HttpServer::new(
                 registry_path.clone(),
                 dl_path,
-                self.token.clone(),
+                token.clone(),
                 self.custom_responders,
             );
             let index_url = if self.http_index {
@@ -228,7 +229,7 @@ impl RegistryBuilder {
             _server: server,
             dl_url,
             path: registry_path,
-            token: self.token,
+            token,
         };
 
         if self.configure_registry {
@@ -252,8 +253,8 @@ impl RegistryBuilder {
                     [source.crates-io]
                     replace-with = 'dummy-registry'
 
-                    [source.dummy-registry]
-                    registry = '{}'",
+                    [registries.dummy-registry]
+                    index = '{}'",
                         registry.index_url
                     )
                     .as_bytes(),

--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -1,3 +1,4 @@
+use cargo::sources::CRATES_IO_REGISTRY;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 
@@ -207,7 +208,10 @@ fn parse_dependencies(config: &Config, matches: &ArgMatches) -> CargoResult<Vec<
     let rev = matches.get_one::<String>("rev");
     let tag = matches.get_one::<String>("tag");
     let rename = matches.get_one::<String>("rename");
-    let registry = matches.registry(config)?;
+    let registry = match matches.registry(config)? {
+        Some(reg) if reg == CRATES_IO_REGISTRY => None,
+        reg => reg,
+    };
     let default_features = default_features(matches);
     let optional = optional(matches);
 

--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -128,7 +128,7 @@ pub fn add_root_urls(
                     if !sid.is_registry() {
                         return false;
                     }
-                    if sid.is_default_registry() {
+                    if sid.is_crates_io() {
                         return registry == CRATES_IO_REGISTRY;
                     }
                     if let Some(index_url) = name2url.get(registry) {

--- a/src/cargo/core/package_id.rs
+++ b/src/cargo/core/package_id.rs
@@ -211,7 +211,7 @@ impl fmt::Display for PackageId {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{} v{}", self.inner.name, self.inner.version)?;
 
-        if !self.inner.source_id.is_default_registry() {
+        if !self.inner.source_id.is_crates_io() {
             write!(f, " ({})", self.inner.source_id)?;
         }
 

--- a/src/cargo/ops/tree/format/mod.rs
+++ b/src/cargo/ops/tree/format/mod.rs
@@ -84,7 +84,7 @@ impl<'a> fmt::Display for Display<'a> {
                             )?;
 
                             let source_id = package.package_id().source_id();
-                            if !source_id.is_default_registry() {
+                            if !source_id.is_crates_io() {
                                 write!(fmt, " ({})", source_id)?;
                             }
                         }

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -252,13 +252,13 @@ fn sync(
 
     // replace original sources with vendor
     for source_id in sources {
-        let name = if source_id.is_default_registry() {
+        let name = if source_id.is_crates_io() {
             CRATES_IO_REGISTRY.to_string()
         } else {
             source_id.url().to_string()
         };
 
-        let source = if source_id.is_default_registry() {
+        let source = if source_id.is_crates_io() {
             VendorSource::Registry {
                 registry: None,
                 replace_with: merged_source_name.to_string(),

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -402,7 +402,7 @@ impl<'a> RegistryDependency<'a> {
 
         // In index, "registry" is null if it is from the same index.
         // In Cargo.toml, "registry" is None if it is from the default
-        if !id.is_default_registry() {
+        if !id.is_crates_io() {
             dep.set_registry_id(id);
         }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -2,7 +2,6 @@ use crate::core::compiler::{BuildConfig, MessageFormat, TimingOutput};
 use crate::core::resolver::CliFeatures;
 use crate::core::{Edition, Workspace};
 use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
-use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::interning::InternedString;
 use crate::util::restricted_names::is_glob_pattern;
@@ -669,17 +668,7 @@ pub trait ArgMatchesExt {
         match self._value_of("registry") {
             Some(registry) => {
                 validate_package_name(registry, "registry name", "")?;
-
-                if registry == CRATES_IO_REGISTRY {
-                    // If "crates.io" is specified, then we just need to return `None`,
-                    // as that will cause cargo to use crates.io. This is required
-                    // for the case where a default alternative registry is used
-                    // but the user wants to switch back to crates.io for a single
-                    // command.
-                    Ok(None)
-                } else {
-                    Ok(Some(registry.to_string()))
-                }
+                Ok(Some(registry.to_string()))
             }
             None => config.default_registry(),
         }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -933,7 +933,7 @@ local-registry, or git).
 * Default: none
 * Environment: not supported
 
-If set, replace this source with the given named source.
+If set, replace this source with the given named source or named registry.
 
 ##### `source.<name>.directory`
 * Type: string (path)

--- a/src/doc/src/reference/source-replacement.md
+++ b/src/doc/src/reference/source-replacement.md
@@ -26,6 +26,11 @@ dependencies through the usage of [the `[patch]` key][overriding
 dependencies], and private registry support is described in [the Registries
 chapter][registries].
 
+When using source replacement, running commands like `cargo publish` that need to
+contact the registry require passing the `--registry` option. This helps avoid
+any ambiguity about which registry to contact, and will use the authentication
+token for the specified registry.
+
 [overriding dependencies]: overriding-dependencies.md
 [registries]: registries.md
 
@@ -50,6 +55,9 @@ directory = "vendor"
 # The crates.io default source for crates is available under the name
 # "crates-io", and here we use the `replace-with` key to indicate that it's
 # replaced with our source above.
+#
+# The `replace-with` key can also reference an alternative registry name
+# defined in the `[registries]` table.
 [source.crates-io]
 replace-with = "my-vendor-source"
 

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1872,7 +1872,7 @@ fn env_vars_and_build_products_for_various_build_targets() {
 
 #[cargo_test]
 fn publish_artifact_dep() {
-    registry::init();
+    let registry = registry::init();
     Package::new("bar", "1.0.0").publish();
     Package::new("baz", "1.0.0").publish();
 
@@ -1901,7 +1901,8 @@ fn publish_artifact_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("publish -Z bindeps --no-verify --token sekrit")
+    p.cargo("publish -Z bindeps --no-verify")
+        .replace_crates_io(registry.index_url())
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
@@ -1924,7 +1925,6 @@ fn publish_artifact_dep() {
               "kind": "normal",
               "name": "bar",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^1.0"
             },
@@ -1934,7 +1934,6 @@ fn publish_artifact_dep() {
               "kind": "build",
               "name": "baz",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^1.0"
             }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1,6 +1,6 @@
 //! Tests for some invalid .cargo/config files.
 
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project, rustc_host};
 
 #[cargo_test]
@@ -62,6 +62,7 @@ Caused by:
 
 #[cargo_test]
 fn bad3() {
+    let registry = registry::init();
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -75,6 +76,7 @@ fn bad3() {
     Package::new("foo", "1.0.0").publish();
 
     p.cargo("publish -v")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr(
             "\
@@ -113,6 +115,7 @@ Caused by:
 
 #[cargo_test]
 fn bad6() {
+    let registry = registry::init();
     let p = project()
         .file("src/lib.rs", "")
         .file(
@@ -126,6 +129,7 @@ fn bad6() {
     Package::new("foo", "1.0.0").publish();
 
     p.cargo("publish -v")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -610,7 +610,7 @@ fn z_flags_rejected() {
 
 #[cargo_test]
 fn publish_allowed() {
-    registry::init();
+    let registry = registry::init();
 
     let p = project()
         .file(
@@ -626,7 +626,8 @@ fn publish_allowed() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("publish --token sekrit")
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .run();
 }

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -66,7 +66,7 @@ fn publish_with_target() {
         return;
     }
 
-    registry::init();
+    let registry = registry::init();
 
     let p = project()
         .file(
@@ -97,12 +97,13 @@ fn publish_with_target() {
 
     let target = cross_compile::alternate();
 
-    p.cargo("publish --token sekrit")
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
         .arg("--target")
         .arg(&target)
         .with_stderr(
             "\
-[UPDATING] `dummy-registry` index
+[UPDATING] crates.io index
 [PACKAGING] foo v0.0.0 ([CWD])
 [VERIFYING] foo v0.0.0 ([CWD])
 [COMPILING] foo v0.0.0 ([CWD]/target/package/foo-0.0.0)

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -1,7 +1,7 @@
 //! Tests for namespaced features.
 
 use super::features2::switch_to_resolver_2;
-use cargo_test_support::registry::{Dependency, Package};
+use cargo_test_support::registry::{self, Dependency, Package};
 use cargo_test_support::{project, publish};
 
 #[cargo_test]
@@ -858,6 +858,7 @@ bar v1.0.0
 
 #[cargo_test]
 fn publish_no_implicit() {
+    let registry = registry::init();
     // Does not include implicit features or dep: syntax on publish.
     Package::new("opt-dep1", "1.0.0").publish();
     Package::new("opt-dep2", "1.0.0").publish();
@@ -884,7 +885,8 @@ fn publish_no_implicit() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("publish --no-verify --token sekrit")
+    p.cargo("publish --no-verify")
+        .replace_crates_io(registry.index_url())
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -907,7 +909,6 @@ fn publish_no_implicit() {
               "kind": "normal",
               "name": "opt-dep1",
               "optional": true,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^1.0"
             },
@@ -917,7 +918,6 @@ fn publish_no_implicit() {
               "kind": "normal",
               "name": "opt-dep2",
               "optional": true,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^1.0"
             }
@@ -971,6 +971,7 @@ feat = ["opt-dep1"]
 
 #[cargo_test]
 fn publish() {
+    let registry = registry::init();
     // Publish behavior with explicit dep: syntax.
     Package::new("bar", "1.0.0").publish();
     let p = project()
@@ -996,7 +997,8 @@ fn publish() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("publish --token sekrit")
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -1022,7 +1024,6 @@ fn publish() {
               "kind": "normal",
               "name": "bar",
               "optional": true,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^1.0"
             }

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -107,7 +107,7 @@ Caused by:
 
 #[cargo_test]
 fn inherit_own_workspace_fields() {
-    registry::init();
+    let registry = registry::init();
 
     let p = project().build();
 
@@ -160,7 +160,9 @@ fn inherit_own_workspace_fields() {
         .file("bar.txt", "") // should be included when packaging
         .build();
 
-    p.cargo("publish --token sekrit").run();
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .run();
     publish::validate_upload_with_contents(
         r#"
         {
@@ -231,6 +233,7 @@ repository = "https://gitlab.com/rust-lang/rust"
 
 #[cargo_test]
 fn inherit_own_dependencies() {
+    let registry = registry::init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -284,7 +287,9 @@ fn inherit_own_dependencies() {
     assert!(lockfile.contains("dep"));
     assert!(lockfile.contains("dep-dev"));
     assert!(lockfile.contains("dep-build"));
-    p.cargo("publish --token sekrit").run();
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .run();
     publish::validate_upload_with_contents(
         r#"
         {
@@ -298,7 +303,6 @@ fn inherit_own_dependencies() {
               "kind": "normal",
               "name": "dep",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.1"
             },
@@ -308,7 +312,6 @@ fn inherit_own_dependencies() {
               "kind": "dev",
               "name": "dep-dev",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.5.2"
             },
@@ -318,7 +321,6 @@ fn inherit_own_dependencies() {
               "kind": "build",
               "name": "dep-build",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.8"
             }
@@ -366,6 +368,7 @@ version = "0.8"
 
 #[cargo_test]
 fn inherit_own_detailed_dependencies() {
+    let registry = registry::init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -408,7 +411,9 @@ fn inherit_own_detailed_dependencies() {
     p.cargo("check").run();
     let lockfile = p.read_lockfile();
     assert!(lockfile.contains("dep"));
-    p.cargo("publish --token sekrit").run();
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .run();
     publish::validate_upload_with_contents(
         r#"
         {
@@ -422,7 +427,6 @@ fn inherit_own_detailed_dependencies() {
               "kind": "normal",
               "name": "dep",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.1.2"
             }
@@ -560,7 +564,7 @@ fn inherited_dependencies_union_features() {
 
 #[cargo_test]
 fn inherit_workspace_fields() {
-    registry::init();
+    let registry = registry::init();
 
     let p = project().build();
 
@@ -624,7 +628,10 @@ fn inherit_workspace_fields() {
         .file("bar/bar.txt", "") // should be included when packaging
         .build();
 
-    p.cargo("publish --token sekrit").cwd("bar").run();
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .cwd("bar")
+        .run();
     publish::validate_upload_with_contents(
         r#"
         {
@@ -701,6 +708,7 @@ repository = "https://gitlab.com/rust-lang/rust"
 
 #[cargo_test]
 fn inherit_dependencies() {
+    let registry = registry::init();
     let p = project()
         .file(
             "Cargo.toml",
@@ -755,7 +763,10 @@ fn inherit_dependencies() {
     assert!(lockfile.contains("dep"));
     assert!(lockfile.contains("dep-dev"));
     assert!(lockfile.contains("dep-build"));
-    p.cargo("publish --token sekrit").cwd("bar").run();
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .cwd("bar")
+        .run();
     publish::validate_upload_with_contents(
         r#"
         {
@@ -769,7 +780,6 @@ fn inherit_dependencies() {
               "kind": "normal",
               "name": "dep",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.1"
             },
@@ -779,7 +789,6 @@ fn inherit_dependencies() {
               "kind": "dev",
               "name": "dep-dev",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.5.2"
             },
@@ -789,7 +798,6 @@ fn inherit_dependencies() {
               "kind": "build",
               "name": "dep-build",
               "optional": false,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^0.8"
             }

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -93,15 +93,19 @@ fn registry_credentials() {
 
 #[cargo_test]
 fn empty_login_token() {
-    let _registry = RegistryBuilder::new().build();
+    let registry = RegistryBuilder::new()
+        .no_configure_registry()
+        .no_configure_token()
+        .build();
     setup_new_credentials();
 
     cargo_process("login")
+        .replace_crates_io(registry.index_url())
         .with_stdout("please paste the API Token found on [..]/me below")
         .with_stdin("\t\n")
         .with_stderr(
             "\
-[UPDATING] `dummy-registry` index
+[UPDATING] crates.io index
 [ERROR] please provide a non-empty token
 ",
         )
@@ -109,6 +113,7 @@ fn empty_login_token() {
         .run();
 
     cargo_process("login")
+        .replace_crates_io(registry.index_url())
         .arg("")
         .with_stderr(
             "\

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -118,6 +118,7 @@ mod rustdocflags;
 mod rustflags;
 mod search;
 mod shell_quoting;
+mod source_replacement;
 mod standard_lib;
 mod test;
 mod timings;

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -16,7 +16,7 @@ fn setup(name: &str, content: Option<&str>) {
 
 #[cargo_test]
 fn simple_list() {
-    registry::init();
+    let registry = registry::init();
     let content = r#"{
         "users": [
             {
@@ -47,7 +47,8 @@ fn simple_list() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("owner -l --token sekrit")
+    p.cargo("owner -l")
+        .replace_crates_io(registry.index_url())
         .with_stdout(
             "\
 github:rust-lang:core (Core)
@@ -59,7 +60,7 @@ octocat
 
 #[cargo_test]
 fn simple_add() {
-    registry::init();
+    let registry = registry::init();
     setup("foo", None);
 
     let p = project()
@@ -77,10 +78,11 @@ fn simple_add() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("owner -a username --token sekrit")
+    p.cargo("owner -a username")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr(
-            "    Updating `[..]` index
+            "    Updating crates.io index
 error: failed to invite owners to crate `foo` on registry at file://[..]
 
 Caused by:
@@ -91,7 +93,7 @@ Caused by:
 
 #[cargo_test]
 fn simple_remove() {
-    registry::init();
+    let registry = registry::init();
     setup("foo", None);
 
     let p = project()
@@ -109,10 +111,11 @@ fn simple_remove() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("owner -r username --token sekrit")
+    p.cargo("owner -r username")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr(
-            "    Updating `[..]` index
+            "    Updating crates.io index
        Owner removing [\"username\"] from crate foo
 error: failed to remove owners from crate `foo` on registry at file://[..]
 

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -106,6 +106,7 @@ fn not_update() {
     drop(lock);
 
     cargo_process("search postgres")
+        .replace_crates_io(registry.index_url())
         .with_stdout_contains(SEARCH_RESULTS)
         .with_stderr("") // without "Updating ... index"
         .run();
@@ -113,9 +114,10 @@ fn not_update() {
 
 #[cargo_test]
 fn replace_default() {
-    let _server = setup().build();
+    let registry = setup().build();
 
     cargo_process("search postgres")
+        .replace_crates_io(registry.index_url())
         .with_stdout_contains(SEARCH_RESULTS)
         .with_stderr_contains("[..]Updating [..] index")
         .run();
@@ -143,22 +145,25 @@ fn multiple_query_params() {
 
 #[cargo_test]
 fn ignore_quiet() {
-    let _server = setup().build();
+    let registry = setup().build();
 
     cargo_process("search -q postgres")
+        .replace_crates_io(registry.index_url())
         .with_stdout_contains(SEARCH_RESULTS)
         .run();
 }
 
 #[cargo_test]
 fn colored_results() {
-    let _server = setup().build();
+    let registry = setup().build();
 
     cargo_process("search --color=never postgres")
+        .replace_crates_io(registry.index_url())
         .with_stdout_does_not_contain("[..]\x1b[[..]")
         .run();
 
     cargo_process("search --color=always postgres")
+        .replace_crates_io(registry.index_url())
         .with_stdout_contains("[..]\x1b[[..]")
         .run();
 }

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -1,0 +1,243 @@
+//! Tests for `[source]` table (source replacement).
+
+use std::fs;
+
+use cargo_test_support::registry::{Package, RegistryBuilder, TestRegistry};
+use cargo_test_support::{cargo_process, paths, project, t};
+
+fn setup_replacement(config: &str) -> TestRegistry {
+    let crates_io = RegistryBuilder::new()
+        .no_configure_registry()
+        .http_api()
+        .build();
+
+    let root = paths::root();
+    t!(fs::create_dir(&root.join(".cargo")));
+    t!(fs::write(root.join(".cargo/config"), config,));
+    crates_io
+}
+
+#[cargo_test]
+fn crates_io_token_not_sent_to_replacement() {
+    // verifies that the crates.io token is not sent to a replacement registry during publish.
+    let crates_io = setup_replacement(
+        r#"
+        [source.crates-io]
+        replace-with = 'alternative'
+    "#,
+    );
+    let _alternative = RegistryBuilder::new()
+        .alternative()
+        .http_api()
+        .no_configure_token()
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("publish --no-verify --registry crates-io")
+        .replace_crates_io(crates_io.index_url())
+        .with_stderr_contains("[UPDATING] crates.io index")
+        .run();
+}
+
+#[cargo_test]
+fn token_sent_to_correct_registry() {
+    // verifies that the crates.io token is not sent to a replacement registry during yank.
+    let crates_io = setup_replacement(
+        r#"
+        [source.crates-io]
+        replace-with = 'alternative'
+    "#,
+    );
+    let _alternative = RegistryBuilder::new().alternative().http_api().build();
+
+    cargo_process("yank foo@0.0.1 --registry crates-io")
+        .replace_crates_io(crates_io.index_url())
+        .with_stderr(
+            "\
+[UPDATING] crates.io index
+[YANK] foo@0.0.1
+",
+        )
+        .run();
+
+    cargo_process("yank foo@0.0.1 --registry alternative")
+        .replace_crates_io(crates_io.index_url())
+        .with_stderr(
+            "\
+[UPDATING] `alternative` index
+[YANK] foo@0.0.1
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn ambiguous_registry() {
+    // verifies that an error is issued when a source-replacement is configured
+    // and no --registry argument is given.
+    let crates_io = setup_replacement(
+        r#"
+        [source.crates-io]
+        replace-with = 'alternative'
+    "#,
+    );
+    let _alternative = RegistryBuilder::new()
+        .alternative()
+        .http_api()
+        .no_configure_token()
+        .build();
+
+    cargo_process("yank foo@0.0.1")
+        .replace_crates_io(crates_io.index_url())
+        .with_status(101)
+        .with_stderr(
+            "\
+error: crates-io is replaced with remote registry alternative;
+include `--registry alternative` or `--registry crates-io`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn yank_with_default_crates_io() {
+    // verifies that no error is given when registry.default is used.
+    let crates_io = setup_replacement(
+        r#"
+        [source.crates-io]
+        replace-with = 'alternative'
+
+        [registry]
+        default = 'crates-io'
+    "#,
+    );
+    let _alternative = RegistryBuilder::new().alternative().http_api().build();
+
+    cargo_process("yank foo@0.0.1")
+        .replace_crates_io(crates_io.index_url())
+        .with_stderr(
+            "\
+[UPDATING] crates.io index
+[YANK] foo@0.0.1
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn yank_with_default_alternative() {
+    // verifies that no error is given when registry.default is an alt registry.
+    let crates_io = setup_replacement(
+        r#"
+        [source.crates-io]
+        replace-with = 'alternative'
+
+        [registry]
+        default = 'alternative'
+    "#,
+    );
+    let _alternative = RegistryBuilder::new().alternative().http_api().build();
+
+    cargo_process("yank foo@0.0.1")
+        .replace_crates_io(crates_io.index_url())
+        .with_stderr(
+            "\
+[UPDATING] `alternative` index
+[YANK] foo@0.0.1
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn publish_with_replacement() {
+    // verifies that the crates.io token is not sent to a replacement registry during publish.
+    let crates_io = setup_replacement(
+        r#"
+        [source.crates-io]
+        replace-with = 'alternative'
+    "#,
+    );
+    let _alternative = RegistryBuilder::new()
+        .alternative()
+        .http_api()
+        .no_configure_token()
+        .build();
+
+    // Publish bar only to alternative. This tests that the publish verification build
+    // does uses the source replacement.
+    Package::new("bar", "1.0.0").alternative(true).publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+
+                [dependencies]
+                bar = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    // Verifies that the crates.io index is used to find the publishing endpoint
+    // and that the crate is sent to crates.io. The source replacement is only used
+    // for the verification step.
+    p.cargo("publish --registry crates-io")
+        .replace_crates_io(crates_io.index_url())
+        .with_stderr(
+            "[UPDATING] crates.io index
+[WARNING] manifest has no documentation, homepage or repository.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[PACKAGING] foo v0.0.1 ([..])
+[VERIFYING] foo v0.0.1 ([..])
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v1.0.0 (registry `alternative`)
+[COMPILING] bar v1.0.0
+[COMPILING] foo v0.0.1 ([..]foo-0.0.1)
+[FINISHED] dev [..]
+[UPLOADING] foo v0.0.1 ([..])",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn undefined_default() {
+    // verifies that no error is given when registry.default is used.
+    let crates_io = setup_replacement(
+        r#"
+        [registry]
+        default = 'undefined'
+    "#,
+    );
+
+    cargo_process("yank foo@0.0.1")
+        .replace_crates_io(crates_io.index_url())
+        .with_status(101)
+        .with_stderr(
+            "[ERROR] no index found for registry: `undefined`
+",
+        )
+        .run();
+}

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -2,7 +2,7 @@
 
 use super::features2::switch_to_resolver_2;
 use cargo_test_support::paths::CargoPathExt;
-use cargo_test_support::registry::{Dependency, Package};
+use cargo_test_support::registry::{self, Dependency, Package};
 use cargo_test_support::{project, publish};
 use std::fmt::Write;
 
@@ -523,6 +523,7 @@ bar v1.0.0
 
 #[cargo_test]
 fn publish() {
+    let registry = registry::init();
     // Publish behavior with /? syntax.
     Package::new("bar", "1.0.0").feature("feat", &[]).publish();
     let p = project()
@@ -547,7 +548,8 @@ fn publish() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("publish --token sekrit")
+    p.cargo("publish")
+        .replace_crates_io(registry.index_url())
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -573,7 +575,6 @@ fn publish() {
               "kind": "normal",
               "name": "bar",
               "optional": true,
-              "registry": "https://github.com/rust-lang/crates.io-index",
               "target": null,
               "version_req": "^1.0"
             }

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -14,7 +14,7 @@ fn setup(name: &str, version: &str) {
 
 #[cargo_test]
 fn explicit_version() {
-    registry::init();
+    let registry = registry::init();
     setup("foo", "0.0.1");
 
     let p = project()
@@ -32,12 +32,15 @@ fn explicit_version() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank --version 0.0.1 --token sekrit").run();
+    p.cargo("yank --version 0.0.1")
+        .replace_crates_io(registry.index_url())
+        .run();
 
-    p.cargo("yank --undo --version 0.0.1 --token sekrit")
+    p.cargo("yank --undo --version 0.0.1")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr(
-            "    Updating `[..]` index
+            "    Updating crates.io index
       Unyank foo@0.0.1
 error: failed to undo a yank from the registry at file:///[..]
 
@@ -49,7 +52,7 @@ Caused by:
 
 #[cargo_test]
 fn inline_version() {
-    registry::init();
+    let registry = registry::init();
     setup("foo", "0.0.1");
 
     let p = project()
@@ -67,12 +70,15 @@ fn inline_version() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank foo@0.0.1 --token sekrit").run();
+    p.cargo("yank foo@0.0.1")
+        .replace_crates_io(registry.index_url())
+        .run();
 
-    p.cargo("yank --undo foo@0.0.1 --token sekrit")
+    p.cargo("yank --undo foo@0.0.1")
+        .replace_crates_io(registry.index_url())
         .with_status(101)
         .with_stderr(
-            "    Updating `[..]` index
+            "    Updating crates.io index
       Unyank foo@0.0.1
 error: failed to undo a yank from the registry at file:///[..]
 
@@ -84,7 +90,6 @@ Caused by:
 
 #[cargo_test]
 fn version_required() {
-    registry::init();
     setup("foo", "0.0.1");
 
     let p = project()
@@ -102,7 +107,7 @@ fn version_required() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank foo --token sekrit")
+    p.cargo("yank foo")
         .with_status(101)
         .with_stderr("error: `--version` is required")
         .run();
@@ -110,7 +115,6 @@ fn version_required() {
 
 #[cargo_test]
 fn inline_version_without_name() {
-    registry::init();
     setup("foo", "0.0.1");
 
     let p = project()
@@ -128,7 +132,7 @@ fn inline_version_without_name() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank @0.0.1 --token sekrit")
+    p.cargo("yank @0.0.1")
         .with_status(101)
         .with_stderr("error: missing crate name for `@0.0.1`")
         .run();
@@ -136,7 +140,6 @@ fn inline_version_without_name() {
 
 #[cargo_test]
 fn inline_and_explicit_version() {
-    registry::init();
     setup("foo", "0.0.1");
 
     let p = project()
@@ -154,7 +157,7 @@ fn inline_and_explicit_version() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("yank foo@0.0.1 --version 0.0.1 --token sekrit")
+    p.cargo("yank foo@0.0.1 --version 0.0.1")
         .with_status(101)
         .with_stderr("error: cannot specify both `@0.0.1` and `--version`")
         .run();


### PR DESCRIPTION
### Implements [RFC 3289](https://github.com/rust-lang/rfcs/pull/3289)
* When the crates-io source is replaced, the user needs to specify `--registry <NAME>` when running an API operation to disambiguate which registry to use. Otherwise, cargo will issue a new error.
* In source replacement, the `replace-with` key can reference the name of an alt registry in the `[registries]` table.
* Publishing to source-replaced crates.io is no longer permitted using the crates.io token (`registry.token`). We have had a deprecation warning in place since #7973 (1.45.0).

### Testing
* Tests that interacting with crates.io use the new `replace_crates_io` function, which internally sets an environment variable to change the URL of crates.io.

Changes are insta-stable.

cc #10894
r? @Eh2406 