### PR TITLE
Add warning when PATH env separator is in project path

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -19,15 +19,17 @@ use tempfile::Builder as TempFileBuilder;
 /// error message.
 pub fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> Result<OsString> {
     env::join_paths(paths.iter()).with_context(|| {
-        let paths = paths.iter().map(Path::new).collect::<Vec<_>>();
+        let paths = paths.iter()
+            .map(|s| s.as_ref().to_string_lossy())
+            .map(|s| format!("  \"{s}\""))
+            .collect::<Vec<String>>()
+            .join(",\n");
+
         format!(
-            "failed to join paths from `${}` together\
-                 \n    \
-                 If you set `${}` manually, check if it contains an unterminated quote character \
-                 or path separators (usually `:` or `:`). Please avoid using them.\
-                 \n\n    \
-                 Otherwise, check if any of paths listed contain one of those characters: {:?}",
-            env, env, paths
+            "failed to join paths from `${env}` together\n\
+                 If you set `${env}` manually, check if it contains an unterminated quote character \
+                 or path separators (usually `:` or `;`). Please avoid using them. \
+                 Otherwise, check if any of paths listed below contain one of those characters:\n{paths}"
         )
     })
 }

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -18,18 +18,18 @@ use tempfile::Builder as TempFileBuilder;
 /// environment variable this is will be used for, which is included in the
 /// error message.
 pub fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> Result<OsString> {
-    env::join_paths(paths.iter())
-        .with_context(|| {
-            let paths = paths.iter().map(Path::new).collect::<Vec<_>>();
-            format!("failed to join path array: {:?}", paths)
-        })
-        .with_context(|| {
-            format!(
-                "failed to join search paths together\n\
-                     Does ${} have an unterminated quote character?",
-                env
-            )
-        })
+    env::join_paths(paths.iter()).with_context(|| {
+        let paths = paths.iter().map(Path::new).collect::<Vec<_>>();
+        format!(
+            "failed to join paths from `${}` together\
+                 \n    \
+                 If you set `${}` manually, check if it contains an unterminated quote character \
+                 or path separators (usually `:` or `:`). Please avoid using them.\
+                 \n\n    \
+                 Otherwise, check if any of paths listed contain one of those characters: {:?}",
+            env, env, paths
+        )
+    })
 }
 
 /// Returns the name of the environment variable used for searching for

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -19,18 +19,17 @@ use tempfile::Builder as TempFileBuilder;
 /// error message.
 pub fn join_paths<T: AsRef<OsStr>>(paths: &[T], env: &str) -> Result<OsString> {
     env::join_paths(paths.iter()).with_context(|| {
-        let paths = paths.iter()
-            .map(|s| s.as_ref().to_string_lossy())
-            .map(|s| format!("  \"{s}\""))
-            .collect::<Vec<String>>()
-            .join(",\n");
+        let mut message = format!(
+            "failed to join paths from `${env}` together\n\n\
+             Check if any of path segments listed below contain an \
+             unterminated quote character or path separator:"
+        );
+        for path in paths {
+            use std::fmt::Write;
+            write!(&mut message, "\n    {:?}", Path::new(path)).unwrap();
+        }
 
-        format!(
-            "failed to join paths from `${env}` together\n\
-                 If you set `${env}` manually, check if it contains an unterminated quote character \
-                 or path separators (usually `:` or `;`). Please avoid using them. \
-                 Otherwise, check if any of paths listed below contain one of those characters:\n{paths}"
-        )
+        message
     })
 }
 
@@ -744,4 +743,45 @@ fn exclude_from_time_machine(path: &Path) {
     }
     // Errors are ignored, since it's an optional feature and failure
     // doesn't prevent Cargo from working
