### PR TITLE
Disable scrape_examples_complex_reverse_dependencies

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2420,7 +2420,12 @@ fn scrape_examples_avoid_build_script_cycle() {
         .run();
 }
 
-#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
+// FIXME: This test is broken with latest nightly 2022-08-02.
+// The example is calling a function from a proc-macro, but proc-macros don't
+// export functions. It is not clear what this test is trying to exercise.
+// #[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
+#[ignore]
+#[cargo_test]
 fn scrape_examples_complex_reverse_dependencies() {
     let p = project()
         .file(


### PR DESCRIPTION
The test `scrape_examples_complex_reverse_dependencies` no longer works on the latest nightly. It fails with the error:

```
error[E0433]: failed to resolve: could not resolve path `a::f`
 --> examples/ex.rs:1:13
  |
1 | fn main() { a::f(); }
  |             ^^^^ could not resolve path `a::f`
  |
  = note: this error was originally ignored because you are running `rustdoc`
  = note: try running again with `rustc` or `cargo check` and you may get a more detailed error

error: Compilation failed, aborting rustdoc

For more information about this error, try `rustc --explain E0433`.
error: could not document `foo`
```

It is not clear to me what this test was trying to exercise, so I'm not sure how to fix it.  It has an example that is trying to call a function from a proc-macro, but proc-macros do not export functions.

Disabling for now to get CI passing.

cc @willcrichton 
