### PR TITLE
WIP: Add a general mechanism for setting rustflags in Cargo for the current crate only

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -48,6 +48,7 @@ pub fn cli() -> App {
         ))
         .arg_unit_graph()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help bench` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -45,6 +45,7 @@ pub fn cli() -> App {
         .arg_unit_graph()
         .arg_future_incompat_report()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help build` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -37,6 +37,7 @@ pub fn cli() -> App {
         .arg_unit_graph()
         .arg_future_incompat_report()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help check` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -40,6 +40,7 @@ pub fn cli() -> App {
         .arg_ignore_rust_version()
         .arg_unit_graph()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help doc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -54,6 +54,7 @@ pub fn cli() -> App {
         ))
         .arg_ignore_rust_version()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help fix` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -82,6 +82,7 @@ pub fn cli() -> App {
         )
         .arg_message_format()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help install` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -35,6 +35,7 @@ pub fn cli() -> App {
         )
         .arg_manifest_path()
         .arg_jobs()
+        .arg_rustflags()
         .after_help("Run `cargo help package` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -32,6 +32,7 @@ pub fn cli() -> App {
         .arg_unit_graph()
         .arg_ignore_rust_version()
         .arg_timings()
+        .arg_rustflags()
         .after_help("Run `cargo help run` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -56,6 +56,7 @@ pub fn cli() -> App {
         .arg_unit_graph()
         .arg_future_incompat_report()
         .arg_timings()
+        .arg_rustflags()
         .after_help(
             "Run `cargo help test` for more detailed information.\n\
              Run `cargo test -- --help` for test binary options.\n",

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1302,12 +1302,15 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
     // Fill out a bunch more information that we'll be tracking typically
     // hashed to take up less space on disk as we just need to know when things
     // change.
-    let extra_flags = if unit.mode.is_doc() {
+    let mut rustflags = if unit.mode.is_doc() {
         cx.bcx.rustdocflags_args(unit)
     } else {
         cx.bcx.rustflags_args(unit)
     }
     .to_vec();
+
+    // Append the command line user specified RUSTFLAGS to the env var or config RUSTFLAGS.
+    rustflags.extend(unit.rustflags.iter().map(InternedString::to_string));
 
     let profile_hash = util::hash_u64((
         &unit.profile,
@@ -1345,7 +1348,7 @@ fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Finger
         metadata,
         config: config.finish(),
         compile_kind,
-        rustflags: extra_flags,
+        rustflags,
         fs_status: FsStatus::Stale,
         outputs,
     })

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -241,9 +241,15 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
     let dep_info_loc = fingerprint::dep_info_loc(cx, unit);
 
     rustc.args(cx.bcx.rustflags_args(unit));
+
+    // Append any user specified rustflags on the command line
+    // via the --rustflag argument.
+    rustc.args(&unit.rustflags);
+
     if cx.bcx.config.cli_unstable().binary_dep_depinfo {
         rustc.arg("-Z").arg("binary-dep-depinfo");
     }
+
     let mut output_options = OutputOptions::new(cx, unit);
     let package_id = unit.pkg.package_id();
     let target = Target::clone(&unit.target);

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -214,6 +214,8 @@ pub fn generate_std_roots(
                 *kind,
                 mode,
                 features.clone(),
+                /*rustflags*/
+                Default::default(), // Setting command line rustflags for the standard library is not supported
                 /*is_std*/ true,
                 /*dep_hash*/ 0,
                 IsArtifact::No,

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -55,6 +55,8 @@ pub struct UnitInner {
     /// The `cfg` features to enable for this unit.
     /// This must be sorted.
     pub features: Vec<InternedString>,
+    /// The rustflags to set for this unit.
+    pub rustflags: Vec<InternedString>,
     // if `true`, the dependency is an artifact dependency, requiring special handling when
     // calculating output directories, linkage and environment variables provided to builds.
     pub artifact: IsArtifact,
@@ -181,6 +183,7 @@ impl UnitInterner {
         kind: CompileKind,
         mode: CompileMode,
         features: Vec<InternedString>,
+        rustflags: Vec<InternedString>,
         is_std: bool,
         dep_hash: u64,
         artifact: IsArtifact,
@@ -213,6 +216,7 @@ impl UnitInterner {
             kind,
             mode,
             features,
+            rustflags,
             is_std,
             dep_hash,
             artifact,

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -284,6 +284,7 @@ fn compute_deps(
                 unit,
                 dep_pkg,
                 dep_lib,
+                /*rustflags*/ Default::default(),
                 dep_unit_for,
                 unit.kind,
                 mode,
@@ -295,6 +296,7 @@ fn compute_deps(
                 unit,
                 dep_pkg,
                 dep_lib,
+                /*rustflags*/ Default::default(),
                 dep_unit_for,
                 CompileKind::Host,
                 mode,
@@ -307,6 +309,7 @@ fn compute_deps(
                 unit,
                 dep_pkg,
                 dep_lib,
+                /*rustflags*/ Default::default(),
                 dep_unit_for,
                 unit.kind.for_target(dep_lib),
                 mode,
@@ -377,6 +380,7 @@ fn compute_deps(
                         unit,
                         &unit.pkg,
                         t,
+                        /*rustflags*/ Default::default(),
                         UnitFor::new_normal(unit_for.root_compile_kind()),
                         unit.kind.for_target(t),
                         CompileMode::Build,
@@ -479,6 +483,7 @@ fn compute_deps_custom_build(
         unit,
         &unit.pkg,
         &unit.target,
+        /*rustflags*/ Default::default(),
         script_unit_for,
         // Build scripts always compiled for the host.
         CompileKind::Host,
@@ -568,6 +573,7 @@ fn artifact_targets_to_unit_deps(
                                     target
                                         .clone()
                                         .set_kind(TargetKind::Lib(vec![target_kind.clone()])),
+                                    /*rustflags*/ Default::default(),
                                     parent_unit_for,
                                     compile_kind,
                                     CompileMode::Build,
@@ -580,6 +586,7 @@ fn artifact_targets_to_unit_deps(
                         parent,
                         artifact_pkg,
                         target,
+                        /*rustflags*/ Default::default(),
                         parent_unit_for,
                         compile_kind,
                         CompileMode::Build,
@@ -655,6 +662,7 @@ fn compute_deps_doc(
             unit,
             dep_pkg,
             dep_lib,
+            /*rustflags*/ Default::default(),
             dep_unit_for,
             unit.kind.for_target(dep_lib),
             mode,
@@ -669,6 +677,7 @@ fn compute_deps_doc(
                     unit,
                     dep_pkg,
                     dep_lib,
+                    /*rustflags*/ Default::default(),
                     dep_unit_for,
                     unit.kind.for_target(dep_lib),
                     unit.mode,
@@ -699,6 +708,7 @@ fn compute_deps_doc(
                 unit,
                 &unit.pkg,
                 lib,
+                /*rustflags*/ Default::default(),
                 dep_unit_for,
                 unit.kind.for_target(lib),
                 unit.mode,
@@ -717,6 +727,7 @@ fn compute_deps_doc(
                 scrape_unit,
                 &scrape_unit.pkg,
                 &scrape_unit.target,
+                /*rustflags*/ Default::default(),
                 unit_for,
                 scrape_unit.kind,
                 scrape_unit.mode,
@@ -740,11 +751,15 @@ fn maybe_lib(
         .map(|t| {
             let mode = check_or_build_mode(unit.mode, t);
             let dep_unit_for = unit_for.with_dependency(unit, t, unit_for.root_compile_kind());
+
+            // When adding the lib targets for the current unit also pass down the user specified
+            // rustflags for the package.
             new_unit_dep(
                 state,
                 unit,
                 &unit.pkg,
                 t,
+                unit.rustflags.clone(),
                 dep_unit_for,
                 unit.kind.for_target(t),
                 mode,
@@ -805,6 +820,7 @@ fn dep_build_script(
                 unit,
                 &unit.pkg,
                 t,
+                Default::default(),
                 script_unit_for,
                 unit.kind,
                 CompileMode::RunCustomBuild,
@@ -839,6 +855,7 @@ fn new_unit_dep(
     parent: &Unit,
     pkg: &Package,
     target: &Target,
+    rustflags: Vec<InternedString>,
     unit_for: UnitFor,
     kind: CompileKind,
     mode: CompileMode,
@@ -853,7 +870,7 @@ fn new_unit_dep(
         kind,
     );
     new_unit_dep_with_profile(
-        state, parent, pkg, target, unit_for, kind, mode, profile, artifact,
+        state, parent, pkg, target, rustflags, unit_for, kind, mode, profile, artifact,
     )
 }
 
@@ -862,6 +879,7 @@ fn new_unit_dep_with_profile(
     parent: &Unit,
     pkg: &Package,
     target: &Target,
+    rustflags: Vec<InternedString>,
     unit_for: UnitFor,
     kind: CompileKind,
     mode: CompileMode,
@@ -885,6 +903,7 @@ fn new_unit_dep_with_profile(
         kind,
         mode,
         features,
+        rustflags,
         state.is_std,
         /*dep_hash*/ 0,
         artifact.map_or(IsArtifact::No, |_| IsArtifact::Yes),

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -822,6 +822,7 @@ fn run_verify(
                 CompileMode::Build,
             )?,
             cli_features: opts.cli_features.clone(),
+            rustflags: Vec::new(),
             spec: ops::Packages::Packages(Vec::new()),
             filter: ops::CompileFilter::Default {
                 required_features_filterable: true,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -81,6 +81,7 @@ Each new feature described below should explain how to use it.
     * [panic-abort-tests](#panic-abort-tests) — Allows running tests with the "abort" panic strategy.
     * [crate-type](#crate-type) — Supports passing crate types to the compiler.
     * [keep-going](#keep-going) — Build as much as possible rather than aborting on the first error.
+    * [rustflags](#rustflags) — Supports passing RUSTFLAGS to the compiler for the root crate.
 * rustdoc
     * [`doctest-in-workspace`](#doctest-in-workspace) — Fixes workspace-relative paths when running doctests.
     * [rustdoc-map](#rustdoc-map) — Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
@@ -426,6 +427,26 @@ The `-Z unstable-options` command-line option must be used in order to use
 
 ```console
 cargo check --keep-going -Z unstable-options
+```
+
+### rustflags
+* Tracking Issue: [#00000](https://github.com/rust-lang/cargo/issues/00000)
+
+`cargo build --rustflags` (and similarly for `run`, `test` etc) forward the
+rustflags specified to the compiler only for the root crate. Dependencies,
+including transitive dependencies, will not have these rustflags enabled.
+
+For example if the current package depends on dependencies `foo` and `bar`,
+`cargo test --rustflags -C instrument-coverage ` will
+instrument only the libraries for the current package and not for `foo` or `bar`.
+
+This option supports multiple values that begin with a leading hypen(`-`),
+as such, a value terminator (`;`) is required to indicate the end of these
+values. This terminator will allow additional cargo options to be passed via
+the command line after the values to the `--rustflags` option.
+
+```console
+cargo test --rustflags -C instrument-coverage ; -Z unstable-options
 ```
 
 ### config-include


### PR DESCRIPTION
### What does this PR try to resolve?

This PR implements [RFC #3310](https://github.com/rust-lang/rfcs/pull/3310), adding a general mechanism for setting rustflags that only apply to the root crate.

### How should we test and review this PR?

This change contains tests at `tests/testsuite/rustflags.rs` to ensure the new feature works as expected and that rustflags are only where expected.

### Additional information

None.