### PR TITLE
feat(publish): Support 'publish.timeout' config behind '-Zpublish-timeout'

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -197,6 +197,7 @@ fn substitute_macros(input: &str) -> String {
         ("[MIGRATING]", "   Migrating"),
         ("[EXECUTABLE]", "  Executable"),
         ("[SKIPPING]", "    Skipping"),
+        ("[WAITING]", "     Waiting"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -686,6 +686,7 @@ unstable_cli_options!(
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     separate_nightlies: bool = (HIDDEN),
     terminal_width: Option<Option<usize>>  = ("Provide a terminal width to rustc for error truncation"),
+    publish_timeout: bool = ("Enable the `publish.timeout` key in .cargo/config.toml file"),
     unstable_options: bool = ("Allow the usage of unstable options"),
     // TODO(wcrichto): move scrape example configuration into Cargo.toml before stabilization
     // See: https://github.com/rust-lang/cargo/pull/9525#discussion_r728470927
@@ -930,6 +931,7 @@ impl CliUnstable {
             "jobserver-per-rustc" => self.jobserver_per_rustc = parse_empty(k, v)?,
             "host-config" => self.host_config = parse_empty(k, v)?,
             "target-applies-to-host" => self.target_applies_to_host = parse_empty(k, v)?,
+            "publish-timeout" => self.publish_timeout = parse_empty(k, v)?,
             "features" => {
                 // `-Z features` has been stabilized since 1.51,
                 // but `-Z features=compare` is still allowed for convenience

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -99,6 +99,7 @@ Each new feature described below should explain how to use it.
     * [credential-process](#credential-process) — Adds support for fetching registry tokens from an external authentication program.
     * [`cargo logout`](#cargo-logout) — Adds the `logout` command to remove the currently saved registry token.
     * [sparse-registry](#sparse-registry) — Adds support for fetching from static-file HTTP registries (`sparse+`)
+    * [publish-timeout](#publish-timeout) — Controls the timeout between uploading the crate and being available in the index
 
 ### allow-features
 
@@ -840,6 +841,23 @@ When fetching index metadata over HTTP, Cargo only downloads the metadata for re
 crates, which can save significant time and bandwidth.
 
 The format of the sparse index is identical to a checkout of a git-based index.
+
+### publish-timeout
+* Tracking Issue: [11222](https://github.com/rust-lang/cargo/issues/11222)
+
+The `publish.timeout` key in a config file can be used to control how long
+`cargo publish` waits between posting a package to the registry and it being
+available in the local index.
+
+A timeout of `0` prevents any checks from occurring.
+
+It requires the `-Zpublish-timeout` command-line options to be set.
+
+```toml
+# config.toml
+[publish]
+timeout = 300  # in seconds
+```
 
 ### credential-process
 * Tracking Issue: [#8933](https://github.com/rust-lang/cargo/issues/8933)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -5,6 +5,7 @@ use cargo_test_support::paths;
 use cargo_test_support::registry::{self, Package, Response};
 use cargo_test_support::{basic_manifest, no_such_file_err_msg, project, publish};
 use std::fs;
+use std::sync::{Arc, Mutex};
 
 const CLEAN_FOO_JSON: &str = r#"
     {


### PR DESCRIPTION
Originally, crates.io would block on publish requests until the publish
was complete, giving `cargo publish` this behavior by extension.  When
crates.io switched to asynchronous publishing, this intermittently broke
people's workflows when publishing multiple crates.  I say interittent
because it usually works until it doesn't and it is unclear why to the
end user because it will be published by the time they check.  In the
end, callers tend to either put in timeouts (and pray), poll the
server's API, or use `crates-index` crate to poll the index.

This isn't sufficient because
- For any new interested party, this is a pit of failure they'll fall
  into
- crates-index has re-implemented index support incorrectly in the past,
  currently doesn't handle auth, doesn't support `git-cli`, etc.
- None of these previous options work if we were to implement
  workspace-publish support (https://github.com/rust-lang/cargo/issues/1169)
- The new sparse registry might increase the publish times, making the
  delay easier to hit manually
- The new sparse registry goes through CDNs so checking the server's API
  might not be sufficient
- Once the sparse registry is available, crates-index users will find
  out when the package is ready in git but it might not be ready through
  the sparse registry because of CDNs

This introduces unstable support for blocking by setting
`publish.timeout` to non-zero value.

A step towards #9507