### PR TITLE
Add global option --absolute-paths

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -333,6 +333,7 @@ fn config_configure(
     let frozen = args.flag("frozen") || global_args.frozen;
     let locked = args.flag("locked") || global_args.locked;
     let offline = args.flag("offline") || global_args.offline;
+    let absolute_paths = args.flag("absolute-paths") || global_args.offline;
     let mut unstable_flags = global_args.unstable_flags;
     if let Some(values) = args.get_many::<String>("unstable-features") {
         unstable_flags.extend(values.cloned());
@@ -351,6 +352,7 @@ fn config_configure(
         arg_target_dir,
         &unstable_flags,
         &config_args,
+        absolute_paths,
     )?;
     Ok(())
 }
@@ -470,6 +472,7 @@ See 'cargo help <command>' for more information on a specific command.\n",
         .arg(flag("frozen", "Require Cargo.lock and cache are up to date").global(true))
         .arg(flag("locked", "Require Cargo.lock is up to date").global(true))
         .arg(flag("offline", "Run without accessing the network").global(true))
+        .arg(flag("absolute-paths", "Use absolute paths when calling rust").global(true))
         .arg(multi_opt("config", "KEY=VALUE", "Override a configuration value").global(true))
         .arg(
             Arg::new("unstable-features")

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -200,6 +200,8 @@ pub struct Config {
     doc_extern_map: LazyCell<RustdocExternMap>,
     progress_config: ProgressConfig,
     env_config: LazyCell<EnvConfig>,
+    /// Use absolute paths when invoking rustc
+    absolute_paths: bool,
     /// This should be false if:
     /// - this is an artifact of the rustc distribution process for "stable" or for "beta"
     /// - this is an `#[test]` that does not opt in with `enable_nightly_features`
@@ -274,6 +276,7 @@ impl Config {
             frozen: false,
             locked: false,
             offline: false,
+            absolute_paths: false,
             jobserver: unsafe {
                 if GLOBAL_JOBSERVER.is_null() {
                     None
@@ -896,6 +899,7 @@ impl Config {
         target_dir: &Option<PathBuf>,
         unstable_flags: &[String],
         cli_config: &[String],
+        absolute_paths: bool,
     ) -> CargoResult<()> {
         for warning in self
             .unstable_flags
@@ -961,6 +965,7 @@ impl Config {
                 .and_then(|n| n.offline)
                 .unwrap_or(false);
         self.target_dir = cli_target_dir;
+        self.absolute_paths = absolute_paths;
 
         self.load_unstable_flags_from_config()?;
 
@@ -1012,6 +1017,10 @@ impl Config {
 
     pub fn lock_update_allowed(&self) -> bool {
         !self.frozen && !self.locked
+    }
+
+    pub fn absolute_paths(&self) -> bool {
+        self.absolute_paths
     }
 
     /// Loads configuration from the filesystem.

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -116,8 +116,12 @@ pub fn path_args(ws: &Workspace<'_>, unit: &Unit) -> (PathBuf, PathBuf) {
     };
     assert!(src.is_absolute());
     if unit.pkg.package_id().source_id().is_path() {
-        if let Ok(path) = src.strip_prefix(ws_root) {
-            return (path.to_path_buf(), ws_root.to_path_buf());
+        if ws.config().absolute_paths() {
+            return (src, ws_root.to_path_buf());
+        } else {
+            if let Ok(path) = src.strip_prefix(ws_root) {
+                return (path.to_path_buf(), ws_root.to_path_buf());
+            }
         }
     }
     (src, unit.pkg.root().to_path_buf())

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -90,6 +90,7 @@ impl ConfigBuilder {
             &None,
             &self.unstable,
             &self.config_args,
+            false,
         )?;
         Ok(config)
     }

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -224,3 +224,26 @@ dependencies; the dependency on `baz` was either added or\
         )
         .run();
 }
+
+#[cargo_test]
+fn absolute_path_tests() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+            "#,
+        )
+        .file("src/main.rs", "fn main() { failure }")
+        .build();
+
+    println!("{}", foo.root().to_str().unwrap());
+    foo.cargo("--absolute-paths build")
+        .with_stderr_contains("[..]--> [ROOT]/foo/src/main.rs:1:13[..]")
+        .with_stderr_contains("[COMPILING] foo v0.0.1 ([ROOT]/foo)")
+        .with_status(101)
+        .run();
+}


### PR DESCRIPTION
Using this option will call rustc with absolute file paths and rustc will report absolute paths in error cases etc. This will cause the build cache to invalidate when the folder is moved, but will make external integrations easier.

### What does this PR try to resolve?
Closes #5450

Adds option `--absolute-paths` that will run and print absolute paths when invoking rustc.
This makes integration in IDEs easier and allows output paths to be clicked.


<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
