### PR TITLE
doc: clarify config-relative paths for `--config <path>`

### DIFF
--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -145,8 +145,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -355,8 +355,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -304,8 +304,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -289,8 +289,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -119,8 +119,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -260,8 +260,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -104,8 +104,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -362,8 +362,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -79,8 +79,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-init.txt
+++ b/src/doc/man/generated_txt/cargo-init.txt
@@ -87,8 +87,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -326,8 +326,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-locate-project.txt
+++ b/src/doc/man/generated_txt/cargo-locate-project.txt
@@ -62,8 +62,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-login.txt
+++ b/src/doc/man/generated_txt/cargo-login.txt
@@ -62,8 +62,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -391,8 +391,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-new.txt
+++ b/src/doc/man/generated_txt/cargo-new.txt
@@ -82,8 +82,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-owner.txt
+++ b/src/doc/man/generated_txt/cargo-owner.txt
@@ -89,8 +89,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -230,8 +230,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -109,8 +109,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -197,8 +197,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -204,8 +204,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -306,8 +306,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -276,8 +276,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-search.txt
+++ b/src/doc/man/generated_txt/cargo-search.txt
@@ -59,8 +59,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -373,8 +373,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -269,8 +269,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-uninstall.txt
+++ b/src/doc/man/generated_txt/cargo-uninstall.txt
@@ -71,8 +71,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -109,8 +109,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -105,8 +105,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-verify-project.txt
+++ b/src/doc/man/generated_txt/cargo-verify-project.txt
@@ -82,8 +82,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -85,8 +85,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/generated_txt/cargo.txt
+++ b/src/doc/man/generated_txt/cargo.txt
@@ -188,8 +188,13 @@ OPTIONS
            <https://rust-lang.github.io/rustup/overrides.html> for more
            information about how toolchain overrides work.
 
-       --config KEY=VALUE
-           Overrides a Cargo configuration value.
+       --config KEY=VALUE or PATH
+           Overrides a Cargo configuration value. The argument should be in
+           TOML syntax of KEY=VALUE, or provided as a path to an extra
+           configuration file. This flag may be specified multiple times. See
+           the command-line overrides section
+           <https://doc.rust-lang.org/cargo/reference/config.html#command-line-overrides>
+           for more information.
 
        -h, --help
            Prints help information.

