### PR TITLE
Add test for deleted index entry

### DIFF
--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -581,7 +581,6 @@ impl Summaries {
                 return Poll::Ready(Ok(cached_summaries));
             }
             LoadResponse::NotFound => {
-                debug_assert!(cached_summaries.is_none());
                 if let Err(e) = fs::remove_file(cache_path) {
                     if e.kind() != ErrorKind::NotFound {
                         log::debug!("failed to remove from cache: {}", e);


### PR DESCRIPTION
This adds a test for when an entry is deleted from the index. This is done on crates.io occasionally for things like copyright takedown requests.

This behavior was tripping a debug assert which this removes. I'm not entirely certain why the debug assert is there, but I think it is not correct, since this is obviously a scenario where there might be a cached file, but the index responds with NotFound.