### PR TITLE
Error when precise without -p flag

### DIFF
--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -9,17 +9,21 @@ pub fn cli() -> Command {
         .arg_quiet()
         .arg(flag("workspace", "Only update the workspace packages").short('w'))
         .arg_package_spec_simple("Package to update")
-        .arg(flag(
-            "aggressive",
-            "Force updating all dependencies of SPEC as well when used with -p",
-        ))
+        .arg(
+            flag(
+                "aggressive",
+                "Force updating all dependencies of SPEC as well when used with -p",
+            )
+            .requires("package"),
+        )
         .arg_dry_run("Don't actually write the lockfile")
         .arg(
             opt(
                 "precise",
                 "Update a single dependency to exactly PRECISE when used with -p",
             )
-            .value_name("PRECISE"),
+            .value_name("PRECISE")
+            .requires("package"),
         )
         .arg_manifest_path()
         .after_help("Run `cargo help update` for more detailed information.\n")

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -9,13 +9,10 @@ pub fn cli() -> Command {
         .arg_quiet()
         .arg(flag("workspace", "Only update the workspace packages").short('w'))
         .arg_package_spec_simple("Package to update")
-        .arg(
-            flag(
-                "aggressive",
-                "Force updating all dependencies of SPEC as well when used with -p",
-            )
-            .requires("package"),
-        )
+        .arg(flag(
+            "aggressive",
+            "Force updating all dependencies of SPEC as well when used with -p",
+        ))
         .arg_dry_run("Don't actually write the lockfile")
         .arg(
             opt(

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -36,25 +36,6 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
 }
 
 pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoResult<()> {
-    // Currently this is only a warning, but after a transition period this will become
-    // a hard error.
-    // See https://github.com/rust-lang/cargo/issues/10919#issuecomment-1214464756.
-    // We should declare the `precise` and `aggressive` arguments
-    // require the `package` argument in the clap.
-    if opts.aggressive && opts.to_update.is_empty() {
-        ws.config().shell().warn(
-            "aggressive is only supported with \"--package <SPEC>\", \
-        this will become a hard error in a future release.",
-        )?;
-    }
-
-    if opts.precise.is_some() && opts.to_update.is_empty() {
-        ws.config().shell().warn(
-            "precise is only supported with \"--package <SPEC>\", \
-        this will become a hard error in a future release.",
-        )?;
-    }
-
     if opts.aggressive && opts.precise.is_some() {
         anyhow::bail!("cannot specify both aggressive and precise simultaneously")
     }

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -453,11 +453,15 @@ fn update_precise_without_package() {
     Package::new("serde", "0.3.0").publish();
 
     p.cargo("update --precise 0.3.0")
+        .with_status(1)
         .with_stderr(
             "\
-[WARNING] precise is only supported with \"--package <SPEC>\", this will become a hard error in a future release.
-[UPDATING] `[..]` index
-[UPDATING] serde v0.2.0 -> v0.2.1
+[ERROR] The following required arguments were not provided:
+  --package [<SPEC>]
+
+Usage: cargo[EXE] update --package [<SPEC>] --precise <PRECISE>
+
+For more information try '--help'
 ",
         )
         .run();
@@ -525,11 +529,15 @@ fn update_aggressive_without_package() {
     Package::new("serde", "0.2.1").publish();
 
     p.cargo("update --aggressive")
+        .with_status(1)
         .with_stderr(
             "\
-[WARNING] aggressive is only supported with \"--package <SPEC>\", this will become a hard error in a future release.
-[UPDATING] `[..]` index
-[UPDATING] serde v0.2.0 -> v0.2.1
+[ERROR] The following required arguments were not provided:
+  --package [<SPEC>]
+
+Usage: cargo[EXE] update --package [<SPEC>] --aggressive
+
+For more information try '--help'
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -428,46 +428,6 @@ fn update_precise_do_not_force_update_deps() {
 }
 
 #[cargo_test]
-fn update_precise_without_package() {
-    Package::new("serde", "0.2.0").publish();
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.0.1"
-                authors = []
-
-                [dependencies]
-                serde = "0.2"
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("build").run();
-
-    Package::new("serde", "0.2.1").publish();
-    Package::new("serde", "0.3.0").publish();
-
-    p.cargo("update --precise 0.3.0")
-        .with_status(1)
-        .with_stderr(
-            "\
-[ERROR] The following required arguments were not provided:
-  --package [<SPEC>]
-
-Usage: cargo[EXE] update --package [<SPEC>] --precise <PRECISE>
-
-For more information try '--help'
-",
-        )
-        .run();
-}
-
-#[cargo_test]
 fn update_aggressive() {
     Package::new("log", "0.1.0").publish();
     Package::new("serde", "0.2.1").dep("log", "0.1").publish();
@@ -499,45 +459,6 @@ fn update_aggressive() {
 [UPDATING] `[..]` index
 [UPDATING] log v0.1.0 -> v0.1.1
 [UPDATING] serde v0.2.1 -> v0.2.2
-",
-        )
-        .run();
-}
-
-#[cargo_test]
-fn update_aggressive_without_package() {
-    Package::new("serde", "0.2.0").publish();
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "bar"
-                version = "0.0.1"
-                authors = []
-
-                [dependencies]
-                serde = "0.2"
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("build").run();
-
-    Package::new("serde", "0.2.1").publish();
-
-    p.cargo("update --aggressive")
-        .with_status(1)
-        .with_stderr(
-            "\
-[ERROR] The following required arguments were not provided:
-  --package [<SPEC>]
-
-Usage: cargo[EXE] update --package [<SPEC>] --aggressive
-
-For more information try '--help'
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/10919

Follow up https://github.com/rust-lang/cargo/pull/10988, see https://github.com/rust-lang/cargo/issues/10919#issuecomment-1214464756

### How should we test and review this PR?

You can manually build and test it. You can try `cargo update --precise xxx` without -p flag.

### Additional information
It has already been released on stable. `rustc 1.65.0 (897e37553 2022-11-02)`
