### PR TITLE
Improve error message for an array value in the manifest

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1041,11 +1041,11 @@ impl<T> MaybeWorkspace<T> {
     }
 }
 
-fn workspace_vec_string<'de, D>(
+fn maybe_workspace_vec_string<'de, D>(
     deserializer: D,
 ) -> Result<Option<MaybeWorkspace<Vec<String>>>, D::Error>
-    where
-        D: de::Deserializer<'de>,
+where
+    D: de::Deserializer<'de>,
 {
     struct Visitor;
 
@@ -1053,12 +1053,12 @@ fn workspace_vec_string<'de, D>(
         type Value = Option<MaybeWorkspace<Vec<String>>>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-            formatter.write_str("an array")
+            formatter.write_str("vector of strings")
         }
 
         fn visit_seq<V>(self, v: V) -> Result<Self::Value, V::Error>
-            where
-                V: de::SeqAccess<'de>,
+        where
+            V: de::SeqAccess<'de>,
         {
             let seq = de::value::SeqAccessDeserializer::new(v);
             let defined = Vec::<String>::deserialize(seq).map(MaybeWorkspace::Defined)?;
@@ -1066,8 +1066,8 @@ fn workspace_vec_string<'de, D>(
         }
 
         fn visit_map<V>(self, map: V) -> Result<Self::Value, V::Error>
-            where
-                V: de::MapAccess<'de>,
+        where
+            V: de::MapAccess<'de>,
         {
             let mvd = de::value::MapAccessDeserializer::new(map);
             let workspace = TomlWorkspaceField::deserialize(mvd).map(MaybeWorkspace::Workspace)?;
@@ -1098,7 +1098,7 @@ pub struct TomlProject {
     #[serde(deserialize_with = "version_trim_whitespace")]
     version: MaybeWorkspace<semver::Version>,
     #[serde(default)]
-    #[serde(deserialize_with = "workspace_vec_string")]
+    #[serde(deserialize_with = "maybe_workspace_vec_string")]
     authors: Option<MaybeWorkspace<Vec<String>>>,
     build: Option<StringOrBool>,
     metabuild: Option<StringOrVec>,
@@ -1108,10 +1108,10 @@ pub struct TomlProject {
     forced_target: Option<String>,
     links: Option<String>,
     #[serde(default)]
-    #[serde(deserialize_with = "workspace_vec_string")]
+    #[serde(deserialize_with = "maybe_workspace_vec_string")]
     exclude: Option<MaybeWorkspace<Vec<String>>>,
     #[serde(default)]
-    #[serde(deserialize_with = "workspace_vec_string")]
+    #[serde(deserialize_with = "maybe_workspace_vec_string")]
     include: Option<MaybeWorkspace<Vec<String>>>,
     publish: Option<MaybeWorkspace<VecStringOrBool>>,
     workspace: Option<String>,
@@ -1128,10 +1128,10 @@ pub struct TomlProject {
     documentation: Option<MaybeWorkspace<String>>,
     readme: Option<MaybeWorkspace<StringOrBool>>,
     #[serde(default)]
-    #[serde(deserialize_with = "workspace_vec_string")]
+    #[serde(deserialize_with = "maybe_workspace_vec_string")]
     keywords: Option<MaybeWorkspace<Vec<String>>>,
     #[serde(default)]
-    #[serde(deserialize_with = "workspace_vec_string")]
+    #[serde(deserialize_with = "maybe_workspace_vec_string")]
     categories: Option<MaybeWorkspace<Vec<String>>>,
     license: Option<MaybeWorkspace<String>>,
     license_file: Option<MaybeWorkspace<String>>,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1041,6 +1041,43 @@ impl<T> MaybeWorkspace<T> {
     }
 }
 
+fn workspace_vec_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<MaybeWorkspace<Vec<String>>>, D::Error>
+    where
+        D: de::Deserializer<'de>,
+{
+    struct Visitor;
+
+    impl<'de> de::Visitor<'de> for Visitor {
+        type Value = Option<MaybeWorkspace<Vec<String>>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("an array")
+        }
+
+        fn visit_seq<V>(self, v: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::SeqAccess<'de>,
+        {
+            let seq = de::value::SeqAccessDeserializer::new(v);
+            let defined = Vec::<String>::deserialize(seq).map(MaybeWorkspace::Defined)?;
+            Ok(Some(defined))
+        }
+
+        fn visit_map<V>(self, map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+        {
+            let mvd = de::value::MapAccessDeserializer::new(map);
+            let workspace = TomlWorkspaceField::deserialize(mvd).map(MaybeWorkspace::Workspace)?;
+            Ok(Some(workspace))
+        }
+    }
+
+    deserializer.deserialize_any(Visitor)
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct TomlWorkspaceField {
     workspace: bool,
@@ -1060,6 +1097,8 @@ pub struct TomlProject {
     name: InternedString,
     #[serde(deserialize_with = "version_trim_whitespace")]
     version: MaybeWorkspace<semver::Version>,
+    #[serde(default)]
+    #[serde(deserialize_with = "workspace_vec_string")]
     authors: Option<MaybeWorkspace<Vec<String>>>,
     build: Option<StringOrBool>,
     metabuild: Option<StringOrVec>,
@@ -1068,7 +1107,11 @@ pub struct TomlProject {
     #[serde(rename = "forced-target")]
     forced_target: Option<String>,
     links: Option<String>,
+    #[serde(default)]
+    #[serde(deserialize_with = "workspace_vec_string")]
     exclude: Option<MaybeWorkspace<Vec<String>>>,
+    #[serde(default)]
+    #[serde(deserialize_with = "workspace_vec_string")]
     include: Option<MaybeWorkspace<Vec<String>>>,
     publish: Option<MaybeWorkspace<VecStringOrBool>>,
     workspace: Option<String>,
@@ -1084,7 +1127,11 @@ pub struct TomlProject {
     homepage: Option<MaybeWorkspace<String>>,
     documentation: Option<MaybeWorkspace<String>>,
     readme: Option<MaybeWorkspace<StringOrBool>>,
+    #[serde(default)]
+    #[serde(deserialize_with = "workspace_vec_string")]
     keywords: Option<MaybeWorkspace<Vec<String>>>,
+    #[serde(default)]
+    #[serde(deserialize_with = "workspace_vec_string")]
     categories: Option<MaybeWorkspace<Vec<String>>>,
     license: Option<MaybeWorkspace<String>>,
     license_file: Option<MaybeWorkspace<String>>,

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1706,6 +1706,30 @@ Caused by:
         .run();
 }
 
+#[cargo_test]
+fn cargo_metadata_with_invalid_authors_field() {
+    let p = project()
+        .file("src/foo.rs", "")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                authors = ""
+            "#,
+        )
+        .build();
+
+    p.cargo("metadata")
+        .with_status(101)
+        .with_stderr(
+            r#"[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  invalid type: string "", expected vector of strings for key `package.authors`"#,
+        )
+        .run();
+}
+
 const MANIFEST_OUTPUT: &str = r#"
 {
     "packages": [{


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/10942

The error message will be:

```
error: failed to parse manifest at `/Users/..`

Caused by:
  invalid type: string "Ky", expected an array for key `package.authors`
```