### PR TITLE
Fix 410 gone response handling

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -235,7 +235,7 @@ impl<'cfg> HttpRegistry<'cfg> {
                 result.with_context(|| format!("failed to download from `{}`", url))?;
                 let code = handle.response_code()?;
                 // Keep this list of expected status codes in sync with the codes handled in `load`
-                if !matches!(code, 200 | 304 | 401 | 404 | 451) {
+                if !matches!(code, 200 | 304 | 410 | 404 | 451) {
                     let url = handle.effective_url()?.unwrap_or(&url);
                     return Err(HttpNotSuccessful {
                         code,


### PR DESCRIPTION
This changes the sparse-registry support for the 410 "Gone" HTTP response code. This is out of sync with the [load function](https://github.com/rust-lang/cargo/blob/8adf1df292c20bd21f91effc6fbff1c19a514c89/src/cargo/sources/registry/http_remote.rs#L375) mentioned in the comment. I assume it is supposed to be 410 and not 401 since 401 is "Unauthorized", and that doesn't signify that the resource is "not found".

r? @arlosi 