### PR TITLE
Ensure rustc-echo-wrapper works with an overridden build.target-dir

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1209,7 +1209,7 @@ pub trait TestEnv: Sized {
             .current_dir(&paths::root())
             .env("HOME", paths::home())
             .env("CARGO_HOME", paths::home().join(".cargo"))
-            .env("__CARGO_TEST_ROOT", paths::root())
+            .env("__CARGO_TEST_ROOT", paths::global_root())
             // Force Cargo to think it's on the stable channel for all tests, this
             // should hopefully not surprise us as we add cargo features over time and
             // cargo rides the trains.


### PR DESCRIPTION
Without this when running with an overridden target-dir there are about a dozen test failures like

```console
> mkdir .cargo
> echo '[build]\ntarget-dir = "not-target"' > .cargo/config
> cargo test -- fix::does_not_crash
---- fix::does_not_crash_with_rustc_wrapper stdout ----
running `/home/nemo157/sources/cargo/not-target/debug/cargo build`
running `/home/nemo157/sources/cargo/not-target/debug/cargo fix --allow-no-vcs`
thread 'fix::does_not_crash_with_rustc_wrapper' panicked at '
test failed running `/home/nemo157/sources/cargo/not-target/debug/cargo fix --allow-no-vcs`
error: process exited with code 101 (expected 0)
--- stdout

--- stderr
error: failed to run `rustc` to learn about target-specific information

Caused by:
  could not execute process `/home/nemo157/sources/cargo/not-target/tmp/cit/rustc-echo-wrapper/target/debug/rustc-echo-wrapper rustc - --crate-name ___ --print=file-names --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (never executed)

Caused by:
  No such file or directory (os error 2)
', tests/testsuite/fix.rs:1228:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Because the `rustc-echo-wrapper` is compiled to `not-target/debug/rustc-echo-wrapper`.

This is resolved by forcing the target-dir to be a manifest-relative one for this specific build.