### PR TITLE
improve error message for cargo add/remove

### DIFF
--- a/tests/testsuite/cargo_remove/invalid_package_multiple/stderr.log
+++ b/tests/testsuite/cargo_remove/invalid_package_multiple/stderr.log
@@ -1,1 +1,2 @@
-error: 2 packages selected. Please specify one with `-p <PKG_ID>`
+error: `cargo remove` could not determine which package to modify. Use the `--package` option to specify a package. 
+available packages: dep-a, dep-b


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->


### What does this PR try to resolve?

When I see the old error:
```
> cargo add paste
error: 2 packages selected.  Please specify one with `-p <PKGID>`
```
I was a little bit confused, and thought it says there are 2 packages called "paste". The new message is similar to `cargo run`