### PR TITLE
ci: update toolchain for building api doc

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -21,6 +21,8 @@ jobs:
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.9/mdbook-v0.4.9-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
+    - name: Update toolchain
+      run: rustup update --no-self-update stable && rustup default stable
     - name: Build API doc
       run: |
           cargo doc --document-private-items --no-deps


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fix https://github.com/rust-lang/cargo/actions/runs/3108417823/jobs/5037588107

Instead of using provided toolchain, update manually.

### How should we test and review this PR?

Test passes on my own fork.
https://github.com/weihanglo/cargo/actions/runs/3108607404/jobs/5037987769

<!-- homu-ignore:end -->
