### PR TITLE
Add globbing to `workspace.exclude` list

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1590,7 +1590,10 @@ impl WorkspaceRootConfig {
         let excluded = self
             .exclude
             .iter()
-            .any(|ex| manifest_path.starts_with(self.root_dir.join(ex)));
+            .filter_map(|ex| self.root_dir.join(ex).to_str().and_then(|p| glob(p).ok()))
+            .flatten()
+            .filter_map(|ex| ex.ok())
+            .any(|ex| manifest_path.starts_with(ex));
 
         let explicit_member = match self.members {
             Some(ref members) => members

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1610,13 +1610,17 @@ fn excluded_glob() {
         )
         .file("src/lib.rs", "")
         .file("repos/foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
-        .file("repos/foo/src/lib.rs", "");
+        .file("repos/foo/src/lib.rs", "")
+        .file("repos/bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("repos/bar/src/lib.rs", "");
     let p = p.build();
 
     p.cargo("build").run();
     assert!(p.root().join("target").is_dir());
     p.cargo("build").cwd("repos/foo").run();
     assert!(p.root().join("repos/foo/target").is_dir());
+    p.cargo("build").cwd("repos/bar").run();
+    assert!(p.root().join("repos/bar/target").is_dir());
 }
 
 #[cargo_test]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1609,6 +1609,18 @@ fn excluded_glob() {
             "#,
         )
         .file("src/lib.rs", "")
+        .file(
+            "repos/workspace/Cargo.toml",
+            r#"
+                [workspace]
+                members = ["crates/*"]
+            "#,
+        )
+        .file(
+            "repos/workspace/crates/xyz/Cargo.toml",
+            &basic_manifest("xyz", "0.1.0"),
+        )
+        .file("repos/workspace/crates/xyz/src/lib.rs", "")
         .file("repos/foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
         .file("repos/foo/src/lib.rs", "")
         .file("repos/bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
@@ -1617,6 +1629,8 @@ fn excluded_glob() {
 
     p.cargo("build").run();
     assert!(p.root().join("target").is_dir());
+    p.cargo("build").cwd("repos/workspace").run();
+    assert!(p.root().join("repos/workspace/target").is_dir());
     p.cargo("build").cwd("repos/foo").run();
     assert!(p.root().join("repos/foo/target").is_dir());
     p.cargo("build").cwd("repos/bar").run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1594,6 +1594,32 @@ fn excluded_simple() {
 }
 
 #[cargo_test]
+fn excluded_glob() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "ws"
+                version = "0.1.0"
+                authors = []
+
+                [workspace]
+                exclude = ["repos/*"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("repos/foo/Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("repos/foo/src/lib.rs", "");
+    let p = p.build();
+
+    p.cargo("build").run();
+    assert!(p.root().join("target").is_dir());
+    p.cargo("build").cwd("repos/foo").run();
+    assert!(p.root().join("repos/foo/target").is_dir());
+}
+
+#[cargo_test]
 fn exclude_members_preferred() {
     let p = project()
         .file(


### PR DESCRIPTION
## Motivation

Hello, I've added the ability to use globs in `workspace.exclude` to facilitate easier usage of git submodules as dependencies.

A common way of using git submodules is to have them all under a subfolder like `repos` or `third-party` and it would be nice to be able to just add new submodules without having to change the `workspace.exclude` list every time.

This small change allows the usage of globs in `workspace.exclude` just like it's allowed in `workspace.members` eg:
```
[workspace]
memebers = ["crates/*"]
exclude = ["repos/*"]
```

## Implementation

The current implementation is not ideal as it just silently eats any globbing errors. However, in the interest of making the change as minimal as possible for the initial round of reviews, I deemed that acceptable.
If desired I can refactor the `is_excluded` function to return a `CargoResult<bool>` similar to what `expand_member_path` does for its glob handling.

## Testing

I've added a test case to the testsuite called `excluded_glob` which should cover most cases but I'm open to hear if I missed any edge cases.
