### PR TITLE
[BETA 1.64] Only override published resolver when the workspace is different

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -102,6 +102,7 @@ use anyhow::{bail, Error};
 use cargo_util::ProcessBuilder;
 use serde::{Deserialize, Serialize};
 
+use crate::core::resolver::ResolveBehavior;
 use crate::util::errors::CargoResult;
 use crate::util::{indented_lines, iter_join};
 use crate::Config;
@@ -240,6 +241,14 @@ impl Edition {
             Edition2015 => false,
             Edition2018 => true,
             Edition2021 => false,
+        }
+    }
+
+    pub(crate) fn default_resolve_behavior(&self) -> ResolveBehavior {
+        if *self >= Edition::Edition2021 {
+            ResolveBehavior::V2
+        } else {
+            ResolveBehavior::V1
         }
     }
 }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -16,7 +16,7 @@ use crate::core::features::Features;
 use crate::core::registry::PackageRegistry;
 use crate::core::resolver::features::CliFeatures;
 use crate::core::resolver::ResolveBehavior;
-use crate::core::{Dependency, Edition, FeatureValue, PackageId, PackageIdSpec};
+use crate::core::{Dependency, FeatureValue, PackageId, PackageIdSpec};
 use crate::core::{EitherManifest, Package, SourceId, VirtualManifest};
 use crate::ops;
 use crate::sources::{PathSource, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
@@ -287,16 +287,12 @@ impl<'cfg> Workspace<'cfg> {
         // - If the root package specifies edition 2021, use v2.
         // - Otherwise, use the default v1.
         self.resolve_behavior = match self.root_maybe() {
-            MaybePackage::Package(p) => p.manifest().resolve_behavior().or_else(|| {
-                if p.manifest().edition() >= Edition::Edition2021 {
-                    Some(ResolveBehavior::V2)
-                } else {
-                    None
-                }
-            }),
-            MaybePackage::Virtual(vm) => vm.resolve_behavior(),
+            MaybePackage::Package(p) => p
+                .manifest()
+                .resolve_behavior()
+                .unwrap_or_else(|| p.manifest().edition().default_resolve_behavior()),
+            MaybePackage::Virtual(vm) => vm.resolve_behavior().unwrap_or(ResolveBehavior::V1),
         }
-        .unwrap_or(ResolveBehavior::V1);
     }
 
     /// Returns the current package of this workspace.

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -951,7 +951,6 @@ version = "0.1.0"
 description = "foo"
 homepage = "https://example.com/"
 license = "MIT"
-resolver = "1"
 
 [dependencies.opt-dep1]
 version = "1.0"
@@ -1059,7 +1058,6 @@ version = "0.1.0"
 description = "foo"
 homepage = "https://example.com/"
 license = "MIT"
-resolver = "1"
 
 [dependencies.bar]
 version = "1.0"

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -218,7 +218,6 @@ keywords = ["cli"]
 categories = ["development-tools"]
 license = "MIT"
 repository = "https://github.com/example/example"
-resolver = "1"
 
 [badges.gitlab]
 branch = "master"
@@ -349,7 +348,6 @@ fn inherit_own_dependencies() {
 name = "bar"
 version = "0.2.0"
 authors = []
-resolver = "1"
 
 [dependencies.dep]
 version = "0.1"
@@ -454,7 +452,6 @@ fn inherit_own_detailed_dependencies() {
 name = "bar"
 version = "0.2.0"
 authors = []
-resolver = "1"
 
 [dependencies.dep]
 version = "0.1.2"
@@ -691,7 +688,6 @@ categories = ["development-tools"]
 license = "MIT"
 license-file = "LICENSE"
 repository = "https://github.com/example/example"
-resolver = "1"
 
 [badges.gitlab]
 branch = "master"
@@ -823,7 +819,6 @@ fn inherit_dependencies() {
 name = "bar"
 version = "0.2.0"
 authors = []
-resolver = "1"
 
 [dependencies.dep]
 version = "0.1"

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1119,7 +1119,6 @@ authors = []
 exclude = ["*.txt"]
 description = "foo"
 license = "MIT"
-resolver = "1"
 
 [package.metadata]
 foo = "bar"
@@ -1190,7 +1189,6 @@ fn ignore_workspace_specifier() {
 name = "bar"
 version = "0.1.0"
 authors = []
-resolver = "1"
 "#,
         cargo::core::package::MANIFEST_PREAMBLE
     );
@@ -2335,7 +2333,7 @@ fn workspace_overrides_resolver() {
             "Cargo.toml",
             r#"
                 [workspace]
-                members = ["bar"]
+                members = ["bar", "baz"]
             "#,
         )
         .file(
@@ -2348,9 +2346,19 @@ fn workspace_overrides_resolver() {
             "#,
         )
         .file("bar/src/lib.rs", "")
+        .file(
+            "baz/Cargo.toml",
+            r#"
+                [package]
+                name = "baz"
+                version = "0.1.0"
+                edition = "2015"
+            "#,
+        )
+        .file("baz/src/lib.rs", "")
         .build();
 
-    p.cargo("package --no-verify").cwd("bar").run();
+    p.cargo("package --no-verify -p bar -p baz").run();
 
     let f = File::open(&p.root().join("target/package/bar-0.1.0.crate")).unwrap();
     let rewritten_toml = format!(
@@ -2366,6 +2374,24 @@ resolver = "1"
     validate_crate_contents(
         f,
         "bar-0.1.0.crate",
+        &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
+        &[("Cargo.toml", &rewritten_toml)],
+    );
+
+    // When the crate has the same implicit resolver as the workspace it is not overridden
+    let f = File::open(&p.root().join("target/package/baz-0.1.0.crate")).unwrap();
+    let rewritten_toml = format!(
+        r#"{}
+[package]
+edition = "2015"
+name = "baz"
+version = "0.1.0"
+"#,
+        cargo::core::package::MANIFEST_PREAMBLE
+    );
+    validate_crate_contents(
+        f,
+        "baz-0.1.0.crate",
         &["Cargo.toml", "Cargo.toml.orig", "src/lib.rs"],
         &[("Cargo.toml", &rewritten_toml)],
     );

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1178,7 +1178,6 @@ fn publish_git_with_version() {
                      authors = []\n\
                      description = \"foo\"\n\
                      license = \"MIT\"\n\
-                     resolver = \"1\"\n\
                      \n\
                      [dependencies.dep1]\n\
                      version = \"1.0\"\n\
@@ -1285,7 +1284,6 @@ homepage = "foo"
 documentation = "foo"
 license = "MIT"
 repository = "foo"
-resolver = "1"
 
 [dev-dependencies]
 "#,

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -608,7 +608,6 @@ version = "0.1.0"
 description = "foo"
 homepage = "https://example.com/"
 license = "MIT"
-resolver = "1"
 
 [dependencies.bar]
 version = "1.0"


### PR DESCRIPTION
### What does this PR try to resolve?

Ensures when publishing a package that uses an implicit `resolver = "1"` to maintain an MSRV before the `resolver` key was stabilized the implicitness is retained rather than being turned into an explicit setting.

fixes #10954 (assuming that the workspace and its packages are configured with a consistent resolver)

Note: this is a backport of #10961 to beta