### PR TITLE
Config file loaded via CLI takes priority over env vars

### DIFF
--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -473,7 +473,13 @@ impl<'de, 'config> de::MapAccess<'de> for ValueDeserializer<'config> {
             Definition::Environment(env) => {
                 seed.deserialize(Tuple2Deserializer(1i32, env.as_str()))
             }
-            Definition::Cli => seed.deserialize(Tuple2Deserializer(2i32, "")),
+            Definition::Cli(path) => {
+                let str = path
+                    .as_ref()
+                    .map(|p| p.to_string_lossy())
+                    .unwrap_or_default();
+                seed.deserialize(Tuple2Deserializer(2i32, str))
+            }
         }
     }
 }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1068,7 +1068,7 @@ impl Config {
         let home = self.home_path.clone().into_path_unlocked();
 
         self.walk_tree(path, &home, |path| {
-            let value = self.load_file(path, true)?;
+            let value = self.load_file(path)?;
             cfg.merge(value, false).with_context(|| {
                 format!("failed to merge configuration at `{}`", path.display())
             })?;
@@ -1085,8 +1085,8 @@ impl Config {
     /// Loads a config value from a path.
     ///
     /// This is used during config file discovery.
-    fn load_file(&self, path: &Path, includes: bool) -> CargoResult<ConfigValue> {
-        self._load_file(path, &mut HashSet::new(), includes, WhyLoad::FileDiscovery)
+    fn load_file(&self, path: &Path) -> CargoResult<ConfigValue> {
+        self._load_file(path, &mut HashSet::new(), true, WhyLoad::FileDiscovery)
     }
 
     /// Loads a config value from a path with options.
@@ -1476,7 +1476,7 @@ impl Config {
             None => return Ok(()),
         };
 
-        let mut value = self.load_file(&credentials, true)?;
+        let mut value = self.load_file(&credentials)?;
         // Backwards compatibility for old `.cargo/credentials` layout.
         {
             let (value_map, def) = match value {

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1019,6 +1019,9 @@ impl Config {
         self.load_values_from(&self.cwd)
     }
 
+    /// Like [`load_values`](Config::load_values) but without merging config values.
+    ///
+    /// This is primarily crafted for `cargo config` command.
     pub(crate) fn load_values_unmerged(&self) -> CargoResult<Vec<ConfigValue>> {
         let mut result = Vec::new();
         let mut seen = HashSet::new();
@@ -1035,6 +1038,9 @@ impl Config {
         Ok(result)
     }
 
+    /// Like [`load_includes`](Config::load_includes) but without merging config values.
+    ///
+    /// This is primarily crafted for `cargo config` command.
     fn load_unmerged_include(
         &self,
         cv: &mut CV,
@@ -1054,6 +1060,7 @@ impl Config {
         Ok(())
     }
 
+    /// Start a config file discovery from a path and merges all config values found.
     fn load_values_from(&self, path: &Path) -> CargoResult<HashMap<String, ConfigValue>> {
         // This definition path is ignored, this is just a temporary container
         // representing the entire file.
@@ -1075,10 +1082,22 @@ impl Config {
         }
     }
 
+    /// Loads a config value from a path.
+    ///
+    /// This is used during config file discovery.
     fn load_file(&self, path: &Path, includes: bool) -> CargoResult<ConfigValue> {
         self._load_file(path, &mut HashSet::new(), includes, WhyLoad::FileDiscovery)
     }
 
+    /// Loads a config value from a path with options.
+    ///
+    /// This is actual implementation of loading a config value from a path.
+    ///
+    /// * `includes` determines whether to load configs from [`config-include`].
+    /// * `seen` is used to check for cyclic includes.
+    /// * `why_load` tells why a config is being loaded.
+    ///
+    /// [`config-include`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#config-include
     fn _load_file(
         &self,
         path: &Path,
@@ -1118,7 +1137,8 @@ impl Config {
     ///
     /// Returns `value` with the given include files merged into it.
     ///
-    /// `seen` is used to check for cyclic includes.
+    /// * `seen` is used to check for cyclic includes.
+    /// * `why_load` tells why a config is being loaded.
     fn load_includes(
         &self,
         mut value: CV,

--- a/src/cargo/util/config/value.rs
+++ b/src/cargo/util/config/value.rs
@@ -59,7 +59,8 @@ pub enum Definition {
     /// Defined in an environment variable, includes the environment key.
     Environment(String),
     /// Passed in on the command line.
-    Cli,
+    /// A path is attached if the config value is a path to a config file.
+    Cli(Option<PathBuf>),
 }
 
 impl Definition {
@@ -69,8 +70,8 @@ impl Definition {
     /// CLI and env are the current working directory.
     pub fn root<'a>(&'a self, config: &'a Config) -> &'a Path {
         match self {
-            Definition::Path(p) => p.parent().unwrap().parent().unwrap(),
-            Definition::Environment(_) | Definition::Cli => config.cwd(),
+            Definition::Path(p) | Definition::Cli(Some(p)) => p.parent().unwrap().parent().unwrap(),
+            Definition::Environment(_) | Definition::Cli(None) => config.cwd(),
         }
     }
 
@@ -80,8 +81,8 @@ impl Definition {
     pub fn is_higher_priority(&self, other: &Definition) -> bool {
         matches!(
             (self, other),
-            (Definition::Cli, Definition::Environment(_))
-                | (Definition::Cli, Definition::Path(_))
+            (Definition::Cli(_), Definition::Environment(_))
+                | (Definition::Cli(_), Definition::Path(_))
                 | (Definition::Environment(_), Definition::Path(_))
         )
     }
@@ -100,9 +101,9 @@ impl PartialEq for Definition {
 impl fmt::Display for Definition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Definition::Path(p) => p.display().fmt(f),
+            Definition::Path(p) | Definition::Cli(Some(p)) => p.display().fmt(f),
             Definition::Environment(key) => write!(f, "environment variable `{}`", key),
-            Definition::Cli => write!(f, "--config cli option"),
+            Definition::Cli(None) => write!(f, "--config cli option"),
         }
     }
 }
@@ -218,8 +219,11 @@ impl<'de> de::Deserialize<'de> for Definition {
         match discr {
             0 => Ok(Definition::Path(value.into())),
             1 => Ok(Definition::Environment(value)),
-            2 => Ok(Definition::Cli),
-            _ => panic!("unexpected discriminant {} value {}", discr, value),
+            2 => {
+                let path = (value.len() > 0).then_some(value.into());
+                Ok(Definition::Cli(path))
+            }
+            _ => panic!("unexpected discriminant {discr} value {value}"),
         }
     }
 }

--- a/src/cargo/util/config/value.rs
+++ b/src/cargo/util/config/value.rs
@@ -59,7 +59,7 @@ pub enum Definition {
     /// Defined in an environment variable, includes the environment key.
     Environment(String),
     /// Passed in on the command line.
-    /// A path is attached if the config value is a path to a config file.
+    /// A path is attached when the config value is a path to a config file.
     Cli(Option<PathBuf>),
 }
 

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -254,3 +254,31 @@ Caused by:
   expected array, but found string",
     );
 }
+
+#[cargo_test]
+fn cli_include_take_prioirty_over_env() {
+    write_config_at(".cargo/include.toml", "k='include'");
+
+    // k=env
+    let config = ConfigBuilder::new().env("CARGO_K", "env").build();
+    assert_eq!(config.get::<String>("k").unwrap(), "env");
+
+    // k=env
+    // --config 'include=".cargo/include.toml"'
+    let config = ConfigBuilder::new()
+        .env("CARGO_K", "env")
+        .unstable_flag("config-include")
+        .config_arg("include='.cargo/include.toml'")
+        .build();
+    assert_eq!(config.get::<String>("k").unwrap(), "include");
+
+    // k=env
+    // --config '.cargo/foo.toml'
+    write_config_at(".cargo/foo.toml", "include='include.toml'");
+    let config = ConfigBuilder::new()
+        .env("CARGO_K", "env")
+        .unstable_flag("config-include")
+        .config_arg(".cargo/foo.toml")
+        .build();
+    assert_eq!(config.get::<String>("k").unwrap(), "include");
+}

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -256,7 +256,7 @@ Caused by:
 }
 
 #[cargo_test]
-fn cli_include_take_prioirty_over_env() {
+fn cli_include_take_priority_over_env() {
     write_config_at(".cargo/include.toml", "k='include'");
 
     // k=env


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #10992

Behaviour changes: After this commit, config files loaded via CLI take
priority over env vars. Config files loaded via [`config-include`]
feature also get a higher priority over env vars, if the initial config
file is being loaded via CLI.

Cargo knows why it loads a specific config file with `WhyLoad` enum,
and store in the field of `Definition::Cli(…)`. With this additional data,
config files loaded via `--config <path>` get a `Definition::Cli(Some(…))`.
In contrast, `--config <value>` with ordinary values become `Definition::Cli(None)`.

The error message of the `Definition::Cli(Some(…))` is identical to
`Definition::Path(…)`, so we won't lose any path information to debug.

[`config-include`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#config-include


### How should we test and review this PR?

Reviewing commit by commit is probably fine. The first two commits adding tests to `config-cli` and `config-include`, which exercises the expected behaviour we are going to fix in the next commits.

To check the precedence, set up a project with an extra config file, such as

```
# Expect to have a target-dir named `foo`
CARGO_BUILD_TARGET_DIR='env' cargo c --config 'build.target-dir = "cli"' --config .cargo/foo.toml

# Inside .cargo/foo.toml
[build]
target-dir = "foo"
```

### Additional information

This is a bit hacky IMO. I don't like leaking the path info to `Definition::Cli`. However, it is really tricky to provide information for deserialization before values get merged.
