### PR TITLE
Update curl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.1" }
 crates-io = { path = "crates/crates-io", version = "0.34.0" }
 curl = { version = "0.4.44", features = ["http2"] }
-curl-sys = "0.4.58"
+curl-sys = "0.4.59"
 env_logger = "0.9.0"
 pretty_env_logger = { version = "0.4", optional = true }
 anyhow = "1.0.47"


### PR DESCRIPTION
This updates curl-sys which pulls in https://github.com/alexcrichton/curl-rust/pull/472 which should fix the build errors with clang.