### PR TITLE
Semver: Note that it is not a breaking change to make an `unsafe` function safe

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1114,8 +1114,8 @@ fn main() {
 }
 ```
 
-Making an a previously `unsafe` associated function or method on structs /
-enums safe is also a minor change, while the same is not true for associated
+Making a previously `unsafe` associated function or method on structs / enums
+safe is also a minor change, while the same is not true for associated
 function on traits:
 
 ```rust,ignore

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -88,6 +88,7 @@ considered incompatible.
         * [Possibly-breaking: introducing a new function type parameter](#fn-generic-new)
         * [Minor: generalizing a function to use generics (supporting original type)](#fn-generalize-compatible)
         * [Major: generalizing a function to use generics with type mismatch](#fn-generalize-mismatch)
+        * [Minor: making an `unsafe` function safe](#fn-unsafe-safe)
     * Attributes
         * [Major: switching from `no_std` support to requiring `std`](#attr-no-std-to-std)
 * Tooling and environment compatibility
@@ -1078,6 +1079,73 @@ fn main() {
 }
 ```
 
+<a id="fn-unsafe-safe"></a>
+### Minor: making an `unsafe` function safe
+
+It is not a breaking change to make a previously `unsafe` function safe, as in
+the example below.
+
+Going the other way (making a safe function `unsafe`) is a breaking change.
+
+```rust,ignore
+// MINOR CHANGE
+
+///////////////////////////////////////////////////////////
+// Before
+pub unsafe fn foo() {}
+
+///////////////////////////////////////////////////////////
+// After
+pub fn foo() {}
+
+///////////////////////////////////////////////////////////
+// Example use of the library that will safely work.
+use updated_crate::foo;
+
+unsafe fn bar(f: unsafe fn()) {
+    f()
+}
+
+fn main() {
+    unsafe { foo() }; // The `unused_unsafe` lint will trigger here
+    unsafe { bar(foo) };
+}
+```
+
+Making an a previously `unsafe` associated function or method on structs /
+enums safe is also a minor change, while the same is not true for associated
+function on traits:
+
+```rust,ignore
+// MAJOR CHANGE
+
+///////////////////////////////////////////////////////////
+// Before
+pub trait Foo {
+    unsafe fn foo();
+}
+
+///////////////////////////////////////////////////////////
+// After
+pub trait Foo {
+    fn foo();
+}
+
+///////////////////////////////////////////////////////////
+// Example usage that will break.
+use updated_crate::Foo;
+
+struct Bar;
+
+impl Foo for Bar {
+    unsafe fn foo() {} // Error: method `foo` has an incompatible type for trait
+}
+```
+
+Note that local crates that have specified `#![deny(warnings)]` (which is an
+[anti-pattern][deny warnings]) will break, since they've explicitly opted out
+of Rust's stability guarantees.
+
 <a id="attr-no-std-to-std"></a>
 ### Major: switching from `no_std` support to requiring `std`
 
@@ -1347,3 +1415,4 @@ document what your commitments are.
 [SemVer]: https://semver.org/
 [struct literal]: ../../reference/expressions/struct-expr.html
 [wildcard patterns]: ../../reference/patterns.html#wildcard-pattern
+[deny warnings]: https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -88,7 +88,7 @@ considered incompatible.
         * [Possibly-breaking: introducing a new function type parameter](#fn-generic-new)
         * [Minor: generalizing a function to use generics (supporting original type)](#fn-generalize-compatible)
         * [Major: generalizing a function to use generics with type mismatch](#fn-generalize-mismatch)
-        * [Minor: making an `unsafe` function safe](#fn-unsafe-safe)
+        * [Possibly-breaking: making an `unsafe` function safe](#fn-unsafe-safe)
     * Attributes
         * [Major: switching from `no_std` support to requiring `std`](#attr-no-std-to-std)
 * Tooling and environment compatibility
@@ -1080,10 +1080,12 @@ fn main() {
 ```
 
 <a id="fn-unsafe-safe"></a>
-### Minor: making an `unsafe` function safe
+### Possibly-breaking: making an `unsafe` function safe
 
-It is not a breaking change to make a previously `unsafe` function safe, as in
-the example below.
+A previously `unsafe` function can be made safe without breaking code. Note
+however that it will likely cause the [`unused_unsafe`][unused_unsafe] lint
+to trigger as in the example below, which will cause local crates that have
+specified `#![deny(warnings)]` to stop compiling.
 
 Going the other way (making a safe function `unsafe`) is a breaking change.
 
@@ -1099,7 +1101,7 @@ pub unsafe fn foo() {}
 pub fn foo() {}
 
 ///////////////////////////////////////////////////////////
-// Example use of the library that will safely work.
+// Example use of the library that will trigger a lint.
 use updated_crate::foo;
 
 unsafe fn bar(f: unsafe fn()) {
@@ -1141,10 +1143,6 @@ impl Foo for Bar {
     unsafe fn foo() {} // Error: method `foo` has an incompatible type for trait
 }
 ```
-
-Note that local crates that have specified `#![deny(warnings)]` (which is an
-[anti-pattern][deny warnings]) will break, since they've explicitly opted out
-of Rust's stability guarantees.
 
 <a id="attr-no-std-to-std"></a>
 ### Major: switching from `no_std` support to requiring `std`
@@ -1415,4 +1413,4 @@ document what your commitments are.
 [SemVer]: https://semver.org/
 [struct literal]: ../../reference/expressions/struct-expr.html
 [wildcard patterns]: ../../reference/patterns.html#wildcard-pattern
-[deny warnings]: https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html
+[unused_unsafe]: ../../rustc/lints/listing/warn-by-default.html#unused-unsafe


### PR DESCRIPTION
I asked this a while ago on [the users forum](https://users.rust-lang.org/t/breaking-change-to-remove-unsafe-from-a-function/80987), and thought it would be nice to have in the main documentation.

I marked this as a "minor" change because the only way it breaks is if the user is opting out of Rust's stability guarantees in general. But happy to make it "possibly breaking" if that suits you?