### PR TITLE
Fix publishing with a dependency on a sparse registry

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1521,8 +1521,7 @@ impl TomlManifest {
                     d.rev.take();
                     // registry specifications are elaborated to the index URL
                     if let Some(registry) = d.registry.take() {
-                        let src = SourceId::alt_registry(config, &registry)?;
-                        d.registry_index = Some(src.url().to_string());
+                        d.registry_index = Some(config.get_registry_index(&registry)?.to_string());
                     }
                     Ok(TomlDependency::Detailed(d))
                 }


### PR DESCRIPTION
### What does this PR try to resolve?
On publishing, the `registry_index` field was being set to the registry URL without the `sparse+` prefix. During the verification build, Cargo would attempt to fetch the registry as a `git` registry. Caused by #11209.

Fixes #11263.

### How should we test and review this PR?

Added a test that fails without the change.
