### PR TITLE
Use GitHubs commit API to check out the tree directly

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -4,8 +4,7 @@ use crate::sources::{DirectorySource, CRATES_IO_DOMAIN, CRATES_IO_INDEX, CRATES_
 use crate::sources::{GitSource, PathSource, RegistrySource};
 use crate::util::{config, CanonicalUrl, CargoResult, Config, IntoUrl};
 use log::trace;
-use serde::de;
-use serde::ser;
+use serde::{de, ser, Serialize};
 use std::cmp::{self, Ordering};
 use std::collections::HashSet;
 use std::fmt::{self, Formatter};
@@ -64,7 +63,7 @@ enum SourceKind {
 }
 
 /// Information to find a specific commit in a Git repository.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
 pub enum GitReference {
     /// From a tag.
     Tag(String),

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -144,7 +144,7 @@ impl<'cfg> Source for GitSource<'cfg> {
             // database, then try to resolve our reference with the preexisting
             // repository.
             (None, Some(db)) if self.config.offline() => {
-                let rev = db.resolve(&self.manifest_reference).with_context(|| {
+                let rev = db.resolve_to_object(&self.manifest_reference).with_context(|| {
                     "failed to lookup reference in preexisting repository, and \
                          can't check for updates in offline mode (--offline)"
                 })?;


### PR DESCRIPTION
Cargo often needs to clone or update repos that have a lot of history, when all it needs is the contents of one particular reference. The most dramatic example is the [index](https://github.com/rust-lang/crates.io-index), which we clone or update regularly. [sparse-registry](https://github.com/rust-lang/cargo/issues/9069) will move us from using git for this particular case entirely, but in the meantime it would be nice to reduce the transfer costs.

[GitHub Blog "Get up to speed with partial clone and shallow clone"](https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/) describe how to use "shallow clone" (`--depth=1`) or "treeless clone" (`--filter=`) to make this less expensive. Unfortunately, `libgit2` does not support either of these features. When GitOxide is ready, we should talk to GitHub about if these features make sense in our use case.

It turns out, without using any fancy features, you can fetch an arbitrary git object ID and everything it links to. If we knew the ID of the Tree of the commit of the reference we were trying to check out, we could fetch everything we needed without any of the history! GitHub provides an [API endpoint for retrieving information about a commit](https://docs.github.com/en/rest/commits/commits). One of the included pieces of information is the ID of the Tree. Even better, we already hit that API as a fast path for discovering that we are up-to-date. So instead of that fast path returning the `sha` we return the `commit.tree.sha`, and we no longer clone the history!

In fact there are more minor implementation details:
1. We need to store the `sha` and `commit.tree.sha` somewhere so that we can use it as an etag, and so that we know what to check out, as git no longer has Commits to refer to. I have chosen to make a blob and a ref point to that blob.
2. Our checkout code needs to be slightly modified because it doesn't make sense to update the HEAD commit if we don't have history.

There is one failing test, specifically added because this cannot be merged until we talk to GitHub about:
> - Is it acceptable for us to drive a significant portion of the traffic to fetching a Tree object instead of its associated Commit?
> - Is it acceptable for us update a repository that has Tree objects checked out, to a different tree object?
> - Occasionally, the call to `https://api.github.com/repos/OWNER/REPO/commits/REF` will fail after succeeding in the past. (For example due to rate limiting.) Leading to us normally cloning a repository which had previously only had Tree objects. Is this acceptable?
>
> You have publicly asked people not to do any kind of fetch in a repository that was checked out using "shallow clone", is this the same situation?

Fundamentally this change reduces disk footprint and network bandwidth by an enormous amount. Different repos will have different ratios. But the [index](https://github.com/rust-lang/crates.io-index) is quite significant, in the 80% range, depending on how recently it was squashed.