### PR TITLE
[master] Run `reach_max_unpack_size` test only on debug build

### DIFF
--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2698,6 +2698,8 @@ fn http_requires_trailing_slash() {
         .run()
 }
 
+// Limit the test to debug builds so that `__CARGO_TEST_MAX_UNPACK_SIZE` will take affect.
+#[cfg(debug_assertions)]
 #[cargo_test]
 fn reach_max_unpack_size() {
     let p = project()


### PR DESCRIPTION
`cargo test --release` fails on test `reach_max_unpack_size` as the binary to exercise is optimized. The alternative approach is removing `cfg!(debug_assertions)` from this line.
<https://github.com/rust-lang/cargo/blob/9ef926dafc217bf4ab781ea2d9bbd029359bd241/src/cargo/sources/registry/mod.rs#L842>

#11089 