--- a/src/doc/man/includes/section-options-common.md
+++ b/src/doc/man/includes/section-options-common.md
@@ -10,8 +10,10 @@ See the [rustup documentation](https://rust-lang.github.io/rustup/overrides.html
 for more information about how toolchain overrides work.
 {{/option}}
 
-{{#option "`--config` KEY=VALUE"}}
-Overrides a Cargo configuration value.
+{{#option "`--config` _KEY=VALUE_ or _PATH_"}}
+Overrides a Cargo configuration value. The argument should be in TOML syntax of `KEY=VALUE`,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the [command-line overrides section](../reference/config.html#command-line-overrides) for more information.
 {{/option}}
 
 {{#option "`-h`" "`--help`"}}

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -182,8 +182,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-add---config"><a class="option-anchor" href="#option-cargo-add---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-add---config"><a class="option-anchor" href="#option-cargo-add---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-add--h"><a class="option-anchor" href="#option-cargo-add--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -421,8 +421,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-bench---config"><a class="option-anchor" href="#option-cargo-bench---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-bench---config"><a class="option-anchor" href="#option-cargo-bench---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench--h"><a class="option-anchor" href="#option-cargo-bench--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -365,8 +365,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-build---config"><a class="option-anchor" href="#option-cargo-build---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-build---config"><a class="option-anchor" href="#option-cargo-build---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-build--h"><a class="option-anchor" href="#option-cargo-build--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -346,8 +346,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-check---config"><a class="option-anchor" href="#option-cargo-check---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-check---config"><a class="option-anchor" href="#option-cargo-check---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-check--h"><a class="option-anchor" href="#option-cargo-check--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -150,8 +150,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-clean---config"><a class="option-anchor" href="#option-cargo-clean---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-clean---config"><a class="option-anchor" href="#option-cargo-clean---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-clean--h"><a class="option-anchor" href="#option-cargo-clean--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -320,8 +320,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-doc---config"><a class="option-anchor" href="#option-cargo-doc---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-doc---config"><a class="option-anchor" href="#option-cargo-doc---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-doc--h"><a class="option-anchor" href="#option-cargo-doc--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -124,8 +124,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-fetch---config"><a class="option-anchor" href="#option-cargo-fetch---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-fetch---config"><a class="option-anchor" href="#option-cargo-fetch---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-fetch--h"><a class="option-anchor" href="#option-cargo-fetch--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -426,8 +426,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-fix---config"><a class="option-anchor" href="#option-cargo-fix---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-fix---config"><a class="option-anchor" href="#option-cargo-fix---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix--h"><a class="option-anchor" href="#option-cargo-fix--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -98,8 +98,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-generate-lockfile---config"><a class="option-anchor" href="#option-cargo-generate-lockfile---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-generate-lockfile---config"><a class="option-anchor" href="#option-cargo-generate-lockfile---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-generate-lockfile--h"><a class="option-anchor" href="#option-cargo-generate-lockfile--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-init.md
+++ b/src/doc/src/commands/cargo-init.md
@@ -111,8 +111,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-init---config"><a class="option-anchor" href="#option-cargo-init---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-init---config"><a class="option-anchor" href="#option-cargo-init---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-init--h"><a class="option-anchor" href="#option-cargo-init--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -375,8 +375,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-install---config"><a class="option-anchor" href="#option-cargo-install---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-install---config"><a class="option-anchor" href="#option-cargo-install---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-install--h"><a class="option-anchor" href="#option-cargo-install--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-locate-project.md
+++ b/src/doc/src/commands/cargo-locate-project.md
@@ -87,8 +87,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-locate-project---config"><a class="option-anchor" href="#option-cargo-locate-project---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-locate-project---config"><a class="option-anchor" href="#option-cargo-locate-project---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-locate-project--h"><a class="option-anchor" href="#option-cargo-locate-project--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -79,8 +79,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-login---config"><a class="option-anchor" href="#option-cargo-login---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-login---config"><a class="option-anchor" href="#option-cargo-login---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-login--h"><a class="option-anchor" href="#option-cargo-login--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -427,8 +427,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-metadata---config"><a class="option-anchor" href="#option-cargo-metadata---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-metadata---config"><a class="option-anchor" href="#option-cargo-metadata---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-metadata--h"><a class="option-anchor" href="#option-cargo-metadata--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-new.md
+++ b/src/doc/src/commands/cargo-new.md
@@ -106,8 +106,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-new---config"><a class="option-anchor" href="#option-cargo-new---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-new---config"><a class="option-anchor" href="#option-cargo-new---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-new--h"><a class="option-anchor" href="#option-cargo-new--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-owner.md
+++ b/src/doc/src/commands/cargo-owner.md
@@ -117,8 +117,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-owner---config"><a class="option-anchor" href="#option-cargo-owner---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-owner---config"><a class="option-anchor" href="#option-cargo-owner---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-owner--h"><a class="option-anchor" href="#option-cargo-owner--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -283,8 +283,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-package---config"><a class="option-anchor" href="#option-cargo-package---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-package---config"><a class="option-anchor" href="#option-cargo-package---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-package--h"><a class="option-anchor" href="#option-cargo-package--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -127,8 +127,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-pkgid---config"><a class="option-anchor" href="#option-cargo-pkgid---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-pkgid---config"><a class="option-anchor" href="#option-cargo-pkgid---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-pkgid--h"><a class="option-anchor" href="#option-cargo-pkgid--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -249,8 +249,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-publish---config"><a class="option-anchor" href="#option-cargo-publish---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-publish---config"><a class="option-anchor" href="#option-cargo-publish---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish--h"><a class="option-anchor" href="#option-cargo-publish--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -258,8 +258,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-run---config"><a class="option-anchor" href="#option-cargo-run---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-run---config"><a class="option-anchor" href="#option-cargo-run---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-run--h"><a class="option-anchor" href="#option-cargo-run--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -359,8 +359,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-rustc---config"><a class="option-anchor" href="#option-cargo-rustc---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-rustc---config"><a class="option-anchor" href="#option-cargo-rustc---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc--h"><a class="option-anchor" href="#option-cargo-rustc--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -339,8 +339,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-rustdoc---config"><a class="option-anchor" href="#option-cargo-rustdoc---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-rustdoc---config"><a class="option-anchor" href="#option-cargo-rustdoc---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc--h"><a class="option-anchor" href="#option-cargo-rustdoc--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-search.md
+++ b/src/doc/src/commands/cargo-search.md
@@ -83,8 +83,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-search---config"><a class="option-anchor" href="#option-cargo-search---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-search---config"><a class="option-anchor" href="#option-cargo-search---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-search--h"><a class="option-anchor" href="#option-cargo-search--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -444,8 +444,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-test---config"><a class="option-anchor" href="#option-cargo-test---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-test---config"><a class="option-anchor" href="#option-cargo-test---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-test--h"><a class="option-anchor" href="#option-cargo-test--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -313,8 +313,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-tree---config"><a class="option-anchor" href="#option-cargo-tree---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-tree---config"><a class="option-anchor" href="#option-cargo-tree---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-tree--h"><a class="option-anchor" href="#option-cargo-tree--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-uninstall.md
+++ b/src/doc/src/commands/cargo-uninstall.md
@@ -93,8 +93,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-uninstall---config"><a class="option-anchor" href="#option-cargo-uninstall---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-uninstall---config"><a class="option-anchor" href="#option-cargo-uninstall---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-uninstall--h"><a class="option-anchor" href="#option-cargo-uninstall--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -138,8 +138,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-update---config"><a class="option-anchor" href="#option-cargo-update---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-update---config"><a class="option-anchor" href="#option-cargo-update---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-update--h"><a class="option-anchor" href="#option-cargo-update--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -134,8 +134,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-vendor---config"><a class="option-anchor" href="#option-cargo-vendor---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-vendor---config"><a class="option-anchor" href="#option-cargo-vendor---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-vendor--h"><a class="option-anchor" href="#option-cargo-vendor--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -104,8 +104,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-verify-project---config"><a class="option-anchor" href="#option-cargo-verify-project---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-verify-project---config"><a class="option-anchor" href="#option-cargo-verify-project---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-verify-project--h"><a class="option-anchor" href="#option-cargo-verify-project--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -113,8 +113,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo-yank---config"><a class="option-anchor" href="#option-cargo-yank---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo-yank---config"><a class="option-anchor" href="#option-cargo-yank---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo-yank--h"><a class="option-anchor" href="#option-cargo-yank--h"></a><code>-h</code></dt>

--- a/src/doc/src/commands/cargo.md
+++ b/src/doc/src/commands/cargo.md
@@ -221,8 +221,10 @@ See the <a href="https://rust-lang.github.io/rustup/overrides.html">rustup docum
 for more information about how toolchain overrides work.</dd>
 
 
-<dt class="option-term" id="option-cargo---config"><a class="option-anchor" href="#option-cargo---config"></a><code>--config</code> KEY=VALUE</dt>
-<dd class="option-desc">Overrides a Cargo configuration value.</dd>
+<dt class="option-term" id="option-cargo---config"><a class="option-anchor" href="#option-cargo---config"></a><code>--config</code> <em>KEY=VALUE</em> or <em>PATH</em></dt>
+<dd class="option-desc">Overrides a Cargo configuration value. The argument should be in TOML syntax of <code>KEY=VALUE</code>,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the <a href="../reference/config.html#command-line-overrides">command-line overrides section</a> for more information.</dd>
 
 
 <dt class="option-term" id="option-cargo--h"><a class="option-anchor" href="#option-cargo--h"></a><code>-h</code></dt>

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -238,13 +238,26 @@ precedence rules as other options specified directly with `--config`.
 
 ### Config-relative paths
 
-Paths in config files may be absolute, relative, or a bare name without any
-path separators. Paths for executables without a path separator will use the
-`PATH` environment variable to search for the executable. Paths for
-non-executables will be relative to where the config value is defined. For
-config files, that is relative to the parent directory of the `.cargo`
-directory where the value was defined. For environment variables it is
-relative to the current working directory.
+Paths in config files may be absolute, relative, or a bare name without any path separators.
+Paths for executables without a path separator will use the `PATH` environment variable to search for the executable. 
+Paths for non-executables will be relative to where the config value is defined.
+
+In particular, rules are:
+
+* For environment variables, paths are relative to the current working directory.
+* For config files, paths are relative to the parent directory of the directory where the config files were defined,
+  no matter those files are from either the [hierarchical probing](#hierarchical-structure)
+  or the [`--config <path>`](#command-line-overrides) option.
+
+> **Note:** To maintain consistency with existing `.cargo/config.toml` probing behavior,
+> it is by design that a path in a config file passed via `--config <path>`
+> is also relative to two levels up from the config file itself.
+>
+> To avoid unexpected results, the rule of thumb is putting your extra config files
+> at the same level of discovered `.cargo/config.toml` in your porject.
+> For instance, given a project `/my/project`, 
+> it is recommended to put config files under `/my/project/.cargo`
+> or a new directory at the same level, such as `/my/project/.config`.
 
 ```toml
 # Relative path examples.

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -245,6 +245,8 @@ Paths for non-executables will be relative to where the config value is defined.
 In particular, rules are:
 
 * For environment variables, paths are relative to the current working directory.
+* For config values loaded directly from the [`--config KEY=VALUE`](#command-line-overrides) option,
+  paths are relative to the current working directory.
 * For config files, paths are relative to the parent directory of the directory where the config files were defined,
   no matter those files are from either the [hierarchical probing](#hierarchical-structure)
   or the [`--config <path>`](#command-line-overrides) option.

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -190,9 +190,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -444,9 +444,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -374,9 +374,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -355,9 +355,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -148,9 +148,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -322,9 +322,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -122,9 +122,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -450,9 +450,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -101,9 +101,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -114,9 +114,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -426,9 +426,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-locate-project.1
+++ b/src/etc/man/cargo-locate-project.1
@@ -87,9 +87,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -78,9 +78,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -425,9 +425,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -109,9 +109,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-owner.1
+++ b/src/etc/man/cargo-owner.1
@@ -120,9 +120,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -294,9 +294,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -156,9 +156,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -244,9 +244,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -255,9 +255,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -373,9 +373,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -341,9 +341,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-search.1
+++ b/src/etc/man/cargo-search.1
@@ -81,9 +81,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -463,9 +463,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -354,9 +354,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-uninstall.1
+++ b/src/etc/man/cargo-uninstall.1
@@ -104,9 +104,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -141,9 +141,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -132,9 +132,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -111,9 +111,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -112,9 +112,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 

--- a/src/etc/man/cargo.1
+++ b/src/etc/man/cargo.1
@@ -244,9 +244,11 @@ See the \fIrustup documentation\fR <https://rust\-lang.github.io/rustup/override
 for more information about how toolchain overrides work.
 .RE
 .sp
-\fB\-\-config\fR KEY=VALUE
+\fB\-\-config\fR \fIKEY=VALUE\fR or \fIPATH\fR
 .RS 4
-Overrides a Cargo configuration value.
+Overrides a Cargo configuration value. The argument should be in TOML syntax of \fBKEY=VALUE\fR,
+or provided as a path to an extra configuration file. This flag may be specified multiple times.
+See the \fIcommand\-line overrides section\fR <https://doc.rust\-lang.org/cargo/reference/config.html#command\-line\-overrides> for more information.
 .RE
 .sp
 \fB\-h\fR, 


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Resolves #10991. 

Instead of changing the behaviour (it might break things), we document the current one as @sunshowers [suggesting](https://github.com/rust-lang/cargo/issues/10991#issuecomment-1215931242).

### How should we test and review this PR?

Check changes in 

- `src/doc/src/reference/config.md` and 
- `src/doc/man/includes/section-options-common.md`.

```shell
cargo help build
# Proofread the manpage change.
mdbook serve
# open http://[::1]:3000/reference/config.html#config-relative-paths
# and proofread the config-relative paths section
```

<!-- homu-ignore:end -->
