### PR TITLE
Remove remove_dir_all

### DIFF
--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -19,7 +19,6 @@ git2 = "0.15.0"
 glob = "0.3"
 itertools = "0.10.0"
 lazy_static = "1.0"
-remove_dir_all = "0.5"
 serde_json = "1.0"
 tar = { version = "0.4.38", default-features = false }
 termcolor = "1.1.2"

--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -141,7 +141,7 @@ impl CargoPathExt for Path {
         // actually performing the removal, but we don't care all that much
         // for our tests.
         if meta.is_dir() {
-            if let Err(e) = remove_dir_all::remove_dir_all(self) {
+            if let Err(e) = fs::remove_dir_all(self) {
                 panic!("failed to remove {:?}: {:?}", self, e)
             }
         } else if let Err(e) = fs::remove_file(self) {


### PR DESCRIPTION
This removes the `remove_dir_all` dependency. It is no longer needed, as there has been significant improvements to std's implementation over the years (particularly recently). This improves the performance of running cargo's testsuite on my machine from 8m to 2m 30s (!!).  

This was added in #7137 to deal with some issues with symbolic links. I believe those seem to be resolved now.

Note that std's implementation is still not bullet proof. In particular, I think there are still some cases where a file can be locked by another process which prevents it from being removed. There are some more notes about this at https://github.com/rust-lang/cargo/pull/7042#issuecomment-504081900 (and various other places linked there).

Closes #9585