### PR TITLE
Add '-C' flag for changing current dir before build

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -28,6 +28,8 @@ pub fn main(config: &mut LazyConfig) -> CliResult {
     let args = cli().try_get_matches()?;
 
     // Update the process-level notion of cwd
+    // This must be completed before config is initialized
+    assert_eq!(config.is_init(), false);
     if let Some(new_cwd) = args.get_one::<std::path::PathBuf>("directory") {
         std::env::set_current_dir(&new_cwd).context("could not change to requested directory")?;
     }
@@ -508,6 +510,13 @@ pub struct LazyConfig {
 impl LazyConfig {
     pub fn new() -> Self {
         Self { config: None }
+    }
+
+    /// Check whether the config is loaded
+    ///
+    /// This is useful for asserts in case the environment needs to be setup before loading
+    pub fn is_init(&self) -> bool {
+        self.config.is_some()
     }
 
     /// Get the config, loading it if needed

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -185,6 +185,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -363,6 +363,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -312,6 +312,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -297,6 +297,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -127,6 +127,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -268,6 +268,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -112,6 +112,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -370,6 +370,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -87,6 +87,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-init.txt
+++ b/src/doc/man/generated_txt/cargo-init.txt
@@ -95,6 +95,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -334,6 +334,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-locate-project.txt
+++ b/src/doc/man/generated_txt/cargo-locate-project.txt
@@ -77,6 +77,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-login.txt
+++ b/src/doc/man/generated_txt/cargo-login.txt
@@ -70,6 +70,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -400,6 +400,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-new.txt
+++ b/src/doc/man/generated_txt/cargo-new.txt
@@ -90,6 +90,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-owner.txt
+++ b/src/doc/man/generated_txt/cargo-owner.txt
@@ -97,6 +97,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -238,6 +238,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -117,6 +117,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -205,6 +205,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-remove.txt
+++ b/src/doc/man/generated_txt/cargo-remove.txt
@@ -103,6 +103,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -212,6 +212,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -314,6 +314,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -284,6 +284,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-search.txt
+++ b/src/doc/man/generated_txt/cargo-search.txt
@@ -67,6 +67,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -381,6 +381,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -298,6 +298,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-uninstall.txt
+++ b/src/doc/man/generated_txt/cargo-uninstall.txt
@@ -79,6 +79,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -117,6 +117,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -113,6 +113,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-verify-project.txt
+++ b/src/doc/man/generated_txt/cargo-verify-project.txt
@@ -90,6 +90,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -93,6 +93,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/generated_txt/cargo.txt
+++ b/src/doc/man/generated_txt/cargo.txt
@@ -196,6 +196,12 @@ OPTIONS
            <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
            for more information.
 
+       -C PATH
+           Changes the current working directory before executing any specified
+           operations. This affects things like where cargo looks by default
+           for the project manifest (Cargo.toml), as well as the directories
+           searched for discovering .cargo/config.toml, for example.
+
        -h, --help
            Prints help information.
 

--- a/src/doc/man/includes/section-options-common.md
+++ b/src/doc/man/includes/section-options-common.md
@@ -16,6 +16,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the [command-line overrides section](../reference/config.html#command-line-overrides) for more information.
 {{/option}}
 
+{{#option "`-C` _PATH_"}}
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (`Cargo.toml`), as well as
+the directories searched for discovering `.cargo/config.toml`, for example.
+{{/option}}
+
 {{#option "`-h`" "`--help`"}}
 Prints help information.
 {{/option}}

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -222,6 +222,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-add--C"><a class="option-anchor" href="#option-cargo-add--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-add--h"><a class="option-anchor" href="#option-cargo-add--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-add---help"><a class="option-anchor" href="#option-cargo-add---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -427,6 +427,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-bench--C"><a class="option-anchor" href="#option-cargo-bench--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-bench--h"><a class="option-anchor" href="#option-cargo-bench--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-bench---help"><a class="option-anchor" href="#option-cargo-bench---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -371,6 +371,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-build--C"><a class="option-anchor" href="#option-cargo-build--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-build--h"><a class="option-anchor" href="#option-cargo-build--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-build---help"><a class="option-anchor" href="#option-cargo-build---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -352,6 +352,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-check--C"><a class="option-anchor" href="#option-cargo-check--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-check--h"><a class="option-anchor" href="#option-cargo-check--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-check---help"><a class="option-anchor" href="#option-cargo-check---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -156,6 +156,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-clean--C"><a class="option-anchor" href="#option-cargo-clean--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-clean--h"><a class="option-anchor" href="#option-cargo-clean--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-clean---help"><a class="option-anchor" href="#option-cargo-clean---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -326,6 +326,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-doc--C"><a class="option-anchor" href="#option-cargo-doc--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-doc--h"><a class="option-anchor" href="#option-cargo-doc--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-doc---help"><a class="option-anchor" href="#option-cargo-doc---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -130,6 +130,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-fetch--C"><a class="option-anchor" href="#option-cargo-fetch--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-fetch--h"><a class="option-anchor" href="#option-cargo-fetch--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-fetch---help"><a class="option-anchor" href="#option-cargo-fetch---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -432,6 +432,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-fix--C"><a class="option-anchor" href="#option-cargo-fix--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-fix--h"><a class="option-anchor" href="#option-cargo-fix--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-fix---help"><a class="option-anchor" href="#option-cargo-fix---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -104,6 +104,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-generate-lockfile--C"><a class="option-anchor" href="#option-cargo-generate-lockfile--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-generate-lockfile--h"><a class="option-anchor" href="#option-cargo-generate-lockfile--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-generate-lockfile---help"><a class="option-anchor" href="#option-cargo-generate-lockfile---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-init.md
+++ b/src/doc/src/commands/cargo-init.md
@@ -117,6 +117,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-init--C"><a class="option-anchor" href="#option-cargo-init--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-init--h"><a class="option-anchor" href="#option-cargo-init--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-init---help"><a class="option-anchor" href="#option-cargo-init---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -381,6 +381,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-install--C"><a class="option-anchor" href="#option-cargo-install--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-install--h"><a class="option-anchor" href="#option-cargo-install--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-install---help"><a class="option-anchor" href="#option-cargo-install---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-locate-project.md
+++ b/src/doc/src/commands/cargo-locate-project.md
@@ -99,6 +99,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-locate-project--C"><a class="option-anchor" href="#option-cargo-locate-project--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-locate-project--h"><a class="option-anchor" href="#option-cargo-locate-project--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-locate-project---help"><a class="option-anchor" href="#option-cargo-locate-project---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -85,6 +85,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-login--C"><a class="option-anchor" href="#option-cargo-login--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-login--h"><a class="option-anchor" href="#option-cargo-login--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-login---help"><a class="option-anchor" href="#option-cargo-login---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -434,6 +434,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-metadata--C"><a class="option-anchor" href="#option-cargo-metadata--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-metadata--h"><a class="option-anchor" href="#option-cargo-metadata--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-metadata---help"><a class="option-anchor" href="#option-cargo-metadata---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-new.md
+++ b/src/doc/src/commands/cargo-new.md
@@ -112,6 +112,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-new--C"><a class="option-anchor" href="#option-cargo-new--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-new--h"><a class="option-anchor" href="#option-cargo-new--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-new---help"><a class="option-anchor" href="#option-cargo-new---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-owner.md
+++ b/src/doc/src/commands/cargo-owner.md
@@ -123,6 +123,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-owner--C"><a class="option-anchor" href="#option-cargo-owner--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-owner--h"><a class="option-anchor" href="#option-cargo-owner--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-owner---help"><a class="option-anchor" href="#option-cargo-owner---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -289,6 +289,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-package--C"><a class="option-anchor" href="#option-cargo-package--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-package--h"><a class="option-anchor" href="#option-cargo-package--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-package---help"><a class="option-anchor" href="#option-cargo-package---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -133,6 +133,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-pkgid--C"><a class="option-anchor" href="#option-cargo-pkgid--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-pkgid--h"><a class="option-anchor" href="#option-cargo-pkgid--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-pkgid---help"><a class="option-anchor" href="#option-cargo-pkgid---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -255,6 +255,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-publish--C"><a class="option-anchor" href="#option-cargo-publish--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-publish--h"><a class="option-anchor" href="#option-cargo-publish--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-publish---help"><a class="option-anchor" href="#option-cargo-publish---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -140,6 +140,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-remove--C"><a class="option-anchor" href="#option-cargo-remove--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-remove--h"><a class="option-anchor" href="#option-cargo-remove--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-remove---help"><a class="option-anchor" href="#option-cargo-remove---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -264,6 +264,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-run--C"><a class="option-anchor" href="#option-cargo-run--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-run--h"><a class="option-anchor" href="#option-cargo-run--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-run---help"><a class="option-anchor" href="#option-cargo-run---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -365,6 +365,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-rustc--C"><a class="option-anchor" href="#option-cargo-rustc--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-rustc--h"><a class="option-anchor" href="#option-cargo-rustc--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-rustc---help"><a class="option-anchor" href="#option-cargo-rustc---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -345,6 +345,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-rustdoc--C"><a class="option-anchor" href="#option-cargo-rustdoc--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-rustdoc--h"><a class="option-anchor" href="#option-cargo-rustdoc--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-rustdoc---help"><a class="option-anchor" href="#option-cargo-rustdoc---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-search.md
+++ b/src/doc/src/commands/cargo-search.md
@@ -89,6 +89,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-search--C"><a class="option-anchor" href="#option-cargo-search--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-search--h"><a class="option-anchor" href="#option-cargo-search--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-search---help"><a class="option-anchor" href="#option-cargo-search---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -450,6 +450,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-test--C"><a class="option-anchor" href="#option-cargo-test--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-test--h"><a class="option-anchor" href="#option-cargo-test--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-test---help"><a class="option-anchor" href="#option-cargo-test---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -336,6 +336,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-tree--C"><a class="option-anchor" href="#option-cargo-tree--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-tree--h"><a class="option-anchor" href="#option-cargo-tree--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-tree---help"><a class="option-anchor" href="#option-cargo-tree---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-uninstall.md
+++ b/src/doc/src/commands/cargo-uninstall.md
@@ -99,6 +99,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-uninstall--C"><a class="option-anchor" href="#option-cargo-uninstall--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-uninstall--h"><a class="option-anchor" href="#option-cargo-uninstall--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-uninstall---help"><a class="option-anchor" href="#option-cargo-uninstall---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -144,6 +144,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-update--C"><a class="option-anchor" href="#option-cargo-update--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-update--h"><a class="option-anchor" href="#option-cargo-update--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-update---help"><a class="option-anchor" href="#option-cargo-update---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -140,6 +140,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-vendor--C"><a class="option-anchor" href="#option-cargo-vendor--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-vendor--h"><a class="option-anchor" href="#option-cargo-vendor--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-vendor---help"><a class="option-anchor" href="#option-cargo-vendor---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -110,6 +110,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-verify-project--C"><a class="option-anchor" href="#option-cargo-verify-project--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-verify-project--h"><a class="option-anchor" href="#option-cargo-verify-project--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-verify-project---help"><a class="option-anchor" href="#option-cargo-verify-project---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -119,6 +119,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo-yank--C"><a class="option-anchor" href="#option-cargo-yank--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo-yank--h"><a class="option-anchor" href="#option-cargo-yank--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo-yank---help"><a class="option-anchor" href="#option-cargo-yank---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/doc/src/commands/cargo.md
+++ b/src/doc/src/commands/cargo.md
@@ -227,6 +227,12 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
+<dt class="option-term" id="option-cargo--C"><a class="option-anchor" href="#option-cargo--C"></a><code>-C</code> <em>PATH</em></dt>
+<dd class="option-desc">Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (<code>Cargo.toml</code>), as well as
+the directories searched for discovering <code>.cargo/config.toml</code>, for example.</dd>
+
+
 <dt class="option-term" id="option-cargo--h"><a class="option-anchor" href="#option-cargo--h"></a><code>-h</code></dt>
 <dt class="option-term" id="option-cargo---help"><a class="option-anchor" href="#option-cargo---help"></a><code>--help</code></dt>
 <dd class="option-desc">Prints help information.</dd>

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -237,6 +237,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -451,6 +451,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -381,6 +381,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -362,6 +362,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -155,6 +155,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -329,6 +329,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -129,6 +129,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -457,6 +457,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -108,6 +108,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -121,6 +121,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -433,6 +433,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -100,6 +100,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -85,6 +85,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -433,6 +433,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -116,6 +116,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-owner.1
+++ b/src/etc/man/cargo-owner.1
@@ -127,6 +127,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -301,6 +301,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -163,6 +163,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -251,6 +251,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-remove.1
+++ b/src/etc/man/cargo-remove.1
@@ -132,6 +132,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -262,6 +262,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -380,6 +380,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -348,6 +348,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-search.1
+++ b/src/etc/man/cargo-search.1
@@ -88,6 +88,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -470,6 +470,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -376,6 +376,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-uninstall.1
+++ b/src/etc/man/cargo-uninstall.1
@@ -111,6 +111,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -148,6 +148,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -139,6 +139,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -118,6 +118,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -119,6 +119,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -251,6 +251,13 @@ or provided as a path to an extra configuration file. This flag may be specified
 See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
+\fB\-C\fR \fIPATH\fR
+.RS 4
+Changes the current working directory before executing any specified operations. This affects
+things like where cargo looks by default for the project manifest (\fBCargo.toml\fR), as well as
+the directories searched for discovering \fB\&.cargo/config.toml\fR, for example.
+.RE
+.sp
 \fB\-h\fR, 
 \fB\-\-help\fR
 .RS 4


### PR DESCRIPTION
This implements the suggestion in #10098 to make cargo change cwd before
completing config processing and starting the build. It is also an
alternative to `--manifest-path` that resolves the issue described
in #2930.

The behavior of this new flag makes cargo build function exactly the same when run at the root of the project as if run elsewhere outside of the project.  This is in contrast to `--manifest-path`, which, for example, results in a different series of directories being searched for `.cargo/config.toml` between the two cases.

Fixes #10098
Reduces impact of #2930 for many, possibly all impacted, by switching to this new cli argument.

### How should we test and review this PR?

The easiest way to reproduce the issue described in #2930 is to create an invalid `.cargo/config.toml` file in the root of a cargo project, for example `!` as the contents of the file.  Running cargo with the current working directory underneath the root of that project will quickly fail with an error, showing that the config file was processed.  This is correct and expected behavior.

Running the the same build with the current working directory set outside of the project, e.g. /tmp, and passing the `--manifest-path /path/to/project/Cargo.toml`.  The build will proceed without erroring as a result of reading the project's `.cargo/config.toml`, because config file searching is done from cwd (e.g. in `/tmp` and `/`) without including the project root, which is a surprising result in the context of the [cargo config documentation](https://doc.rust-lang.org/cargo/reference/config.html), which suggests that a `.cargo/config.toml` file checked into the root of a project's revision control will be processed during the build of that project.

Finally to demonstrate that this PR results in the expected behavior, run cargo similar to the previous run, from /tmp or similar, but instead of `--manifest-path /path/to/project/Cargo.toml`, pass `-C/path/to/project` to cargo (note the missing `Cargo.toml` at the end).  The build will provide the exact same (expected error) behavior as when running it within the project root directory.

### Additional information

~Passing a path with a trailing '/' will result in failure.  It is unclear whether this is a result of improper input sanitization, or whether the config.cwd value is being improperly handled on output.  In either case this needs to be resolved before this PR is merge-ready.~

(the above issue appears to have been a side effect of local corruption of my rustup toolchain, and unrelated to this change)

Because a `struct Config` gets created before command line arguments are processed, a config will exist with the actual cwd recorded, and it must then be replaced with the new value after command line arguments are processed but before anything tries to use the stored cwd value or any other value derived from it for anything.  This change effectively creates a difficult-to-document requirement during cargo initialization regarding the order of events.  For example, should a setting stored in a config file discovered via cwd+ancestors search be wanted before argument processing happens, this could result in unpleasant surprises in the exact use case this feature is being added to fix.

A long flag was deferred out to not block this on deciding what to name it.  A #11696 was created to track this.