### PR TITLE
Add missing edition

### DIFF
--- a/src/doc/src/reference/build-script-examples.md
+++ b/src/doc/src/reference/build-script-examples.md
@@ -49,6 +49,7 @@ Here we can see that we have a `build.rs` build script and our binary in
 [package]
 name = "hello-from-generated-code"
 version = "0.1.0"
+edition = "2021"
 ```
 
 Let’s see what’s inside the build script:


### PR DESCRIPTION
### What does this PR try to resolve?

When I read this doc, I found that we are missing the edition key in this manifest. I think we should add it because `cargo new` always does this.