### PR TITLE
Expose libgit2-sys/vendored feature as vendored-libgit2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,4 +115,5 @@ doc = false
 [features]
 deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
+vendored-libgit2 = ["libgit2-sys/vendored"]
 pretty-env-logger = ["pretty_env_logger"]


### PR DESCRIPTION
### What does this PR try to resolve?

Compiling cargo on MacOS can be problematic due present libraries, `cargo` already supports vendoring for openssl (and it helps https://github.com/pacak/cargo-show-asm/pull/51 to some users). This pull request attempts to extend vendoring support to libgit2 in order to fix more foreign library issues: https://github.com/pacak/cargo-show-asm/issues/50 

While it is possible for me to enable it on my side (https://github.com/pacak/cargo-show-asm/pull/52) a special care needs to keep versions in sync. Exposing this feature in `cargo` directly will make such fixes for my and other crates more robust.

### How should we test and review this PR?
Disabled by default means existing behavior is unchanged, testing with it enabled to confirm if it still works should do the trick.