### PR TITLE
refactor(tests): Make publish tests work with wait-for-publish

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1872,7 +1872,9 @@ fn env_vars_and_build_products_for_various_build_targets() {
 
 #[cargo_test]
 fn publish_artifact_dep() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
+
     Package::new("bar", "1.0.0").publish();
     Package::new("baz", "1.0.0").publish();
 
@@ -1900,6 +1902,15 @@ fn publish_artifact_dep() {
         )
         .file("src/lib.rs", "")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish -Z bindeps --no-verify")
         .replace_crates_io(registry.index_url())

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -1,6 +1,6 @@
 //! Tests for credential-process.
 
-use cargo_test_support::registry::TestRegistry;
+use cargo_test_support::registry::{Package, TestRegistry};
 use cargo_test_support::{basic_manifest, cargo_process, paths, project, registry, Project};
 use std::fs;
 
@@ -93,6 +93,16 @@ fn warn_both_token_and_process() {
         )
         .file("src/lib.rs", "")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .alternative(true)
+        .publish();
 
     p.cargo("publish --no-verify --registry alternative -Z credential-process")
         .masquerade_as_nightly_cargo(&["credential-process"])

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -66,7 +66,8 @@ fn publish_with_target() {
         return;
     }
 
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -858,7 +858,9 @@ bar v1.0.0
 
 #[cargo_test]
 fn publish_no_implicit() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
+
     // Does not include implicit features or dep: syntax on publish.
     Package::new("opt-dep1", "1.0.0").publish();
     Package::new("opt-dep2", "1.0.0").publish();
@@ -884,6 +886,15 @@ fn publish_no_implicit() {
         )
         .file("src/lib.rs", "")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
@@ -971,7 +982,9 @@ feat = ["opt-dep1"]
 
 #[cargo_test]
 fn publish() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
+
     // Publish behavior with explicit dep: syntax.
     Package::new("bar", "1.0.0").publish();
     let p = project()
@@ -996,6 +1009,15 @@ fn publish() {
         )
         .file("src/lib.rs", "")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish")
         .replace_crates_io(registry.index_url())

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -225,6 +225,7 @@ fn simple_with_index() {
 
 #[cargo_test]
 fn git_deps() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -262,6 +263,7 @@ the `git` specification will be removed from the dependency declaration.
 
 #[cargo_test]
 fn path_dependency_no_version() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -301,6 +303,7 @@ the `path` specification will be removed from the dependency declaration.
 
 #[cargo_test]
 fn unpublishable_crate() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -333,6 +336,7 @@ The registry `crates-io` is not listed in the `publish` value in Cargo.toml.
 
 #[cargo_test]
 fn dont_publish_dirty() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project().file("bar", "").build();
@@ -557,6 +561,7 @@ fn ignore_when_crate_ignored() {
 
 #[cargo_test]
 fn new_crate_rejected() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project().file("baz", "").build();
@@ -589,6 +594,7 @@ fn new_crate_rejected() {
 
 #[cargo_test]
 fn dry_run() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -993,6 +999,7 @@ fn publish_with_all_features() {
 
 #[cargo_test]
 fn publish_with_no_default_features() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -1485,7 +1492,9 @@ fn credentials_ambiguous_filename() {
 // crates.io token to another server.
 #[cargo_test]
 fn index_requires_token() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
+
     let credentials = paths::home().join(".cargo/credentials");
     fs::remove_file(&credentials).unwrap();
 
@@ -1548,7 +1557,9 @@ include `--registry dummy-registry` or `--registry crates-io`
 
 #[cargo_test]
 fn publish_with_missing_readme() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
+
     let p = project()
         .file(
             "Cargo.toml",
@@ -1881,6 +1892,7 @@ See [..]
 
 #[cargo_test]
 fn with_duplicate_spec_in_members() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -1977,6 +1989,7 @@ See [..]
 
 #[cargo_test]
 fn in_virtual_workspace() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -2063,6 +2076,7 @@ See [..]
 
 #[cargo_test]
 fn in_package_workspace_not_found() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -2107,6 +2121,7 @@ error: package ID specification `li` did not match any packages
 
 #[cargo_test]
 fn in_package_workspace_found_multiple() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()
@@ -2164,6 +2179,7 @@ error: the `-p` argument must be specified to select a single package to publish
 #[cargo_test]
 // https://github.com/rust-lang/cargo/issues/10536
 fn publish_path_dependency_without_workspace() {
+    // Use local registry for faster test times since no publish will occur
     let registry = registry::init();
 
     let p = project()

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -101,6 +101,7 @@ fn validate_upload_foo_clean() {
 
 #[cargo_test]
 fn simple() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
 
     let p = project()
@@ -117,6 +118,15 @@ fn simple() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.0.1")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
@@ -698,6 +708,7 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
 
 #[cargo_test]
 fn publish_allowed_registry() {
+    // HACK below allows us to use a local registry
     registry::alt_init();
 
     let p = project().build();
@@ -720,6 +731,16 @@ fn publish_allowed_registry() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.0.1")
+        .file("src/lib.rs", "")
+        .alternative(true)
+        .publish();
 
     p.cargo("publish --registry alternative")
         .with_stderr(
@@ -748,6 +769,7 @@ fn publish_allowed_registry() {
 
 #[cargo_test]
 fn publish_implicitly_to_only_allowed_registry() {
+    // HACK below allows us to use a local registry
     registry::alt_init();
 
     let p = project().build();
@@ -770,6 +792,16 @@ fn publish_implicitly_to_only_allowed_registry() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.0.1")
+        .file("src/lib.rs", "")
+        .alternative(true)
+        .publish();
 
     p.cargo("publish")
         .with_stderr(
@@ -1035,6 +1067,7 @@ fn publish_with_no_default_features() {
 
 #[cargo_test]
 fn publish_with_patch() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
     Package::new("bar", "1.0.0").publish();
 
@@ -1077,6 +1110,15 @@ fn publish_with_patch() {
 
     // Remove the usage of new functionality and try again.
     p.change_file("src/main.rs", "extern crate bar; pub fn main() {}");
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.0.1")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish")
         .replace_crates_io(registry.index_url())
@@ -1233,7 +1275,9 @@ include `--registry crates-io` to use crates.io
 // A dependency with both `git` and `version`.
 #[cargo_test]
 fn publish_git_with_version() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
+
     Package::new("dep1", "1.0.1")
         .file("src/lib.rs", "pub fn f() -> i32 {1}")
         .publish();
@@ -1274,6 +1318,16 @@ fn publish_git_with_version() {
         .build();
 
     p.cargo("run").with_stdout("2").run();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
+
     p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
         .with_stderr(
@@ -1367,6 +1421,7 @@ fn publish_git_with_version() {
 
 #[cargo_test]
 fn publish_dev_dep_no_version() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
 
     let p = project()
@@ -1391,6 +1446,15 @@ fn publish_dev_dep_no_version() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
@@ -1846,6 +1910,7 @@ Caused by:
 
 #[cargo_test]
 fn in_package_workspace() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
 
     let p = project()
@@ -1873,6 +1938,13 @@ fn in_package_workspace() {
         )
         .file("li/src/main.rs", "fn main() {}")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("li", "0.0.1").file("src/lib.rs", "").publish();
 
     p.cargo("publish -p li --no-verify")
         .replace_crates_io(registry.index_url())
@@ -1944,6 +2016,7 @@ fn with_duplicate_spec_in_members() {
 
 #[cargo_test]
 fn in_package_workspace_with_members_with_features_old() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
 
     let p = project()
@@ -1970,6 +2043,13 @@ fn in_package_workspace_with_members_with_features_old() {
         )
         .file("li/src/main.rs", "fn main() {}")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("li", "0.0.1").file("src/lib.rs", "").publish();
 
     p.cargo("publish -p li --no-verify")
         .replace_crates_io(registry.index_url())

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -85,20 +85,6 @@ fn validate_upload_li() {
     );
 }
 
-fn validate_upload_foo_clean() {
-    publish::validate_upload(
-        CLEAN_FOO_JSON,
-        "foo-0.0.1.crate",
-        &[
-            "Cargo.lock",
-            "Cargo.toml",
-            "Cargo.toml.orig",
-            "src/main.rs",
-            ".cargo_vcs_info.json",
-        ],
-    );
-}
-
 #[cargo_test]
 fn simple() {
     // HACK below allows us to use a local registry
@@ -148,7 +134,8 @@ See [..]
 // `[registry]` table.
 #[cargo_test]
 fn old_token_location() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(
@@ -193,12 +180,14 @@ See [..]
         )
         .run();
 
-    validate_upload_foo();
+    // Skip `validate_upload_foo` as we just cared we got far enough for verify the token behavior.
+    // Other tests will verify the endpoint gets the right payload.
 }
 
 #[cargo_test]
 fn simple_with_index() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(
@@ -230,7 +219,8 @@ fn simple_with_index() {
         )
         .run();
 
-    validate_upload_foo();
+    // Skip `validate_upload_foo` as we just cared we got far enough for verify the VCS behavior.
+    // Other tests will verify the endpoint gets the right payload.
 }
 
 #[cargo_test]
@@ -388,7 +378,8 @@ to proceed despite this and include the uncommitted changes, pass the `--allow-d
 
 #[cargo_test]
 fn publish_clean() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project().build();
 
@@ -423,12 +414,14 @@ fn publish_clean() {
         )
         .run();
 
-    validate_upload_foo_clean();
+    // Skip `validate_upload_foo_clean` as we just cared we got far enough for verify the VCS behavior.
+    // Other tests will verify the endpoint gets the right payload.
 }
 
 #[cargo_test]
 fn publish_in_sub_repo() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project().no_manifest().file("baz", "").build();
 
@@ -464,12 +457,14 @@ fn publish_in_sub_repo() {
         )
         .run();
 
-    validate_upload_foo_clean();
+    // Skip `validate_upload_foo_clean` as we just cared we got far enough for verify the VCS behavior.
+    // Other tests will verify the endpoint gets the right payload.
 }
 
 #[cargo_test]
 fn publish_when_ignored() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project().file("baz", "").build();
 
@@ -505,23 +500,14 @@ fn publish_when_ignored() {
         )
         .run();
 
-    publish::validate_upload(
-        CLEAN_FOO_JSON,
-        "foo-0.0.1.crate",
-        &[
-            "Cargo.lock",
-            "Cargo.toml",
-            "Cargo.toml.orig",
-            "src/main.rs",
-            ".gitignore",
-            ".cargo_vcs_info.json",
-        ],
-    );
+    // Skip `validate_upload` as we just cared we got far enough for verify the VCS behavior.
+    // Other tests will verify the endpoint gets the right payload.
 }
 
 #[cargo_test]
 fn ignore_when_crate_ignored() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project().no_manifest().file("bar/baz", "").build();
 
@@ -556,17 +542,8 @@ fn ignore_when_crate_ignored() {
         )
         .run();
 
-    publish::validate_upload(
-        CLEAN_FOO_JSON,
-        "foo-0.0.1.crate",
-        &[
-            "Cargo.lock",
-            "Cargo.toml",
-            "Cargo.toml.orig",
-            "src/main.rs",
-            "baz",
-        ],
-    );
+    // Skip `validate_upload` as we just cared we got far enough for verify the VCS behavior.
+    // Other tests will verify the endpoint gets the right payload.
 }
 
 #[cargo_test]
@@ -895,7 +872,8 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
 // Explicitly setting `crates-io` in the publish list.
 #[cargo_test]
 fn publish_with_crates_io_explicit() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(
@@ -941,7 +919,8 @@ The registry `alternative` is not listed in the `publish` value in Cargo.toml.
 
 #[cargo_test]
 fn publish_with_select_features() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(
@@ -986,7 +965,8 @@ fn publish_with_select_features() {
 
 #[cargo_test]
 fn publish_with_all_features() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(
@@ -1515,7 +1495,8 @@ repository = "foo"
 
 #[cargo_test]
 fn credentials_ambiguous_filename() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let credentials_toml = paths::home().join(".cargo/credentials.toml");
     fs::write(credentials_toml, r#"token = "api-token""#).unwrap();
@@ -1548,8 +1529,6 @@ fn credentials_ambiguous_filename() {
 ",
         )
         .run();
-
-    validate_upload_foo();
 }
 
 // --index will not load registry.token to avoid possibly leaking
@@ -2105,7 +2084,8 @@ fn in_virtual_workspace() {
 
 #[cargo_test]
 fn in_virtual_workspace_with_p() {
-    let registry = registry::init();
+    // `publish` generally requires a remote registry
+    let registry = registry::RegistryBuilder::new().http_api().build();
 
     let p = project()
         .file(

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -523,7 +523,9 @@ bar v1.0.0
 
 #[cargo_test]
 fn publish() {
+    // HACK below allows us to use a local registry
     let registry = registry::init();
+
     // Publish behavior with /? syntax.
     Package::new("bar", "1.0.0").feature("feat", &[]).publish();
     let p = project()
@@ -547,6 +549,15 @@ fn publish() {
         )
         .file("src/lib.rs", "")
         .build();
+
+    // HACK: Inject `foo` directly into the index so `publish` won't block for it to be in
+    // the index.
+    //
+    // This is to ensure we can verify the Summary we post to the registry as doing so precludes
+    // the registry from processing the publish.
+    Package::new("foo", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
 
     p.cargo("publish")
         .replace_crates_io(registry.index_url())


### PR DESCRIPTION
In #11062, `cargo publish` will start blocking until the package is in the index.

This PR includes:

Switches some tests from using the local registry to the remote registry.  The local registry translates PUT calls to writing to the file system and we have no where to inject code to move that into the index.  The remote registry was updated in #11111 to handle this.

Updates some tests to directly inject a no-op package into the registry before publish so that when we merge #11062, the blocking code will find that no-op package and be satisfied.  This is an ugly hack that we were trying to avoid (hence #11111 and the above change).  The problem comes with trying to verify we hit the end point with all of the right data.  Alternatively, we could have either  In some cases, I removed the validation of the PUT because it didn't look like that was a focus of the test case; they just cared that a publish happens

- Parsed the index and checked the Summaries and the Crates to ensure the data matched what we expected but that requires the Summaries to always be 100% the same as the PUT call (which they are, for now), could likely hit cargo caching issues much like the implementation of #11062 did
- Allowed the remote test registry to accept a list of expected PUT requests and verify them.  This would be fairly clean but was going to be a bit of work to setup all of that infrastructure and tweaking to make sure we get all of the error reporting just right.

In the end, I went the more surgical route rather continuing to let this get bogged down in test changes and conflicts.

This was verified by rebasing the blocking branch on this and now all tests pass and I don't see signs of 60 second tests.