### PR TITLE
Rebuild and rerun build scripts when RUSTC_WRAPPER has changed

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1322,6 +1322,7 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
     if let Some(linker) = cx.bcx.linker(unit.kind) {
         linker.hash(&mut config);
     }
+    cx.bcx.rustc().wrapper.hash(&mut config);
     if unit.mode.is_doc() && cx.bcx.config.cli_unstable().rustdoc_map {
         if let Ok(map) = cx.bcx.config.doc_extern_map() {
             map.hash(&mut config);


### PR DESCRIPTION
### What does this PR try to resolve?

The current behavior of Cargo, which I think is a bug, is that if you run `cargo build` followed by `RUSTC_WRAPPER=… cargo build`, Cargo will rebuild your crate using the given rustc wrapper, but will *not* rebuild or rerun any build scripts. The same is true of those commands in the opposite order: Cargo will rebuild your crate with no wrapper, but not build scripts.

This PR fixes this to rebuild build scripts too (and rerun them) when RUSTC_WRAPPER has changed.

In general, whatever rationale justifies rebuilding an already successfully built crate on a RUSTC_WRAPPER change (maybe the wrapper is in charge of munging rustc flags somehow?) should apply just as much to justify rebuilding build scripts.

The immediate motivation for the PR is that we had a problematic experience in the `anyhow` crate where compiling via rust-analyzer using rust-analyzer's RUSTC_WRAPPER would break all subsequent command-line cargo invocations, due to the RUSTC_WRAPPER-using build of the build script being cached and not rerun.

### How should we test and review this PR?

I tested by `cargo test --test testsuite -- rerun_build_script_if_add_rustc_wrapper`.