### PR TITLE
Fix: Team name is't lowercased when removing owner

### DIFF
--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -43,7 +43,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             .map(|xs| xs.cloned().collect()),
         to_remove: args
             .get_many::<String>("remove")
-            .map(|xs| xs.cloned().collect()),
+            .map(|xs| xs.cloned().map(|s| s.to_lowercase()).collect()),
         list: args.flag("list"),
         registry,
     };


### PR DESCRIPTION
Fixes https://github.com/rust-lang/crates.io/issues/4281