### PR TITLE
Fix file locking being not supported on Android raising an error

### DIFF
--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -378,7 +378,6 @@ mod sys {
             // For targets in which they are the same, the duplicate pattern causes a warning.
             #[allow(unreachable_patterns)]
             Some(libc::ENOTSUP | libc::EOPNOTSUPP) => true,
-            #[cfg(any(target_os = "linux", target_os = "android"))]
             Some(libc::ENOSYS) => true,
             _ => false,
         }

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -378,7 +378,7 @@ mod sys {
             // For targets in which they are the same, the duplicate pattern causes a warning.
             #[allow(unreachable_patterns)]
             Some(libc::ENOTSUP | libc::EOPNOTSUPP) => true,
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             Some(libc::ENOSYS) => true,
             _ => false,
         }


### PR DESCRIPTION
This PR fixes #10972 by not failing Cargo operations when the `target_os` is Android and file locking is being reported as not being implemented by the kernel.

I am sadly unable to actually test this at the moment, since despite my best efforts I am not able to get Cargo actually cross-compiled for Android (aarch64-linux-android).

I however don't see any reason why this wouldn't work. `target_os` is "android" on Android and not "linux".