### PR TITLE
Add configuration option for controlling crates.io protocol

### DIFF
--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -91,7 +91,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
                 replace_with: None,
             },
         )?;
-        if config.cli_unstable().sparse_registry {
+        if SourceId::crates_io_is_sparse(config)? {
             base.add(
                 CRATES_IO_REGISTRY,
                 SourceConfig {

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2704,6 +2704,24 @@ fn http_requires_z_flag() {
 }
 
 #[cargo_test]
+fn protocol_sparse_requires_z_flag() {
+    cargo_process("install bar")
+        .with_status(101)
+        .env("CARGO_REGISTRIES_CRATES_IO_PROTOCOL", "sparse")
+        .with_stderr("[ERROR] usage of sparse registries requires `-Z sparse-registry`")
+        .run()
+}
+
+#[cargo_test]
+fn protocol() {
+    cargo_process("install bar")
+        .with_status(101)
+        .env("CARGO_REGISTRIES_CRATES_IO_PROTOCOL", "invalid")
+        .with_stderr("[ERROR] unsupported registry protocol `invalid` (defined in environment variable `CARGO_REGISTRIES_CRATES_IO_PROTOCOL`)")
+        .run()
+}
+
+#[cargo_test]
 fn http_requires_trailing_slash() {
     cargo_process("-Z sparse-registry install bar --index sparse+https://index.crates.io")
         .masquerade_as_nightly_cargo(&["sparse-registry"])


### PR DESCRIPTION
### What does this PR try to resolve?

Currently, if `-Z sparse-registry` is passed, then Cargo will access crates.io using the sparse protocol. Since we want to stabilize this feature soon, we need a stable way to control which protocol is used.

This adds a config option `registries.crates-io.protocol` that can be set to either `sparse` or `git`. If the option is unset, it will be `sparse` if `-Z sparse-registry` is enabled, otherwise it will be `git`.

This PR does not stabilize `sparse-registry`. Using `registries.crates-io.protocol` without `-Z sparse-registry` will result in an error.

The next steps after PR are to:
* stabilize `sparse-registry`
* make `sparse` the default protocol

### Additional information
The config option is based on the discussion in this note: https://hackmd.io/@rust-cargo-team/B13O52Zko