### PR TITLE
Solve problem with panic on some non-ASCII strings in `cargo install`

### DIFF
--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -11,19 +11,22 @@ pub fn make_dep_path(dep_name: &str, prefix_only: bool) -> String {
     } else {
         ("/", dep_name)
     };
-    match dep_name.chars().take(4).count() {
-        1 => format!("1{}{}", slash, name),
-        2 => format!("2{}{}", slash, name),
-        3 => {
-            let first_symbol = dep_name.chars().take(1).collect::<String>();
 
-            format!("3/{}{}{}", first_symbol, slash, name)
+    let mut chars = [None; 4];
+    dep_name.chars().enumerate().try_for_each(|(i, c)| {
+        *chars.get_mut(i)? = Some(c);
+        Some(())
+    });
+
+    match chars {
+        [None, ..] => panic!("length of a crate name must not be zero"),
+        [Some(_), None, ..] => format!("1{slash}{name}"),
+        [Some(_), Some(_), None, ..] => format!("2{slash}{name}"),
+        [Some(f0), Some(_), Some(_), None] => {
+            format!("3/{f0}{slash}{name}")
         }
-        _ => {
-            let first_symbol = dep_name.chars().take(2).collect::<String>();
-            let second_symbol = dep_name.chars().skip(2).take(2).collect::<String>();
-
-            format!("{}/{}{}{}", first_symbol, second_symbol, slash, name)
+        [Some(f0), Some(f1), Some(s0), Some(s1)] => {
+            format!("{f0}{f1}/{s0}{s1}{slash}{name}")
         }
     }
 }

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -11,11 +11,20 @@ pub fn make_dep_path(dep_name: &str, prefix_only: bool) -> String {
     } else {
         ("/", dep_name)
     };
-    match dep_name.len() {
+    match dep_name.chars().take(4).count() {
         1 => format!("1{}{}", slash, name),
         2 => format!("2{}{}", slash, name),
-        3 => format!("3/{}{}{}", &dep_name[..1], slash, name),
-        _ => format!("{}/{}{}{}", &dep_name[0..2], &dep_name[2..4], slash, name),
+        3 => {
+            let first_symbol = dep_name.chars().take(1).collect::<String>();
+
+            format!("3/{}{}{}", first_symbol, slash, name)
+        }
+        _ => {
+            let first_symbol = dep_name.chars().take(2).collect::<String>();
+            let second_symbol = dep_name.chars().skip(2).take(2).collect::<String>();
+
+            format!("{}/{}{}{}", first_symbol, second_symbol, slash, name)
+        }
     }
 }
 

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -52,6 +52,9 @@ mod tests {
         assert_eq!(make_dep_path("aBcDe", false), "aB/cD/aBcDe");
     }
 
+    // This test checks that non-ASCII strings are handled correctly in 2 cases
+    // - 3 byte string, where byte index 2 isn't a char boundary
+    // - at least 4 byte string, where byte index 4 isn't a char boundary
     #[test]
     fn test_10993() {
         assert_eq!(make_dep_path("ĉa", true), "2");

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -51,4 +51,13 @@ mod tests {
         assert_eq!(make_dep_path("AbCd", false), "Ab/Cd/AbCd");
         assert_eq!(make_dep_path("aBcDe", false), "aB/cD/aBcDe");
     }
+    
+    #[test]
+    fn test_10993() {
+        assert_eq!(make_dep_path("ĉa", true), "2");
+        assert_eq!(make_dep_path("abcĉ", true), "ab/cĉ");
+
+        assert_eq!(make_dep_path("ĉa", false), "2/ĉa");
+        assert_eq!(make_dep_path("abcĉ", false), "ab/cĉ/abcĉ");
+    }
 }

--- a/crates/cargo-util/src/registry.rs
+++ b/crates/cargo-util/src/registry.rs
@@ -51,7 +51,7 @@ mod tests {
         assert_eq!(make_dep_path("AbCd", false), "Ab/Cd/AbCd");
         assert_eq!(make_dep_path("aBcDe", false), "aB/cD/aBcDe");
     }
-    
+
     #[test]
     fn test_10993() {
         assert_eq!(make_dep_path("ĉa", true), "2");


### PR DESCRIPTION
This make cargo don't panic on some non-ASCII strings when creating `dep_path`.

Close #10993 