### PR TITLE
Change progress indicator for sparse registries

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -15,6 +15,7 @@ pub struct Progress<'cfg> {
 pub enum ProgressStyle {
     Percentage,
     Ratio,
+    Indeterminate,
 }
 
 struct Throttle {
@@ -253,6 +254,7 @@ impl Format {
         let stats = match self.style {
             ProgressStyle::Percentage => format!(" {:6.02}%", pct * 100.0),
             ProgressStyle::Ratio => format!(" {}/{}", cur, max),
+            ProgressStyle::Indeterminate => String::new(),
         };
         let extra_len = stats.len() + 2 /* [ and ] */ + 15 /* status header */;
         let display_width = match self.width().checked_sub(extra_len) {


### PR DESCRIPTION
The progress indicator for sparse registries previously could go backwards as new dependencies are discovered, which confused users.

The new indicator looks like this:
```
    Updating crates.io index
       Fetch [====================>            ] 46 complete; 29 pending
```

The progress bar percentage is based the current depth in the dependency tree, with a hard coded limit at `10/11`. This provides natural feeling progress for many projects that I tested.

`complete` represents the number of index files downloaded, `pending` represents the number of index files that Cargo knows need to be downloaded but have not yet finished.

Fixes #10820