### PR TITLE
Warning when precise or aggressive without -p flag

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -36,6 +36,25 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
 }
 
 pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoResult<()> {
+    // Currently this is only a warning, but after a transition period this will become
+    // a hard error.
+    // See https://github.com/rust-lang/cargo/issues/10919#issuecomment-1214464756.
+    // We should declare the `precise` and `aggressive` arguments
+    // require the `package` argument in the clap.
+    if opts.aggressive && opts.to_update.is_empty() {
+        ws.config().shell().warn(
+            "aggressive is only supported with \"--package <SPEC>\", \
+        this will become a hard error in a future release.",
+        )?;
+    }
+
+    if opts.precise.is_some() && opts.to_update.is_empty() {
+        ws.config().shell().warn(
+            "precise is only supported with \"--package <SPEC>\", \
+        this will become a hard error in a future release.",
+        )?;
+    }
+
     if opts.aggressive && opts.precise.is_some() {
         anyhow::bail!("cannot specify both aggressive and precise simultaneously")
     }

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -428,6 +428,41 @@ fn update_precise_without_package() {
         .run();
 }
 
+#[cargo_test]
+fn update_aggressive_without_package() {
+    Package::new("serde", "0.2.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                serde = "0.2"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build").run();
+
+    Package::new("serde", "0.2.1").publish();
+
+    p.cargo("update --aggressive")
+        .with_stderr(
+            "\
+[WARNING] aggressive is only supported with \"--package <SPEC>\", this will become a hard error in a future release.
+[UPDATING] `[..]` index
+[UPDATING] serde v0.2.0 -> v0.2.1
+",
+        )
+        .run();
+}
+
 // cargo update should respect its arguments even without a lockfile.
 // See issue "Running cargo update without a Cargo.lock ignores arguments"
 // at <https://github.com/rust-lang/cargo/issues/6872>.


### PR DESCRIPTION
### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/10919.

Warning when precise or aggressive without -p flag. It will be a hard error in future.

### How should we test and review this PR?

- Unit test.
