### PR TITLE
Add a warning for invalid target cfgs

### DIFF
--- a/crates/cargo-platform/src/cfg.rs
+++ b/crates/cargo-platform/src/cfg.rs
@@ -81,6 +81,15 @@ impl CfgExpr {
         }
     }
 
+    pub fn is_valid_key(key: &str) -> bool {
+        if key.starts_with("cfg(") && key.ends_with(')') {
+            let cfg = &key[4..key.len() - 1];
+            CfgExpr::from_str(cfg).is_ok()
+        } else {
+            false
+        }
+    }
+
     pub fn matches(&self, cfg: &[Cfg]) -> bool {
         match *self {
             CfgExpr::Not(ref e) => !e.matches(cfg),


### PR DESCRIPTION
### What does this PR try to resolve?
part of https://github.com/rust-lang/cargo/issues/10893

See: https://github.com/rust-lang/cargo/issues/10893#issuecomment-1213153811

Just try to athe dd `is_valid_key` API for `CfgExpr` to add a warning for invalid target configs.

This is just an attempt. Do you guys think it works? We just ignore it now, maybe adding a warning would be an improvement. But I'm not sure if what I'm doing makes sense. Do you guys have a better suggestion?

### How should we test and review this PR?
- [ ] Unit test(TODO)