### PR TITLE
Fix deadlock when build scripts are waiting for input on stdin

### DIFF
--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"


### PR DESCRIPTION
### What does this PR try to resolve?

#10738 introduced a regression where build scripts did not close stdin, causing deadlocks for build scripts waiting for stdin.

Fixes #11196 by not piping `stdin` unless requested by the `ProcessBuilder`.

### How should we test and review this PR?

Run a build script that reads from stdin and check that it no longer hangs. See the POC in the linked issue. The included test hangs without the fix.

r? @ehuss 