### PR TITLE
Reduce references to `[project]` within cargo

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1590,7 +1590,16 @@ impl TomlManifest {
                 project.clone()
             }
             (Some(package), None) => package.clone(),
-            (None, Some(project)) => project.clone(),
+            (None, Some(project)) => {
+                if source_id.is_path() {
+                    config.shell().warn(format!(
+                        "manifest at `{}` contains `[project]` instead of `[package]`, \
+                                this could become a hard error in the future",
+                        package_root.display()
+                    ))?;
+                }
+                project.clone()
+            }
             (None, None) => bail!("no `package` section found"),
         };
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -419,8 +419,8 @@ impl<P: Clone> Default for DetailedTomlDependency<P> {
 #[serde(rename_all = "kebab-case")]
 pub struct TomlManifest {
     cargo_features: Option<Vec<String>>,
-    package: Option<Box<TomlProject>>,
-    project: Option<Box<TomlProject>>,
+    package: Option<Box<TomlPackage>>,
+    project: Option<Box<TomlPackage>>,
     profile: Option<TomlProfiles>,
     lib: Option<TomlLibTarget>,
     bin: Option<Vec<TomlBinTarget>>,
@@ -1071,7 +1071,7 @@ pub struct TomlWorkspaceField {
 /// tables.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
-pub struct TomlProject {
+pub struct TomlPackage {
     edition: Option<MaybeWorkspace<String>>,
     rust_version: Option<MaybeWorkspace<String>>,
     name: InternedString,
@@ -1229,7 +1229,7 @@ impl InheritableFields {
     }
 
     pub fn readme(&self, package_root: &Path) -> CargoResult<StringOrBool> {
-        readme_for_project(self.ws_root.as_path(), self.readme.clone()).map_or(
+        readme_for_package(self.ws_root.as_path(), self.readme.clone()).map_or(
             Err(anyhow!("`workspace.package.readme` was not defined")),
             |readme| {
                 let rel_path =
@@ -1321,7 +1321,7 @@ impl InheritableFields {
     }
 }
 
-impl TomlProject {
+impl TomlPackage {
     pub fn to_package_id(
         &self,
         source_id: SourceId,
@@ -1933,7 +1933,7 @@ impl TomlManifest {
                 .clone()
                 .map(|mw| mw.resolve("documentation", || inherit()?.documentation()))
                 .transpose()?,
-            readme: readme_for_project(
+            readme: readme_for_package(
                 package_root,
                 project
                     .readme
@@ -2393,8 +2393,8 @@ fn inheritable_from_path(
     }
 }
 
-/// Returns the name of the README file for a `TomlProject`.
-pub fn readme_for_project(package_root: &Path, readme: Option<StringOrBool>) -> Option<String> {
+/// Returns the name of the README file for a [`TomlPackage`].
+pub fn readme_for_package(package_root: &Path, readme: Option<StringOrBool>) -> Option<String> {
     match &readme {
         None => default_readme_from_package_root(package_root),
         Some(value) => match value {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1578,10 +1578,10 @@ impl TomlManifest {
         let cargo_features = me.cargo_features.as_ref().unwrap_or(&empty);
         let features = Features::new(cargo_features, config, &mut warnings, source_id.is_path())?;
 
-        let project = me.project.clone().or_else(|| me.package.clone());
-        let project = &mut project.ok_or_else(|| anyhow!("no `package` section found"))?;
+        let package = me.project.clone().or_else(|| me.package.clone());
+        let package = &mut package.ok_or_else(|| anyhow!("no `package` section found"))?;
 
-        let workspace_config = match (me.workspace.as_ref(), project.workspace.as_ref()) {
+        let workspace_config = match (me.workspace.as_ref(), package.workspace.as_ref()) {
             (Some(toml_config), None) => {
                 let mut inheritable = toml_config.package.clone().unwrap_or_default();
                 inheritable.update_ws_path(package_root.to_path_buf());
@@ -1609,7 +1609,7 @@ impl TomlManifest {
             ),
         };
 
-        let package_name = project.name.trim();
+        let package_name = package.name.trim();
         if package_name.is_empty() {
             bail!("package name cannot be an empty string")
         }
@@ -1622,21 +1622,21 @@ impl TomlManifest {
         let inherit =
             || inherit_cell.try_borrow_with(|| get_ws(config, &resolved_path, &workspace_config));
 
-        let version = project
+        let version = package
             .version
             .clone()
             .resolve("version", || inherit()?.version())?;
 
-        project.version = MaybeWorkspace::Defined(version.clone());
+        package.version = MaybeWorkspace::Defined(version.clone());
 
-        let pkgid = project.to_package_id(source_id, version)?;
+        let pkgid = package.to_package_id(source_id, version)?;
 
-        let edition = if let Some(edition) = project.edition.clone() {
+        let edition = if let Some(edition) = package.edition.clone() {
             let edition: Edition = edition
                 .resolve("edition", || inherit()?.edition())?
                 .parse()
                 .with_context(|| "failed to parse the `edition` key")?;
-            project.edition = Some(MaybeWorkspace::Defined(edition.to_string()));
+            package.edition = Some(MaybeWorkspace::Defined(edition.to_string()));
             edition
         } else {
             Edition::Edition2015
@@ -1655,7 +1655,7 @@ impl TomlManifest {
             )));
         }
 
-        let rust_version = if let Some(rust_version) = &project.rust_version {
+        let rust_version = if let Some(rust_version) = &package.rust_version {
             let rust_version = rust_version
                 .clone()
                 .resolve("rust_version", || inherit()?.rust_version())?;
@@ -1682,12 +1682,12 @@ impl TomlManifest {
             None
         };
 
-        if project.metabuild.is_some() {
+        if package.metabuild.is_some() {
             features.require(Feature::metabuild())?;
         }
 
         let resolve_behavior = match (
-            project.resolver.as_ref(),
+            package.resolver.as_ref(),
             me.workspace.as_ref().and_then(|ws| ws.resolver.as_ref()),
         ) {
             (None, None) => None,
@@ -1706,8 +1706,8 @@ impl TomlManifest {
             package_name,
             package_root,
             edition,
-            &project.build,
-            &project.metabuild,
+            &package.build,
+            &package.metabuild,
             &mut warnings,
             &mut errors,
         )?;
@@ -1724,7 +1724,7 @@ impl TomlManifest {
             ));
         }
 
-        if let Some(links) = &project.links {
+        if let Some(links) = &package.links {
             if !targets.iter().any(|t| t.is_custom_build()) {
                 bail!(
                     "package `{}` specifies that it links to `{}` but does not \
@@ -1895,13 +1895,13 @@ impl TomlManifest {
             }
         }
 
-        let exclude = project
+        let exclude = package
             .exclude
             .clone()
             .map(|mw| mw.resolve("exclude", || inherit()?.exclude()))
             .transpose()?
             .unwrap_or_default();
-        let include = project
+        let include = package
             .include
             .clone()
             .map(|mw| mw.resolve("include", || inherit()?.include()))
@@ -1914,61 +1914,61 @@ impl TomlManifest {
             pkgid,
             deps,
             me.features.as_ref().unwrap_or(&empty_features),
-            project.links.as_deref(),
+            package.links.as_deref(),
         )?;
 
         let metadata = ManifestMetadata {
-            description: project
+            description: package
                 .description
                 .clone()
                 .map(|mw| mw.resolve("description", || inherit()?.description()))
                 .transpose()?,
-            homepage: project
+            homepage: package
                 .homepage
                 .clone()
                 .map(|mw| mw.resolve("homepage", || inherit()?.homepage()))
                 .transpose()?,
-            documentation: project
+            documentation: package
                 .documentation
                 .clone()
                 .map(|mw| mw.resolve("documentation", || inherit()?.documentation()))
                 .transpose()?,
             readme: readme_for_package(
                 package_root,
-                project
+                package
                     .readme
                     .clone()
                     .map(|mw| mw.resolve("readme", || inherit()?.readme(package_root)))
                     .transpose()?,
             ),
-            authors: project
+            authors: package
                 .authors
                 .clone()
                 .map(|mw| mw.resolve("authors", || inherit()?.authors()))
                 .transpose()?
                 .unwrap_or_default(),
-            license: project
+            license: package
                 .license
                 .clone()
                 .map(|mw| mw.resolve("license", || inherit()?.license()))
                 .transpose()?,
-            license_file: project
+            license_file: package
                 .license_file
                 .clone()
                 .map(|mw| mw.resolve("license", || inherit()?.license_file(package_root)))
                 .transpose()?,
-            repository: project
+            repository: package
                 .repository
                 .clone()
                 .map(|mw| mw.resolve("repository", || inherit()?.repository()))
                 .transpose()?,
-            keywords: project
+            keywords: package
                 .keywords
                 .clone()
                 .map(|mw| mw.resolve("keywords", || inherit()?.keywords()))
                 .transpose()?
                 .unwrap_or_default(),
-            categories: project
+            categories: package
                 .categories
                 .clone()
                 .map(|mw| mw.resolve("categories", || inherit()?.categories()))
@@ -1980,54 +1980,54 @@ impl TomlManifest {
                 .map(|mw| mw.resolve("badges", || inherit()?.badges()))
                 .transpose()?
                 .unwrap_or_default(),
-            links: project.links.clone(),
+            links: package.links.clone(),
         };
-        project.description = metadata
+        package.description = metadata
             .description
             .clone()
             .map(|description| MaybeWorkspace::Defined(description));
-        project.homepage = metadata
+        package.homepage = metadata
             .homepage
             .clone()
             .map(|homepage| MaybeWorkspace::Defined(homepage));
-        project.documentation = metadata
+        package.documentation = metadata
             .documentation
             .clone()
             .map(|documentation| MaybeWorkspace::Defined(documentation));
-        project.readme = metadata
+        package.readme = metadata
             .readme
             .clone()
             .map(|readme| MaybeWorkspace::Defined(StringOrBool::String(readme)));
-        project.authors = project
+        package.authors = package
             .authors
             .as_ref()
             .map(|_| MaybeWorkspace::Defined(metadata.authors.clone()));
-        project.license = metadata
+        package.license = metadata
             .license
             .clone()
             .map(|license| MaybeWorkspace::Defined(license));
-        project.license_file = metadata
+        package.license_file = metadata
             .license_file
             .clone()
             .map(|license_file| MaybeWorkspace::Defined(license_file));
-        project.repository = metadata
+        package.repository = metadata
             .repository
             .clone()
             .map(|repository| MaybeWorkspace::Defined(repository));
-        project.keywords = project
+        package.keywords = package
             .keywords
             .as_ref()
             .map(|_| MaybeWorkspace::Defined(metadata.keywords.clone()));
-        project.categories = project
+        package.categories = package
             .categories
             .as_ref()
             .map(|_| MaybeWorkspace::Defined(metadata.categories.clone()));
-        project.rust_version = rust_version.clone().map(|rv| MaybeWorkspace::Defined(rv));
-        project.exclude = project
+        package.rust_version = rust_version.clone().map(|rv| MaybeWorkspace::Defined(rv));
+        package.exclude = package
             .exclude
             .as_ref()
             .map(|_| MaybeWorkspace::Defined(exclude.clone()));
-        project.include = project
+        package.include = package
             .include
             .as_ref()
             .map(|_| MaybeWorkspace::Defined(include.clone()));
@@ -2037,12 +2037,12 @@ impl TomlManifest {
             profiles.validate(&features, &mut warnings)?;
         }
 
-        let publish = project
+        let publish = package
             .publish
             .clone()
             .map(|publish| publish.resolve("publish", || inherit()?.publish()).unwrap());
 
-        project.publish = publish.clone().map(|p| MaybeWorkspace::Defined(p));
+        package.publish = publish.clone().map(|p| MaybeWorkspace::Defined(p));
 
         let publish = match publish {
             Some(VecStringOrBool::VecString(ref vecstring)) => Some(vecstring.clone()),
@@ -2058,7 +2058,7 @@ impl TomlManifest {
             )
         }
 
-        if let Some(run) = &project.default_run {
+        if let Some(run) = &package.default_run {
             if !targets
                 .iter()
                 .filter(|t| t.is_bin())
@@ -2070,22 +2070,22 @@ impl TomlManifest {
             }
         }
 
-        let default_kind = project
+        let default_kind = package
             .default_target
             .as_ref()
             .map(|t| CompileTarget::new(&*t))
             .transpose()?
             .map(CompileKind::Target);
-        let forced_kind = project
+        let forced_kind = package
             .forced_target
             .as_ref()
             .map(|t| CompileTarget::new(&*t))
             .transpose()?
             .map(CompileKind::Target);
-        let custom_metadata = project.metadata.clone();
+        let custom_metadata = package.metadata.clone();
         let resolved_toml = TomlManifest {
             cargo_features: me.cargo_features.clone(),
-            package: Some(project.clone()),
+            package: Some(package.clone()),
             project: None,
             profile: me.profile.clone(),
             lib: me.lib.clone(),
@@ -2115,7 +2115,7 @@ impl TomlManifest {
             targets,
             exclude,
             include,
-            project.links.clone(),
+            package.links.clone(),
             metadata,
             custom_metadata,
             profiles,
@@ -2126,13 +2126,13 @@ impl TomlManifest {
             features,
             edition,
             rust_version,
-            project.im_a_teapot,
-            project.default_run.clone(),
+            package.im_a_teapot,
+            package.default_run.clone(),
             Rc::new(resolved_toml),
-            project.metabuild.clone().map(|sov| sov.0),
+            package.metabuild.clone().map(|sov| sov.0),
             resolve_behavior,
         );
-        if project.license_file.is_some() && project.license.is_some() {
+        if package.license_file.is_some() && package.license.is_some() {
             manifest.warnings_mut().add_warning(
                 "only one of `license` or `license-file` is necessary\n\
                  `license` should be used if the package license can be expressed \

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -472,7 +472,7 @@ Dependencies in the `[dependencies]`, `[dev-dependencies]`, `[build-dependencies
 `[workspace.dependencies]` definition of dependencies.
 
 ```toml
-[project]
+[package]
 name = "bar"
 version = "0.2.0"
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1083,7 +1083,7 @@ The `filename` parameter is only available in the `[[bin]]` section of the manif
 ```toml
 cargo-features = ["different-binary-name"]
 
-[project]
+[package]
 name =  "foo"
 version = "0.0.1"
 

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -202,7 +202,7 @@ regex = { version = "1.6.0", default-features = false, features = ["std"] }
 
 ```toml
 # [PROJECT_DIR]/bar/Cargo.toml
-[project]
+[package]
 name = "bar"
 version = "0.2.0"
 

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -13,7 +13,7 @@ fn depend_on_alt_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -62,7 +62,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -104,7 +104,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -146,7 +146,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -190,7 +190,7 @@ fn registry_and_path_dep_works() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -224,7 +224,7 @@ fn registry_incompatible_with_git() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -255,7 +255,7 @@ fn cannot_publish_to_crates_io_with_registry_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -312,7 +312,7 @@ fn publish_with_registry_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -376,7 +376,7 @@ fn alt_registry_and_crates_io_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -479,7 +479,7 @@ fn publish_with_crates_io_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = ["me"]
@@ -616,7 +616,7 @@ fn bad_registry_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1042,7 +1042,7 @@ fn unknown_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1215,7 +1215,7 @@ fn registries_index_relative_url() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1262,7 +1262,7 @@ fn registries_index_relative_path_not_allowed() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -219,7 +219,7 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -332,7 +332,7 @@ fn features_are_not_unified_among_lib_and_bin_dep_of_different_target() {
         .file(
             "Cargo.toml",
             &r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -435,7 +435,7 @@ fn feature_resolution_works_for_cfg_target_specification() {
         .file(
             "Cargo.toml",
             &r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2181,7 +2181,7 @@ fn build_script_features_for_shared_dependency() {
         .file(
             "Cargo.toml",
             &r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 resolver = "2"

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -209,7 +209,7 @@ fn duplicate_packages_in_cargo_lock() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -263,7 +263,7 @@ fn bad_source_in_cargo_lock() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -654,7 +654,7 @@ warning: unused manifest key: target.foo.bar
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -667,7 +667,7 @@ warning: unused manifest key: target.foo.bar
     p.cargo("build")
         .with_stderr(
             "\
-warning: unused manifest key: project.bulid
+warning: unused manifest key: package.bulid
 [COMPILING] foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -679,7 +679,7 @@ warning: unused manifest key: project.bulid
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -329,7 +329,7 @@ fn bench_with_lib_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -452,7 +452,7 @@ fn external_bench_explicit() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -550,7 +550,7 @@ fn bench_autodiscover_2015() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -695,7 +695,7 @@ fn lib_bin_same_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1058,7 +1058,7 @@ fn test_a_bench() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 authors = []
                 version = "0.1.0"
@@ -1216,7 +1216,7 @@ fn test_bench_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 authors = []
                 version = "0.1.0"
@@ -1236,7 +1236,7 @@ fn test_bench_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 authors = []
                 version = "0.1.0"
@@ -1266,7 +1266,7 @@ fn test_bench_multiple_packages() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 authors = []
                 version = "0.1.0"
@@ -1305,7 +1305,7 @@ fn bench_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -1358,7 +1358,7 @@ fn bench_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -1403,7 +1403,7 @@ fn bench_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -1547,7 +1547,7 @@ fn legacy_bench_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -9,7 +9,7 @@ fn gated() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name =  "foo"
                 version = "0.0.1"
 
@@ -44,7 +44,7 @@ fn binary_name1() {
             r#"
                 cargo-features = ["different-binary-name"]
 
-                [project]
+                [package]
                 name =  "foo"
                 version = "0.0.1"
 
@@ -126,7 +126,7 @@ fn binary_name2() {
             r#"
                 cargo-features = ["different-binary-name"]
 
-                [project]
+                [package]
                 name =  "foo"
                 version = "0.0.1"
 
@@ -212,7 +212,7 @@ fn check_env_vars() {
             r#"
                 cargo-features = ["different-binary-name"]
 
-                [project]
+                [package]
                 name =  "foo"
                 version = "0.0.1"
 
@@ -264,7 +264,7 @@ fn check_msg_format_json() {
             r#"
                 cargo-features = ["different-binary-name"]
 
-                [project]
+                [package]
                 name =  "foo"
                 version = "0.0.1"
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -182,7 +182,7 @@ fn cargo_compile_with_invalid_manifest2() {
         .file(
             "Cargo.toml",
             "
-                [project]
+                [package]
                 foo = bar
             ",
         )
@@ -657,7 +657,7 @@ fn cargo_compile_with_warnings_in_a_dep_package() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -700,7 +700,7 @@ fn cargo_compile_with_nested_deps_inferred() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -717,7 +717,7 @@ fn cargo_compile_with_nested_deps_inferred() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -763,7 +763,7 @@ fn cargo_compile_with_nested_deps_correct_bin() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -780,7 +780,7 @@ fn cargo_compile_with_nested_deps_correct_bin() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -826,7 +826,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -840,7 +840,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -890,7 +890,7 @@ fn cargo_compile_with_nested_deps_longhand() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -909,7 +909,7 @@ fn cargo_compile_with_nested_deps_longhand() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -1101,7 +1101,7 @@ fn incompatible_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
 
@@ -1147,7 +1147,7 @@ fn incompatible_dependencies_with_multi_semver() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
 
@@ -1319,7 +1319,7 @@ fn crate_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.5.1-alpha.1"
             description = "This is foo"
@@ -1477,7 +1477,7 @@ fn crate_authors_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.1-alpha.1"
                 authors = ["wycats@example.com", "neikos@example.com"]
@@ -1526,7 +1526,7 @@ fn vv_prints_rustc_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = ["escape='\"@example.com"]
@@ -1606,7 +1606,7 @@ fn many_crate_types_old_style_lib_location() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -1639,7 +1639,7 @@ fn many_crate_types_correct() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -1666,7 +1666,7 @@ fn set_both_dylib_and_cdylib_crate_types() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -1771,7 +1771,7 @@ fn lib_crate_types_conflicting_warning() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = ["wycats@example.com"]
@@ -1798,7 +1798,7 @@ fn examples_crate_types_conflicting_warning() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = ["wycats@example.com"]
@@ -2966,7 +2966,7 @@ fn cargo_platform_specific_dependency() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = ["wycats@example.com"]
@@ -3013,7 +3013,7 @@ fn cargo_platform_specific_dependency_build_dependencies_conflicting_warning() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = ["wycats@example.com"]
@@ -3054,7 +3054,7 @@ fn cargo_platform_specific_dependency_dev_dependencies_conflicting_warning() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = ["wycats@example.com"]
@@ -3093,7 +3093,7 @@ fn bad_platform_specific_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -3123,7 +3123,7 @@ fn cargo_platform_specific_dependency_wrong_platform() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -3757,7 +3757,7 @@ fn compiler_json_error_format() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -4087,7 +4087,7 @@ fn build_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -4119,7 +4119,7 @@ fn build_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -4152,7 +4152,7 @@ fn build_all_exclude_not_found() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -4184,7 +4184,7 @@ fn build_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -4217,7 +4217,7 @@ fn build_all_exclude_glob_not_found() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -4259,7 +4259,7 @@ fn build_all_workspace_implicit_examples() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -4506,7 +4506,7 @@ fn build_all_member_dependency_same_name() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.1.0"
 
@@ -4717,7 +4717,7 @@ fn cdylib_not_lifted() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 authors = []
                 version = "0.1.0"
@@ -4755,7 +4755,7 @@ fn cdylib_final_outputs() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo-bar"
                 authors = []
                 version = "0.1.0"
@@ -4843,7 +4843,7 @@ fn deterministic_cfg_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -5110,7 +5110,7 @@ fn building_a_dependent_crate_without_bin_should_fail() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "testless"
                 version = "0.1.0"
 
@@ -5125,7 +5125,7 @@ fn building_a_dependent_crate_without_bin_should_fail() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -126,7 +126,7 @@ fn cargo_build_plan_build_script() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -204,7 +204,7 @@ fn build_plan_with_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -18,7 +18,7 @@ fn custom_build_script_failed() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -50,7 +50,7 @@ fn custom_build_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -67,7 +67,7 @@ fn custom_build_env_vars() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -664,7 +664,7 @@ fn custom_build_script_wrong_rustc_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -694,7 +694,7 @@ fn custom_build_script_rustc_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -708,7 +708,7 @@ fn custom_build_script_rustc_flags() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -753,7 +753,7 @@ fn custom_build_script_rustc_flags_no_space() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -767,7 +767,7 @@ fn custom_build_script_rustc_flags_no_space() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -812,7 +812,7 @@ fn links_no_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -843,7 +843,7 @@ fn links_duplicates() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -859,7 +859,7 @@ fn links_duplicates() {
         .file(
             "a-sys/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a-sys"
                 version = "0.5.0"
                 authors = []
@@ -947,7 +947,7 @@ fn links_duplicates_deep_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -963,7 +963,7 @@ fn links_duplicates_deep_dependency() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -978,7 +978,7 @@ fn links_duplicates_deep_dependency() {
         .file(
             "a/a-sys/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a-sys"
                 version = "0.5.0"
                 authors = []
@@ -1013,7 +1013,7 @@ fn overrides_and_links() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1051,7 +1051,7 @@ fn overrides_and_links() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1086,7 +1086,7 @@ fn unused_overrides() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1118,7 +1118,7 @@ fn links_passes_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1142,7 +1142,7 @@ fn links_passes_env_vars() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1175,7 +1175,7 @@ fn only_rerun_build_script() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1211,7 +1211,7 @@ fn rebuild_continues_to_pass_env_vars() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1239,7 +1239,7 @@ fn rebuild_continues_to_pass_env_vars() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -1279,7 +1279,7 @@ fn testing_and_such() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1344,7 +1344,7 @@ fn propagation_of_l_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1356,7 +1356,7 @@ fn propagation_of_l_flags() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1375,7 +1375,7 @@ fn propagation_of_l_flags() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -1415,7 +1415,7 @@ fn propagation_of_l_flags_new() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1427,7 +1427,7 @@ fn propagation_of_l_flags_new() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1450,7 +1450,7 @@ fn propagation_of_l_flags_new() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -1489,7 +1489,7 @@ fn build_deps_simple() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1533,7 +1533,7 @@ fn build_deps_not_for_normal() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1579,7 +1579,7 @@ fn build_cmd_with_a_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1601,7 +1601,7 @@ fn build_cmd_with_a_build_cmd() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1657,7 +1657,7 @@ fn out_dir_is_preserved() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1737,7 +1737,7 @@ fn output_separate_lines() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1775,7 +1775,7 @@ fn output_separate_lines_new() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1817,7 +1817,7 @@ fn code_generation() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1874,7 +1874,7 @@ fn release_with_build_script() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1899,7 +1899,7 @@ fn build_script_only() {
         .file(
             "Cargo.toml",
             r#"
-                  [project]
+                  [package]
                   name = "foo"
                   version = "0.0.0"
                   authors = []
@@ -1927,7 +1927,7 @@ fn shared_dep_with_a_build_script() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1977,7 +1977,7 @@ fn transitive_dep_host() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2029,7 +2029,7 @@ fn test_a_lib_with_a_build_command() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2072,7 +2072,7 @@ fn test_dev_dep_build_script() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2085,7 +2085,7 @@ fn test_dev_dep_build_script() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -2283,7 +2283,7 @@ fn test_duplicate_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -2347,7 +2347,7 @@ fn cfg_override() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2714,7 +2714,7 @@ fn flags_go_into_tests() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2728,7 +2728,7 @@ fn flags_go_into_tests() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -2740,7 +2740,7 @@ fn flags_go_into_tests() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -2795,7 +2795,7 @@ fn diamond_passes_args_only_once() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2810,7 +2810,7 @@ fn diamond_passes_args_only_once() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -2823,7 +2823,7 @@ fn diamond_passes_args_only_once() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -2835,7 +2835,7 @@ fn diamond_passes_args_only_once() {
         .file(
             "c/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "c"
                 version = "0.5.0"
                 authors = []
@@ -2879,7 +2879,7 @@ fn adding_an_override_invalidates() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2940,7 +2940,7 @@ fn changing_an_override_invalidates() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3002,7 +3002,7 @@ fn fresh_builds_possible_with_link_libs() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3054,7 +3054,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3110,7 +3110,7 @@ fn generate_good_d_files() {
         .file(
             "awoo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "awoo"
                 version = "0.5.0"
                 build = "build.rs"
@@ -3129,7 +3129,7 @@ fn generate_good_d_files() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "meow"
                 version = "0.5.0"
                 [dependencies]
@@ -3189,7 +3189,7 @@ fn generate_good_d_files_for_external_tools() {
         .file(
             "awoo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "awoo"
                 version = "0.5.0"
                 build = "build.rs"
@@ -3208,7 +3208,7 @@ fn generate_good_d_files_for_external_tools() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "meow"
                 version = "0.5.0"
                 [dependencies]
@@ -3250,7 +3250,7 @@ fn rebuild_only_on_explicit_paths() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3361,7 +3361,7 @@ fn doctest_receives_build_link_args() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3373,7 +3373,7 @@ fn doctest_receives_build_link_args() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -3405,7 +3405,7 @@ fn please_respect_the_dag() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3427,7 +3427,7 @@ fn please_respect_the_dag() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -3457,7 +3457,7 @@ fn non_utf8_output() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3494,7 +3494,7 @@ fn custom_target_dir() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3514,7 +3514,7 @@ fn custom_target_dir() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -3534,7 +3534,7 @@ fn panic_abort_with_build_scripts() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3554,7 +3554,7 @@ fn panic_abort_with_build_scripts() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -3572,7 +3572,7 @@ fn panic_abort_with_build_scripts() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -3596,7 +3596,7 @@ fn warnings_emitted() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3636,7 +3636,7 @@ fn warnings_emitted_when_build_script_panics() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3678,7 +3678,7 @@ fn warnings_hidden_for_upstream() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -3692,7 +3692,7 @@ fn warnings_hidden_for_upstream() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3737,7 +3737,7 @@ fn warnings_printed_on_vv() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -3751,7 +3751,7 @@ fn warnings_printed_on_vv() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3789,7 +3789,7 @@ fn output_shows_on_vv() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -3833,7 +3833,7 @@ fn links_with_dots() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -4055,7 +4055,7 @@ fn deterministic_rustc_dependency_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "dep1"
                 version = "0.1.0"
                 authors = []
@@ -4076,7 +4076,7 @@ fn deterministic_rustc_dependency_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "dep2"
                 version = "0.1.0"
                 authors = []
@@ -4097,7 +4097,7 @@ fn deterministic_rustc_dependency_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "dep3"
                 version = "0.1.0"
                 authors = []
@@ -4118,7 +4118,7 @@ fn deterministic_rustc_dependency_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "dep4"
                 version = "0.1.0"
                 authors = []
@@ -4140,7 +4140,7 @@ fn deterministic_rustc_dependency_flags() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -4172,7 +4172,7 @@ fn links_duplicates_with_cycle() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -4191,7 +4191,7 @@ fn links_duplicates_with_cycle() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -4204,7 +4204,7 @@ fn links_duplicates_with_cycle() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -4258,7 +4258,7 @@ fn _rename_with_link_search_path(cross: bool) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -4399,7 +4399,7 @@ fn optional_build_script_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -941,7 +941,7 @@ fn rustc_workspace_wrapper_includes_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -997,7 +997,7 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -6,7 +6,7 @@ use cargo_test_support::install::exe;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::tools;
-use cargo_test_support::{basic_manifest, project};
+use cargo_test_support::{basic_manifest, git, project};
 
 #[cargo_test]
 fn check_success() {
@@ -1022,5 +1022,85 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
         .with_stderr_contains("WRAPPER CALLED: rustc --crate-name bar [..]")
         .with_stderr_contains("[CHECKING] baz [..]")
         .with_stdout_does_not_contain("WRAPPER CALLED: rustc --crate-name baz [..]")
+        .run();
+}
+
+#[cargo_test]
+fn warn_manifest_package_and_project() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [project]
+                name = "foo"
+                version = "0.0.1"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr(
+            "\
+[WARNING] manifest at `[CWD]` contains both `project` and `package`, this could become a hard error in the future
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn git_manifest_package_and_project() {
+    let p = project();
+    let git_project = git::new("bar", |p| {
+        p.file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "bar"
+            version = "0.0.1"
+
+            [project]
+            name = "bar"
+            version = "0.0.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+    });
+
+    let p = p
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies.bar]
+                version = "0.0.1"
+                git  = '{}'
+
+            "#,
+                git_project.url()
+            ),
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr(
+            "\
+[UPDATING] git repository `[..]`
+[CHECKING] bar v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
         .run();
 }

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -35,7 +35,7 @@ fn features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -59,7 +59,7 @@ fn features_with_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -89,7 +89,7 @@ fn features_with_opt_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -120,7 +120,7 @@ fn features_with_namespaced_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -175,7 +175,7 @@ fn cli_all_options() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -201,7 +201,7 @@ fn features_with_cargo_check() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -251,7 +251,7 @@ fn features_test() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -275,7 +275,7 @@ fn features_doctest() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -355,7 +355,7 @@ fn features_doc() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -443,7 +443,7 @@ fn build_script_override() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -532,7 +532,7 @@ fn config_valid() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -565,7 +565,7 @@ fn config_invalid() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
             "#,

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -20,7 +20,7 @@ fn deleting_database_files() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -78,7 +78,7 @@ fn deleting_checkout_files() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -507,7 +507,7 @@ fn cross_tests() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 authors = []
                 version = "0.0.0"

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1110,7 +1110,7 @@ fn doc_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -1246,7 +1246,7 @@ fn doc_all_member_dependency_same_name() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
 
@@ -2057,7 +2057,7 @@ fn doc_test_in_workspace() {
         .file(
             "crate-a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "crate-a"
                 version = "0.1.0"
             "#,
@@ -2073,7 +2073,7 @@ fn doc_test_in_workspace() {
         .file(
             "crate-b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "crate-b"
                 version = "0.1.0"
             "#,

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -10,7 +10,7 @@ fn invalid1() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -42,7 +42,7 @@ fn same_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -89,7 +89,7 @@ fn invalid3() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -124,7 +124,7 @@ fn invalid4() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -168,7 +168,7 @@ fn invalid5() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -200,7 +200,7 @@ fn invalid6() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -231,7 +231,7 @@ fn invalid7() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -263,7 +263,7 @@ fn invalid8() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -298,7 +298,7 @@ fn invalid9() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -326,7 +326,7 @@ fn invalid10() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -374,7 +374,7 @@ fn no_transitive_dep_feature_requirement() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -445,7 +445,7 @@ fn no_feature_doesnt_build() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -498,7 +498,7 @@ fn default_feature_pulled_in() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -554,7 +554,7 @@ fn cyclic_feature() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -578,7 +578,7 @@ fn cyclic_feature2() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -600,7 +600,7 @@ fn groups_on_groups_on_groups() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -658,7 +658,7 @@ fn many_cli_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -707,7 +707,7 @@ fn union_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -855,7 +855,7 @@ fn transitive_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -895,7 +895,7 @@ fn everything_in_the_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1144,7 +1144,7 @@ fn dep_feature_in_cmd_line() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1228,7 +1228,7 @@ fn all_features_flag_enables_all_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1273,7 +1273,7 @@ fn many_cli_features_comma_delimited() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1321,7 +1321,7 @@ fn many_cli_features_comma_and_space_delimited() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1390,7 +1390,7 @@ fn only_dep_is_optional() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1419,7 +1419,7 @@ fn all_features_all_crates() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1432,7 +1432,7 @@ fn all_features_all_crates() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 authors = []
@@ -1514,7 +1514,7 @@ fn warn_if_default_features() {
         .file(
             "Cargo.toml",
             r#"
-               [project]
+               [package]
                name = "foo"
                version = "0.0.1"
                authors = []
@@ -1548,7 +1548,7 @@ fn no_feature_for_non_optional_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1568,7 +1568,7 @@ fn no_feature_for_non_optional_dep() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 authors = []
@@ -1589,7 +1589,7 @@ fn features_option_given_twice() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1617,7 +1617,7 @@ fn multi_multi_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1646,7 +1646,7 @@ fn cli_parse_ok() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1892,7 +1892,7 @@ fn nonexistent_required_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
             [features]

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1966,7 +1966,7 @@ fn rename_with_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1979,7 +1979,7 @@ fn rename_with_path_deps() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -1992,7 +1992,7 @@ fn rename_with_path_deps() {
         .file(
             "a/b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -2023,7 +2023,7 @@ fn move_target_directory_with_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2035,7 +2035,7 @@ fn move_target_directory_with_path_deps() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -34,7 +34,7 @@ fn cargo_compile_simple_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -102,7 +102,7 @@ fn cargo_compile_git_dep_branch() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -178,7 +178,7 @@ fn cargo_compile_git_dep_tag() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -251,7 +251,7 @@ fn cargo_compile_git_dep_pull_request() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.0"
 
@@ -291,7 +291,7 @@ fn cargo_compile_with_nested_paths() {
             .file(
                 "Cargo.toml",
                 r#"
-                    [project]
+                    [package]
 
                     name = "dep1"
                     version = "0.5.0"
@@ -333,7 +333,7 @@ fn cargo_compile_with_nested_paths() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -381,7 +381,7 @@ fn cargo_compile_with_malformed_nested_paths() {
             .file(
                 "vendor/dep3/Cargo.toml",
                 r#"
-                [project]
+                [package]
                 name = "dep3"
                 version = "0.5.0"
                 [dependencies]
@@ -396,7 +396,7 @@ fn cargo_compile_with_malformed_nested_paths() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -456,7 +456,7 @@ fn cargo_compile_with_meta_package() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -507,7 +507,7 @@ fn cargo_compile_with_short_ssh_git() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -566,7 +566,7 @@ fn two_revs_same_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.0"
                     authors = []
@@ -642,7 +642,7 @@ fn recompilation() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -903,7 +903,7 @@ fn dep_with_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -975,7 +975,7 @@ fn dep_with_relative_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
 
@@ -1036,7 +1036,7 @@ fn dep_with_bad_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -1110,7 +1110,7 @@ fn dep_with_skipped_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.0"
                     authors = []
@@ -1145,7 +1145,7 @@ fn ambiguous_published_deps() {
                 "aaa/Cargo.toml",
                 &format!(
                     r#"
-                    [project]
+                    [package]
                     name = "bar"
                     version = "0.5.0"
                     publish = true
@@ -1157,7 +1157,7 @@ fn ambiguous_published_deps() {
                 "bbb/Cargo.toml",
                 &format!(
                     r#"
-                    [project]
+                    [package]
                     name = "bar"
                     version = "0.5.0"
                     publish = true
@@ -1172,7 +1172,7 @@ fn ambiguous_published_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -1218,7 +1218,7 @@ fn two_deps_only_update_one() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -1290,7 +1290,7 @@ fn stale_cached_version() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.0"
                     authors = []
@@ -1385,7 +1385,7 @@ fn dep_with_changed_submodule() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = ["wycats@example.com"]
@@ -1491,7 +1491,7 @@ fn dev_deps_with_testing() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -1609,7 +1609,7 @@ fn git_name_not_always_needed() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -1652,7 +1652,7 @@ fn git_repo_changing_no_rebuild() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "p1"
                     version = "0.5.0"
                     authors = []
@@ -1692,7 +1692,7 @@ fn git_repo_changing_no_rebuild() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "p2"
                     version = "0.5.0"
                     authors = []
@@ -1728,7 +1728,7 @@ fn git_dep_build_cmd() {
             .file(
                 "Cargo.toml",
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -1748,7 +1748,7 @@ fn git_dep_build_cmd() {
             .file(
                 "bar/Cargo.toml",
                 r#"
-                    [project]
+                    [package]
 
                     name = "bar"
                     version = "0.5.0"
@@ -1804,7 +1804,7 @@ fn fetch_downloads() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -1839,7 +1839,7 @@ fn warnings_in_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -1901,7 +1901,7 @@ fn update_ambiguous() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -1948,7 +1948,7 @@ fn update_one_dep_in_repo_with_many_deps() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -2021,7 +2021,7 @@ fn switch_deps_does_not_update_transitive() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -2055,7 +2055,7 @@ fn switch_deps_does_not_update_transitive() {
         "Cargo.toml",
         &format!(
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2105,7 +2105,7 @@ fn update_one_source_updates_all_packages_in_that_git_source() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -2155,7 +2155,7 @@ fn switch_sources() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2168,7 +2168,7 @@ fn switch_sources() {
             "b/Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "b"
                     version = "0.5.0"
                     authors = []
@@ -2197,7 +2197,7 @@ fn switch_sources() {
         "b/Cargo.toml",
         &format!(
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -2228,7 +2228,7 @@ fn dont_require_submodules_are_checked_out() {
         p.file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2266,7 +2266,7 @@ fn doctest_same_name() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "a"
                     version = "0.5.0"
                     authors = []
@@ -2547,7 +2547,7 @@ fn invalid_git_dependency_manifest() {
             .file(
                 "Cargo.toml",
                 r#"
-                    [project]
+                    [package]
 
                     name = "dep1"
                     version = "0.5.0"
@@ -2575,7 +2575,7 @@ fn invalid_git_dependency_manifest() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
 
                     name = "foo"
                     version = "0.5.0"
@@ -2621,7 +2621,7 @@ Caused by:
     |
   8 |                     categories = [\"algorithms\"]
     |                     ^
-  Duplicate key `categories` in table `project`
+  Duplicate key `categories` in table `package`
 
 ",
             path2url(&git_root),
@@ -2677,7 +2677,7 @@ fn failed_submodule_checkout() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -2723,7 +2723,7 @@ fn use_the_cli() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -2775,7 +2775,7 @@ fn templatedir_doesnt_cause_problems() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "fo"
                     version = "0.5.0"
                     authors = []
@@ -2823,7 +2823,7 @@ fn git_with_cli_force() {
             "Cargo.toml",
             &format!(
                 r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 edition = "2018"
@@ -3052,7 +3052,7 @@ fn default_not_master() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     [dependencies]
@@ -3092,7 +3092,7 @@ fn historical_lockfile_works() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
 
@@ -3149,7 +3149,7 @@ fn historical_lockfile_works_with_vendor() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
 
@@ -3203,7 +3203,7 @@ fn two_dep_forms() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.5.0"
                     [dependencies]
@@ -3218,7 +3218,7 @@ fn two_dep_forms() {
             "a/Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "a"
                     version = "0.5.0"
                     [dependencies]
@@ -3474,7 +3474,7 @@ fn git_with_force_push() {
     let manifest = |extra| {
         format!(
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 edition = "2018"

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -110,7 +110,7 @@ fn http_auth_offered() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -183,7 +183,7 @@ fn https_something_happens() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -244,7 +244,7 @@ fn ssh_something_happens() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -351,7 +351,7 @@ fn instead_of_url_printed() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -235,7 +235,7 @@ fn inherit_own_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.2.0"
             authors = []
@@ -370,7 +370,7 @@ fn inherit_own_detailed_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.2.0"
             authors = []
@@ -519,7 +519,7 @@ fn inherited_dependencies_union_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.2.0"
             authors = []
@@ -716,7 +716,7 @@ fn inherit_dependencies() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+            [package]
             workspace = ".."
             name = "bar"
             version = "0.2.0"
@@ -850,7 +850,7 @@ fn inherit_target_dependencies() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+            [package]
             workspace = ".."
             name = "bar"
             version = "0.2.0"
@@ -900,7 +900,7 @@ fn inherit_dependency_override_optional() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+            [package]
             workspace = ".."
             name = "bar"
             version = "0.2.0"
@@ -938,7 +938,7 @@ fn inherit_dependency_features() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.2.0"
             authors = []
@@ -1011,7 +1011,7 @@ fn inherit_detailed_dependencies() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+            [package]
             workspace = ".."
             name = "bar"
             version = "0.2.0"
@@ -1053,7 +1053,7 @@ fn inherit_path_dependencies() {
         .file(
             "bar/Cargo.toml",
             r#"
-            [project]
+            [package]
             workspace = ".."
             name = "bar"
             version = "0.2.0"

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -33,7 +33,7 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -73,7 +73,7 @@ fn not_found() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -109,7 +109,7 @@ fn depend_on_yanked() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -152,7 +152,7 @@ fn multiple_versions() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -204,7 +204,7 @@ fn multiple_names() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -258,7 +258,7 @@ fn interdependent() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -308,7 +308,7 @@ fn path_dep_rewritten() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "0.1.0"
                 authors = []
@@ -326,7 +326,7 @@ fn path_dep_rewritten() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -370,7 +370,7 @@ fn invalid_dir_bad() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -429,7 +429,7 @@ fn different_directory_replacing_the_registry_is_bad() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -498,7 +498,7 @@ fn crates_io_registry_url_is_optional() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -52,7 +52,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -98,7 +98,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -125,7 +125,7 @@ fn totally_wild_checksums_works() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -191,7 +191,7 @@ fn wrong_checksum_is_an_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -254,7 +254,7 @@ fn unlisted_checksum_is_bad_if_we_calculate() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -320,7 +320,7 @@ fn listed_checksum_bad_if_we_cannot_compute() {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -493,7 +493,7 @@ fn locked_correct_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -545,7 +545,7 @@ dependencies = [
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -604,7 +604,7 @@ dependencies = [
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -619,7 +619,7 @@ dependencies = [
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.2.0"
             "#,
@@ -670,7 +670,7 @@ dependencies = [
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -697,7 +697,7 @@ fn lock_from_the_future() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -749,7 +749,7 @@ dependencies = [
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -773,7 +773,7 @@ fn same_name_version_different_sources() {
             .file(
                 "Cargo.toml",
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.1.0"
                 "#,
@@ -817,7 +817,7 @@ source = "git+{url}#{sha}"
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.1.0"
 

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -22,7 +22,7 @@ fn bad_file_member_exclusion() {
         .file(
             "crates/bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -17,7 +17,7 @@ fn toml_deserialize_manifest_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -32,7 +32,7 @@ fn toml_deserialize_manifest_error() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -66,7 +66,7 @@ fn member_manifest_path_io_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -81,7 +81,7 @@ fn member_manifest_path_io_error() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -116,7 +116,7 @@ fn member_manifest_version_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -131,7 +131,7 @@ fn member_manifest_version_error() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -287,7 +287,7 @@ fn cargo_metadata_with_deps_and_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -2287,7 +2287,7 @@ fn package_default_run() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = ["wycats@example.com"]
@@ -2307,7 +2307,7 @@ fn package_rust_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = ["wycats@example.com"]
@@ -2435,7 +2435,7 @@ fn rename_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2667,7 +2667,7 @@ fn metadata_links() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.5.0"
             links = "a"

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -8,7 +8,7 @@ fn net_retry_loads_from_config() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -44,7 +44,7 @@ fn net_retry_git_outputs_warning() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -12,7 +12,7 @@ fn offline_unused_target_dep() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
             [dependencies]
@@ -40,7 +40,7 @@ fn offline_missing_optional() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
             [dependencies]
@@ -104,7 +104,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
 
@@ -121,7 +121,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.1.0"
 
@@ -151,7 +151,7 @@ fn cargo_compile_offline_not_try_update() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.1.0"
 
@@ -204,7 +204,7 @@ fn compile_offline_without_maxvers_cached() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
 
@@ -220,7 +220,7 @@ fn compile_offline_without_maxvers_cached() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
 
@@ -257,7 +257,7 @@ fn cargo_compile_forbird_git_httpsrepo_offline() {
             "Cargo.toml",
             r#"
 
-            [project]
+            [package]
             name = "foo"
             version = "0.5.0"
             authors = ["chabapok@example.com"]
@@ -298,7 +298,7 @@ fn compile_offline_while_transitive_dep_not_cached() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
 
@@ -337,7 +337,7 @@ fn update_offline_not_cached() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -393,7 +393,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-                [project]
+                [package]
                 name = "cache_git_dep"
                 version = "0.5.0"
 
@@ -413,7 +413,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
         "Cargo.toml",
         &format!(
             r#"
-            [project]
+            [package]
             name = "cache_git_dep"
             version = "0.5.0"
 
@@ -432,7 +432,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
             "Cargo.toml",
             &format!(
                 r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
 
@@ -470,7 +470,7 @@ fn cargo_compile_offline_with_cached_git_dep() {
         "Cargo.toml",
         &format!(
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.5.0"
 
@@ -591,7 +591,7 @@ fn update_offline_cached() {
             "Cargo.toml",
             format!(
                 r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -609,7 +609,7 @@ fn update_offline_cached() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
 

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -31,7 +31,7 @@ fn static_library_with_debug() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -67,7 +67,7 @@ fn dynamic_library_with_debug() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -104,7 +104,7 @@ fn rlib_with_debug() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -139,7 +139,7 @@ fn include_only_the_binary_from_the_current_package() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -36,7 +36,7 @@ fn simple_list() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -66,7 +66,7 @@ fn simple_add() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -98,7 +98,7 @@ fn simple_remove() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -17,7 +17,7 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -85,7 +85,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -111,7 +111,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -251,7 +251,7 @@ fn vcs_file_collision() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 description = "foo"
                 version = "0.0.1"
@@ -290,7 +290,7 @@ fn orig_file_collision() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 description = "foo"
                 version = "0.0.1"
@@ -328,7 +328,7 @@ fn path_dependency_no_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -367,7 +367,7 @@ fn git_dependency_no_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -403,7 +403,7 @@ fn exclude() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -525,7 +525,7 @@ fn include() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -577,7 +577,7 @@ fn package_git_submodule() {
             .file(
                 "Cargo.toml",
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = ["foo@example.com"]
@@ -680,7 +680,7 @@ src/main.rs
 #[cargo_test]
 fn ignore_nested() {
     let cargo_toml = r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -814,7 +814,7 @@ fn broken_symlink() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -865,7 +865,7 @@ fn broken_but_excluded_symlink() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1022,7 +1022,7 @@ fn do_not_package_if_repository_is_dirty() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 license = "MIT"
@@ -1039,7 +1039,7 @@ fn do_not_package_if_repository_is_dirty() {
     p.change_file(
         "Cargo.toml",
         r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             license = "MIT"
@@ -1131,7 +1131,7 @@ fn generated_manifest() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1139,7 +1139,7 @@ fn generated_manifest() {
                 license = "MIT"
                 description = "foo"
 
-                [project.metadata]
+                [package.metadata]
                 foo = 'bar'
 
                 [workspace]
@@ -1203,7 +1203,7 @@ fn ignore_workspace_specifier() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
 
@@ -1257,7 +1257,7 @@ fn package_two_kinds_of_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1439,7 +1439,7 @@ fn package_with_select_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1468,7 +1468,7 @@ fn package_with_all_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1497,7 +1497,7 @@ fn package_no_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2071,7 +2071,7 @@ fn reserved_windows_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2240,7 +2240,7 @@ fn reproducible_output() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2331,7 +2331,7 @@ fn in_workspace() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2346,7 +2346,7 @@ fn in_workspace() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -1485,7 +1485,7 @@ fn replace_prerelease() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1501,7 +1501,7 @@ fn replace_prerelease() {
         .file(
             "baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "1.1.0-pre.1"
                 authors = []
@@ -1538,7 +1538,7 @@ fn patch_older() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1551,7 +1551,7 @@ fn patch_older() {
         .file(
             "baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "1.0.1"
                 authors = []

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -15,7 +15,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -31,7 +31,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -109,7 +109,7 @@ fn cargo_compile_with_root_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -151,7 +151,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -199,7 +199,7 @@ fn cargo_compile_with_transitive_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -215,7 +215,7 @@ fn cargo_compile_with_transitive_dev_deps() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -260,7 +260,7 @@ fn no_rebuild_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -308,7 +308,7 @@ fn deep_dependencies_trigger_rebuild() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -322,7 +322,7 @@ fn deep_dependencies_trigger_rebuild() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -395,7 +395,7 @@ fn no_rebuild_two_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -411,7 +411,7 @@ fn no_rebuild_two_deps() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -447,7 +447,7 @@ fn nested_deps_recompile() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -492,7 +492,7 @@ fn error_message_for_missing_manifest() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -657,7 +657,7 @@ fn path_dep_build_cmd() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "foo"
                 version = "0.5.0"
@@ -673,7 +673,7 @@ fn path_dep_build_cmd() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
 
                 name = "bar"
                 version = "0.5.0"
@@ -732,7 +732,7 @@ fn dev_deps_no_rebuild_lib() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                     name = "foo"
                     version = "0.5.0"
                     authors = []
@@ -782,7 +782,7 @@ fn custom_target_no_rebuild() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -798,7 +798,7 @@ fn custom_target_no_rebuild() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -840,7 +840,7 @@ fn override_and_depend() {
         .file(
             "a/a1/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a1"
                 version = "0.5.0"
                 authors = []
@@ -854,7 +854,7 @@ fn override_and_depend() {
         .file(
             "b/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.5.0"
                 authors = []
@@ -915,7 +915,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "top"
                 version = "0.5.0"
                 authors = []
@@ -930,7 +930,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -949,7 +949,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
     p.change_file(
         "foo/Cargo.toml",
         r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.5.0"
             authors = []
@@ -981,7 +981,7 @@ fn workspace_produces_rlib() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "top"
                 version = "0.5.0"
                 authors = []

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -240,7 +240,7 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -256,7 +256,7 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -301,7 +301,7 @@ fn profile_in_virtual_manifest_works() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -480,7 +480,7 @@ fn thin_lto_works() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "top"
                 version = "0.5.0"
                 authors = []

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -106,7 +106,7 @@ fn simple() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -142,7 +142,7 @@ fn old_token_location() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -193,7 +193,7 @@ fn simple_with_index() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -219,7 +219,7 @@ fn git_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -255,7 +255,7 @@ fn path_dependency_no_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -293,7 +293,7 @@ fn unpublishable_crate() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -326,7 +326,7 @@ fn dont_publish_dirty() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -366,7 +366,7 @@ fn publish_clean() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -395,7 +395,7 @@ fn publish_in_sub_repo() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -424,7 +424,7 @@ fn publish_when_ignored() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -466,7 +466,7 @@ fn ignore_when_crate_ignored() {
         .nocommit_file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -503,7 +503,7 @@ fn new_crate_rejected() {
         .nocommit_file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -532,7 +532,7 @@ fn dry_run() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -573,7 +573,7 @@ fn registry_not_in_publish_list() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -608,7 +608,7 @@ fn publish_empty_list() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -641,7 +641,7 @@ fn publish_allowed_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -681,7 +681,7 @@ fn publish_implicitly_to_only_allowed_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -721,7 +721,7 @@ fn publish_fail_with_no_registry_specified() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -755,7 +755,7 @@ fn block_publish_no_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -787,7 +787,7 @@ fn publish_with_crates_io_explicit() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -820,7 +820,7 @@ fn publish_with_select_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -853,7 +853,7 @@ fn publish_with_all_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -886,7 +886,7 @@ fn publish_with_no_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -920,7 +920,7 @@ fn publish_with_patch() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1006,7 +1006,7 @@ fn publish_checks_for_token_before_verify() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1304,7 +1304,7 @@ fn credentials_ambiguous_filename() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1370,7 +1370,7 @@ fn registry_token_with_source_replacement() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1454,7 +1454,7 @@ fn api_error_json() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1501,7 +1501,7 @@ fn api_error_200() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1548,7 +1548,7 @@ fn api_error_code() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1598,7 +1598,7 @@ fn api_curl_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1650,7 +1650,7 @@ fn api_other_error() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1837,7 +1837,7 @@ fn in_virtual_workspace() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1871,7 +1871,7 @@ fn in_virtual_workspace_with_p() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -43,7 +43,7 @@ fn simple(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -102,7 +102,7 @@ fn deps(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -153,7 +153,7 @@ fn nonexistent(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -196,7 +196,7 @@ fn wrong_case(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -242,7 +242,7 @@ fn mis_hyphenated(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -286,7 +286,7 @@ fn wrong_version(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -345,7 +345,7 @@ fn bad_cksum(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -395,7 +395,7 @@ fn update_registry(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -452,7 +452,7 @@ fn package_with_path_deps(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -520,7 +520,7 @@ fn lockfile_locks(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -569,7 +569,7 @@ fn lockfile_locks_transitively(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -622,7 +622,7 @@ fn yanks_are_not_used(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -674,7 +674,7 @@ fn relying_on_a_yank_is_bad(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -720,7 +720,7 @@ fn yanks_in_lockfiles_are_ok(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -770,7 +770,7 @@ fn yanks_in_lockfiles_are_ok_for_other_update(cargo: fn(&Project, &str) -> Execs
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -834,7 +834,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -858,7 +858,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep(cargo: fn(&Project, &str) -> Execs) {
     p.change_file(
         "Cargo.toml",
         r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -888,7 +888,7 @@ fn update_with_lockfile_if_packages_missing(cargo: fn(&Project, &str) -> Execs) 
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -933,7 +933,7 @@ fn update_lockfile(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1040,7 +1040,7 @@ fn dev_dependency_not_used(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1125,7 +1125,7 @@ fn bad_license_file(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1158,7 +1158,7 @@ fn updating_a_dep(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1171,7 +1171,7 @@ fn updating_a_dep(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.0.1"
                 authors = []
@@ -1209,7 +1209,7 @@ fn updating_a_dep(cargo: fn(&Project, &str) -> Execs) {
     p.change_file(
         "a/Cargo.toml",
         r#"
-        [project]
+        [package]
         name = "a"
         version = "0.0.1"
         authors = []
@@ -1257,7 +1257,7 @@ fn git_and_registry_dep(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "b"
                 version = "0.0.1"
                 authors = []
@@ -1273,7 +1273,7 @@ fn git_and_registry_dep(cargo: fn(&Project, &str) -> Execs) {
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -1331,7 +1331,7 @@ fn update_publish_then_update(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1359,7 +1359,7 @@ fn update_publish_then_update(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1411,7 +1411,7 @@ fn fetch_downloads(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1452,7 +1452,7 @@ fn update_transitive_dependency(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1510,7 +1510,7 @@ fn update_backtracking_ok(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1569,7 +1569,7 @@ fn update_multiple_packages(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1639,7 +1639,7 @@ fn bundled_crate_in_registry(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = []
@@ -1691,7 +1691,7 @@ fn update_same_prefix_oh_my_how_was_this_a_bug(cargo: fn(&Project, &str) -> Exec
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ugh"
                 version = "0.5.0"
                 authors = []
@@ -1728,7 +1728,7 @@ fn use_semver(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1768,7 +1768,7 @@ fn use_semver_package_incorrectly(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "a/Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "a"
             version = "0.1.1-alpha.0"
             authors = []
@@ -1777,7 +1777,7 @@ fn use_semver_package_incorrectly(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "b/Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "b"
             version = "0.1.0"
             authors = []
@@ -1821,7 +1821,7 @@ fn only_download_relevant(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1871,7 +1871,7 @@ fn resolve_and_backtracking(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1907,7 +1907,7 @@ fn upstream_warnings_on_extra_verbose(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1935,7 +1935,7 @@ fn disallow_network_http() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -1970,7 +1970,7 @@ fn disallow_network_git() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -2017,7 +2017,7 @@ fn add_dep_dont_update_registry(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -2030,7 +2030,7 @@ fn add_dep_dont_update_registry(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "0.5.0"
                 authors = []
@@ -2049,7 +2049,7 @@ fn add_dep_dont_update_registry(cargo: fn(&Project, &str) -> Execs) {
     p.change_file(
         "Cargo.toml",
         r#"
-        [project]
+        [package]
         name = "bar"
         version = "0.5.0"
         authors = []
@@ -2086,7 +2086,7 @@ fn bump_version_dont_update_registry(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -2099,7 +2099,7 @@ fn bump_version_dont_update_registry(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "0.5.0"
                 authors = []
@@ -2118,7 +2118,7 @@ fn bump_version_dont_update_registry(cargo: fn(&Project, &str) -> Execs) {
     p.change_file(
         "Cargo.toml",
         r#"
-        [project]
+        [package]
         name = "bar"
         version = "0.6.0"
         authors = []
@@ -2156,7 +2156,7 @@ fn toml_lies_but_index_is_truth(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.3.0"
                 authors = []
@@ -2172,7 +2172,7 @@ fn toml_lies_but_index_is_truth(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = []
@@ -2210,7 +2210,7 @@ fn vv_prints_warnings(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "fo"
                 version = "0.5.0"
                 authors = []
@@ -2245,7 +2245,7 @@ fn bad_and_or_malicious_packages_rejected(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "fo"
                 version = "0.5.0"
                 authors = []
@@ -2295,7 +2295,7 @@ fn git_init_templatedir_missing(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "fo"
                 version = "0.5.0"
                 authors = []
@@ -2369,7 +2369,7 @@ fn rename_deps_and_features(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -2412,7 +2412,7 @@ fn ignore_invalid_json_lines(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -2446,7 +2446,7 @@ fn readonly_registry_still_works(cargo: fn(&Project, &str) -> Execs) {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []
@@ -2552,7 +2552,7 @@ fn package_lock_inside_package_is_overwritten() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2590,7 +2590,7 @@ fn package_lock_as_a_symlink_inside_package_is_overwritten() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2671,7 +2671,7 @@ fn http_requires_z_flag() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2706,7 +2706,7 @@ fn reach_max_unpack_size() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
 

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -14,7 +14,7 @@ fn rename_dependency() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -36,7 +36,7 @@ fn rename_with_different_names() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -49,7 +49,7 @@ fn rename_with_different_names() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 authors = []
@@ -244,7 +244,7 @@ fn can_run_doc_tests() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
 

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -13,7 +13,7 @@ fn build_bin_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -68,7 +68,7 @@ fn build_bin_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -94,7 +94,7 @@ fn build_bin_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -139,7 +139,7 @@ fn build_example_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -176,7 +176,7 @@ fn build_example_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -202,7 +202,7 @@ fn build_example_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -272,7 +272,7 @@ fn test_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -330,7 +330,7 @@ fn test_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -363,7 +363,7 @@ fn test_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -420,7 +420,7 @@ fn bench_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -488,7 +488,7 @@ fn bench_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -531,7 +531,7 @@ fn bench_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -608,7 +608,7 @@ fn install_default_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -692,7 +692,7 @@ fn install_arg_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -719,7 +719,7 @@ fn install_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -837,7 +837,7 @@ fn dep_feature_in_toml() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -879,7 +879,7 @@ fn dep_feature_in_toml() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 authors = []
@@ -938,7 +938,7 @@ fn dep_feature_in_cmd_line() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -990,7 +990,7 @@ fn dep_feature_in_cmd_line() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 authors = []
@@ -1096,7 +1096,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1162,7 +1162,7 @@ fn run_default() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1199,7 +1199,7 @@ fn run_default_multiple_required_features() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -321,7 +321,7 @@ fn specify_default_run() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -344,7 +344,7 @@ fn bogus_default_run() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -453,7 +453,7 @@ fn autodiscover_examples_project(rust_edition: &str, autoexamples: Option<bool>)
             "Cargo.toml",
             &format!(
                 r#"
-                    [project]
+                    [package]
                     name = "foo"
                     version = "0.0.1"
                     authors = []
@@ -562,7 +562,7 @@ fn autobins_disables() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             autobins = false
@@ -699,7 +699,7 @@ fn example_with_release_flag() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -804,7 +804,7 @@ fn run_dylib_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1078,7 +1078,7 @@ fn run_bin_different_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1148,7 +1148,7 @@ fn run_with_library_paths() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1207,7 +1207,7 @@ fn library_paths_sorted_alphabetically() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1392,7 +1392,7 @@ fn default_run_workspace() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.0.1"
                 default-run = "a"
@@ -1418,7 +1418,7 @@ fn run_link_system_path_macos() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             [lib]

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -8,7 +8,7 @@ fn rust_version_satisfied() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -30,7 +30,7 @@ fn rust_version_bad_caret() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -56,7 +56,7 @@ fn rust_version_bad_pre_release() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -82,7 +82,7 @@ fn rust_version_bad_nonsense() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -108,7 +108,7 @@ fn rust_version_too_high() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []
@@ -174,7 +174,7 @@ fn rust_version_older_than_edition() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.0.1"
             authors = []

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -10,7 +10,7 @@ fn features_are_quoted() {
         .file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
             authors = ["mikeyhew@example.com"]

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -493,7 +493,7 @@ fn test_with_lib_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -605,7 +605,7 @@ fn external_test_explicit() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -656,7 +656,7 @@ fn external_test_named_test() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -788,7 +788,7 @@ fn lib_bin_same_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -1917,7 +1917,7 @@ fn example_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -2921,7 +2921,7 @@ fn test_all_workspace() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -2948,7 +2948,7 @@ fn test_all_exclude() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -2977,7 +2977,7 @@ fn test_all_exclude_not_found() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -3005,7 +3005,7 @@ fn test_all_exclude_glob() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -3034,7 +3034,7 @@ fn test_all_exclude_glob_not_found() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -3209,7 +3209,7 @@ fn test_all_member_dependency_same_name() {
         .file(
             "a/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.1.0"
 
@@ -3233,7 +3233,7 @@ fn doctest_only_with_dev_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.1.0"
 
@@ -3319,7 +3319,7 @@ fn doctest_and_registry() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.1.0"
 
@@ -3344,7 +3344,7 @@ fn doctest_and_registry() {
         .file(
             "c/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "c"
                 version = "0.1.0"
 
@@ -3425,7 +3425,7 @@ fn cyclic_dev() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -3446,7 +3446,7 @@ fn publish_a_crate_without_tests() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "testless"
                 version = "0.1.0"
                 exclude = ["tests/*"]
@@ -3467,7 +3467,7 @@ fn publish_a_crate_without_tests() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -3495,7 +3495,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
         .file(
             "root/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "root"
                 version = "0.1.0"
                 authors = []
@@ -3517,7 +3517,7 @@ fn find_dependency_of_proc_macro_dependency_with_target() {
         .file(
             "proc_macro_dep/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "proc_macro_dep"
                 version = "0.1.0"
                 authors = []

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -11,7 +11,7 @@ fn simple_explicit() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -24,7 +24,7 @@ fn simple_explicit() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -52,7 +52,7 @@ fn simple_explicit_default_members() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -66,7 +66,7 @@ fn simple_explicit_default_members() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -87,7 +87,7 @@ fn non_virtual_default_members_build_other_member() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -125,7 +125,7 @@ fn non_virtual_default_members_build_root_project() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -154,7 +154,7 @@ fn inferred_root() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -186,7 +186,7 @@ fn inferred_path_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -221,7 +221,7 @@ fn transitive_path_dep() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -236,7 +236,7 @@ fn transitive_path_dep() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -278,7 +278,7 @@ fn parent_pointer_works() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -293,7 +293,7 @@ fn parent_pointer_works() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -316,7 +316,7 @@ fn same_names_in_workspace() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -329,7 +329,7 @@ fn same_names_in_workspace() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -357,7 +357,7 @@ fn parent_doesnt_point_to_child() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -392,7 +392,7 @@ fn invalid_parent_pointer() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -421,7 +421,7 @@ fn invalid_members() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -455,7 +455,7 @@ fn bare_workspace_ok() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -475,7 +475,7 @@ fn two_roots() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -488,7 +488,7 @@ fn two_roots() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -518,7 +518,7 @@ fn workspace_isnt_root() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -542,7 +542,7 @@ fn dangling_member() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -555,7 +555,7 @@ fn dangling_member() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -566,7 +566,7 @@ fn dangling_member() {
         .file(
             "baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "0.1.0"
                 authors = []
@@ -594,7 +594,7 @@ fn cycle() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -605,7 +605,7 @@ fn cycle() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -629,7 +629,7 @@ fn share_dependencies() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -645,7 +645,7 @@ fn share_dependencies() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -680,7 +680,7 @@ fn fetch_fetches_all() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -693,7 +693,7 @@ fn fetch_fetches_all() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -724,7 +724,7 @@ fn lock_works_for_everyone() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -740,7 +740,7 @@ fn lock_works_for_everyone() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -968,7 +968,7 @@ fn include_virtual() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -1002,7 +1002,7 @@ fn members_include_path_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1018,7 +1018,7 @@ fn members_include_path_deps() {
         .file(
             "p1/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "p1"
                 version = "0.1.0"
                 authors = []
@@ -1051,7 +1051,7 @@ fn new_warns_you_this_will_not_work() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1112,7 +1112,7 @@ fn lock_doesnt_change_depending_on_crate() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1128,7 +1128,7 @@ fn lock_doesnt_change_depending_on_crate() {
         .file(
             "baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "0.1.0"
                 authors = []
@@ -1304,7 +1304,7 @@ fn workspace_with_transitive_dev_deps() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.5.0"
                 authors = ["mbrubeck@example.com"]
@@ -1319,7 +1319,7 @@ fn workspace_with_transitive_dev_deps() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.5.0"
                 authors = ["mbrubeck@example.com"]
@@ -1370,7 +1370,7 @@ fn relative_path_for_member_works() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1383,7 +1383,7 @@ fn relative_path_for_member_works() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -1403,7 +1403,7 @@ fn relative_path_for_root_works() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1433,7 +1433,7 @@ fn path_dep_outside_workspace_is_not_member() {
         .file(
             "ws/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ws"
                 version = "0.1.0"
                 authors = []
@@ -1459,7 +1459,7 @@ fn test_in_and_out_of_workspace() {
         .file(
             "ws/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ws"
                 version = "0.1.0"
                 authors = []
@@ -1475,7 +1475,7 @@ fn test_in_and_out_of_workspace() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1491,7 +1491,7 @@ fn test_in_and_out_of_workspace() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 workspace = "../ws"
                 name = "bar"
                 version = "0.1.0"
@@ -1523,7 +1523,7 @@ fn test_path_dependency_under_member() {
         .file(
             "ws/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ws"
                 version = "0.1.0"
                 authors = []
@@ -1538,7 +1538,7 @@ fn test_path_dependency_under_member() {
         .file(
             "foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 workspace = "../ws"
                 name = "foo"
                 version = "0.1.0"
@@ -1573,7 +1573,7 @@ fn excluded_simple() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ws"
                 version = "0.1.0"
                 authors = []
@@ -1599,7 +1599,7 @@ fn exclude_members_preferred() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ws"
                 version = "0.1.0"
                 authors = []
@@ -1630,7 +1630,7 @@ fn exclude_but_also_depend() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "ws"
                 version = "0.1.0"
                 authors = []
@@ -1753,7 +1753,7 @@ fn glob_syntax() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1767,7 +1767,7 @@ fn glob_syntax() {
         .file(
             "crates/bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -1778,7 +1778,7 @@ fn glob_syntax() {
         .file(
             "crates/baz/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "baz"
                 version = "0.1.0"
                 authors = []
@@ -1789,7 +1789,7 @@ fn glob_syntax() {
         .file(
             "crates/qux/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "qux"
                 version = "0.1.0"
                 authors = []
@@ -1825,7 +1825,7 @@ fn glob_syntax() {
 fn glob_syntax_2() {
     let p = project()
         .file("Cargo.toml", r#"
-            [project]
+            [package]
             name = "foo"
             version = "0.1.0"
             authors = []
@@ -1836,7 +1836,7 @@ fn glob_syntax_2() {
         "#)
         .file("src/main.rs", "fn main() {}")
         .file("crates/bar/Cargo.toml", r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.1.0"
             authors = []
@@ -1844,7 +1844,7 @@ fn glob_syntax_2() {
         "#)
         .file("crates/bar/src/main.rs", "fn main() {}")
         .file("crates/baz/Cargo.toml", r#"
-            [project]
+            [package]
             name = "baz"
             version = "0.1.0"
             authors = []
@@ -1852,7 +1852,7 @@ fn glob_syntax_2() {
         "#)
         .file("crates/baz/src/main.rs", "fn main() {}")
         .file("crates/qux/Cargo.toml", r#"
-            [project]
+            [package]
             name = "qux"
             version = "0.1.0"
             authors = []
@@ -1889,7 +1889,7 @@ fn glob_syntax_invalid_members() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -1939,7 +1939,7 @@ fn dep_used_with_separate_features() {
         .file(
             "feat_lib/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "feat_lib"
                 version = "0.1.0"
                 authors = []
@@ -1952,7 +1952,7 @@ fn dep_used_with_separate_features() {
         .file(
             "caller1/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "caller1"
                 version = "0.1.0"
                 authors = []
@@ -1966,7 +1966,7 @@ fn dep_used_with_separate_features() {
         .file(
             "caller2/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "caller2"
                 version = "0.1.0"
                 authors = []
@@ -2365,7 +2365,7 @@ fn member_dep_missing() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
 
@@ -2377,7 +2377,7 @@ fn member_dep_missing() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
 
@@ -2420,7 +2420,7 @@ fn simple_primary_package_env_var() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []
@@ -2433,7 +2433,7 @@ fn simple_primary_package_env_var() {
         .file(
             "bar/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -2492,7 +2492,7 @@ fn ensure_correct_workspace_when_nested() {
             r#"
                 [workspace]
 
-                [project]
+                [package]
                 name = "bar"
                 version = "0.1.0"
                 authors = []
@@ -2509,7 +2509,7 @@ fn ensure_correct_workspace_when_nested() {
         .file(
             "sub/foo/Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.1.0"
                 authors = []

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -21,7 +21,7 @@ fn explicit_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -56,7 +56,7 @@ fn inline_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -91,7 +91,7 @@ fn version_required() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -117,7 +117,7 @@ fn inline_version_without_name() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -143,7 +143,7 @@ fn inline_and_explicit_version() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []


### PR DESCRIPTION
There was an issue (#11129) with `[project]` being put in the docs but nothing else stating what `[project]` is. This was an oversight by me when writing the docs as `[project]` is still supported in cargo. [Back in 2014](https://github.com/rust-lang/cargo/commit/86b2a2a432a73b3747cca3593850293a5fc3951a) `[project]` was [renamed to `[package]`](https://github.com/rust-lang/cargo/issues/3388#issuecomment-266504735), since then it has kinda sat as something that exists and is supported but not really. I brought this up in a [zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/removal.20of.20.60.5Bproject.5D.60), and it was suggested that we could show a warning when `[project]` is used in a manifest of a _top-level_ crate. 

To go slightly further than this I tried to change as many references from `[project]` to `[package]` as possible. This should hopefully help with confusion between `[project]` and `[package]` in the future.

This PR also includes a cherry-picked commit from #11131 as it was having issues with bors and fits well with the changes that are being made in this PR.

This should ideally be reviewed commit by commit