### PR TITLE
fix(semver-check): adapt to a different error for variant not covered

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -391,7 +391,7 @@ pub enum E {
 fn main() {
     use updated_crate::E;
     let x = E::Variant1;
-    match x { // Error: `Variant2` not covered
+    match x { // Error: `E::Variant2` not covered
         E::Variant1 => {}
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

Here foudn the error <https://github.com/rust-lang/cargo/actions/runs/3387258044/jobs/5627752968>.

I am not sure which commit in rust-lang/rust is causing the error, but this PR should work.
<!-- homu-ignore:end -->
