### PR TITLE
Fix typo

### DIFF
--- a/src/doc/src/reference/overriding-dependencies.md
+++ b/src/doc/src/reference/overriding-dependencies.md
@@ -212,7 +212,7 @@ version = "0.1.0"
 
 [dependencies]
 my-library = { git = 'https://example.com/git/my-library' }
-uuid = "1.0"
+uuid = "1.0.1"
 
 [patch.crates-io]
 uuid = { git = 'https://github.com/uuid-rs/uuid', branch = '2.0.0' }


### PR DESCRIPTION
Documentation typo fix.

As far as I can tell the example should say 1.0.1 not 1.0