### PR TITLE
Fix not a hyperlink warnings

### DIFF
--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -203,8 +203,8 @@ impl ProcessBuilder {
     ///
     /// Ref:
     ///
-    /// - https://doc.rust-lang.org/rustdoc/command-line-arguments.html#path-load-command-line-flags-from-a-path
-    /// - https://doc.rust-lang.org/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path>
+    /// - <https://doc.rust-lang.org/rustdoc/command-line-arguments.html#path-load-command-line-flags-from-a-path>
+    /// - <https://doc.rust-lang.org/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path>
     pub fn retry_with_argfile(&mut self, enabled: bool) -> &mut Self {
         self.retry_with_argfile = enabled;
         self


### PR DESCRIPTION
### What does this PR try to resolve?
Fix not a hyperlink warnings.
```log
warning: this URL is not a hyperlink
   --> crates/cargo-util/src/process_builder.rs:206:11
    |
206 |     /// - https://doc.rust-lang.org/rustdoc/command-line-arguments.html#path-load-command-line-flags-from-a-path
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://doc.rust-lang.org/rustdoc/command-line-arguments.html#path-load-command-line-flags-from-a-path>`
    |
    = note: `#[warn(rustdoc::bare_urls)]` on by default
    = note: bare URLs are not automatically turned into clickable links

warning: this URL is not a hyperlink
   --> crates/cargo-util/src/process_builder.rs:207:11
    |
207 |     /// - https://doc.rust-lang.org/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path>
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://doc.rust-lang.org/rustc/command-line-arguments.html#path-load-command-line-flags-from-a-path>`
    |
    = note: bare URLs are not automatically turned into clickable links

warning: `cargo-util` (lib doc) generated 2 warnings
```


### How should we test and review this PR?

`cargo doc --open`
