### PR TITLE
Clean more aggressively in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,13 @@ jobs:
 
     # Deny warnings on CI to avoid warnings getting into the codebase.
     - run: cargo test --features 'deny-warnings'
+    # The testsuite generates a huge amount of data, and fetch-smoke-test was
+    # running out of disk space.
+    - name: Clear test output
+      run: |
+        df -h
+        rm -rf target/tmp
+        df -h
     - name: Check operability of rustc invocation with argfile
       env:
         __CARGO_TEST_FORCE_ARGFILE: 1
@@ -111,7 +118,7 @@ jobs:
         cargo check --manifest-path benches/capture/Cargo.toml
     # The testsuite generates a huge amount of data, and fetch-smoke-test was
     # running out of disk space.
-    - name: Clear test output
+    - name: Clear benchmark output
       run: |
         df -h
         rm -rf target/tmp


### PR DESCRIPTION
The Windows x86_64 gnu CI job is running dangerously low on disk space. This PR adds another step to delete test output more aggressively. The test output with x86_64-pc-windows-gnu is nearly 9.5GB. The benchmark step is adding about 1GB of space (unfortunately it is rebuilding cargo, which may be hard to avoid without a workspace).

Eventually we should probably look at figuring out how to reduce the amount of disk space used by the testsuite. Perhaps something like #9701 (see comments there). Or, making aggressive changes to the tests themselves. Many tests can probably be changed to use `cargo check` instead of `cargo build` (or maybe even `cargo tree`). We can default to not generating debuginfo. Or perhaps there are other changes to put the tests on a diet.
