### PR TITLE
switch to `std::task::ready!()` where possible

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::task::Poll;
+use std::task::{ready, Poll};
 
 use crate::core::PackageSet;
 use crate::core::{Dependency, PackageId, QueryKind, Source, SourceId, SourceMap, Summary};
@@ -482,10 +482,7 @@ impl<'cfg> PackageRegistry<'cfg> {
         for &s in self.overrides.iter() {
             let src = self.sources.get_mut(s).unwrap();
             let dep = Dependency::new_override(dep.package_name(), s);
-            let mut results = match src.query_vec(&dep, QueryKind::Exact) {
-                Poll::Ready(results) => results?,
-                Poll::Pending => return Poll::Pending,
-            };
+            let mut results = ready!(src.query_vec(&dep, QueryKind::Exact))?;
             if !results.is_empty() {
                 return Poll::Ready(Ok(Some(results.remove(0))));
             }
@@ -580,10 +577,7 @@ impl<'cfg> Registry for PackageRegistry<'cfg> {
         assert!(self.patches_locked);
         let (override_summary, n, to_warn) = {
             // Look for an override and get ready to query the real source.
-            let override_summary = match self.query_overrides(dep) {
-                Poll::Ready(override_summary) => override_summary?,
-                Poll::Pending => return Poll::Pending,
-            };
+            let override_summary = ready!(self.query_overrides(dep))?;
 
             // Next up on our list of candidates is to check the `[patch]`
             // section of the manifest. Here we look through all patches
@@ -880,23 +874,17 @@ fn summary_for_patch(
     // No summaries found, try to help the user figure out what is wrong.
     if let Some(locked) = locked {
         // Since the locked patch did not match anything, try the unlocked one.
-        let orig_matches = match source.query_vec(orig_patch, QueryKind::Exact) {
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(deps) => deps,
-        }
-        .unwrap_or_else(|e| {
-            log::warn!(
-                "could not determine unlocked summaries for dep {:?}: {:?}",
-                orig_patch,
-                e
-            );
-            Vec::new()
-        });
+        let orig_matches =
+            ready!(source.query_vec(orig_patch, QueryKind::Exact)).unwrap_or_else(|e| {
+                log::warn!(
+                    "could not determine unlocked summaries for dep {:?}: {:?}",
+                    orig_patch,
+                    e
+                );
+                Vec::new()
+            });
 
-        let summary = match summary_for_patch(orig_patch, &None, orig_matches, source) {
-            Poll::Pending => return Poll::Pending,
-            Poll::Ready(summary) => summary?,
-        };
+        let summary = ready!(summary_for_patch(orig_patch, &None, orig_matches, source))?;
 
         // The unlocked version found a match. This returns a value to
         // indicate that this entry should be unlocked.
@@ -905,18 +893,15 @@ fn summary_for_patch(
     // Try checking if there are *any* packages that match this by name.
     let name_only_dep = Dependency::new_override(orig_patch.package_name(), orig_patch.source_id());
 
-    let name_summaries = match source.query_vec(&name_only_dep, QueryKind::Exact) {
-        Poll::Pending => return Poll::Pending,
-        Poll::Ready(deps) => deps,
-    }
-    .unwrap_or_else(|e| {
-        log::warn!(
-            "failed to do name-only summary query for {:?}: {:?}",
-            name_only_dep,
-            e
-        );
-        Vec::new()
-    });
+    let name_summaries =
+        ready!(source.query_vec(&name_only_dep, QueryKind::Exact)).unwrap_or_else(|e| {
+            log::warn!(
+                "failed to do name-only summary query for {:?}: {:?}",
+                name_only_dep,
+                e
+            );
+            Vec::new()
+        });
     let mut vers = name_summaries
         .iter()
         .map(|summary| summary.version())


### PR DESCRIPTION
In Rust 1.64.0, [`std::task::ready`](https://doc.rust-lang.org/stable/std/task/macro.ready.html) was [stabilized](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#stabilized-apis). Using `ready!()` can make what is happening clearer in the code as it expands to roughly:
```rust
let num = match fut.poll(cx) {
    Poll::Ready(t) => t,
    Poll::Pending => return Poll::Pending,
};
```
This PR replaces places using `Poll::Pending => return Poll::Pending`  with `ready!()` where appropriate.

I was unsure about how useful the new macro would be in one place in [`cargo/registry/index.rs`](https://github.com/rust-lang/cargo/blob/247ca7fd04e5c7cc383bcac7d72316e98fbea2bc/src/cargo/sources/registry/index.rs#L425-L429), so I left it out and will add it in if needed.


Close #11128 

r? @Eh2406 
