### PR TITLE
Add Accept-Encoding request header to enable compression

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -643,6 +643,9 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
         handle.useragent(&format!("cargo {}", version()))?;
     }
 
+    // Empty string accept encoding expands to the encodings supported by the current libcurl.
+    handle.accept_encoding("")?;
+
     fn to_ssl_version(s: &str) -> CargoResult<SslVersion> {
         let version = match s {
             "default" => SslVersion::Default,


### PR DESCRIPTION
### What does this PR try to resolve?

Cargo does not request compression from servers. Enabling compression can save bandwidth and improve performance.

### How should we test and review this PR?

I validated locally that the header was being sent using a local proxy (Fiddler). It sent `Accept-Encoding: deflate, gzip` on Windows.