### PR TITLE
Update libcurl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.1" }
 crates-io = { path = "crates/crates-io", version = "0.34.0" }
-curl = { version = "0.4.43", features = ["http2"] }
-curl-sys = "0.4.55"
+curl = { version = "0.4.44", features = ["http2"] }
+curl-sys = "0.4.58"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0"


### PR DESCRIPTION
This updates to the latest libcurl from 7.83.1 to 7.86.0. There are extensive changes documented thoroughly at https://curl.se/changes.html. There are 5 CVEs as documented at https://curl.se/docs/security.html, though none of them look particularly serious for our use case.

This adds a limit of TLS 1.2 for Windows. There have been some issues with TLS 1.3 (which was recently added), and I'm not confident enabling it, yet. Perhaps some day in the future when it looks like it is more reliable, the limit can be removed.
