### PR TITLE
Unlink old final artifacts before compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ features = [
 [dev-dependencies]
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
+same-file = "1.0.6"
 snapbox = { version = "0.3.0", features = ["diff", "path"] }
 
 [build-dependencies]


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Some linkers do not remove the executable, but truncate and modify it.
That results in the old hard-link being modified even after renamed.
We delete the old artifact here to prevent this behavior from confusing users.

Fixes #11101; fixes #8348

### How should we test and review this PR?

I can only reproduce the original issue on x86_64-pc-windows-msvc with linker.exe. If you can reproduce it on Linux, please share which linker you're using.

### New (?) dev-dependency

`same-file` is already in our dependency graph (dependents: walkdir, ignore, cargo-util), so adding it to `dev-dependencies` won't affect much.

<!-- homu-ignore:end -->