+}
+
+#[cfg(test)]
+mod tests {
+    use super::join_paths;
+
+    #[test]
+    fn join_paths_lists_paths_on_error() {
+        let valid_paths = vec!["/testing/one", "/testing/two"];
+        // does not fail on valid input
+        let _joined = join_paths(&valid_paths, "TESTING1").unwrap();
+
+        #[cfg(unix)]
+        {
+            let invalid_paths = vec!["/testing/one", "/testing/t:wo/three"];
+            let err = join_paths(&invalid_paths, "TESTING2").unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "failed to join paths from `$TESTING2` together\n\n\
+             Check if any of path segments listed below contain an \
+             unterminated quote character or path separator:\
+             \n    \"/testing/one\"\
+             \n    \"/testing/t:wo/three\"\
+             "
+            );
+        }
+        #[cfg(windows)]
+        {
+            let invalid_paths = vec!["/testing/one", "/testing/t\"wo/three"];
+            let err = join_paths(&invalid_paths, "TESTING2").unwrap_err();
+            assert_eq!(
+                err.to_string(),
+                "failed to join paths from `$TESTING2` together\n\n\
+             Check if any of path segments listed below contain an \
+             unterminated quote character or path separator:\
+             \n    \"/testing/one\"\
+             \n    \"/testing/t\\\"wo/three\"\
+             "
+            );
+        }
+    }
 }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -261,6 +261,18 @@ fn check_name(
     Ok(())
 }
 
+/// Checks if the path contains any invalid PATH env characters.
+fn check_path(path: &Path, shell: &mut Shell) -> CargoResult<()> {
+    if path.to_string_lossy().contains(&[';', ':', '"'][..]) {
+        shell.warn(format!(
+            "the path `{}` contains invalid PATH characters (usually `:`, `;`, or `\"`)\n\
+            It is recommended to use a different name to avoid problems.",
+            path.to_string_lossy()
+        ))?;
+    }
+    Ok(())
+}
+
 fn detect_source_paths_and_types(
     package_path: &Path,
     package_name: &str,
@@ -421,6 +433,8 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
         )
     }
 
+    check_path(path, &mut config.shell())?;
+
     let is_bin = opts.kind.is_bin();
 
     let name = get_name(path, opts)?;
@@ -457,6 +471,8 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<NewProjectKind> {
     if path.join("Cargo.toml").exists() {
         anyhow::bail!("`cargo init` cannot be run on existing Cargo packages")
     }
+
+    check_path(path, &mut config.shell())?;
 
     let name = get_name(path, opts)?;
 

--- a/tests/testsuite/init/mod.rs
+++ b/tests/testsuite/init/mod.rs
@@ -28,6 +28,7 @@ mod mercurial_autodetect;
 mod multibin_project_name_clash;
 #[cfg(not(windows))]
 mod no_filename;
+mod path_contains_separator;
 mod pijul_autodetect;
 mod reserved_name;
 mod simple_bin;

--- a/tests/testsuite/init/mod.rs
+++ b/tests/testsuite/init/mod.rs
@@ -28,6 +28,7 @@ mod mercurial_autodetect;
 mod multibin_project_name_clash;
 #[cfg(not(windows))]
 mod no_filename;
+#[cfg(unix)]
 mod path_contains_separator;
 mod pijul_autodetect;
 mod reserved_name;

--- a/tests/testsuite/init/path_contains_separator/in/test:ing/mod.rs
+++ b/tests/testsuite/init/path_contains_separator/in/test:ing/mod.rs
@@ -1,0 +1,7 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::{command_is_available, paths, Project};
+use std::fs;
+use std::process::Command;
+
+use crate::test_root;

--- a/tests/testsuite/init/path_contains_separator/in/test:ing/mod.rs
+++ b/tests/testsuite/init/path_contains_separator/in/test:ing/mod.rs
@@ -1,7 +1,0 @@
-use cargo_test_support::compare::assert_ui;
-use cargo_test_support::prelude::*;
-use cargo_test_support::{command_is_available, paths, Project};
-use std::fs;
-use std::process::Command;
-
-use crate::test_root;

--- a/tests/testsuite/init/path_contains_separator/mod.rs
+++ b/tests/testsuite/init/path_contains_separator/mod.rs
@@ -1,6 +1,6 @@
 use cargo_test_support::compare::assert_ui;
 use cargo_test_support::prelude::*;
-use cargo_test_support::Project;
+use cargo_test_support::{t, Project};
 
 use cargo_test_support::curr_dir;
 
@@ -8,6 +8,10 @@ use cargo_test_support::curr_dir;
 fn path_contains_separator() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root().join("test:ing");
+
+    if !project_root.exists() {
+        t!(std::fs::create_dir(&project_root));
+    }
 
     snapbox::cmd::Command::cargo_ui()
         .arg_line("init --bin --vcs none --edition 2015 --name testing")

--- a/tests/testsuite/init/path_contains_separator/mod.rs
+++ b/tests/testsuite/init/path_contains_separator/mod.rs
@@ -1,0 +1,22 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::Project;
+
+use cargo_test_support::curr_dir;
+
+#[cargo_test]
+fn path_contains_separator() {
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = &project.root().join("test:ing");
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg_line("init --bin --vcs none --edition 2015 --name testing")
+        .current_dir(project_root)
+        .assert()
+        .success()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), project_root);
+    assert!(!project_root.join(".gitignore").is_file());
+}

