### PR TITLE
Increase the maximum unpacked size of a crate to 1GiB (CVE-2022-36114 mitigation)

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -196,7 +196,7 @@ const VERSION_TEMPLATE: &str = "{version}";
 const PREFIX_TEMPLATE: &str = "{prefix}";
 const LOWER_PREFIX_TEMPLATE: &str = "{lowerprefix}";
 const CHECKSUM_TEMPLATE: &str = "{sha256-checksum}";
-const MAX_UNPACK_SIZE: u64 = 512 * 1024 * 1024;
+const MAX_UNPACK_SIZE: u64 = 1024 * 1024 * 1024;
 
 /// A "source" for a local (see `local::LocalRegistry`) or remote (see
 /// `remote::RemoteRegistry`) registry.


### PR DESCRIPTION
Hello, we host a crate on a private registry that includes a vendored static C++ library supporting several targets (mobiles and desktop on various architectures). Some releases of the crate have been above 512MB, as the vendored size keeps scaling with the number of supported targets.

With the latest stable cargo, CI is broken for our users due to the zip-bomb detection triggering on previous releases above 512MiB.   
The commit message with more rationale for adjusting the zip-bomb threshold follows.

---

A use-case of private registries is to host projects that may require slightly higher limits than what is a good fit for the public crates.io registry, such as crates with vendored binary dependencies, or other larger crates that may not fit on crates.io.

When supporting many targets (architecture/OS combinations), the size of a crate on a private registry with vendored dependencies is proportional in the number of targets, so as support for more targets is added, a crate can reasonably exceed 512MiB.

The limit to pick is somewhat arbitrary, but in the context of CVE-2022-36114 we should be considerate of users with lower-end or older hardware, who may be the most vulnerable to zip-bombs.

As a comparison point, on my system building a hello world with `reqwest` that GETs example.org and prints the reply consumes 538M under the target/ folder.
Projects beyond hello worlds that include crates from private registries would usually require on the order of 1-10 GiBs free disk space for the target folder.

It seems resonable to pick a threshold for treating a Rust crate in an external registry as a zip bomb up to be in the same order of magnitude (or just above) disk usage numbers that a regular user could be expected to encounter in normal, non-malicious scenarios.

This commit only bumps the limit to 1GiB based on need, but it may not be entirely unreasonable in the future to consider even slightly higher thresholds to not be zip-bombs, on a "pro re nata" (as needed) basis.
