### PR TITLE
Migrate from highfive to triagebot

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,5 +1,3 @@
-[assign]
-
 [ping.windows]
 message = """\
 Hey Windows Group! This bug has been identified as a good "Windows candidate".
@@ -13,3 +11,11 @@ label = "O-windows"
 
 [shortcut]
 
+[autolabel."S-waiting-on-review"]
+new_pr = true
+
+[assign]
+contributing_url = "https://rust-lang.github.io/cargo/contrib/"
+
+[assign.owners]
+"*" = ["@ehuss", "@epage", "@weihanglo"]


### PR DESCRIPTION
This migrates the rust-lang/cargo repo to use triagebot instead of highfive.