### PR TITLE
Fix confusing error messages when using -Zsparse-registry

### DIFF
--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -428,7 +428,10 @@ impl SourceId {
         let url = self.inner.url.as_str();
         url == CRATES_IO_INDEX
             || url == CRATES_IO_HTTP_INDEX
-            || std::env::var("__CARGO_TEST_CRATES_IO_URL_DO_NOT_USE_THIS").as_deref() == Ok(url)
+            || std::env::var("__CARGO_TEST_CRATES_IO_URL_DO_NOT_USE_THIS")
+                .as_deref()
+                .map(|u| u.trim_start_matches("sparse+"))
+                == Ok(url)
     }
 
     /// Hashes `self`.

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -100,11 +100,17 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
     }
 
     fn describe(&self) -> String {
-        format!(
-            "{} (which is replacing {})",
-            self.inner.describe(),
-            self.to_replace
-        )
+        if self.replace_with.is_crates_io() && self.to_replace.is_crates_io() {
+            // Built-in source replacement of crates.io for sparse registry or tests
+            // doesn't need duplicate description (crates.io replacing crates.io).
+            self.inner.describe()
+        } else {
+            format!(
+                "{} (which is replacing {})",
+                self.inner.describe(),
+                self.to_replace
+            )
+        }
     }
 
     fn is_replaced(&self) -> bool {

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2319,13 +2319,13 @@ fn wait_for_publish() {
         .with_status(0)
         .with_stderr(
             "\
-[UPDATING] `crates-io` index
+[UPDATING] crates.io index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] delay v0.0.1 ([CWD])
 [UPLOADING] delay v0.0.1 ([CWD])
-[UPDATING] `crates-io` index
-[WAITING] on `delay` to propagate to `crates-io` index (which is replacing registry `crates-io`) (ctrl-c to wait asynchronously)
+[UPDATING] crates.io index
+[WAITING] on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
 ",
         )
         .run();
@@ -2416,13 +2416,13 @@ fn wait_for_publish_underscore() {
         .with_status(0)
         .with_stderr(
             "\
-[UPDATING] `crates-io` index
+[UPDATING] crates.io index
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] delay_with_underscore v0.0.1 ([CWD])
 [UPLOADING] delay_with_underscore v0.0.1 ([CWD])
-[UPDATING] `crates-io` index
-[WAITING] on `delay_with_underscore` to propagate to `crates-io` index (which is replacing registry `crates-io`) (ctrl-c to wait asynchronously)
+[UPDATING] crates.io index
+[WAITING] on `delay_with_underscore` to propagate to crates.io index (ctrl-c to wait asynchronously)
 ",
         )
         .run();


### PR DESCRIPTION
Built-in replacements of crates.io have confusing a description:
> crates.io index (which is replacing registry `crates-io`)

This adds a special case for built-in source replacements of `crates-io`. User-defined replacements of crates.io continue to use the existing description.

Also fixes the test framework `__CARGO_TEST_CRATES_IO_URL_DO_NOT_USE_THIS` variable to strip the `sparse+` prefix when checking if a url `is_crates_io`.

Fixes #11277
