### PR TITLE
Update contrib docs for highfive transition

### DIFF
--- a/src/doc/contrib/src/process/index.md
+++ b/src/doc/contrib/src/process/index.md
@@ -95,18 +95,19 @@ implemented.
 The Cargo project uses several bots:
 
 * [GitHub Actions] are used to automatically run all tests for each PR.
-* [rust-highfive] automatically assigns reviewers for PRs.
+* [triagebot] automatically assigns reviewers for PRs, see [Assignment] for
+  how to configure.
 * [bors] is used to merge PRs. See [The merging process].
 * [triagebot] is used for assigning issues to non-members, see [Issue
   assignment](#issue-assignment).
 * [rfcbot] is used for making asynchronous decisions by team members.
 
-[rust-highfive]: https://github.com/rust-highfive
 [bors]: https://buildbot2.rust-lang.org/homu/
 [The merging process]: working-on-cargo.md#the-merging-process
 [GitHub Actions]: https://github.com/features/actions
 [triagebot]: https://github.com/rust-lang/triagebot/wiki
 [rfcbot]: https://github.com/rust-lang/rfcbot-rs
+[Assignment]: https://github.com/rust-lang/triagebot/wiki/Assignment
 
 ## Issue assignment
 

--- a/src/doc/contrib/src/process/working-on-cargo.md
+++ b/src/doc/contrib/src/process/working-on-cargo.md
@@ -110,7 +110,7 @@ open a Pull Request
   #1234 to the PR. When the PR is merged, GitHub will automatically close the
   issue.
 
-The [rust-highfive] bot will automatically assign a reviewer for the PR. It
+[`@rustbot`] will automatically assign a reviewer for the PR. It
 may take at least a few days for someone to respond. If you don't get a
 response in over a week, feel free to ping the assigned reviewer.
 
@@ -162,7 +162,6 @@ more information on how Cargo releases are made.
 [how-to-clone]: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository
 [Testing chapter]: ../tests/index.md
 [GitHub's keywords]: https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue
-[rust-highfive]: https://github.com/rust-highfive
 [bors]: https://buildbot2.rust-lang.org/homu/
 [`@bors`]: https://github.com/bors
 [homu-cargo]: https://buildbot2.rust-lang.org/homu/queue/cargo


### PR DESCRIPTION
As of #11293, this repo is now using triagebot (AKA @rustbot) for auto-assignment of PRs. This PR updates the contributor documentation to accommodate this change.