### PR TITLE
chore: Don't show genned docs in ripgrep

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,6 @@
+# Output generated from src/doc/man
+#
+# The goal is to help people find the right file to edit
+src/doc/man/generated_txt
+src/doc/src/commands
+src/etc/man


### PR DESCRIPTION
The goal is to help new (and existing) users more quickly find the
appropriate files to edit (like in #11033).  The main downside is for
someone trying to find output to verify what it looks like, a simple
search won't turn up results but there are other ways around that
(`--no-ignore`, `git status` after doing a man generation, etc).