### PR TITLE
Add reasons to all ignored tests.

### DIFF
--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -5,7 +5,7 @@ use cargo_test_support::{paths, project, registry::Package};
 #[cargo_test]
 // I don't know why, but `Command` forces all env keys to be upper case on
 // Windows. Seems questionable, since I think Windows is case-preserving.
-#[cfg_attr(windows, ignore)]
+#[cfg_attr(windows, ignore = "broken due to not preserving case on Windows")]
 fn source_config_env() {
     // Try to define [source] with environment variables.
     let p = project()

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1331,7 +1331,8 @@ fn build_script_deps_adopts_target_platform_if_target_equals_target() {
 }
 
 #[cargo_test]
-#[cfg_attr(target_env = "msvc", ignore)] // TODO(ST): rename bar (dependency) to something else and un-ignore this with RFC-3176
+// TODO(ST): rename bar (dependency) to something else and un-ignore this with RFC-3176
+#[cfg_attr(target_env = "msvc", ignore = "msvc not working")]
 fn profile_override_basic() {
     let p = project()
         .file(
@@ -1450,7 +1451,7 @@ foo v0.0.0 ([CWD])
 //       For reference, see comments by ehuss https://github.com/rust-lang/cargo/pull/9992#discussion_r801086315 and
 //       joshtriplett https://github.com/rust-lang/cargo/pull/9992#issuecomment-1033394197 .
 #[cargo_test]
-#[ignore]
+#[ignore = "broken, need artifact info in index"]
 fn targets_are_picked_up_from_non_workspace_artifact_deps() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -4236,8 +4236,10 @@ fn rename_with_link_search_path() {
 }
 
 #[cargo_test]
-// Don't have a cdylib cross target on macos.
-#[cfg_attr(target_os = "macos", ignore)]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "don't have a cdylib cross target on macos"
+)]
 fn rename_with_link_search_path_cross() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -91,9 +91,11 @@ This may become a hard error in the future; see <https://github.com/rust-lang/ca
 }
 
 #[cargo_test]
-// --out-dir and examples are currently broken on MSVC and apple.
 // See https://github.com/rust-lang/cargo/issues/7493
-#[cfg_attr(any(target_env = "msvc", target_vendor = "apple"), ignore)]
+#[cfg_attr(
+    any(target_env = "msvc", target_vendor = "apple"),
+    ignore = "--out-dir and examples are currently broken on MSVC and apple"
+)]
 fn collision_export() {
     // `--out-dir` combines some things which can cause conflicts.
     let p = project()

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -1206,8 +1206,10 @@ fn platform_specific_variables_reflected_in_build_scripts() {
 }
 
 #[cargo_test]
-// Don't have a dylib cross target on macos.
-#[cfg_attr(target_os = "macos", ignore)]
+#[cfg_attr(
+    target_os = "macos",
+    ignore = "don't have a dylib cross target on macos"
+)]
 fn cross_test_dylib() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2424,7 +2424,7 @@ fn scrape_examples_avoid_build_script_cycle() {
 // The example is calling a function from a proc-macro, but proc-macros don't
 // export functions. It is not clear what this test is trying to exercise.
 // #[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
-#[ignore]
+#[ignore = "broken, needs fixing"]
 #[cargo_test]
 fn scrape_examples_complex_reverse_dependencies() {
     let p = project()

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -110,7 +110,7 @@ fn default_toolchain_is_stable() -> bool {
 //   The optional dependency `new-baz-dep` should not be activated.
 // * `bar` 1.0.2 has a dependency on `baz` that *requires* the new feature
 //   syntax.
-#[ignore]
+#[ignore = "must be run manually, requires old cargo installations"]
 #[cargo_test]
 fn new_features() {
     let registry = registry::init();
@@ -534,7 +534,7 @@ fn new_features() {
 }
 
 #[cargo_test]
-#[ignore]
+#[ignore = "must be run manually, requires old cargo installations"]
 fn index_cache_rebuild() {
     // Checks that the index cache gets rebuilt.
     //
@@ -618,7 +618,7 @@ foo v0.1.0 [..]
 }
 
 #[cargo_test]
-#[ignore]
+#[ignore = "must be run manually, requires old cargo installations"]
 fn avoids_split_debuginfo_collision() {
     // Test needs two different toolchains.
     // If the default toolchain is stable, then it won't work.

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -94,7 +94,10 @@ Caused by:
 }
 
 #[cargo_test]
-#[ignore] // dir-name is currently disabled
+// We are currently uncertain if dir-name will ever be exposed to the user.
+// The code for it still roughly exists, but only for the internal profiles.
+// This test was kept in case we ever want to enable support for it again.
+#[ignore = "dir-name is disabled"]
 fn invalid_dir_name() {
     let p = project()
         .file(

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -55,8 +55,7 @@ fn simple() {
     assert!(myfun.contains(r#"href="https://docs.rs/bar/1.0.0/bar/struct.Straw.html""#));
 }
 
-// Broken, temporarily disable until https://github.com/rust-lang/rust/pull/82776 is resolved.
-#[ignore]
+#[ignore = "Broken, temporarily disabled until https://github.com/rust-lang/rust/pull/82776 is resolved."]
 #[cargo_test]
 // #[cargo_test(nightly, reason = "--extern-html-root-url is unstable")]
 fn std_docs() {


### PR DESCRIPTION
This adds a reason string to all `#[ignore]` attributes. This will be displayed when running the test (since 1.61), which can help quickly see and identify why tests are being ignored. It looks roughly like:

```
test basic ... ignored, requires nightly, CARGO_RUN_BUILD_STD_TESTS must be set
test build::simple_terminal_width ... ignored, --diagnostic-width is stabilized in 1.64
test check_cfg::features_with_cargo_check ... ignored, --check-cfg is unstable
test plugins::panic_abort_plugins ... ignored, requires rustc_private
```
