### PR TITLE
Added more optimizations to the 'release' profile

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -683,6 +683,8 @@ impl Profile {
             name: InternedString::new("release"),
             root: ProfileRoot::Release,
             opt_level: InternedString::new("3"),
+            lto: Lto::Bool(true),
+            codegen_units: Some(1),
             ..Profile::default()
         }
     }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR adds even more optimizations to the release profile, it enables the link time optimizations and adds the codegen-units flag with a value of 1.
I created this pull request so that release can truly live up to its name, and be much more optimized, although, yes, at the cost of a longer build time. With that being said, I think this is a good compromise for many people who, like me, are looking for the most optimized build binaries.

### How should we test and review this PR?

To test this, simply take any existing Rust project, and build it with my cargo fork with the added optimizations, and compare the performance of the output binary to one produced by a regular cargo.
