### PR TITLE
fix(cli): Error trailing args rather than ignore

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -242,11 +242,15 @@ fn expand_aliases(
             (Some(_), None) => {
                 // Command is built-in and is not conflicting with alias, but contains ignored values.
                 if let Some(mut values) = args.get_many::<String>("") {
-                    config.shell().warn(format!(
-                        "trailing arguments after built-in command `{}` are ignored: `{}`",
+                    return Err(anyhow::format_err!(
+                        "\
+trailing arguments after built-in command `{}` are unsupported: `{}`
+
+To pass the arguments to the subcommand, remove `--`",
                         cmd,
                         values.join(" "),
-                    ))?;
+                    )
+                    .into());
                 }
             }
             (None, None) => {}

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -324,11 +324,12 @@ fn weird_check() {
         .build();
 
     p.cargo("-- check --invalid_argument -some-other-argument")
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] trailing arguments after built-in command `check` are ignored: `--invalid_argument -some-other-argument`
-[CHECKING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[ERROR] trailing arguments after built-in command `check` are unsupported: `--invalid_argument -some-other-argument`
+
+To pass the arguments to the subcommand, remove `--`
 ",
         )
         .run();


### PR DESCRIPTION
This warning has been in for a sufficient time, requires a hack from clap to avoid all argument ID validation, and allows users to run the wrong command (imagine `cargo -- publish --dry-run`).

See also https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Cargo.20ignoring.20arguments.20with.20.60cargo.20--.20check.20--ignored.60