### PR TITLE
Propagate change of artifact bin dep to its parent fingerprint

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -1254,20 +1254,24 @@ fn calculate(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Arc<Fingerpri
 /// Calculate a fingerprint for a "normal" unit, or anything that's not a build
 /// script. This is an internal helper of `calculate`, don't call directly.
 fn calculate_normal(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Fingerprint> {
-    // Recursively calculate the fingerprint for all of our dependencies.
-    //
-    // Skip fingerprints of binaries because they don't actually induce a
-    // recompile, they're just dependencies in the sense that they need to be
-    // built.
-    //
-    // Create Vec since mutable cx is needed in closure.
-    let deps = Vec::from(cx.unit_deps(unit));
-    let mut deps = deps
-        .into_iter()
-        .filter(|dep| !dep.unit.target.is_bin())
-        .map(|dep| DepFingerprint::new(cx, unit, &dep))
-        .collect::<CargoResult<Vec<_>>>()?;
-    deps.sort_by(|a, b| a.pkg_id.cmp(&b.pkg_id));
+    let deps = {
+        // Recursively calculate the fingerprint for all of our dependencies.
+        //
+        // Skip fingerprints of binaries because they don't actually induce a
+        // recompile, they're just dependencies in the sense that they need to be
+        // built. The only exception here are artifact dependencies,
+        // which is an actual dependency that needs a recompile.
+        //
+        // Create Vec since mutable cx is needed in closure.
+        let deps = Vec::from(cx.unit_deps(unit));
+        let mut deps = deps
+            .into_iter()
+            .filter(|dep| !dep.unit.target.is_bin() || dep.unit.artifact.is_true())
+            .map(|dep| DepFingerprint::new(cx, unit, &dep))
+            .collect::<CargoResult<Vec<_>>>()?;
+        deps.sort_by(|a, b| a.pkg_id.cmp(&b.pkg_id));
+        deps
+    };
 
     // Afterwards calculate our own fingerprint information.
     let target_root = target_root(cx);

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2276,3 +2276,71 @@ fn build_script_features_for_shared_dependency() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
 }
+
+#[cargo_test]
+fn calc_bin_artifact_fingerprint() {
+    // This records the WRONG behaviour. See rust-lang/cargo#10527
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                resolver = "2"
+
+                [dependencies]
+                bar = { path = "bar/", artifact = "bin" }
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {
+                    let _b = include_bytes!(env!("CARGO_BIN_FILE_BAR"));
+                }
+            "#,
+        )
+        .file("bar/Cargo.toml", &basic_bin_manifest("bar"))
+        .file("bar/src/main.rs", r#"fn main() { println!("foo") }"#)
+        .build();
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr(
+            "\
+[COMPILING] bar v0.5.0 ([CWD]/bar)
+[CHECKING] foo v0.1.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+
+    p.change_file("bar/src/main.rs", r#"fn main() { println!("bar") }"#);
+    // Change in bin artifact but not propagated to parent fingerprint.
+    // This is WRONG!
+    p.cargo("check -v -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr(
+            "\
+[COMPILING] bar v0.5.0 ([CWD]/bar)
+[RUNNING] `rustc --crate-name bar [..]`
+[FRESH] foo v0.1.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+
+    // Only run the second time can parent fingerpint perceive the change.
+    // This is WRONG!
+    p.cargo("check -v -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr(
+            "\
+[FRESH] bar v0.5.0 ([CWD]/bar)
+[CHECKING] foo v0.1.0 ([CWD])
+[RUNNING] `rustc --crate-name foo [..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Cargo previously excludes binaries from fingerprint calculation, as they usually don't induce a recompile. That is not true for artifact bin deps.

fixes #10527 

### How should we test and review this PR?

Run the demo from #10527. The shasum should reflect the change immediately with the second run of `cargo run`.
<!-- homu-ignore:end -->
