### PR TITLE
Fix wait-for-publish with sparse registry

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -469,6 +469,7 @@ impl Drop for HttpServerHandle {
 }
 
 /// Request to the test http server
+#[derive(Clone)]
 pub struct Request {
     pub url: Url,
     pub method: String,

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -549,6 +549,7 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
         // All it does is ensure that a subsequent load will double-check files with the
         // server rather than rely on a locally cached copy of the index files.
         debug!("invalidated index cache");
+        self.fresh.clear();
         self.requested_update = true;
     }
 


### PR DESCRIPTION
The `wait-for-publish` feature doesn't work when publishing a new version of an existing crate on a sparse registry. 

The `invalidate_cache` method doesn't clear the `fresh` list, so repeated requests just use the in-memory data if it's available. This didn't show up in the tests, because the test only simulated the `not found` to `crate available` transition, rather than the `old file` to `crate available` transition.

This change modifies the test by capturing the publish request, then deferring it until after later request for the index file.

r? @epage 

Fixes #11314