### PR TITLE
chore(ci): Ensure intradoc links are valid

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,9 @@ jobs:
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-    - run: cargo doc --no-deps
+    - run: cargo doc --document-private-items --no-deps
+      env:
+        RUSTDOCFLAGS: -D warnings
     - run: cd src/doc && mdbook build --dest-dir ../../target/doc
     - run: |
         cd src/doc

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -5,6 +5,7 @@
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]
+#![allow(rustdoc::private_intra_doc_links)]
 
 //! # Cargo as a library
 //!

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -348,7 +348,7 @@ pub fn fix_get_proxy_lock_addr() -> Option<String> {
 /// If there are warnings or errors, this does not return,
 /// and the process exits with the corresponding `rustc` exit code.
 ///
-/// See [`fix_proxy_lock_addr`]
+/// See [`fix_get_proxy_lock_addr`]
 pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
     let args = FixArgs::get()?;
     trace!("cargo-fix as rustc got file {:?}", args.file);


### PR DESCRIPTION
The plan is to move the architecture documents over to rustdoc so they can more easily stay up-to-date.  To do so, we'll need to enforce that the intradoc links stay valid.

As part of this, the PR run for `cargo doc` was updated to the command in #11019