### PR TITLE
Bump snapbox to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ features = [
 [dev-dependencies]
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
-snapbox = { version = "0.2.8", features = ["diff", "path"] }
+snapbox = { version = "0.3.0", features = ["diff", "path"] }
 
 [build-dependencies]
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -11,7 +11,7 @@ doctest = false
 anyhow = "1.0.34"
 cargo-test-macro = { path = "../cargo-test-macro" }
 cargo-util = { path = "../cargo-util" }
-snapbox = { version = "0.2.8", features = ["diff", "path"] }
+snapbox = { version = "0.3.0", features = ["diff", "path"] }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 git2 = "0.14.2"


### PR DESCRIPTION
0.3 has a small number of [breaking changes], but makes diffs much
easier to visually parse by eliding large sections of unchanged content.

[breaking changes]: https://github.com/assert-rs/trycmd/blob/main/crates/snapbox/CHANGELOG.md#030---2022-08-01

r? @epage 