### PR TITLE
Add missing edition

### DIFF
--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -29,6 +29,7 @@ in `Cargo.toml`:
 [package]
 name = "my-project"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 other-crate = { version = "1.0", registry = "my-registry" }


### PR DESCRIPTION
When I read this doc, I found that we are missing the edition key in this manifest. I think we should add it because` cargo new` always does this.