### PR TITLE
Always allow hg to be missing on CI.

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -156,10 +156,10 @@ fn has_command(command: &str) -> bool {
     let output = match Command::new(command).arg("--version").output() {
         Ok(output) => output,
         Err(e) => {
-            // hg is not installed on GitHub macos.
-            // Consider installing it if Cargo gains more hg support, but
-            // otherwise it isn't critical.
-            if is_ci() && !(cfg!(target_os = "macos") && command == "hg") {
+            // hg is not installed on GitHub macOS or certain constrained
+            // environments like Docker. Consider installing it if Cargo gains
+            // more hg support, but otherwise it isn't critical.
+            if is_ci() && command != "hg" {
                 panic!(
                     "expected command `{}` to be somewhere in PATH: {}",
                     command, e


### PR DESCRIPTION
`hg` isn't installed on rust-lang/rust Docker images, which causes this check to fail.

Rather than trying to carefully enforce the requirements for `hg` being tested, this just ignores the test if it is unavailable on CI. I think this is something that can be revisited if Cargo ever gains more hg support.
