### PR TITLE
Very slight `cargo add` documentation improvements

### DIFF
--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -31,6 +31,11 @@ If no source is specified, then a best effort will be made to select one, includ
 
 When you add a package that is already present, the existing entry will be updated with the flags specified.
 
+Upon successful invocation, the enabled (`+`) and disabled (`-`) [features] of the specified
+dependency will be listed in the command's output.
+
+[features]: ../reference/features.md
+
 ## OPTIONS
 
 ### Source options

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -32,6 +32,10 @@ DESCRIPTION
        When you add a package that is already present, the existing entry will
        be updated with the flags specified.
 
+       Upon successful invocation, the enabled (+) and disabled (-) features
+       <https://doc.rust-lang.org/cargo/reference/features.md> of the specified
+       dependency will be listed in the command's output.
+
 OPTIONS
    Source options
        --git url

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -31,6 +31,11 @@ If no source is specified, then a best effort will be made to select one, includ
 
 When you add a package that is already present, the existing entry will be updated with the flags specified.
 
+Upon successful invocation, the enabled (`+`) and disabled (`-`) [features] of the specified
+dependency will be listed in the command's output.
+
+[features]: ../reference/features.md
+
 ## OPTIONS
 
 ### Source options

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -43,6 +43,9 @@ If no source is specified, then a best effort will be made to select one, includ
 .RE
 .sp
 When you add a package that is already present, the existing entry will be updated with the flags specified.
+.sp
+Upon successful invocation, the enabled (\fB+\fR) and disabled (\fB\-\fR) \fIfeatures\fR <https://doc.rust\-lang.org/cargo/reference/features.md> of the specified
+dependency will be listed in the command's output.
 .SH "OPTIONS"
 .SS "Source options"
 .sp


### PR DESCRIPTION
As discussed in https://github.com/rust-lang/book/pull/3331, a quick explanation of the `Features` part of the message that gets printed to stdout when adding some dependency.

Consider the following example:

```
cargo add my-crate
    Updating crates.io index
      Adding my-crate v0.1.0 to dependencies.
             Features:
             + foo
             - bar
```

It was not clear to me what `+foo` and `-bar` meant until @carols10cents' kindly explained it to me. Hopefully the documentation now clarifies this.

TODO:

- [x] Run `./build-man.sh`