### PR TITLE
Override to resolver=1 in published package

### DIFF
--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -119,11 +119,12 @@ impl ResolveBehavior {
         }
     }
 
-    pub fn to_manifest(&self) -> Option<String> {
+    pub fn to_manifest(&self) -> String {
         match self {
-            ResolveBehavior::V1 => None,
-            ResolveBehavior::V2 => Some("2".to_string()),
+            ResolveBehavior::V1 => "1",
+            ResolveBehavior::V2 => "2",
         }
+        .to_owned()
     }
 }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1342,7 +1342,7 @@ impl TomlManifest {
             .unwrap()
             .clone();
         package.workspace = None;
-        package.resolver = ws.resolve_behavior().to_manifest();
+        package.resolver = Some(ws.resolve_behavior().to_manifest());
         if let Some(license_file) = &package.license_file {
             let license_file = license_file
                 .as_defined()

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -951,6 +951,7 @@ version = "0.1.0"
 description = "foo"
 homepage = "https://example.com/"
 license = "MIT"
+resolver = "1"
 
 [dependencies.opt-dep1]
 version = "1.0"
@@ -1058,6 +1059,7 @@ version = "0.1.0"
 description = "foo"
 homepage = "https://example.com/"
 license = "MIT"
+resolver = "1"
 
 [dependencies.bar]
 version = "1.0"

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -218,6 +218,7 @@ keywords = ["cli"]
 categories = ["development-tools"]
 license = "MIT"
 repository = "https://github.com/example/example"
+resolver = "1"
 
 [badges.gitlab]
 branch = "master"
@@ -348,6 +349,7 @@ fn inherit_own_dependencies() {
 name = "bar"
 version = "0.2.0"
 authors = []
+resolver = "1"
 
 [dependencies.dep]
 version = "0.1"
@@ -452,6 +454,7 @@ fn inherit_own_detailed_dependencies() {
 name = "bar"
 version = "0.2.0"
 authors = []
+resolver = "1"
 
 [dependencies.dep]
 version = "0.1.2"
@@ -688,6 +691,7 @@ categories = ["development-tools"]
 license = "MIT"
 license-file = "LICENSE"
 repository = "https://github.com/example/example"
+resolver = "1"
 
 [badges.gitlab]
 branch = "master"
@@ -819,6 +823,7 @@ fn inherit_dependencies() {
 name = "bar"
 version = "0.2.0"
 authors = []
+resolver = "1"
 
 [dependencies.dep]
 version = "0.1"

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1178,6 +1178,7 @@ fn publish_git_with_version() {
                      authors = []\n\
                      description = \"foo\"\n\
                      license = \"MIT\"\n\
+                     resolver = \"1\"\n\
                      \n\
                      [dependencies.dep1]\n\
                      version = \"1.0\"\n\
@@ -1284,6 +1285,7 @@ homepage = "foo"
 documentation = "foo"
 license = "MIT"
 repository = "foo"
+resolver = "1"
 
 [dev-dependencies]
 "#,

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -608,6 +608,7 @@ version = "0.1.0"
 description = "foo"
 homepage = "https://example.com/"
 license = "MIT"
+resolver = "1"
 
 [dependencies.bar]
 version = "1.0"


### PR DESCRIPTION
As discussed in #10112 this avoids inconsistent dependency resolution in development and packaged builds when an edition 2021 crate is published from a workspace using the default resolver=1.