### PR TITLE
Warn when an edition 2021 crate is in a virtual workspace with default resolver

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1006,7 +1006,7 @@ impl<'cfg> Workspace<'cfg> {
                         self.config.shell().warn(
                             format_args!("\
                         some crates are on edition {edition} which defaults to `resolver = \"{resolver}\"`,\n\
-                     \x20   but a virtual workspace defaults to `resolver = \"1\"`\n\
+                     \x20   but virtual workspaces default to `resolver = \"1\"`\n\
                      \x20   specify the desired resolver version explicitly in the workspace root's manifest\
                             ",
                         ))?;

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1010,6 +1010,10 @@ impl<'cfg> Workspace<'cfg> {
                      \x20   specify the desired resolver version explicitly in the workspace root's manifest\
                             ",
                         ))?;
+                        self.config.shell().note(
+                            "to keep the current resolver, specify `workspace.resolver = \"1\"`",
+                        )?;
+                        self.config.shell().note(format_args!("to use the edition {edition} resolver, specify `workspace.resolver = \"{resolver}\"`"))?;
                     }
                 }
             }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1003,17 +1003,11 @@ impl<'cfg> Workspace<'cfg> {
                         .max()
                     {
                         let resolver = edition.default_resolve_behavior().to_manifest();
-                        self.config.shell().warn(
-                            format_args!("\
-                        some crates are on edition {edition} which defaults to `resolver = \"{resolver}\"`,\n\
-                     \x20   but virtual workspaces default to `resolver = \"1\"`\n\
-                     \x20   specify the desired resolver version explicitly in the workspace root's manifest\
-                            ",
-                        ))?;
+                        self.config.shell().warn(format_args!("some crates are on edition {edition} which defaults to `resolver = \"{resolver}\"`, but virtual workspaces default to `resolver = \"1\"`"))?;
                         self.config.shell().note(
-                            "to keep the current resolver, specify `workspace.resolver = \"1\"`",
+                            "to keep the current resolver, specify `workspace.resolver = \"1\"` in the workspace root's manifest",
                         )?;
-                        self.config.shell().note(format_args!("to use the edition {edition} resolver, specify `workspace.resolver = \"{resolver}\"`"))?;
+                        self.config.shell().note(format_args!("to use the edition {edition} resolver, specify `workspace.resolver = \"{resolver}\"` in the workspace root's manifest"))?;
                     }
                 }
             }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1007,7 +1007,7 @@ impl<'cfg> Workspace<'cfg> {
                             format_args!("\
                         some crates are on edition {edition} which defaults to `resolver = \"{resolver}\"`,\n\
                      \x20   but a virtual workspace defaults to `resolver = \"1\"`\n\
-                     \x20   specify the desired resolver version explicitly at the workspace root\
+                     \x20   specify the desired resolver version explicitly in the workspace root's manifest\
                             ",
                         ))?;
                     }

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/in/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/in/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["crates/*"]
 
 [workspace.lints.rust]

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = ["crates/*"]
 
 [workspace.lints.rust]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table.in/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table.in/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "crates/*",
 ]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/out/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/out/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "crates/*",
 ]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "crates/*",
 ]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "crates/*",
 ]

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1431,11 +1431,9 @@ fn edition_2021_workspace_member() {
     p.cargo("check")
         .with_stderr(
             "\
-warning: some crates are on edition 2021 which defaults to `resolver = \"2\"`,
-    but virtual workspaces default to `resolver = \"1\"`
-    specify the desired resolver version explicitly in the workspace root's manifest
-note: to keep the current resolver, specify `workspace.resolver = \"1\"`
-note: to use the edition 2021 resolver, specify `workspace.resolver = \"2\"`
+warning: some crates are on edition 2021 which defaults to `resolver = \"2\"`, but virtual workspaces default to `resolver = \"1\"`
+note: to keep the current resolver, specify `workspace.resolver = \"1\"` in the workspace root's manifest
+note: to use the edition 2021 resolver, specify `workspace.resolver = \"2\"` in the workspace root's manifest
 [CHECKING] a v0.1.0 [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1434,6 +1434,8 @@ fn edition_2021_workspace_member() {
 warning: some crates are on edition 2021 which defaults to `resolver = \"2\"`,
     but virtual workspaces default to `resolver = \"1\"`
     specify the desired resolver version explicitly in the workspace root's manifest
+note: to keep the current resolver, specify `workspace.resolver = \"1\"`
+note: to use the edition 2021 resolver, specify `workspace.resolver = \"2\"`
 [CHECKING] a v0.1.0 [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1433,7 +1433,7 @@ fn edition_2021_workspace_member() {
             "\
 warning: some crates are on edition 2021 which defaults to `resolver = \"2\"`,
     but a virtual workspace defaults to `resolver = \"1\"`
-    specify the desired resolver version explicitly at the workspace root
+    specify the desired resolver version explicitly in the workspace root's manifest
 [CHECKING] a v0.1.0 [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1432,7 +1432,7 @@ fn edition_2021_workspace_member() {
         .with_stderr(
             "\
 warning: some crates are on edition 2021 which defaults to `resolver = \"2\"`,
-    but a virtual workspace defaults to `resolver = \"1\"`
+    but virtual workspaces default to `resolver = \"1\"`
     specify the desired resolver version explicitly in the workspace root's manifest
 [CHECKING] a v0.1.0 [..]
 [FINISHED] [..]

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1407,6 +1407,41 @@ workspace: [..]/foo/Cargo.toml
 }
 
 #[cargo_test]
+fn edition_2021_workspace_member() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [workspace]
+            members = ["a"]
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+            [package]
+            name = "a"
+            version = "0.1.0"
+            edition = "2021"
+            "#,
+        )
+        .file("a/src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_stderr(
+            "\
+warning: some crates are on edition 2021 which defaults to `resolver = \"2\"`,
+    but a virtual workspace defaults to `resolver = \"1\"`
+    specify the desired resolver version explicitly at the workspace root
+[CHECKING] a v0.1.0 [..]
+[FINISHED] [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn resolver_ws_root_and_member() {
     // Check when specified in both ws root and member.
     let p = project()


### PR DESCRIPTION
Edition 2021 updates the default resolver to version "2", but developers using virtual workspaces commonly don't get this update because the virtual workspace defaults to version "1". Warn when this situation occurs so those developers can explicitly configure their workspace and will be more likely to know that they will need to update it in the future.

Fixes #10112 