### PR TITLE
Add an error when no crates are found from `cargo search`

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -8,7 +8,7 @@ use std::task::Poll;
 use std::time::Duration;
 use std::{cmp, env};
 
-use anyhow::{bail, format_err, Context as _};
+use anyhow::{anyhow, bail, format_err, Context as _};
 use cargo_util::paths;
 use crates_io::{self, NewCrate, NewCrateDependency, Registry};
 use curl::easy::{Easy, InfoType, SslOpt, SslVersion};
@@ -983,6 +983,14 @@ pub fn search(
             registry.host()
         )
     })?;
+
+    if total_crates == 0 {
+        return Err(anyhow!(
+            "could not find any crates matching `{}` from the registry at {}",
+            query,
+            registry.host()
+        ));
+    }
 
     let names = crates
         .iter()

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -162,3 +162,29 @@ fn colored_results() {
         .with_stdout_contains("[..]\x1b[[..]")
         .run();
 }
+
+#[cargo_test]
+fn no_results() {
+    let _server = RegistryBuilder::new()
+        .http_api()
+        .add_responder("/api/v1/crates", |_| Response {
+            code: 200,
+            headers: vec![],
+            body: br#"
+{
+    "crates": [],
+    "meta": {
+        "total": 0
+    }
+}
+            "#
+            .to_vec(),
+        })
+        .build();
+    cargo_process("search z12345")
+        .with_status(101)
+        .with_stderr_contains(
+            "[ERROR] could not find any crates matching `z12345` from the registry at [..]",
+        )
+        .run();
+}


### PR DESCRIPTION
#11037 requested that an error code be added when no results are found when running `cargo search`. 

This makes it so `cargo search` returns an error when no results are found and adds a test to ensure consistency in the future.

close #11037 