### PR TITLE
Mention that aliases are recursive

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -59,6 +59,7 @@ c = "check"
 t = "test"
 r = "run"
 rr = "run --release"
+recursive_example = "rr --example recursions"
 space_example = ["run", "--release", "--", "\"command list\""]
 
 [build]
@@ -334,6 +335,14 @@ r = "run"
 ```
 
 Aliases are not allowed to redefine existing built-in commands.
+
+Aliases are recursive:
+
+```toml
+[alias]
+rr = "run --release"
+recursive_example = "rr --example recursions"
+```
 
 #### `[build]`
 


### PR DESCRIPTION
Instead of duplicating portions of commands that are used identically across many aliases, the user can instead reuse any previously defined aliases.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

Today I started working with [`xtask`](https://github.com/matklad/cargo-xtask/), which is a build system based on a simple cargo alias:

```toml
[alias]
xtask = "run --package xtask --"
```

Since the word "xtask" is rather difficult to type in my opinion (at least my left hand struggles quite a bit) I wanted to add another alias, `x` as a shorthand (similar to what `build`, `run`, etc. have by default). Thereby I discovered that I needn't replicate the whole alias, because aliases are recursive. I consulted the docs and couldn't find a mention of this, hence I'm adding it as part of this PR so other users can discover it.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

I don't think this requires a separate test, it's a minor change to the documentation only.

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

### What does this PR try to resolve?

Today I started working with [`xtask`](https://github.com/matklad/cargo-xtask/), which is a build system based on a simple cargo alias:

```toml
[alias]
xtask = "run --package xtask --"
```

Since the word "xtask" is rather difficult to type in my opinion (at least my left hand struggles quite a bit) I wanted to add another alias, `x` as a shorthand (similar to what `build`, `run`, etc. have by default). Thereby I discovered that I needn't replicate the whole alias, because aliases are recursive. I consulted the docs and couldn't find a mention of this, hence I'm adding it as part of this PR so other users can discover it.


### How should we test and review this PR?

I don't think this requires a separate test, it's a minor change to the documentation only.


### Additional information