### PR TITLE
Update non-ASCII crate name warning message

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -253,8 +253,7 @@ fn check_name(
     if restricted_names::is_non_ascii_name(name) {
         shell.warn(format!(
             "the name `{}` contains non-ASCII characters\n\
-            Support for non-ASCII crate names is experimental and only valid \
-            on the nightly toolchain.",
+            Non-ASCII crate names are not supported by Rust.",
             name
         ))?;
     }

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -435,7 +435,7 @@ fn non_ascii_name() {
         .with_stderr(
             "\
 [WARNING] the name `Привет` contains non-ASCII characters
-Support for non-ASCII crate names is experimental and only valid on the nightly toolchain.
+Non-ASCII crate names are not supported by Rust.
 [CREATED] binary (application) `Привет` package
 ",
         )


### PR DESCRIPTION
This PR fixes an outdated warning when initializing crates sometimes.

### What does this PR try to resolve?
Per [a Zulip convo](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Non-ASCII.20crate.20name.20status/near/294876491) on the topic, non-ASCII crate names are no longer allowed on any toolchain since https://github.com/rust-lang/rust/pull/73305, during the `non_ascii_idents` feature's development. Cargo however tells the user that they are accepted on Nightly. Rust and Cargo should agree on this point to avoid future confusion.

### How should we test and review this PR?
This should be covered by the existing test that was changed but if desired its easy to test with a checkout:

```
Running `/Users/fox/x/Forks/cargo/target/release/cargo init 'ああああ'`
warning: the name `ああああ` contains non-ASCII characters
Non-ASCII crate names are not supported by Rust.
```