### PR TITLE
Differentiate the warning when an alias (built-in or user-defined) shadows an external subcommand

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -262,12 +262,13 @@ To pass the arguments to the subcommand, remove `--`",
             }
             (None, Ok(None)) => {}
             (None, Ok(Some(alias))) => {
-                // Check if this alias is shadowing an external subcommand
+                // Check if a user-defined alias is shadowing an external subcommand
                 // (binary of the form `cargo-<subcommand>`)
                 // Currently this is only a warning, but after a transition period this will become
                 // a hard error.
-                if let Some(path) = super::find_external_subcommand(config, cmd) {
-                    config.shell().warn(format!(
+                if super::builtin_aliases_execs(cmd).is_none() {
+                    if let Some(path) = super::find_external_subcommand(config, cmd) {
+                        config.shell().warn(format!(
                         "\
 user-defined alias `{}` is shadowing an external subcommand found at: `{}`
 This was previously accepted but is being phased out; it will become a hard error in a future release.
@@ -275,6 +276,7 @@ For more information, see issue #10049 <https://github.com/rust-lang/cargo/issue
                         cmd,
                         path.display(),
                     ))?;
+                    }
                 }
 
                 let mut alias = alias

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -151,6 +151,30 @@ fn dependent_alias() {
 }
 
 #[cargo_test]
+fn builtin_alias_shadowing_external_subcommand() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .executable("cargo-t", "")
+        .build();
+
+    let mut paths: Vec<_> = env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect();
+    paths.push(p.root());
+    let path = env::join_paths(paths).unwrap();
+
+    p.cargo("t")
+        .env("PATH", &path)
+        .with_stderr(
+            "\
+[COMPILING] foo v0.5.0 [..]
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] unittests src/main.rs [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn alias_shadowing_external_subcommand() {
     let echo = echo_subcommand();
     let p = project()


### PR DESCRIPTION
Fixes #11149
