### PR TITLE
Bump crate versions of `cargo-util` and `crates-io`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ path = "src/cargo/lib.rs"
 atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
-cargo-util = { path = "crates/cargo-util", version = "0.2.1" }
-crates-io = { path = "crates/crates-io", version = "0.34.0" }
+cargo-util = { path = "crates/cargo-util", version = "0.2.3" }
+crates-io = { path = "crates/crates-io", version = "0.35.0" }
 curl = { version = "0.4.44", features = ["http2"] }
 curl-sys = "0.4.59"
 env_logger = "0.9.0"

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?
<!-- homu-ignore:end -->

Bump crate versions of `cargo-util` and `crates-io`.

* `cargo-util`: The latest commit published to crates.io is 4bc8f24d3e899462e43621aab981f6383a370365 (v0.2.2 on [docs.rs](https://docs.rs/crate/cargo-util/0.2.2/source/.cargo_vcs_info.json)). 
  No major change and new features. Looks like we only need a patch version bump.
* `crates-io`: The latest commit published to crates.io is d1fd9fe2c40a1a56af9132b5c92ab963ac7ae422 (v0.34.0 on [docs.rs](https://docs.rs/crate/crates-io/0.34.0/source/.cargo_vcs_info.json)). 
  We derive `Deserialize` for some structs. Not sure whether deriving a trait counts breaks things. Perhaps breaks someone using [remote deriving](https://serde.rs/remote-derive.html)? Anyway, I made it a breaking release for visibility.

<!-- homu-ignore:start -->

This PR also updates root Cargo.toml accordingly.

### How should we test and review this PR?

Find any potential breakage I overlooked, and suggest a different kind of version bump.

### Additional information

I could do this right before the next release, but I'd rather do it now due to my poor memory.
<!-- homu-ignore:end -->
