### PR TITLE
chore: Add `.fleet` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ rustc
 __pycache__
 .idea/
 .vscode/
+.fleet/
 *.iml
 *.swp


### PR DESCRIPTION
When trying out [Jetbrains Fleet](https://www.jetbrains.com/fleet/), I noticed that it added a new directory for its configuration files. I thought it would be a good idea to add it to the `.gitignore` as it entered [public preview](https://blog.jetbrains.com/fleet/2022/10/introducing-the-fleet-public-preview/) earlier today.