### PR TITLE
Resolve rustc path early to bypass rustup wrapper

### DIFF
--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -47,13 +47,18 @@ impl Rustc {
         let _p = profile::start("Rustc::new");
 
         // In order to avoid calling through rustup multiple times, we first ask
-        // rustc to give us the "resolved" rustc path, and use that instead.
+        // rustc to give us the "resolved" rustc path, and use that instead. If
+        // this doesn't give us a path, then we just use the original path such
+        // that the following logic can handle any resulting errors normally.
         let mut cmd = ProcessBuilder::new(&path);
         cmd.arg("--print=rustc-path");
         if let Ok(output) = cmd.output() {
             if output.status.success() {
                 if let Ok(resolved) = String::from_utf8(output.stdout) {
-                    path = PathBuf::from(resolved.trim());
+                    let resolved = PathBuf::from(resolved.trim());
+                    if resolved.exists() {
+                        path = resolved;
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->
<!-- homu-ignore:end -->

This is the cargo side of [rust#100681](https://github.com/rust-lang/rust/pull/100681).

### What does this PR try to resolve?

Fixes #10986, obsoletes(?) [rustup#3035](https://github.com/rust-lang/rustup/issues/3035)

The goal is to bypass the `rustup` wrapper when invoking `rustc` multiple times. See #10986 for more context.

### How should we test and review this PR?

Relies on https://github.com/rust-lang/rust/pull/100681.

A local `rustup run stage1 ($env.CARGO_TARGET_DIR | path join release/cargo.exe) build`[^0][^1] succeeded in building, though I'm terribly unsure how to go about testing that this is because `--print=rustc-path` is being respected, especially since I allow `--print=rustc-path` to fail and stick to the old behavior.

[^0]: [nushell](https://www.nushell.sh/) shell syntax
[^1]: Actually, the test run was without the `if output.status.success()` check, which I added afterwards.

### Additional information

cc @davidlattimore, @bjorn3
