### PR TITLE
Improve the error message if `publish` is `false` or empty list

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -137,7 +137,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         if allowed_registries.is_empty() {
             bail!(
                 "`{}` cannot be published.\n\
-                 `publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.",
+                 `package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.",
                 pkg.name(),
             );
         } else if !allowed_registries.contains(&reg_name) {

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -134,7 +134,13 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         let reg_name = publish_registry
             .clone()
             .unwrap_or_else(|| CRATES_IO_REGISTRY.to_string());
-        if !allowed_registries.contains(&reg_name) {
+        if allowed_registries.is_empty() {
+            bail!(
+                "`{}` cannot be published.\n\
+                 `publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.",
+                pkg.name(),
+            );
+        } else if !allowed_registries.contains(&reg_name) {
             bail!(
                 "`{}` cannot be published.\n\
                  The registry `{}` is not listed in the `publish` value in Cargo.toml.",

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -143,7 +143,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         } else if !allowed_registries.contains(&reg_name) {
             bail!(
                 "`{}` cannot be published.\n\
-                 The registry `{}` is not listed in the `publish` value in Cargo.toml.",
+                 The registry `{}` is not listed in the `package.publish` value in Cargo.toml.",
                 pkg.name(),
                 reg_name
             );

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -655,7 +655,7 @@ fn registry_not_in_publish_list() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-The registry `alternative` is not listed in the `publish` value in Cargo.toml.
+The registry `alternative` is not listed in the `package.publish` value in Cargo.toml.
 ",
         )
         .run();
@@ -819,7 +819,7 @@ fn publish_fail_with_no_registry_specified() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-The registry `crates-io` is not listed in the `publish` value in Cargo.toml.
+The registry `crates-io` is not listed in the `package.publish` value in Cargo.toml.
 ",
         )
         .run();
@@ -880,7 +880,7 @@ fn publish_with_crates_io_explicit() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-The registry `alternative` is not listed in the `publish` value in Cargo.toml.
+The registry `alternative` is not listed in the `package.publish` value in Cargo.toml.
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -325,7 +325,7 @@ fn unpublishable_crate() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-The registry `crates-io` is not listed in the `publish` value in Cargo.toml.
+`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
 ",
         )
         .run();
@@ -684,7 +684,7 @@ fn publish_empty_list() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-The registry `alternative` is not listed in the `publish` value in Cargo.toml.
+`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
 ",
         )
         .run();
@@ -848,7 +848,7 @@ fn block_publish_no_registry() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-The registry `alternative` is not listed in the `publish` value in Cargo.toml.
+`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/11262

Improve the error message if `publish` is the false or empty list. 

Say `publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
### How should we test and review this PR?

Unit test

### Additional information

If there was a way we could tell `publish` to be empty or `false`, I think it would get better. If you know an easy way to implement it, please feel free to comment.