### PR TITLE
Remove the prepended newline in `cargo vendor` config output

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -43,7 +43,7 @@ pub fn vendor(ws: &Workspace<'_>, opts: &VendorOptions<'_>) -> CargoResult<()> {
             crate::drop_print!(
                 config,
                 "{}",
-                &toml::to_string_pretty(&vendor_config).unwrap()
+                &toml::to_string_pretty(&vendor_config).unwrap().trim_start()
             );
         }
     }

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -58,8 +58,7 @@ fn vendor_sample_config() {
 
     p.cargo("vendor --respect-source-config")
         .with_stdout(
-            r#"
-[source.crates-io]
+            r#"[source.crates-io]
 replace-with = "vendored-sources"
 
 [source.vendored-sources]
@@ -103,8 +102,7 @@ fn vendor_path_specified() {
     // path is normalized by `ops::vendor` on Windows.
     assert_eq!(
         &String::from_utf8(output.stdout).unwrap(),
-        r#"
-[source.crates-io]
+        r#"[source.crates-io]
 replace-with = "vendored-sources"
 
 [source.vendored-sources]


### PR DESCRIPTION
`cargo vendor` prints all progress to `stderr`.
After it finished the vendoring it prints the necessary configuration to `stdout`.

The `stdout` output starts with a newline which will be removed by this PR.

Tested with `cargo vendor | tee vendor_config`.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
