### PR TITLE
fix: gleaning rustdocflags from `target.cfg(…)` is not supported

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -749,9 +749,15 @@ fn rustflags_from_target(
             .target_cfgs()?
             .iter()
             .filter_map(|(key, cfg)| {
-                cfg.rustflags
-                    .as_ref()
-                    .map(|rustflags| (key, &rustflags.val))
+                match flag {
+                    Flags::Rust => cfg
+                        .rustflags
+                        .as_ref()
+                        .map(|rustflags| (key, &rustflags.val)),
+                    // `target.cfg(…).rustdocflags` is currently not supported.
+                    // In fact, neither is `target.<triple>.rustdocflags`.
+                    Flags::Rustdoc => None,
+                }
             })
             .filter(|(key, _rustflags)| CfgExpr::matches_key(key, target_cfg))
             .for_each(|(_key, cfg_rustflags)| {

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -122,3 +122,35 @@ fn whitespace() {
     let contents = p.read_file("target/doc/foo/index.html");
     assert!(contents.contains(SPACED_VERSION));
 }
+
+#[cargo_test]
+fn not_affected_by_target_rustflags() {
+    let cfg = if cfg!(windows) { "windows" } else { "unix" };
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config",
+            &format!(
+                r#"
+                    [target.'cfg({cfg})']
+                    rustflags = ["-D", "missing-docs"]
+
+                    [build]
+                    rustdocflags = ["--cfg", "foo"]
+                "#,
+            ),
+        )
+        .build();
+
+    // `cargo build` should fail due to missing docs.
+    p.cargo("build -v")
+        .with_status(101)
+        .with_stderr_contains("[RUNNING] `rustc [..] -D missing-docs[..]`")
+        .run();
+
+    // This is wrong behaviour. `cargo doc` shouldn't fail.
+    p.cargo("doc -v")
+        .with_status(101)
+        .with_stderr_contains("[RUNNING] `rustdoc [..] -D missing-docs[..]`")
+        .run();
+}

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -148,9 +148,8 @@ fn not_affected_by_target_rustflags() {
         .with_stderr_contains("[RUNNING] `rustc [..] -D missing-docs[..]`")
         .run();
 
-    // This is wrong behaviour. `cargo doc` shouldn't fail.
+    // `cargo doc` shouldn't fail.
     p.cargo("doc -v")
-        .with_status(101)
-        .with_stderr_contains("[RUNNING] `rustdoc [..] -D missing-docs[..]`")
+        .with_stderr_contains("[RUNNING] `rustdoc [..] --cfg foo[..]`")
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #11310 

The bug was `rustflags_from_target` trying to learn rustdocflags from
`target.cfg(…).rustflags`, which is definitely wrong.

As of this writing, either `target.cfg(…).rustdocflags` or
`target.<triple>.rustdocflags` is not supported.

### How should we test and review this PR?

See f8d1b30ad3fe1d5fa0f172031de7c937b235f3ba as an example.
<!-- homu-ignore:end -->
