### PR TITLE
fix: Update help headings to  match clap

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -83,7 +83,7 @@ Example uses:
         ])
         .arg_quiet()
         .arg_dry_run("Don't actually write the manifest")
-        .next_help_heading("SOURCE")
+        .next_help_heading("Source")
         .args([
             clap::Arg::new("path")
                 .long("path")
@@ -131,7 +131,7 @@ This is the catch all, handling hashes to named references in remote repositorie
                 .value_name("NAME")
                 .help("Package registry for this dependency"),
         ])
-        .next_help_heading("SECTION")
+        .next_help_heading("Section")
         .args([
             flag("dev",
                 "Add as development dependency")

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -20,7 +20,7 @@ pub fn cli() -> clap::Command {
         .arg_manifest_path()
         .arg_quiet()
         .arg_dry_run("Don't actually write the manifest")
-        .next_help_heading("SECTION")
+        .next_help_heading("Section")
         .args([
             clap::Arg::new("dev")
                 .long("dev")


### PR DESCRIPTION
This was missed when upgrading to clap v4

Fixes #11238

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
