### PR TITLE
SourceId: Test and fix ambiguous serialization of Git references

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -742,4 +742,16 @@ mod tests {
         let s3 = SourceId::new(foo, loc, None).unwrap();
         assert_ne!(s1, s3);
     }
+
+    #[test]
+    fn gitrefs_roundtrip() {
+        let base = "https://host/path".into_url().unwrap();
+        let branch = GitReference::Branch("*-._+20%30 Z/z#foo=bar&zap[]?to\\()'\"".to_string());
+        let s1 = SourceId::for_git(&base, branch).unwrap();
+        let ser1 = format!("{}", s1.as_url());
+        let s2 = SourceId::from_url(&ser1).expect("Failed to deserialize");
+        let ser2 = format!("{}", s2.as_url());
+        assert_eq!(ser1, ser2, "Serialized forms don't match");
+        assert_eq!(s1, s2, "SourceId doesn't round-trip");
+    }
 }

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -273,7 +273,7 @@ fn cargo_compile_git_dep_pull_request() {
         .cargo("build")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [COMPILING] dep1 v0.5.0 ({}?rev=refs/pull/330/head#[..])\n\
+             [COMPILING] dep1 v0.5.0 ({}?rev=refs%2Fpull%2F330%2Fhead#[..])\n\
              [COMPILING] foo v0.0.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),


### PR DESCRIPTION
For some branch names (or tags or refs), generate_lockfile will serialize poorly.  Parsing the Cargo.lock will refer to a branch that wasn't the intended one in Cargo.toml.

Because a branch name can contain the '#' character, the precise reference could be corrupted through a branch/tag/ref as well.

First commit adds a test showing the problem, second commit fixes it by having the serializer match the deserializer by encoding a x-www-form-urlencoded query string.

Fixes #11085.