### PR TITLE
Enable two windows tests

### DIFF
--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -351,9 +351,7 @@ fn same_project() {
 
 // Make sure that if Cargo dies while holding a lock that it's released and the
 // next Cargo to come in will take over cleanly.
-// older win versions don't support job objects, so skip test there
 #[cargo_test]
-#[cfg_attr(target_os = "windows", ignore)]
 fn killing_cargo_releases_the_lock() {
     let p = project()
         .file(

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -16,7 +16,6 @@ fn simple() {
 }
 
 #[cargo_test]
-#[cfg_attr(target_os = "windows", ignore)]
 fn version_works_without_rustc() {
     let p = project().build();
     p.cargo("version").env("PATH", "").run();


### PR DESCRIPTION
These two tests were disabled on Windows a long time ago. AFAICT, the reasons are no longer relevant, and it should be safe to enable these tests. See each commit for a more detailed exposition.