### PR TITLE
Make cargo forward pre-existing CARGO if set

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -410,8 +410,10 @@ impl Project {
     /// Example:
     ///     p.cargo("build --bin foo").run();
     pub fn cargo(&self, cmd: &str) -> Execs {
-        let mut execs = self.process(&cargo_exe());
+        let cargo = cargo_exe();
+        let mut execs = self.process(&cargo);
         if let Some(ref mut p) = execs.process_builder {
+            p.env("CARGO", cargo);
             p.arg_line(cmd);
         }
         execs
@@ -1328,7 +1330,9 @@ impl ArgLine for snapbox::cmd::Command {
 }
 
 pub fn cargo_process(s: &str) -> Execs {
-    let mut p = process(&cargo_exe());
+    let cargo = cargo_exe();
+    let mut p = process(&cargo);
+    p.env("CARGO", cargo);
     p.arg_line(s);
     execs().with_process_builder(p)
 }

--- a/src/cargo/ops/registry/auth.rs
+++ b/src/cargo/ops/registry/auth.rs
@@ -123,7 +123,7 @@ fn run_command(
 
     let mut cmd = Command::new(&exe);
     cmd.args(args)
-        .env("CARGO", config.cargo_exe()?)
+        .env(crate::CARGO_ENV, config.cargo_exe()?)
         .env("CARGO_REGISTRY_NAME", name)
         .env("CARGO_REGISTRY_API_URL", api_url);
     match action {

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -23,6 +23,12 @@ system:
 * `CARGO_TARGET_DIR` — Location of where to place all generated artifacts,
   relative to the current working directory. See [`build.target-dir`] to set
   via config.
+* `CARGO` - If set, Cargo will forward this value instead of setting it
+  to its own auto-detected path when it builds crates and when it
+  executes build scripts and external subcommands. This value is not
+  directly executed by Cargo, and should always point at a command that
+  behaves exactly like `cargo`, as that's what users of the variable
+  will be expecting.
 * `RUSTC` — Instead of running `rustc`, Cargo will execute this specified
   compiler instead. See [`build.rustc`] to set via config.
 * `RUSTC_WRAPPER` — Instead of simply running `rustc`, Cargo will execute this

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -335,12 +335,25 @@ fn cargo_subcommand_env() {
 
     let cargo = cargo_exe().canonicalize().unwrap();
     let mut path = path();
-    path.push(target_dir);
+    path.push(target_dir.clone());
     let path = env::join_paths(path.iter()).unwrap();
 
     cargo_process("envtest")
         .env("PATH", &path)
         .with_stdout(cargo.to_str().unwrap())
+        .run();
+
+    // Check that subcommands inherit an overriden $CARGO
+    let envtest_bin = target_dir
+        .join("cargo-envtest")
+        .with_extension(std::env::consts::EXE_EXTENSION)
+        .canonicalize()
+        .unwrap();
+    let envtest_bin = envtest_bin.to_str().unwrap();
+    cargo_process("envtest")
+        .env("PATH", &path)
+        .env(cargo::CARGO_ENV, &envtest_bin)
+        .with_stdout(envtest_bin)
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3485,6 +3485,19 @@ fn cargo_test_env() {
         .with_stderr_contains(cargo.to_str().unwrap())
         .with_stdout_contains("test env_test ... ok")
         .run();
+
+    // Check that `cargo test` propagates the environment's $CARGO
+    let rustc = cargo_util::paths::resolve_executable("rustc".as_ref())
+        .unwrap()
+        .canonicalize()
+        .unwrap();
+    let rustc = rustc.to_str().unwrap();
+    p.cargo("test --lib -- --nocapture")
+        // we use rustc since $CARGO is only used if it points to a path that exists
+        .env(cargo::CARGO_ENV, rustc)
+        .with_stderr_contains(rustc)
+        .with_stdout_contains("test env_test ... ok")
+        .run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
Currently, Cargo will always set `$CARGO` to point to what it detects its own path to be (using `std::env::current_exe`). Unfortunately, this runs into trouble when Cargo is used as a library, or when `current_exe` is not actually the binary itself (e.g., when invoked through Valgrind or `ld.so`), since `$CARGO` will not point at something that can be used as `cargo`. This, in turn, means that users can't currently rely on `$CARGO` to do the right thing, and will sometimes have to invoke `cargo` directly from `$PATH` instead, which may not reflect the `cargo` that's currently in use.

This patch makes Cargo re-use the existing value of `$CARGO` if it's already set in the environment. For Cargo subcommands, this will mean that the initial invocation of `cargo` in `cargo foo` will set `$CARGO`, and then Cargo-as-a-library inside of `cargo-foo` will inherit that (correct) value instead of overwriting it with the incorrect value `cargo-foo`. For other execution environments that do not have `cargo` in their call stack, it gives them the opportunity to set a working value for `$CARGO`.

One note about the implementation of this is that the test suite now needs to override `$CARGO` explicitly so that the _user's_ `$CARGO` does not interfere with the contents of the tests. It _could_ remove `$CARGO` instead, but overriding it seemed less error-prone.

Fixes #10119.
Fixes #10113.