### PR TITLE
[Not ready for review] Dedup cli args

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -52,7 +52,7 @@
 use std::borrow::Cow;
 use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::env;
 use std::ffi::OsStr;
 use std::fmt;
@@ -1166,7 +1166,9 @@ impl Config {
         let cli_args = match &self.cli_config {
             Some(cli_args) => cli_args,
             None => return Ok(loaded_args),
-        };
+        }
+        .iter()
+        .collect::<BTreeSet<&String>>();
         let mut seen = HashSet::new();
         for arg in cli_args {
             let arg_as_path = self.cwd.join(arg);


### PR DESCRIPTION

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/10893

### How should we test and review this PR?

 I've tried to add a test for it, but the cargo test framework does not support passing the shell style arg into cmd.

```rust
#[cargo_test]
fn custom_runner_with_cli_cfg() {
    let p = project()
        .file("src/main.rs", "fn main() {}")
        .build();

    p.cargo("run --config \"target.'cfg(all())'.runner=['run']\" --config \"target.'cfg(all())'.runner=['run'] -- --param\"")
        .with_status(101)
        .with_stderr_contains(
            "\
[COMPILING] foo v0.0.1 ([CWD])
[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
[RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
",
        )
        .run();
}
```

So I use the case in issue to test it manually.

