### PR TITLE
Http publish not noop

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -11,6 +11,7 @@ doctest = false
 anyhow = "1.0.34"
 cargo-test-macro = { path = "../cargo-test-macro" }
 cargo-util = { path = "../cargo-util" }
+crates-io = { path = "../crates-io" }
 snapbox = { version = "0.3.0", features = ["diff", "path"] }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }

--- a/crates/cargo-test-support/src/publish.rs
+++ b/crates/cargo-test-support/src/publish.rs
@@ -1,7 +1,8 @@
 use crate::compare::{assert_match_exact, find_json_mismatch};
-use crate::registry::{self, alt_api_path};
+use crate::registry::{self, alt_api_path, FeatureMap};
 use flate2::read::GzDecoder;
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::fs::File;
 use std::io::{self, prelude::*, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -153,5 +154,92 @@ pub fn validate_crate_contents(
                 .unwrap_or_else(|| panic!("file `{}` missing in archive", e_file_name));
             assert_match_exact(e_file_contents, actual_contents);
         }
+    }
+}
+
+pub(crate) fn create_index_line(
+    name: serde_json::Value,
+    vers: &str,
+    deps: Vec<serde_json::Value>,
+    cksum: &str,
+    features: crate::registry::FeatureMap,
+    yanked: bool,
+    links: Option<String>,
+    v: Option<u32>,
+) -> String {
+    // This emulates what crates.io does to retain backwards compatibility.
+    let (features, features2) = split_index_features(features.clone());
+    let mut json = serde_json::json!({
+        "name": name,
+        "vers": vers,
+        "deps": deps,
+        "cksum": cksum,
+        "features": features,
+        "yanked": yanked,
+        "links": links,
+    });
+    if let Some(f2) = &features2 {
+        json["features2"] = serde_json::json!(f2);
+        json["v"] = serde_json::json!(2);
+    }
+    if let Some(v) = v {
+        json["v"] = serde_json::json!(v);
+    }
+
+    json.to_string()
+}
+
+pub(crate) fn write_to_index(registry_path: &PathBuf, name: &str, line: String, local: bool) {
+    let file = cargo_util::registry::make_dep_path(name, false);
+
+    // Write file/line in the index.
+    let dst = if local {
+        registry_path.join("index").join(&file)
+    } else {
+        registry_path.join(&file)
+    };
+    let prev = fs::read_to_string(&dst).unwrap_or_default();
+    t!(fs::create_dir_all(dst.parent().unwrap()));
+    t!(fs::write(&dst, prev + &line[..] + "\n"));
+
+    // Add the new file to the index.
+    if !local {
+        let repo = t!(git2::Repository::open(&registry_path));
+        let mut index = t!(repo.index());
+        t!(index.add_path(Path::new(&file)));
+        t!(index.write());
+        let id = t!(index.write_tree());
+
+        // Commit this change.
+        let tree = t!(repo.find_tree(id));
+        let sig = t!(repo.signature());
+        let parent = t!(repo.refname_to_id("refs/heads/master"));
+        let parent = t!(repo.find_commit(parent));
+        t!(repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            "Another commit",
+            &tree,
+            &[&parent]
+        ));
+    }
+}
+
+fn split_index_features(mut features: FeatureMap) -> (FeatureMap, Option<FeatureMap>) {
+    let mut features2 = FeatureMap::new();
+    for (feat, values) in features.iter_mut() {
+        if values
+            .iter()
+            .any(|value| value.starts_with("dep:") || value.contains("?/"))
+        {
+            let new_values = values.drain(..).collect();
+            features2.insert(feat.clone(), new_values);
+        }
+    }
+    if features2.is_empty() {
+        (features, None)
+    } else {
+        (features, Some(features2))
     }
 }

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -36,7 +36,7 @@ pub struct Crate {
     pub max_version: String,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct NewCrate {
     pub name: String,
     pub vers: String,
@@ -57,7 +57,7 @@ pub struct NewCrate {
     pub links: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct NewCrateDependency {
     pub optional: bool,
     pub default_features: bool,

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2048,3 +2048,45 @@ error: package ID specification `bar` did not match any packages
         )
         .run();
 }
+
+#[cargo_test]
+fn http_api_not_noop() {
+    let _registry = registry::RegistryBuilder::new().http_api().build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("publish --token api-token").run();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+
+                [dependencies]
+                foo = "0.0.1"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build").run();
+}


### PR DESCRIPTION
Currently the `cargo-test-support` `HttpServer` is noop on publish. This was causing issues with #11062 as there is [not function registry to pull from](https://github.com/rust-lang/cargo/pull/11062#issuecomment-1241220565). [A suggested fix](https://github.com/rust-lang/cargo/pull/11062#issuecomment-1241349110) to this was to have the test `HttpServer` act like a real registry and write to the filesystem. This would allow for tests to be run over the HTTP API and not fail since there was nothing to pull from. 

This PR implements that suggestion by adding a body field to `Request`, and when hitting the publish endpoint it will try and write the `.crate` and manifest information to the filesystem.