### PR TITLE
Clarify version spec

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -35,8 +35,8 @@ below.
 
 **Caret requirement** Example: `^1.2.3`
 
-Specifying with the carret is exactly equivalent to specifying without the caret
-(as `1.2.3`). In other words, the carret requiement is the default.
+Specifying with the caret is exactly equivalent to specifying without the caret
+(as `1.2.3`). In other words, the caret requiement is the default.
 
 For a caret requirement, an update is allowed if the new
 version does not modify the left-most non-zero integer in the


### PR DESCRIPTION
### What does this PR try to resolve?

Made the language more homoegenous and used `x`, `y`, and `z` consistently to major, minor, patch variables, to reduce confusion. This also removed the incorrect usage of the term "digit" in the original version.

### How should we test and review this PR?

doc review

### Additional information
