### PR TITLE
Call out that not all config values can be set via env vars

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -190,8 +190,9 @@ variable.
 
 Environment variables will take precedence over TOML configuration files.
 Currently only integer, boolean, string and some array values are supported to
-be defined by environment variables. Descriptions below indicate which keys
-support environment variables.
+be defined by environment variables. [Descriptions below](#configuration-keys)
+indicate which keys support environment variables and otherwise they are not
+supported due to [technicial issues](https://github.com/rust-lang/cargo/issues/5416).
 
 In addition to the system above, Cargo recognizes a few other specific
 [environment variables][env].

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -75,9 +75,9 @@ system:
 
 #### Configuration environment variables
 
-Cargo reads environment variables for configuration values. See the
-[configuration chapter][config-env] for more details. In summary, the
-supported environment variables are:
+Cargo reads environment variables for some configuration values.
+See the [configuration chapter][config-env] for more details.
+In summary, the supported environment variables are:
 
 * `CARGO_ALIAS_<name>` — Command aliases, see [`alias`].
 * `CARGO_BUILD_JOBS` — Number of parallel jobs, see [`build.jobs`].


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Call out that not all configuration values can be set via environment variables, 
and state the limitation with a link to #5416.

Closes #11041, as #5416 contains more discussions.

### How should we test and review this PR?

```shell
mdbook serve src/doc 
# and proofread
```
<!-- homu-ignore:end -->
