### PR TITLE
refactor(cli): Prepare for clap v4

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -391,14 +391,14 @@ impl GlobalArgs {
     }
 }
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     let is_rustup = std::env::var_os("RUSTUP_HOME").is_some();
     let usage = if is_rustup {
         "cargo [+toolchain] [OPTIONS] [SUBCOMMAND]"
     } else {
         "cargo [OPTIONS] [SUBCOMMAND]"
     };
-    App::new("cargo")
+    Command::new("cargo")
         .allow_external_subcommands(true)
         .setting(AppSettings::DeriveDisplayOrder)
         // Doesn't mix well with our list of common cargo commands.  See clap-rs/clap#3108 for

--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -12,7 +12,7 @@ use cargo::util::interning::InternedString;
 use cargo::util::toml_mut::manifest::DepTable;
 use cargo::CargoResult;
 
-pub fn cli() -> clap::Command<'static> {
+pub fn cli() -> Command {
     clap::Command::new("add")
         .setting(clap::AppSettings::DeriveDisplayOrder)
         .about("Add dependencies to a Cargo.toml manifest file")

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 use cargo::ops::{self, TestOptions};
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("bench")
         .trailing_var_arg(true)
         .about("Execute all benchmarks of a local package")

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("build")
         // subcommand aliases are handled in aliased_command()
         // .alias("b")

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("check")
         // subcommand aliases are handled in aliased_command()
         // .alias("c")

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -3,7 +3,7 @@ use crate::command_prelude::*;
 use cargo::ops::{self, CleanOptions};
 use cargo::util::print_available_packages;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("clean")
         .about("Remove artifacts that cargo has generated in the past")
         .arg_quiet()

--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 use cargo::ops::cargo_config;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("config")
         .about("Inspect configuration values")
         .after_help("Run `cargo help config` for more detailed information.\n")

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops::{self, DocOptions};
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("doc")
         // subcommand aliases are handled in aliased_command()
         // .alias("d")

--- a/src/bin/cargo/commands/fetch.rs
+++ b/src/bin/cargo/commands/fetch.rs
@@ -3,7 +3,7 @@ use crate::command_prelude::*;
 use cargo::ops;
 use cargo::ops::FetchOptions;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("fetch")
         .about("Fetch dependencies of a package from the network")
         .arg_quiet()

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("fix")
         .about("Automatically fix lint warnings reported by rustc")
         .arg_quiet()

--- a/src/bin/cargo/commands/generate_lockfile.rs
+++ b/src/bin/cargo/commands/generate_lockfile.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("generate-lockfile")
         .about("Generate the lockfile for a package")
         .arg_quiet()

--- a/src/bin/cargo/commands/git_checkout.rs
+++ b/src/bin/cargo/commands/git_checkout.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 const REMOVED: &str = "The `git-checkout` subcommand has been removed.";
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("git-checkout")
         .about("This subcommand has been removed")
         .hide(true)

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 const COMPRESSED_MAN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/man.tgz"));
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("help")
         .about("Displays help for a cargo subcommand")
         .arg(Arg::new("SUBCOMMAND"))

--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("init")
         .about("Create a new cargo package in an existing directory")
         .arg_quiet()

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -6,7 +6,7 @@ use cargo::util::IntoUrl;
 
 use cargo_util::paths;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("install")
         .about("Install a Rust binary. Default location is $HOME/.cargo/bin")
         .arg_quiet()

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -3,7 +3,7 @@ use anyhow::bail;
 use cargo::{drop_println, CargoResult};
 use serde::Serialize;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("locate-project")
         .about("Print a JSON representation of a Cargo.toml file's location")
         .arg_quiet()

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("login")
         .about(
             "Save an api token from the registry locally. \

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("logout")
         .about("Remove an API token from the registry locally")
         .arg_quiet()

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 use cargo::ops::{self, OutputMetadataOptions};
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("metadata")
         .about(
             "Output the resolved dependencies of a package, \

--- a/src/bin/cargo/commands/mod.rs
+++ b/src/bin/cargo/commands/mod.rs
@@ -1,6 +1,6 @@
 use crate::command_prelude::*;
 
-pub fn builtin() -> Vec<App> {
+pub fn builtin() -> Vec<Command> {
     vec![
         add::cli(),
         bench::cli(),

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("new")
         .about("Create a new cargo package at <path>")
         .arg_quiet()

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops::{self, OwnersOptions};
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("owner")
         .about("Manage the owners of a crate on the registry")
         .arg_quiet()

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops::{self, PackageOpts};
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("package")
         .about("Assemble the local package into a distributable tarball")
         .arg_quiet()

--- a/src/bin/cargo/commands/pkgid.rs
+++ b/src/bin/cargo/commands/pkgid.rs
@@ -3,7 +3,7 @@ use crate::command_prelude::*;
 use cargo::ops;
 use cargo::util::print_available_packages;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("pkgid")
         .about("Print a fully qualified package specification")
         .arg_quiet()

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops::{self, PublishOpts};
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("publish")
         .about("Upload a package to the registry")
         .arg_quiet()

--- a/src/bin/cargo/commands/read_manifest.rs
+++ b/src/bin/cargo/commands/read_manifest.rs
@@ -1,6 +1,6 @@
 use crate::command_prelude::*;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("read-manifest")
         .about(
             "\

--- a/src/bin/cargo/commands/report.rs
+++ b/src/bin/cargo/commands/report.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 use cargo::core::compiler::future_incompat::{OnDiskReports, REPORT_PREAMBLE};
 use cargo::drop_println;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("report")
         .about("Generate and display various kinds of reports")
         .after_help("Run `cargo help report` for more detailed information.\n")

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -4,7 +4,7 @@ use cargo::core::Verbosity;
 use cargo::ops::{self, CompileFilter, Packages};
 use cargo_util::ProcessError;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("run")
         // subcommand aliases are handled in aliased_command()
         // .alias("r")

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -5,7 +5,7 @@ use cargo::util::interning::InternedString;
 const PRINT_ARG_NAME: &str = "print";
 const CRATE_TYPE_ARG_NAME: &str = "crate-type";
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("rustc")
         .trailing_var_arg(true)
         .about("Compile a package, and pass extra options to the compiler")

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -2,7 +2,7 @@ use cargo::ops::{self, DocOptions};
 
 use crate::command_prelude::*;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("rustdoc")
         .trailing_var_arg(true)
         .about("Build a package's documentation, using specified custom flags.")

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -4,7 +4,7 @@ use std::cmp::min;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("search")
         .about("Search packages in crates.io")
         .arg_quiet()

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -1,7 +1,7 @@
 use crate::command_prelude::*;
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("test")
         // Subcommand aliases are handled in `aliased_command()`.
         // .alias("t")

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -9,7 +9,7 @@ use cargo::util::CargoResult;
 use std::collections::HashSet;
 use std::str::FromStr;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("tree")
         .about("Display a tree visualization of a dependency graph")
         .arg_quiet()

--- a/src/bin/cargo/commands/uninstall.rs
+++ b/src/bin/cargo/commands/uninstall.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("uninstall")
         .about("Remove a Rust binary")
         .arg_quiet()

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -3,7 +3,7 @@ use crate::command_prelude::*;
 use cargo::ops::{self, UpdateOptions};
 use cargo::util::print_available_packages;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("update")
         .about("Update dependencies as recorded in the local lock file")
         .arg_quiet()

--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 use cargo::ops;
 use std::path::PathBuf;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("vendor")
         .about("Vendor all dependencies for a project locally")
         .arg_quiet()

--- a/src/bin/cargo/commands/verify_project.rs
+++ b/src/bin/cargo/commands/verify_project.rs
@@ -3,7 +3,7 @@ use crate::command_prelude::*;
 use std::collections::HashMap;
 use std::process;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("verify-project")
         .about("Check correctness of crate manifest")
         .arg_quiet()

--- a/src/bin/cargo/commands/version.rs
+++ b/src/bin/cargo/commands/version.rs
@@ -1,7 +1,7 @@
 use crate::cli;
 use crate::command_prelude::*;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("version")
         .about("Show version information")
         .arg_quiet()

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -2,7 +2,7 @@ use crate::command_prelude::*;
 
 use cargo::ops;
 
-pub fn cli() -> App {
+pub fn cli() -> Command {
     subcommand("yank")
         .about("Remove a pushed crate from the index")
         .arg_quiet()

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -319,7 +319,7 @@ pub trait ArgMatchesExt {
             None => None,
             Some(arg) => Some(arg.parse::<u32>().map_err(|_| {
                 clap::Error::raw(
-                    clap::ErrorKind::ValueValidation,
+                    clap::error::ErrorKind::ValueValidation,
                     format!("Invalid value: could not parse `{}` as a number", arg),
                 )
             })?),
@@ -332,7 +332,7 @@ pub trait ArgMatchesExt {
             None => None,
             Some(arg) => Some(arg.parse::<i32>().map_err(|_| {
                 clap::Error::raw(
-                    clap::ErrorKind::ValueValidation,
+                    clap::error::ErrorKind::ValueValidation,
                     format!("Invalid value: could not parse `{}` as a number", arg),
                 )
             })?),

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -22,9 +22,9 @@ pub use crate::core::compiler::CompileMode;
 pub use crate::{CliError, CliResult, Config};
 pub use clap::{value_parser, AppSettings, Arg, ArgAction, ArgMatches};
 
-pub type App = clap::Command<'static>;
+pub type Command = clap::Command<'static>;
 
-pub trait AppExt: Sized {
+pub trait CommandExt: Sized {
     fn _arg(self, arg: Arg<'static>) -> Self;
 
     /// Do not use this method, it is only for backwards compatibility.
@@ -255,7 +255,7 @@ pub trait AppExt: Sized {
     }
 }
 
-impl AppExt for App {
+impl CommandExt for Command {
     fn _arg(self, arg: Arg<'static>) -> Self {
         self.arg(arg)
     }
@@ -295,8 +295,8 @@ pub fn multi_opt(name: &'static str, value_name: &'static str, help: &'static st
         .action(ArgAction::Append)
 }
 
-pub fn subcommand(name: &'static str) -> App {
-    App::new(name)
+pub fn subcommand(name: &'static str) -> Command {
+    Command::new(name)
         .dont_collapse_args_in_usage(true)
         .setting(AppSettings::DeriveDisplayOrder)
 }


### PR DESCRIPTION
This is two minor refactors that better align us with the upcoming clap v4
- `clap::ErrorKind` has moved to `clap::error::ErrroKind` during 3.x and in 4.0 the old location no longer works
- `clap::App` was renamed to `clap::Command` and in v4 the lifetime will be removed which will remove the need for us to have an alias at all.  This does the rename so we can just use what clap has in v4.