### PR TITLE
Fix cargo install --index when used with registry.default

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -126,10 +126,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     } else if krates.is_empty() {
         from_cwd = true;
         SourceId::for_path(config.cwd())?
-    } else if let Some(registry) = args.registry(config)? {
-        SourceId::alt_registry(config, &registry)?
     } else if let Some(index) = args.get_one::<String>("index") {
         SourceId::for_registry(&index.into_url()?)?
+    } else if let Some(registry) = args.registry(config)? {
+        SourceId::alt_registry(config, &registry)?
     } else {
         SourceId::crates_io(config)?
     };

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -1031,11 +1031,8 @@ fn get_source_id(
 ) -> CargoResult<RegistrySourceIds> {
     let sid = match (reg, index) {
         (None, None) => SourceId::crates_io(config)?,
+        (_, Some(i)) => SourceId::for_registry(&i.into_url()?)?,
         (Some(r), None) => SourceId::alt_registry(config, r)?,
-        (None, Some(i)) => SourceId::for_registry(&i.into_url()?)?,
-        (Some(_), Some(_)) => {
-            bail!("both `--index` and `--registry` should not be set at the same time")
-        }
     };
     // Load source replacements that are built-in to Cargo.
     let builtin_replacement_sid = SourceConfigMap::empty(config)?

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1291,6 +1291,25 @@ fn both_index_and_registry() {
 }
 
 #[cargo_test]
+fn both_index_and_default() {
+    let p = project().file("src/lib.rs", "").build();
+    for cmd in &[
+        "publish",
+        "owner",
+        "search",
+        "yank --version 1.0.0",
+        "install foo",
+    ] {
+        p.cargo(cmd)
+            .env("CARGO_REGISTRY_DEFAULT", "undefined")
+            .arg(format!("--index=index_url"))
+            .with_status(101)
+            .with_stderr("[ERROR] invalid url `index_url`: relative URL without a base")
+            .run();
+    }
+}
+
+#[cargo_test]
 fn sparse_lockfile() {
     let _registry = registry::RegistryBuilder::new()
         .http_index()


### PR DESCRIPTION
Setting `registry.default` causes the `args.registry` call to return the default registry as if it were passed through `--registry`, which leaves the `--index` argument ignored in `cargo install`, since `registry` is checked first.

Fixes #11301 by checking for `index` before `registry`.

Note that if you try to pass both `--index` and `--registry`, then a command-line parser error (correctly) occurs:
```
The argument '--registry <REGISTRY>' cannot be used with '--index <INDEX>'
```