### PR TITLE
Remove lingering unstable flag `-Zfeatures`

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -931,10 +931,13 @@ impl CliUnstable {
             "host-config" => self.host_config = parse_empty(k, v)?,
             "target-applies-to-host" => self.target_applies_to_host = parse_empty(k, v)?,
             "features" => {
-                // For now this is still allowed (there are still some
-                // unstable options like "compare"). This should be removed at
-                // some point, and migrate to a new -Z flag for any future
-                // things.
+                // `-Z features` has been stabilized since 1.51,
+                // but `-Z features=compare` is still allowed for convenience
+                // to validate that the feature resolver resolves features
+                // in the same way as the dependency resolver,
+                // until we feel confident to remove entirely.
+                //
+                // See rust-lang/cargo#11168
                 let feats = parse_features(v);
                 let stab_is_not_empty = feats.iter().any(|feat| {
                     matches!(


### PR DESCRIPTION
From [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/.E2.9C.94.20-Zfeatures):

> Eric Huss: When trying to validate that the feature resolver resolves features in the same way as the dependency resolver. I think it is identical, but there are a lot of complex use cases and flags that aren't covered in the testsuite so I'm not entirely confident. If we ever come across a scenario where it isn't the same, the compare option can be useful to see what differs.

In the future we could pick 61b94c3b0435250a0abb8080867b4af8d7dd88f8 to remove this Z flag.

