### PR TITLE
Add support for git submodule relative paths

### DIFF
--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -191,7 +191,7 @@ impl<'cfg> Source for GitSource<'cfg> {
             .join("checkouts")
             .join(&self.ident)
             .join(short_id.as_str());
-        db.copy_to(actual_rev, &checkout_path, self.config)?;
+        db.copy_to(actual_rev, &checkout_path, self.config, self.url())?;
 
         let source_id = self.source_id.with_precise(Some(actual_rev.to_string()));
         let path_source = PathSource::new_recursive(&checkout_path, source_id, self.config);

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str;
 use std::time::{Duration, Instant};
-use url::{Url, ParseError};
+use url::{ParseError, Url};
 
 fn serialize_str<T, S>(t: &T, s: S) -> Result<S::Ok, S::Error>
 where
@@ -328,16 +328,22 @@ impl<'a> GitCheckout<'a> {
     fn update_submodules(&self, cargo_config: &Config, parent_remote_url: &Url) -> CargoResult<()> {
         return update_submodules(&self.repo, cargo_config, parent_remote_url);
 
-        fn update_submodules(repo: &git2::Repository, cargo_config: &Config, parent_remote_url: &Url) -> CargoResult<()> {
+        fn update_submodules(
+            repo: &git2::Repository,
+            cargo_config: &Config,
+            parent_remote_url: &Url,
+        ) -> CargoResult<()> {
             debug!("update submodules for: {:?}", repo.workdir().unwrap());
 
             for mut child in repo.submodules()? {
-                update_submodule(repo, &mut child, cargo_config, parent_remote_url).with_context(|| {
-                    format!(
-                        "failed to update submodule `{}`",
-                        child.name().unwrap_or("")
-                    )
-                })?;
+                update_submodule(repo, &mut child, cargo_config, parent_remote_url).with_context(
+                    || {
+                        format!(
+                            "failed to update submodule `{}`",
+                            child.name().unwrap_or("")
+                        )
+                    },
+                )?;
             }
             Ok(())
         }


### PR DESCRIPTION
Fixes #7992

This PR is a re-application of @francis-starlab 's !9592 , so all credits go to him

GIt allows submodules to have relative URLs, but cargo does not handle this correctly, and simply fails to update submodules as described in issue #7992. This PR fixes that by passing in the parent git repo url to `update_submodules`.

Original fix fails on Windows due to collision of `std::fs::canonicalize` and URL paths obtained from `files://` schema, specifically paths like `/C:/...` which are obviously deemed incorrect. Will look for solution and post it soon.