--- a/tests/testsuite/init/path_contains_separator/out/Cargo.toml
+++ b/tests/testsuite/init/path_contains_separator/out/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "testing"
+version = "0.1.0"
+edition = "2015"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/testsuite/init/path_contains_separator/out/src/main.rs
+++ b/tests/testsuite/init/path_contains_separator/out/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/testsuite/init/path_contains_separator/stderr.log
+++ b/tests/testsuite/init/path_contains_separator/stderr.log
@@ -1,3 +1,3 @@
-warning: the path `[ROOT]/case/test:ing/.` contains PATH separators (usually `:` or `:`)
+warning: the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)
 It is recommended to use a different name to avoid problems.
      Created binary (application) package

--- a/tests/testsuite/init/path_contains_separator/stderr.log
+++ b/tests/testsuite/init/path_contains_separator/stderr.log
@@ -1,0 +1,3 @@
+warning: the path `[ROOT]/case/test:ing/.` contains PATH separators (usually `:` or `:`)
+It is recommended to use a different name to avoid problems.
+     Created binary (application) package

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -529,3 +529,17 @@ Caused by:
         )
         .run();
 }
+
+#[cfg(unix)]
+#[cargo_test]
+fn path_with_invalid_character() {
+    cargo_process("new --name testing test:ing")
+        .with_stderr(
+            "\
+[WARNING] the path `[CWD]/test:ing` contains invalid PATH characters (usually `:`, `;`, or `\"`)
+It is recommended to use a different name to avoid problems.
+[CREATED] binary (application) `testing` package
+",
+        )
+        .run();
+}


### PR DESCRIPTION
Closes #3736 

Adds a check during `cargo init` and `cargo new` to check if the path contains an invalid PATH character (`:`, `;`, or `"`). These characters can break things in various ways (including `cargo test`). These characters are not valid in certain environment variables and cannot be escaped.

For more information see:
https://github.com/rust-lang/rust/blob/7feb003882ecf7699e6705b537673e20985accff/library/std/src/sys/unix/os.rs#L233
https://man7.org/linux/man-pages/man8/ld.so.8.html
https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html
https://doc.rust-lang.org/std/env/fn.join_paths.html#errors

To test cargo new and cargo init:
`cargo new --name testing test:ing`
`mkdir test:ing2 && cd 'test:ing2' && cargo init --name testing`

To test the updated error message when in a directory with invalid characters:
`cargo new testing3 && mv testing3 test:ing3 && cd 'test:ing3' && cargo test`

cc @weihanglo 


<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
