### PR TITLE
Report codegen timings for binary crates

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -850,13 +850,16 @@ fn build_base_args(
 
     if unit.mode.is_check() {
         cmd.arg("--emit=dep-info,metadata");
-    } else if !unit.requires_upstream_objects() {
+    } else {
         // Always produce metadata files for rlib outputs. Metadata may be used
         // in this session for a pipelined compilation, or it may be used in a
         // future Cargo session as part of a pipelined compile.
+        // Also include metadata for outputs that need to be linked and thus
+        // can't be pipelined as this will cause rustc to report when codegen
+        // starts even when the crate type doesn't actually support metadata
+        // files. This allows measuring how long codegen takes, which will be
+        // included in the report produced if `--timings` is passed.
         cmd.arg("--emit=dep-info,metadata,link");
-    } else {
-        cmd.arg("--emit=dep-info,link");
     }
 
     let prefer_dynamic = (unit.target.for_host() && !unit.target.is_custom_build())

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -667,7 +667,7 @@ fn test_profile() {
 [RUNNING] `rustc --crate-name bar [..]crate-type lib[..]
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name foo [..]--crate-type lib --emit=dep-info,metadata,link -C linker-plugin-lto[..]
-[RUNNING] `rustc --crate-name foo [..]--emit=dep-info,link -C lto=thin [..]--test[..]
+[RUNNING] `rustc --crate-name foo [..]--emit=dep-info,metadata,link -C lto=thin [..]--test[..]
 [FINISHED] [..]
 [RUNNING] [..]
 [DOCTEST] foo


### PR DESCRIPTION
This is done by enabling `--emit metadata` for binary crates too despite them not actually supporting crate metadata. Rustc will produce a harmless empty metadata file, but also report exactly when codegen starts just like currently happens for rlibs.

<!-- homu-ignore:start -->
[Zulip stream](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/reporting.20codegen.20timings.20for.20binary.20crates)
<!-- homu-ignore:end -->
