### PR TITLE
Fix links to workspace inheritance headings in workspace docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@
 
 - 🎉 Packages can now inherit settings from the workspace so that the settings
   can be centralized in one place. See
-  [`workspace.package`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-workspacepackage-table)
+  [`workspace.package`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-package-table)
   and
-  [`workspace.dependencies`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-workspacedependencies-table)
+  [`workspace.dependencies`](https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-dependencies-table)
   for more details on how to define these common settings.
   [#10859](https://github.com/rust-lang/cargo/pull/10859)
 - Added the


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

#11082 adjusted some headings of workspace inheritance features. 
This PR update the changelog accordingly.

### How should we test and review this PR?

Should we wait for https://github.com/rust-lang/rust/pull/101909 merged and published?
<!-- homu-ignore:end -->
