### PR TITLE
Remove sparse+ prefix for index.crates.io

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -188,7 +188,7 @@ use crate::util::{
 
 const PACKAGE_SOURCE_LOCK: &str = ".cargo-ok";
 pub const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
-pub const CRATES_IO_HTTP_INDEX: &str = "sparse+https://index.crates.io/";
+pub const CRATES_IO_HTTP_INDEX: &str = "https://index.crates.io/";
 pub const CRATES_IO_REGISTRY: &str = "crates-io";
 pub const CRATES_IO_DOMAIN: &str = "crates.io";
 const CRATE_TEMPLATE: &str = "{crate}";


### PR DESCRIPTION
### What does this PR try to resolve?

#11209 changed how sparse registry URLs are stored in a `SourceId` to remove the `sparse+` prefix, however the URL was not updated.

Fixes #11246

### How should we test and review this PR?

Run a command that requires sparse registry `cargo  -Z sparse-registry update --dry-run`

Tests can't really be added for this case, since the `index.crates.io` URL was incorrect, and tests shouldn't access the network.

r? @Eh2406