### PR TITLE
resolver docs: link to version requirements syntax full explanation

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -37,7 +37,8 @@ with leading zeros. For example, `0.1.0` and `0.1.2` are compatible, but
 `0.1.0` and `0.2.0` are not. Similarly, `0.0.1` and `0.0.2` are not
 compatible.
 
-As a quick refresher, the *version requirement* syntax Cargo uses for
+As a quick refresher, the
+[*version requirement* syntax][Specifying Dependencies] Cargo uses for
 dependencies is:
 
 Requirement | Example | Equivalence | Description


### PR DESCRIPTION
Staring at https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility, I was confused was this is a "refresher" for. Let's add a link to the main documentation this summarizes.