### PR TITLE
Improve error msg for get target runner

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -409,7 +409,7 @@ fn target_runner(
     let matching_runner = cfgs.next();
     if let Some((key, runner)) = cfgs.next() {
         anyhow::bail!(
-            "several matching instances of `target.'cfg(..)'.runner` in `.cargo/config`\n\
+            "several matching instances of `target.'cfg(..)'.runner` in configurations\n\
              first match `{}` located in {}\n\
              second match `{}` located in {}",
             matching_runner.unwrap().0,

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -252,7 +252,7 @@ fn custom_runner_cfg_collision() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] several matching instances of `target.'cfg(..)'.runner` in `.cargo/config`
+[ERROR] several matching instances of `target.'cfg(..)'.runner` in configurations
 first match `cfg(not(target_arch = \"avr\"))` located in [..]/foo/.cargo/config
 second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config
 ",


### PR DESCRIPTION
Actually, we'll get this config from three places. So this msg may be confusing when you set it up in `.cargo/config.toml` or pass it by `--config`.
We already printed the location of the config, so I think it's OK to change it to `configurations`.