### PR TITLE
Add names to CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,24 +37,31 @@ jobs:
     strategy:
       matrix:
         include:
-        - os: ubuntu-latest
+        - name: Linux x86_64 stable
+          os: ubuntu-latest
           rust: stable
           other: i686-unknown-linux-gnu
-        - os: ubuntu-latest
+        - name: Linux x86_64 beta
+          os: ubuntu-latest
           rust: beta
           other: i686-unknown-linux-gnu
-        - os: ubuntu-latest
+        - name: Linux x86_64 nightly
+          os: ubuntu-latest
           rust: nightly
           other: i686-unknown-linux-gnu
-        - os: macos-latest
+        - name: macOS x86_64 stable
+          os: macos-latest
           rust: stable
           other: x86_64-apple-ios
-        - os: windows-latest
+        - name: Windows x86_64 MSVC stable
+          os: windows-latest
           rust: stable-msvc
           other: i686-pc-windows-msvc
-        - os: windows-latest
+        - name: Windows x86_64 gnu nightly
+          os: windows-latest
           rust: nightly-gnu
           other: i686-pc-windows-gnu
+    name: Tests ${{ matrix.name }}
     steps:
     - uses: actions/checkout@v3
     - name: Dump Environment


### PR DESCRIPTION
This adds names to the CI jobs. I've often found the existing auto-generated names to be confusing, and I think it would help to make them a little more succinct and clearer.

Before: 
<img width="314" alt="image" src="https://user-images.githubusercontent.com/43198/187777515-6237f765-d747-4d74-8e06-baa86fbe8b2f.png">

After:
<img width="295" alt="image" src="https://user-images.githubusercontent.com/43198/187777559-6e21f08a-cf4c-4aaf-86ba-201bdd90c84f.png">
