### PR TITLE
make unknown features on `cargo add` more discoverable

### DIFF
--- a/tests/testsuite/cargo_add/features_unknown/stderr.log
+++ b/tests/testsuite/cargo_add/features_unknown/stderr.log
@@ -1,9 +1,5 @@
     Updating `dummy-registry` index
       Adding your-face v99999.0.0 to dependencies.
-             Features:
-             + noze
-             - ears
-             - eyes
-             - mouth
-             - nose
-error: unrecognized features: ["noze"]
+error: unrecognized feature for crate your-face: noze
+disabled features:
+    ears, eyes, mouth, nose

--- a/tests/testsuite/cargo_add/features_unknown_no_features/in
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/features_unknown_no_features/mod.rs
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/mod.rs
@@ -1,0 +1,25 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::Project;
+
+use crate::cargo_add::init_registry;
+use cargo_test_support::curr_dir;
+
+#[cargo_test]
+fn features_unknown_no_features() {
+    init_registry();
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .arg_line("my-package --features noze")
+        .current_dir(cwd)
+        .assert()
+        .code(101)
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/features_unknown_no_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/out/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"

--- a/tests/testsuite/cargo_add/features_unknown_no_features/stderr.log
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/stderr.log
@@ -1,0 +1,4 @@
+    Updating `dummy-registry` index
+      Adding my-package v99999.0.0 to dependencies.
+error: unrecognized feature for crate my-package: noze
+no features available for crate my-package

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -20,6 +20,7 @@ mod features_multiple_occurrences;
 mod features_preserve;
 mod features_spaced_values;
 mod features_unknown;
+mod features_unknown_no_features;
 mod git;
 mod git_branch;
 mod git_conflicts_namever;

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/in/dependency/Cargo.toml
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/in/dependency/Cargo.toml
@@ -6,7 +6,13 @@ version = "0.0.0"
 default-base = []
 default-test-base = []
 default-merge-base = []
-default = ["default-base", "default-test-base", "default-merge-base"]
+long-feature-name-because-of-formatting-reasons = []
+default = [
+    "default-base",
+    "default-test-base",
+    "default-merge-base",
+    "long-feature-name-because-of-formatting-reasons",
+]
 test-base = []
 test = ["test-base", "default-test-base"]
 merge-base = []

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/out/dependency/Cargo.toml
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/out/dependency/Cargo.toml
@@ -6,7 +6,13 @@ version = "0.0.0"
 default-base = []
 default-test-base = []
 default-merge-base = []
-default = ["default-base", "default-test-base", "default-merge-base"]
+long-feature-name-because-of-formatting-reasons = []
+default = [
+    "default-base",
+    "default-test-base",
+    "default-merge-base",
+    "long-feature-name-because-of-formatting-reasons",
+]
 test-base = []
 test = ["test-base", "default-test-base"]
 merge-base = []

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/stderr.log
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/stderr.log
@@ -1,12 +1,7 @@
       Adding foo (workspace) to dependencies.
-             Features as of v0.0.0:
-             + default-base
-             + default-merge-base
-             + default-test-base
-             + not_recognized
-             + test
-             + test-base
-             - merge
-             - merge-base
-             - unrelated
-error: unrecognized features: ["not_recognized"]
+error: unrecognized feature for crate foo: not_recognized
+disabled features:
+    merge, merge-base, unrelated
+enabled features:
+    default-base, default-merge-base, default-test-base
+    long-feature-name-because-of-formatting-reasons, test, test-base


### PR DESCRIPTION
When adding an unknown feature via `cargo add -F krate/feat`, it can be easy to miss the fact that the change failed.

This fixes that by showing the following output on fail

<img width="474" alt="image" src="https://user-images.githubusercontent.com/1502855/191100141-3603cc9a-d4b6-4d6a-bbc6-41b34144b3f0.png">