### PR TITLE
Ignore `workspace.default-members` when running `cargo install` on root package of a non-virtual workspace

### DIFF
--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -6,10 +6,11 @@ use cargo_util::ProcessBuilder;
 use serde::ser;
 use std::cell::RefCell;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::thread::available_parallelism;
 
 /// Configuration information for a rustc build.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BuildConfig {
     /// The requested kind of compilation for this session
     pub requested_kinds: Vec<CompileKind>,
@@ -33,7 +34,7 @@ pub struct BuildConfig {
     pub primary_unit_rustc: Option<ProcessBuilder>,
     /// A thread used by `cargo fix` to receive messages on a socket regarding
     /// the success/failure of applying fixes.
-    pub rustfix_diagnostic_server: RefCell<Option<RustfixDiagnosticServer>>,
+    pub rustfix_diagnostic_server: Arc<RefCell<Option<RustfixDiagnosticServer>>>,
     /// The directory to copy final artifacts to. Note that even if `out_dir` is
     /// set, a copy of artifacts still could be found a `target/(debug\release)`
     /// as usual.
@@ -100,7 +101,7 @@ impl BuildConfig {
             build_plan: false,
             unit_graph: false,
             primary_unit_rustc: None,
-            rustfix_diagnostic_server: RefCell::new(None),
+            rustfix_diagnostic_server: Arc::new(RefCell::new(None)),
             export_dir: None,
             future_incompat_report: false,
             timing_outputs: Vec::new(),

--- a/src/cargo/ops/cargo_compile/compile_filter.rs
+++ b/src/cargo/ops/cargo_compile/compile_filter.rs
@@ -34,7 +34,7 @@ pub enum FilterRule {
 ///
 /// [`generate_root_units`]: super::UnitGenerator::generate_root_units
 /// [`Packages`]: crate::ops::Packages
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CompileFilter {
     /// The default set of Cargo targets.
     Default {

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -68,7 +68,7 @@ pub use packages::Packages;
 /// of it as `CompileOptions` are high-level settings requested on the
 /// command-line, and `BuildConfig` are low-level settings for actually
 /// driving `rustc`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompileOptions {
     /// Configuration information for a rustc build
     pub build_config: BuildConfig,

--- a/src/cargo/ops/cargo_compile/packages.rs
+++ b/src/cargo/ops/cargo_compile/packages.rs
@@ -13,7 +13,7 @@ use anyhow::{bail, Context as _};
 ///
 /// Generally, it represents the combination of all `-p` flag. When working within
 /// a workspace, `--exclude` and `--workspace` flags also contribute to it.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub enum Packages {
     /// Packages selected by default. Usually means no flag provided.
     Default,


### PR DESCRIPTION
### What does this PR try to resolve?

* Fixes #11058 

Two observable behaviors are fixed:

1. When running `cargo install` with `--path` or `--git` and specifically requesting the root package of a non-virtual workspace, `cargo install` will accidentally build `workspace.default-members` instead of the requested root package.
2. Further, if that `default-members` does not include the root package, it will install binaries from those other packages (the `default-members`) and claim they were the binaries from the root package! There is no way, actually, to install the root package binaries.

These two behaviors have the same root cause:

* `cargo install` effectively does `cargo build --release` in the requested package directory, but when this is the root of a non-virtual workspace, that builds `default-members` instead of the requested package.

### How should we test and review this PR?

I have included a test exhibiting this behavior. It currently fails in the manner indicated in the test, and passes with the changes included in this PR.

I'm not sure the solution in the PR is the _best_ solution, but the alternative I am able to come up with involves much more extensive changes to how `cargo install` works, to produce a distinct `CompileOptions` for every package built. I tried to keep the new workspace "API" `ignore_default_members()` as narrowly-scoped in its effect as possible.

### Additional information

The only way I could think this behavior change could impact someone is if they were somehow using `cargo install --path` (or `--git`) and wanting it to actually install the binaries from all of `default-members`. However, I don't believe that's possible, since if there are multiple packages with binaries, I believe cargo requires the packages to be specified. So someone would have to be additionally relying on specifying just the root package, but then wanting the binaries from more than just the root. I think this is probably an acceptable risk for merging!