### PR TITLE
Add more doc comments for three modules

### DIFF
--- a/src/cargo/util/profile.rs
+++ b/src/cargo/util/profile.rs
@@ -1,3 +1,9 @@
+//! # An internal profiler for Cargo itself
+//!
+//! > **Note**: This might not be the module you are looking for.
+//! > For information about how Cargo handles compiler flags with profiles,
+//! > please see the module [`cargo::core::profiles`](crate::core::profiles).
+
 use std::cell::RefCell;
 use std::env;
 use std::fmt;

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -241,6 +241,17 @@ _cargo() {
                     _arguments -s -S $common $manifest
                         ;;
 
+                remove | rm)
+                    _arguments -s -A "^--" $common $manifest \
+                        "--dev[remove as a dev dependency]" \
+                        "--build[remove as a build dependency]" \
+                        "--target=[remove as a dependency from the given target platform]" \
+                        "--dry-run[don't actually write the manifest]" \
+                        '(-p --package)'{-p+,--package=}'[package to remove from]:package:_cargo_package_names' \
+                        '1: :_guard "^-*" "crate name"' \
+                        '*:args:_default'
+                        ;;
+
                 run | r)
                     _arguments -s -S $common $parallel $features $msgfmt $triple $target $manifest \
                         '--example=[name of the bin target]:name:_cargo_example_names' \

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -73,6 +73,8 @@ _cargo()
 	local opt__pkgid="$opt_common $opt_mani $opt_lock $opt_pkg"
 	local opt__publish="$opt_common $opt_mani $opt_feat $opt_lock $opt_parallel --allow-dirty --dry-run --token --no-verify --index --registry --target --target-dir"
 	local opt__read_manifest="$opt_help $opt_quiet $opt_verbose $opt_mani $opt_color $opt_lock --no-deps"
+	local opt__remove="$opt_common $opt_pkg $opt_lock $opt_mani --dry-run --dev --build --target"
+	local opt__rm="$opt__remove"
 	local opt__report="$opt_help $opt_verbose $opt_color future-incompat future-incompatibilities"
 	local opt__report__future_incompat="$opt_help $opt_verbose $opt_color $opt_pkg --id"
 	local opt__run="$opt_common $opt_pkg $opt_feat $opt_mani $opt_lock $opt_parallel --message-format --target --bin --example --release --target-dir --profile"


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Add missing doc comments for modules

- `cargo::ops::cargo_compile`: Document all public items and some private ones.
- `cargo::core::compiler::unit_dependencies`: This has nothing to document, only intra-doc link updates
- `cargo::util::profile`: Just add a module level doc indicating it is not profile for compiler flags.

### How should we test and review this PR?

```
cargo doc --document-private-items --no-deps --open
```

Then proofread it!

### Additional information
<!-- homu-ignore:end -->
