### PR TITLE
Update comment about ResolveVersion default version

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -46,8 +46,10 @@ pub struct Resolve {
     summaries: HashMap<PackageId, Summary>,
 }
 
-/// A version to indicate how a `Cargo.lock` should be serialized. Currently
-/// [V3 is the default](ResolveVersion::default) when creating a new lockfile.
+/// A version to indicate how a `Cargo.lock` should be serialized.
+///
+/// When creating a new lockfile, the default version defined in
+/// [`ResolveVersion::default`] is used.
 /// If an old version of lockfile already exists, it will stay as-is.
 ///
 /// It's theorized that we can add more here over time to track larger changes

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -47,8 +47,8 @@ pub struct Resolve {
 }
 
 /// A version to indicate how a `Cargo.lock` should be serialized. Currently
-/// V2 is the default when creating a new lockfile. If a V1 lockfile already
-/// exists, it will stay as V1.
+/// V3 is the default when creating a new lockfile. If an old version of
+/// lockfile already exists, it will stay as-is.
 ///
 /// It's theorized that we can add more here over time to track larger changes
 /// to the `Cargo.lock` format, but we've yet to see how that strategy pans out.
@@ -59,12 +59,13 @@ pub enum ResolveVersion {
     /// A more compact format, more amenable to avoiding source-control merge
     /// conflicts. The `dependencies` arrays are compressed and checksums are
     /// listed inline. Introduced in 2019 in version 1.38. New lockfiles use
-    /// V2 by default starting in 1.41.
+    /// V2 by default from 1.41 to 1.52.
     V2,
     /// A format that explicitly lists a `version` at the top of the file as
     /// well as changing how git dependencies are encoded. Dependencies with
     /// `branch = "master"` are no longer encoded the same way as those without
-    /// branch specifiers.
+    /// branch specifiers. Introduced in 2020 in version 1.47. New lockfiles use
+    /// V3 by default staring in 1.53.
     V3,
 }
 

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -47,8 +47,8 @@ pub struct Resolve {
 }
 
 /// A version to indicate how a `Cargo.lock` should be serialized. Currently
-/// V3 is the default when creating a new lockfile. If an old version of
-/// lockfile already exists, it will stay as-is.
+/// [V3 is the default](ResolveVersion::default) when creating a new lockfile.
+/// If an old version of lockfile already exists, it will stay as-is.
 ///
 /// It's theorized that we can add more here over time to track larger changes
 /// to the `Cargo.lock` format, but we've yet to see how that strategy pans out.
@@ -396,7 +396,7 @@ impl fmt::Debug for Resolve {
 impl Default for ResolveVersion {
     /// The default way to encode new or updated `Cargo.lock` files.
     ///
-    /// It's important that if a new version of `ResolveVersion` is added that
+    /// It's important that if a new version of [`ResolveVersion`] is added that
     /// this is not updated until *at least* the support for the version is in
     /// the stable release of Rust.
     ///


### PR DESCRIPTION
### What does this PR try to resolve?

Point out that the current `ResolveVersion` defaults to `V3`

### How should we test and review this PR?


- Introduced in 1.47.0 https://github.com/rust-lang/cargo/blob/rust-1.47.0/src/cargo/core/resolver/resolve.rs#L60-L73
- As default in 1.53.0 https://github.com/rust-lang/cargo/blob/rust-1.53.0/src/cargo/core/resolver/resolve.rs#L412


<!-- homu-ignore:end -->
