### PR TITLE
Fix singular verb in tests page

### DIFF
--- a/src/doc/src/guide/tests.md
+++ b/src/doc/src/guide/tests.md
@@ -33,7 +33,7 @@ This will run any test with `foo` in its name.
 
 `cargo test` runs additional checks as well. It will compile any examples
 you’ve included to ensure they still compile. It also runs documentation
-tests to ensure your code samples from documentation comments compiles.
+tests to ensure your code samples from documentation comments compile.
 Please see the [testing guide][testing] in the Rust documentation for a general
 view of writing and organizing tests. See [Cargo Targets: Tests] to learn more
 about different styles of tests in Cargo.


### PR DESCRIPTION
The word "compile" refers to the "code samples" which is plural.