### PR TITLE
Ignore broken but excluded file during traversing

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -432,7 +432,11 @@ impl<'cfg> PathSource<'cfg> {
                     self.config.shell().warn(err)?;
                 }
                 Err(err) => match err.path() {
-                    // If the error occurs with a path, simply recover from it.
+                    // If an error occurs with a path, filter it again.
+                    // If it is excluded, Just ignore it in this case.
+                    // See issue rust-lang/cargo#10917
+                    Some(path) if !filter(path, path.is_dir()) => {}
+                    // Otherwise, simply recover from it.
                     // Don't worry about error skipping here, the callers would
                     // still hit the IO error if they do access it thereafter.
                     Some(path) => ret.push(path.to_path_buf()),


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fixes #10917

Walkdir's [`filter_entry()`][1] won't call the predicate if the entry
is essentially an `Err` from its underyling `IntoIter`. That means
Cargo hasn't had a chance to call `filter` on an entry that should be
excluded but eventually return an `Err` and cause the loop to stop.
For instance, a broken symlink which should bee excluded by `filter`
will generate an error since `filter` closure is not called with it.

The solution is calling `filter` if an error occurs with a path
(because it has yet been called with that path).
If it's exactly excluded, ignore the error.

[1]: https://github.com/BurntSushi/walkdir/blob/abf3a15887758e0af54ebca827c7b6f8b311cb45/src/lib.rs#L1042-L1058


### How should we test and review this PR?

Follow the reproducible steps in #10917

### Additional information

<!-- homu-ignore:end -->