### PR TITLE
chore: Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ features = [
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
 same-file = "1.0.6"
-snapbox = { version = "0.3.0", features = ["diff", "path"] }
+snapbox = { version = "0.4.0", features = ["diff", "path"] }
 
 [build-dependencies]
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1.0.34"
 cargo-test-macro = { path = "../cargo-test-macro" }
 cargo-util = { path = "../cargo-util" }
 crates-io = { path = "../crates-io" }
-snapbox = { version = "0.3.0", features = ["diff", "path"] }
+snapbox = { version = "0.4.0", features = ["diff", "path"] }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
 git2 = "0.15.0"

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -24,5 +24,5 @@ walkdir = "2.3.1"
 core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
-miow = "0.3.6"
+miow = "0.4.0"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }


### PR DESCRIPTION
This upgrades several dependencies to the latest "major" release.  The original intent was just to get onto the latest snapbox but I noticed several others that could be updated and thought "why not".

- `snapbox` broke compatibility on less used APIs
- Its unclear from the docs if `miow` or `remove_dir_all` even broke compatibility

I did not touch `mdman` as that has several large, stale deps