### PR TITLE
Use `std::thread::scope` to replace crossbeam

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.1" }
 crates-io = { path = "crates/crates-io", version = "0.34.0" }
-crossbeam-utils = "0.8"
 curl = { version = "0.4.43", features = ["http2"] }
 curl-sys = "0.4.55"
 env_logger = "0.9.0"


### PR DESCRIPTION
Drop one dependency as `std::thread::Scope` got stabilized in 1.63.

Haven't done any benchmark. (Should we?)