### PR TITLE
Clarify when cargo detects changes

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -323,9 +323,9 @@ cross-compiling, so keep that in consideration of the impact on compile time.
 
 When rebuilding a package, Cargo does not necessarily know if the build script
 needs to be run again. By default, it takes a conservative approach of always
-re-running the build script if any rust file within the package is changed (or the
-list of files controlled by the [`exclude` and `include` fields]). For most
-cases, this is not a good choice, so it is recommended that every build script
+re-running the build script if *any* file within the package directory is changed
+(or the list of files controlled by the [`exclude` and `include` fields]). For
+most cases, this is not a good choice, so it is recommended that every build script
 emit at least one of the `rerun-if` instructions (described below). If these
 are emitted, then Cargo will only re-run the script if the given value has
 changed. If Cargo is re-running the build scripts of your own crate or a

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -323,7 +323,7 @@ cross-compiling, so keep that in consideration of the impact on compile time.
 
 When rebuilding a package, Cargo does not necessarily know if the build script
 needs to be run again. By default, it takes a conservative approach of always
-re-running the build script if any file within the package is changed (or the
+re-running the build script if any rust file within the package is changed (or the
 list of files controlled by the [`exclude` and `include` fields]). For most
 cases, this is not a good choice, so it is recommended that every build script
 emit at least one of the `rerun-if` instructions (described below). If these


### PR DESCRIPTION
### What does this PR try to resolve?

Its not clear if "any file" means "any rust file" or "any file, including non rust files". I think the confusion stemmed from the focus on it belonging to the rust package. So it was unclear if any file in the directory counts as belonging to the package, or if the package only contains rust source files, and therefore a `.proto` or `.fbs` file in the same directory as the Cargo.toml would not trigger a rebuild.

I amended the wording to focus on directories rather than packages.

### How should we test and review this PR?
Please let me know which change it should be, and I will update my PR accordingly. Also, please let me know if my edit is accurate, or if it is misleading!
