### PR TITLE
WIP: Add normalized querykind Fixes #1079

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -294,7 +294,7 @@ pub(super) fn activation_error(
             // Maybe the user mistyped the name? Like `dep-thing` when `Dep_Thing`
             // was meant. So we try asking the registry for a `fuzzy` search for suggestions.
             let mut candidates = loop {
-                match registry.query_vec(&new_dep, QueryKind::Fuzzy) {
+                match registry.query_vec(&new_dep, QueryKind::Alternatives) {
                     Poll::Ready(Ok(candidates)) => break candidates,
                     Poll::Ready(Err(e)) => return to_resolve_err(e),
                     Poll::Pending => match registry.block_until_ready() {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -117,6 +117,9 @@ pub enum QueryKind {
     /// Path/Git sources may return all dependencies that are at that URI,
     /// whereas an `Index` source may return dependencies that have the same canonicalization.
     Alternatives,
+    /// Behavior like `Exact` for path sources and like `Alternatives` for
+    /// registry sources
+    Normalized,
 }
 
 pub enum MaybePackage {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -116,7 +116,7 @@ pub enum QueryKind {
     /// Each source gets to define what `close` means for it.
     /// Path/Git sources may return all dependencies that are at that URI,
     /// whereas an `Index` source may return dependencies that have the same canonicalization.
-    Fuzzy,
+    Alternatives,
 }
 
 pub enum MaybePackage {

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -455,7 +455,7 @@ fn get_latest_dependency(
         }
         MaybeWorkspace::Other(query) => {
             let possibilities = loop {
-                match registry.query_vec(&query, QueryKind::Alternatives) {
+                match registry.query_vec(&query, QueryKind::Normalized) {
                     std::task::Poll::Ready(res) => {
                         break res?;
                     }
@@ -497,7 +497,7 @@ fn select_package(
         MaybeWorkspace::Other(query) => {
             let possibilities = loop {
                 // Exact to avoid returning all for path/git
-                match registry.query_vec(&query, QueryKind::Exact) {
+                match registry.query_vec(&query, QueryKind::Normalized) {
                     std::task::Poll::Ready(res) => {
                         break res?;
                     }
@@ -611,7 +611,7 @@ fn populate_available_features(
         MaybeWorkspace::Other(query) => query,
     };
     let possibilities = loop {
-        match registry.query_vec(&query, QueryKind::Alternatives) {
+        match registry.query_vec(&query, QueryKind::Normalized) {
             std::task::Poll::Ready(res) => {
                 break res?;
             }

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -455,7 +455,7 @@ fn get_latest_dependency(
         }
         MaybeWorkspace::Other(query) => {
             let possibilities = loop {
-                match registry.query_vec(&query, QueryKind::Fuzzy) {
+                match registry.query_vec(&query, QueryKind::Alternatives) {
                     std::task::Poll::Ready(res) => {
                         break res?;
                     }
@@ -611,7 +611,7 @@ fn populate_available_features(
         MaybeWorkspace::Other(query) => query,
     };
     let possibilities = loop {
-        match registry.query_vec(&query, QueryKind::Fuzzy) {
+        match registry.query_vec(&query, QueryKind::Alternatives) {
             std::task::Poll::Ready(res) => {
                 break res?;
             }

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -59,6 +59,14 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         let matches = packages.filter(|pkg| match kind {
             QueryKind::Exact => dep.matches(pkg.summary()),
             QueryKind::Alternatives => true,
+            QueryKind::Normalized => {
+                let src_id = pkg.package_id().source_id();
+                if src_id.is_path() {
+                    dep.matches(pkg.summary())
+                } else {
+                    true
+                }
+            }
         });
         for summary in matches.map(|pkg| pkg.summary().clone()) {
             f(summary);

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -58,7 +58,7 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         let packages = self.packages.values().map(|p| &p.0);
         let matches = packages.filter(|pkg| match kind {
             QueryKind::Exact => dep.matches(pkg.summary()),
-            QueryKind::Fuzzy => true,
+            QueryKind::Alternatives => true,
         });
         for summary in matches.map(|pkg| pkg.summary().clone()) {
             f(summary);

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -508,6 +508,7 @@ impl<'cfg> Source for PathSource<'cfg> {
             let matched = match kind {
                 QueryKind::Exact => dep.matches(s),
                 QueryKind::Alternatives => true,
+                QueryKind::Normalized => dep.matches(s),
             };
             if matched {
                 f(s.clone())

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -507,7 +507,7 @@ impl<'cfg> Source for PathSource<'cfg> {
         for s in self.packages.iter().map(|p| p.summary()) {
             let matched = match kind {
                 QueryKind::Exact => dep.matches(s),
-                QueryKind::Fuzzy => true,
+                QueryKind::Alternatives => true,
             };
             if matched {
                 f(s.clone())

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -739,7 +739,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
             .query_inner(dep, &mut *self.ops, &self.yanked_whitelist, &mut |s| {
                 let matched = match kind {
                     QueryKind::Exact => dep.matches(&s),
-                    QueryKind::Fuzzy => true,
+                    QueryKind::Alternatives => true,
                 };
                 if matched {
                     f(s);

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -740,6 +740,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
                 let matched = match kind {
                     QueryKind::Exact => dep.matches(&s),
                     QueryKind::Alternatives => true,
+                    QueryKind::Normalized => true,
                 };
                 if matched {
                     f(s);

--- a/tests/testsuite/cargo_add_with_vendored_pkgs.rs
+++ b/tests/testsuite/cargo_add_with_vendored_pkgs.rs
@@ -1,11 +1,12 @@
 use cargo_test_support::project;
 
-
 #[cargo_test]
 fn carg_add_with_vendored_packages() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("hi!"); }"#)
-        .file("Cargo.toml", r#"[package]
+        .file(
+            "Cargo.toml",
+            r#"[package]
 name = "example"
 version = "0.1.0"
 edition = "2021"
@@ -13,29 +14,37 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xml-rs = "0.8.4""#)
+xml-rs = "0.8.4""#,
+        )
         .build();
 
     p.cargo("vendor ./vendor")
-        .with_stdout(r#"
+        .with_stdout(
+            r#"
 [source.crates-io]
 replace-with = "vendored-sources"
 
 [source.vendored-sources]
-directory = "./vendor""#)
+directory = "./vendor""#,
+        )
         .run();
-    p.change_file(".cargo/config.toml", r#"
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
     [source.crates-io]
     replace-with = "vendored-sources"
     
     [source.vendored-sources]
-    directory = "./vendor""#);
+    directory = "./vendor""#,
+    );
     p.cargo("add cbindgen")
         // current output
         //.with_stdout(r#"warning: translating `cbindgen` to `xml-rs`
-      //Adding xml-rs v0.8.4 to dependencies."#)
-      // correct output
-        .with_stdout(r#"    Updating crates.io index
-      Adding xml-rs v0.8.4 to dependencies."#)
+        //Adding xml-rs v0.8.4 to dependencies."#)
+        // correct output
+        .with_stdout(
+            r#"    Updating crates.io index
+      Adding xml-rs v0.8.4 to dependencies."#,
+        )
         .run();
 }

--- a/tests/testsuite/cargo_add_with_vendored_pkgs.rs
+++ b/tests/testsuite/cargo_add_with_vendored_pkgs.rs
@@ -1,0 +1,41 @@
+use cargo_test_support::project;
+
+
+#[cargo_test]
+fn carg_add_with_vendored_packages() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("hi!"); }"#)
+        .file("Cargo.toml", r#"[package]
+name = "example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+xml-rs = "0.8.4""#)
+        .build();
+
+    p.cargo("vendor ./vendor")
+        .with_stdout(r#"
+[source.crates-io]
+replace-with = "vendored-sources"
+
+[source.vendored-sources]
+directory = "./vendor""#)
+        .run();
+    p.change_file(".cargo/config.toml", r#"
+    [source.crates-io]
+    replace-with = "vendored-sources"
+    
+    [source.vendored-sources]
+    directory = "./vendor""#);
+    p.cargo("add cbindgen")
+        // current output
+        //.with_stdout(r#"warning: translating `cbindgen` to `xml-rs`
+      //Adding xml-rs v0.8.4 to dependencies."#)
+      // correct output
+        .with_stdout(r#"    Updating crates.io index
+      Adding xml-rs v0.8.4 to dependencies."#)
+        .run();
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -20,6 +20,7 @@ mod build_script_env;
 mod build_script_extra_link_arg;
 mod cache_messages;
 mod cargo_add;
+mod cargo_add_with_vendored_pkgs;
 mod cargo_alias_config;
 mod cargo_command;
 mod cargo_config;


### PR DESCRIPTION
### What does this PR try to resolve?

See [this thread](https://github.com/rust-lang/cargo/issues/10729), particularly [this comment](https://github.com/rust-lang/cargo/issues/10729#issuecomment-1191633351)

### How should we test and review this PR?

Currently trying to get a functional or ui test to work but am having issues.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

TODO:
- tests
   - UI Test: When I tried to write this test, I was having issues replicating the issue since I couldn't get the `.cargo/config.toml` file in `tests/testsuite/<command>/<case>/in` to be persisted. I have this test on another branch, `add-normalized-querykind-test`, which is just `master` + tests.
   - Functional test, this is the output:


<details>
  <summary>Click to expand</summary>

```
 ~/code/cargo/ [add-normalized-querykind+] cargo  test --test testsuite -- cargo_add_with_vendored_pkgs
> cargo test --test testsuite -- cargo_add_with_vendored_pkgs
   Compiling cargo v0.65.0 (/Users/thomasharmon/code/cargo)
    Finished test [unoptimized + debuginfo] target(s) in 3.64s
     Running tests/testsuite/main.rs (target/debug/deps/testsuite-a0b7d1f599e8fa04)

running 1 test
test cargo_add_with_vendored_pkgs::carg_add_with_vendored_packages ... FAILED

failures:

---- cargo_add_with_vendored_pkgs::carg_add_with_vendored_packages stdout ----
running `/Users/thomasharmon/code/cargo/target/debug/cargo vendor ./vendor`
running `/Users/thomasharmon/code/cargo/target/debug/cargo add cbindgen`
thread 'cargo_add_with_vendored_pkgs::carg_add_with_vendored_packages' panicked at '
test failed running `/Users/thomasharmon/code/cargo/target/debug/cargo add cbindgen`
error: stdout did not match:
1        -    Updating crates.io index
2        -      Adding xml-rs v0.8.4 to dependencies.


other output:
warning: translating `cbindgen` to `xml-rs`
      Adding xml-rs v0.8.4 to dependencies.

', tests/testsuite/cargo_add_with_vendored_pkgs.rs:49:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    cargo_add_with_vendored_pkgs::carg_add_with_vendored_packages

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2597 filtered out; finished in 29.65s

error: test failed, to rerun pass '--test testsuite'
```
</details>
