### PR TITLE
Add retry support to sparse registries

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -72,7 +72,7 @@ pub struct RegistryBuilder {
     /// Write the registry in configuration.
     configure_registry: bool,
     /// API responders.
-    custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request) -> Response>>,
+    custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
 }
 
 pub struct TestRegistry {
@@ -117,7 +117,7 @@ impl RegistryBuilder {
 
     /// Adds a custom HTTP response for a specific url
     #[must_use]
-    pub fn add_responder<R: 'static + Send + Fn(&Request) -> Response>(
+    pub fn add_responder<R: 'static + Send + Fn(&Request, &HttpServer) -> Response>(
         mut self,
         url: &'static str,
         responder: R,
@@ -497,12 +497,12 @@ pub struct Response {
     pub body: Vec<u8>,
 }
 
-struct HttpServer {
+pub struct HttpServer {
     listener: TcpListener,
     registry_path: PathBuf,
     dl_path: PathBuf,
     token: Option<String>,
-    custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request) -> Response>>,
+    custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
 }
 
 impl HttpServer {
@@ -510,7 +510,10 @@ impl HttpServer {
         registry_path: PathBuf,
         dl_path: PathBuf,
         token: Option<String>,
-        api_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request) -> Response>>,
+        api_responders: HashMap<
+            &'static str,
+            Box<dyn Send + Fn(&Request, &HttpServer) -> Response>,
+        >,
     ) -> HttpServerHandle {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -620,7 +623,7 @@ impl HttpServer {
 
         // Check for custom responder
         if let Some(responder) = self.custom_responders.get(req.url.path()) {
-            return responder(&req);
+            return responder(&req, self);
         }
         let path: Vec<_> = req.url.path()[1..].split('/').collect();
         match (req.method.as_str(), path.as_slice()) {
@@ -668,7 +671,7 @@ impl HttpServer {
     }
 
     /// Unauthorized response
-    fn unauthorized(&self, _req: &Request) -> Response {
+    pub fn unauthorized(&self, _req: &Request) -> Response {
         Response {
             code: 401,
             headers: vec![],
@@ -677,7 +680,7 @@ impl HttpServer {
     }
 
     /// Not found response
-    fn not_found(&self, _req: &Request) -> Response {
+    pub fn not_found(&self, _req: &Request) -> Response {
         Response {
             code: 404,
             headers: vec![],
@@ -686,7 +689,7 @@ impl HttpServer {
     }
 
     /// Respond OK without doing anything
-    fn ok(&self, _req: &Request) -> Response {
+    pub fn ok(&self, _req: &Request) -> Response {
         Response {
             code: 200,
             headers: vec![],
@@ -694,8 +697,17 @@ impl HttpServer {
         }
     }
 
+    /// Return an internal server error (HTTP 500)
+    pub fn internal_server_error(&self, _req: &Request) -> Response {
+        Response {
+            code: 500,
+            headers: vec![],
+            body: br#"internal server error"#.to_vec(),
+        }
+    }
+
     /// Serve the download endpoint
-    fn dl(&self, req: &Request) -> Response {
+    pub fn dl(&self, req: &Request) -> Response {
         let file = self
             .dl_path
             .join(req.url.path().strip_prefix("/dl/").unwrap());
@@ -711,7 +723,7 @@ impl HttpServer {
     }
 
     /// Serve the registry index
-    fn index(&self, req: &Request) -> Response {
+    pub fn index(&self, req: &Request) -> Response {
         let file = self
             .registry_path
             .join(req.url.path().strip_prefix("/index/").unwrap());
@@ -761,7 +773,7 @@ impl HttpServer {
         }
     }
 
-    fn publish(&self, req: &Request) -> Response {
+    pub fn publish(&self, req: &Request) -> Response {
         if let Some(body) = &req.body {
             // Get the metadata of the package
             let (len, remaining) = body.split_at(4);

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -27,7 +27,7 @@ use crate::core::{Dependency, Manifest, PackageId, SourceId, Target};
 use crate::core::{SourceMap, Summary, Workspace};
 use crate::ops;
 use crate::util::config::PackageCacheLock;
-use crate::util::errors::{CargoResult, HttpNot200};
+use crate::util::errors::{CargoResult, HttpNotSuccessful};
 use crate::util::interning::InternedString;
 use crate::util::network::Retry;
 use crate::util::{self, internal, Config, Progress, ProgressStyle};
@@ -868,18 +868,19 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                         let code = handle.response_code()?;
                         if code != 200 && code != 0 {
                             let url = handle.effective_url()?.unwrap_or(url);
-                            return Err(HttpNot200 {
+                            return Err(HttpNotSuccessful {
                                 code,
                                 url: url.to_string(),
+                                body: data,
                             }
                             .into());
                         }
-                        Ok(())
+                        Ok(data)
                     })
                     .with_context(|| format!("failed to download from `{}`", dl.url))?
             };
             match ret {
-                Some(()) => break (dl, data),
+                Some(data) => break (dl, data),
                 None => {
                     self.pending_ids.insert(dl.id);
                     self.enqueue(dl, handle)?

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -28,7 +28,7 @@ use crate::sources::{RegistrySource, SourceConfigMap, CRATES_IO_DOMAIN, CRATES_I
 use crate::util::config::{self, Config, SslVersionConfig, SslVersionConfigRange};
 use crate::util::errors::CargoResult;
 use crate::util::important_paths::find_root_manifest_for_wd;
-use crate::util::IntoUrl;
+use crate::util::{truncate_with_ellipsis, IntoUrl};
 use crate::{drop_print, drop_println, version};
 
 mod auth;
@@ -963,18 +963,6 @@ pub fn search(
     limit: u32,
     reg: Option<String>,
 ) -> CargoResult<()> {
-    fn truncate_with_ellipsis(s: &str, max_width: usize) -> String {
-        // We should truncate at grapheme-boundary and compute character-widths,
-        // yet the dependencies on unicode-segmentation and unicode-width are
-        // not worth it.
-        let mut chars = s.chars();
-        let mut prefix = (&mut chars).take(max_width - 1).collect::<String>();
-        if chars.next().is_some() {
-            prefix.push('…');
-        }
-        prefix
-    }
-
     let (mut registry, _, source_id) =
         registry(config, None, index.as_deref(), reg.as_deref(), false, false)?;
     let (crates, total_crates) = registry.search(query, limit).with_context(|| {

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -110,3 +110,15 @@ pub fn indented_lines(text: &str) -> String {
         })
         .collect()
 }
+
+pub fn truncate_with_ellipsis(s: &str, max_width: usize) -> String {
+    // We should truncate at grapheme-boundary and compute character-widths,
+    // yet the dependencies on unicode-segmentation and unicode-width are
+    // not worth it.
+    let mut chars = s.chars();
+    let mut prefix = (&mut chars).take(max_width - 1).collect::<String>();
+    if chars.next().is_some() {
+        prefix.push('…');
+    }
+    prefix
+}

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -1,6 +1,6 @@
 use anyhow::Error;
 
-use crate::util::errors::{CargoResult, HttpNot200};
+use crate::util::errors::{CargoResult, HttpNotSuccessful};
 use crate::util::Config;
 use std::task::Poll;
 
@@ -31,6 +31,7 @@ impl<'a> Retry<'a> {
         })
     }
 
+    /// Returns `Ok(None)` for operations that should be re-tried.
     pub fn r#try<T>(&mut self, f: impl FnOnce() -> CargoResult<T>) -> CargoResult<Option<T>> {
         match f() {
             Err(ref e) if maybe_spurious(e) && self.remaining > 0 => {
@@ -73,7 +74,7 @@ fn maybe_spurious(err: &Error) -> bool {
             return true;
         }
     }
-    if let Some(not_200) = err.downcast_ref::<HttpNot200>() {
+    if let Some(not_200) = err.downcast_ref::<HttpNotSuccessful>() {
         if 500 <= not_200.code && not_200.code < 600 {
             return true;
         }
@@ -114,14 +115,16 @@ fn with_retry_repeats_the_call_then_works() {
     use crate::core::Shell;
 
     //Error HTTP codes (5xx) are considered maybe_spurious and will prompt retry
-    let error1 = HttpNot200 {
+    let error1 = HttpNotSuccessful {
         code: 501,
         url: "Uri".to_string(),
+        body: Vec::new(),
     }
     .into();
-    let error2 = HttpNot200 {
+    let error2 = HttpNotSuccessful {
         code: 502,
         url: "Uri".to_string(),
+        body: Vec::new(),
     }
     .into();
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
@@ -137,14 +140,16 @@ fn with_retry_finds_nested_spurious_errors() {
 
     //Error HTTP codes (5xx) are considered maybe_spurious and will prompt retry
     //String error messages are not considered spurious
-    let error1 = anyhow::Error::from(HttpNot200 {
+    let error1 = anyhow::Error::from(HttpNotSuccessful {
         code: 501,
         url: "Uri".to_string(),
+        body: Vec::new(),
     });
     let error1 = anyhow::Error::from(error1.context("A non-spurious wrapping err"));
-    let error2 = anyhow::Error::from(HttpNot200 {
+    let error2 = anyhow::Error::from(HttpNotSuccessful {
         code: 502,
         url: "Uri".to_string(),
+        body: Vec::new(),
     });
     let error2 = anyhow::Error::from(error2.context("A second chained error"));
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1443,7 +1443,7 @@ fn api_error_json() {
     let _registry = registry::RegistryBuilder::new()
         .alternative()
         .http_api()
-        .add_responder("/api/v1/crates/new", |_| Response {
+        .add_responder("/api/v1/crates/new", |_, _| Response {
             body: br#"{"errors": [{"detail": "you must be logged in"}]}"#.to_vec(),
             code: 403,
             headers: vec![],
@@ -1490,7 +1490,7 @@ fn api_error_200() {
     let _registry = registry::RegistryBuilder::new()
         .alternative()
         .http_api()
-        .add_responder("/api/v1/crates/new", |_| Response {
+        .add_responder("/api/v1/crates/new", |_, _| Response {
             body: br#"{"errors": [{"detail": "max upload size is 123"}]}"#.to_vec(),
             code: 200,
             headers: vec![],
@@ -1537,7 +1537,7 @@ fn api_error_code() {
     let _registry = registry::RegistryBuilder::new()
         .alternative()
         .http_api()
-        .add_responder("/api/v1/crates/new", |_| Response {
+        .add_responder("/api/v1/crates/new", |_, _| Response {
             body: br#"go away"#.to_vec(),
             code: 400,
             headers: vec![],
@@ -1590,7 +1590,7 @@ fn api_curl_error() {
     let _registry = registry::RegistryBuilder::new()
         .alternative()
         .http_api()
-        .add_responder("/api/v1/crates/new", |_| {
+        .add_responder("/api/v1/crates/new", |_, _| {
             panic!("broke");
         })
         .build();
@@ -1639,7 +1639,7 @@ fn api_other_error() {
     let _registry = registry::RegistryBuilder::new()
         .alternative()
         .http_api()
-        .add_responder("/api/v1/crates/new", |_| Response {
+        .add_responder("/api/v1/crates/new", |_, _| Response {
             body: b"\xff".to_vec(),
             code: 200,
             headers: vec![],

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -78,7 +78,7 @@ postgres = \"0.17.3\"    # A native, synchronous PostgreSQL client
 fn setup() -> RegistryBuilder {
     RegistryBuilder::new()
         .http_api()
-        .add_responder("/api/v1/crates", |_| Response {
+        .add_responder("/api/v1/crates", |_, _| Response {
             code: 200,
             headers: vec![],
             body: SEARCH_API_RESPONSE.to_vec(),


### PR DESCRIPTION
Sparse (HTTP) registries currently do not respect Cargo's retry policy for http requests.

This change makes sparse registries use the same retry system as package downloads.