### PR TITLE
Grammar fixup unused patch message

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -796,7 +796,7 @@ fn emit_warnings_of_unused_patches(
                 writeln!(msg, "Patch `{}` {}", unused, MESSAGE)?;
                 write!(
                     msg,
-                    "Perhaps you misspell the source URL being patched.\n\
+                    "Perhaps you misspelled the source URL being patched.\n\
                     Possible URLs for `[patch.<URL>]`:",
                 )?;
                 for id in ids.iter() {

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -431,7 +431,7 @@ fn unused_with_mismatch_source_being_patched() {
             "\
 [UPDATING] `dummy-registry` index
 [WARNING] Patch `bar v0.2.0 ([CWD]/bar)` was not used in the crate graph.
-Perhaps you misspell the source URL being patched.
+Perhaps you misspelled the source URL being patched.
 Possible URLs for `[patch.<URL>]`:
     crates-io
 [WARNING] Patch `bar v0.3.0 ([CWD]/baz)` was not used in the crate graph.
@@ -1769,7 +1769,7 @@ fn two_semver_compatible() {
         .with_stderr(
             "\
 warning: Patch `bar v0.1.1 [..]` was not used in the crate graph.
-Perhaps you misspell the source URL being patched.
+Perhaps you misspelled the source URL being patched.
 Possible URLs for `[patch.<URL>]`:
     [CWD]/bar
 [FINISHED] [..]",
@@ -1823,7 +1823,7 @@ fn multipatch_select_big() {
         .with_stderr(
             "\
 warning: Patch `bar v0.1.0 [..]` was not used in the crate graph.
-Perhaps you misspell the source URL being patched.
+Perhaps you misspelled the source URL being patched.
 Possible URLs for `[patch.<URL>]`:
     [CWD]/bar
 [FINISHED] [..]",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

This is a minor grammar fixup to to message printed when patch source URLs mismatch (introduced in #10130).