### PR TITLE
Search upward if the path does not exist when `cargo new`

### DIFF
--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -302,6 +302,43 @@ fn subpackage_git_with_gitignore() {
 }
 
 #[cargo_test]
+fn subpackage_no_git_with_git_in_ancestor() {
+    cargo_process("new foo").run();
+
+    assert!(paths::root().join("foo/.git").is_dir());
+    assert!(paths::root().join("foo/.gitignore").is_file());
+
+    cargo_process("new foo/non-existent/subcomponent").run();
+
+    assert!(!paths::root()
+        .join("foo/non-existent/subcomponent/.git")
+        .is_dir());
+    assert!(!paths::root()
+        .join("foo/non-existent/subcomponent/.gitignore")
+        .is_file());
+}
+
+#[cargo_test]
+fn subpackage_git_with_gitignore_in_ancestor() {
+    cargo_process("new foo").run();
+
+    assert!(paths::root().join("foo/.git").is_dir());
+    assert!(paths::root().join("foo/.gitignore").is_file());
+
+    let gitignore = paths::root().join("foo/.gitignore");
+    fs::write(gitignore, b"non-existent").unwrap();
+
+    cargo_process("new foo/non-existent/subcomponent").run();
+
+    assert!(paths::root()
+        .join("foo/non-existent/subcomponent/.git")
+        .is_dir());
+    assert!(paths::root()
+        .join("foo/non-existent/subcomponent/.gitignore")
+        .is_file());
+}
+
+#[cargo_test]
 fn subpackage_git_with_vcs_arg() {
     cargo_process("new foo").run();
 


### PR DESCRIPTION
Try to Search upward if the path does not exist when `cargo new`.

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/10981

### How should we test and review this PR?

Run the unit test or try the case which comes from the issue.