### PR TITLE
Fix rustdoc warning about unclosed HTML tag

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -381,7 +381,7 @@ pub struct DetailedTomlDependency<P: Clone = String> {
     package: Option<String>,
     public: Option<bool>,
 
-    /// One ore more of 'bin', 'cdylib', 'staticlib', 'bin:<name>'.
+    /// One or more of `bin`, `cdylib`, `staticlib`, `bin:<name>`.
     artifact: Option<StringOrVec>,
     /// If set, the artifact should also be a dependency
     lib: Option<bool>,


### PR DESCRIPTION
nightly rustdoc is warning about `<name>` being an unclosed HTML tag. Fix by using backticks instead of single quotes.