### PR TITLE
artifact deps shoud works when target field specified coexists with `optional = true`

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -1049,14 +1049,8 @@ impl<'a, 'cfg> State<'a, 'cfg> {
         features.activated_features(pkg_id, features_for)
     }
 
-    fn is_dep_activated(
-        &self,
-        pkg_id: PackageId,
-        features_for: FeaturesFor,
-        dep_name: InternedString,
-    ) -> bool {
-        self.features()
-            .is_dep_activated(pkg_id, features_for, dep_name)
+    fn is_activated(&self, pkg_id: PackageId, features_for: FeaturesFor) -> bool {
+        self.features().is_activated(pkg_id, features_for)
     }
 
     fn get(&self, id: PackageId) -> &'a Package {
@@ -1071,7 +1065,7 @@ impl<'a, 'cfg> State<'a, 'cfg> {
         let kind = unit.kind;
         self.resolve()
             .deps(pkg_id)
-            .filter_map(|(id, deps)| {
+            .filter_map(|(dep_id, deps)| {
                 assert!(!deps.is_empty());
                 let deps: Vec<_> = deps
                     .iter()
@@ -1103,8 +1097,8 @@ impl<'a, 'cfg> State<'a, 'cfg> {
                         // If this is an optional dependency, and the new feature resolver
                         // did not enable it, don't include it.
                         if dep.is_optional() {
-                            let features_for = unit_for.map_to_features_for(dep.artifact());
-                            if !self.is_dep_activated(pkg_id, features_for, dep.name_in_toml()) {
+                            let dep_features_for = unit_for.map_to_features_for(dep.artifact());
+                            if !self.is_activated(dep_id, dep_features_for) {
                                 return false;
                             }
                         }
@@ -1117,7 +1111,7 @@ impl<'a, 'cfg> State<'a, 'cfg> {
                 if deps.is_empty() {
                     None
                 } else {
-                    Some((id, deps))
+                    Some((dep_id, deps))
                 }
             })
             .collect()

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -1040,6 +1040,7 @@ impl<'a, 'cfg> State<'a, 'cfg> {
         }
     }
 
+    /// See [`ResolvedFeatures::activated_features`].
     fn activated_features(
         &self,
         pkg_id: PackageId,
@@ -1049,6 +1050,7 @@ impl<'a, 'cfg> State<'a, 'cfg> {
         features.activated_features(pkg_id, features_for)
     }
 
+    /// See [`ResolvedFeatures::is_activated`].
     fn is_activated(&self, pkg_id: PackageId, features_for: FeaturesFor) -> bool {
         self.features().is_activated(pkg_id, features_for)
     }

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -325,17 +325,10 @@ impl ResolvedFeatures {
     ///
     /// This handles dependencies disabled via `cfg` expressions and optional
     /// dependencies which are not enabled.
-    pub fn is_dep_activated(
-        &self,
-        pkg_id: PackageId,
-        features_for: FeaturesFor,
-        dep_name: InternedString,
-    ) -> bool {
-        let key = features_for.apply_opts(&self.opts);
-        self.activated_dependencies
-            .get(&(pkg_id, key))
-            .map(|deps| deps.contains(&dep_name))
-            .unwrap_or(false)
+    pub fn is_activated(&self, pkg_id: PackageId, features_for: FeaturesFor) -> bool {
+        log::trace!("is_activated {} {features_for}", pkg_id.name());
+        self.activated_features_unverified(pkg_id, features_for.apply_opts(&self.opts))
+            .is_some()
     }
 
     /// Variant of `activated_features` that returns `None` if this is
@@ -475,7 +468,6 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
         }
         Ok(ResolvedFeatures {
             activated_features: r.activated_features,
-            activated_dependencies: r.activated_dependencies,
             opts: r.opts,
         })
     }

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -56,11 +56,9 @@ type ActivateMap = HashMap<PackageFeaturesKey, BTreeSet<InternedString>>;
 
 /// Set of all activated features for all packages in the resolve graph.
 pub struct ResolvedFeatures {
+    /// Map of features activated for each package.
     activated_features: ActivateMap,
-    /// Optional dependencies that should be built.
-    ///
-    /// The value is the `name_in_toml` of the dependencies.
-    activated_dependencies: ActivateMap,
+    /// Options that change how the feature resolver operates.
     opts: FeatureOpts,
 }
 
@@ -321,10 +319,10 @@ impl ResolvedFeatures {
             .expect("activated_features for invalid package")
     }
 
-    /// Returns if the given dependency should be included.
+    /// Asks the resolved features if the given package should be included.
     ///
-    /// This handles dependencies disabled via `cfg` expressions and optional
-    /// dependencies which are not enabled.
+    /// One scenario to use this function is to deteremine a optional dependency
+    /// should be built or not.
     pub fn is_activated(&self, pkg_id: PackageId, features_for: FeaturesFor) -> bool {
         log::trace!("is_activated {} {features_for}", pkg_id.name());
         self.activated_features_unverified(pkg_id, features_for.apply_opts(&self.opts))

--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -365,11 +365,7 @@ fn add_pkg(
                 if dep.is_optional() {
                     // If the new feature resolver does not enable this
                     // optional dep, then don't use it.
-                    if !resolved_features.is_dep_activated(
-                        package_id,
-                        features_for,
-                        dep.name_in_toml(),
-                    ) {
+                    if !resolved_features.is_activated(dep_id, features_for) {
                         return false;
                     }
                 }

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2308,11 +2308,14 @@ fn build_with_target_and_optional() {
 
     p.cargo("build -Z bindeps -F d1 -v")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_stderr_contains(
+        .with_stderr(
             "\
-[ERROR] environment variable `CARGO_BIN_FILE_D1` not defined
+[COMPILING] d1 v0.0.1 [..]
+[RUNNING] `rustc --crate-name d1 [..]--crate-type bin[..]
+[COMPILING] foo v0.0.1 [..]
+[RUNNING] `rustc --crate-name foo [..]--cfg[..]d1[..]
+[FINISHED] dev [..]
 ",
-    )
-        .with_status(101)
+        )
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

fixes #10526

Previously, `is_dep_activated` depends on `activated_dependencies`,
which is a map of `PackageFeaturesKey` to its own activated `DepFeature`s.
`PackageFeaturesKey` in feature resolver is always comprised of

* A `PackageId` of a given dependency, and
* A enum value that helps decoupling activated features for that dependency.
  Currently depending on the type of given dependency.

Looking into issue 10526, it has an `activated_dependencies` of

```
{
    (mycrate, NormalOrDevOrArtifactTarget(None)) -> [dep:mybindep]
}
```

However, this [line][1] accidentally use a parent's `pkgid`
and a dependency's `FeaturesFor` to compose a key:

```
(mycrate, NormalOrDevOrArtifactTarget("x86_64-unknown-linux-gnu"))
```

That is never a valid key to query features for artifacts dependency.
A valid key should be comprised of components both from the parent:

```
(mycrate, NormalOrDevOrArtifactTarget(None))
```

Or both from the dependency itself:

```
(mybindep, NormalOrDevOrArtifactTarget("x86_64-unknown-linux-gnu"))
```

As aforementioned `activated_dependencies` only stores parent packages
and their activated features. Those informations are included in
`activated_features` as well, so this commit goes with the route that
removes `activated_dependencies` and uses only dependency's infomation
to query if itself is activated.

[1]: https://github.com/rust-lang/cargo/blob/0b84a35c2c7d70df4875a03eb19084b0e7a543ef/src/cargo/core/compiler/unit_dependencies.rs#L1097-L1098

### How should we test and review this PR?

This first commit logs the current "incorrect" behaviour.
The second commit contain the fix.
The last commit update some docs.

### Additional information

There could be some other refactors to make the interaction between `-Zbindeps` and feature resolver a bit better. I'll try to send more follow-ups if life don't bite me again.
<!-- homu-ignore:end -->
