### PR TITLE
Add more tests for aggressive or precise update

### DIFF
--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -429,6 +429,43 @@ fn update_precise_without_package() {
 }
 
 #[cargo_test]
+fn update_aggressive() {
+    Package::new("log", "0.1.0").publish();
+    Package::new("serde", "0.2.1").dep("log", "0.1").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                serde = "0.2"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build").run();
+
+    Package::new("log", "0.1.1").publish();
+    Package::new("serde", "0.2.2").dep("log", "0.1").publish();
+
+    p.cargo("update -p serde:0.2.1 --aggressive")
+        .with_stderr(
+            "\
+[UPDATING] `[..]` index
+[UPDATING] log v0.1.0 -> v0.1.1
+[UPDATING] serde v0.2.1 -> v0.2.2
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn update_aggressive_without_package() {
     Package::new("serde", "0.2.0").publish();
 


### PR DESCRIPTION
### What does this PR try to resolve?

When I was working on https://github.com/rust-lang/cargo/pull/10988, I found there is no test for the aggressive update. So I added it.

Also, I added a test for precise update to make sure it won't force update the deps of SPEC.
### How should we test and review this PR?

Unit tests.