### PR TITLE
Add warning when `cargo tree -i <spec>` can not find packages

### DIFF
--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -214,9 +214,11 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         .collect::<CargoResult<Vec<PackageIdSpec>>>()?;
 
     if root_indexes.len() == 0 {
-        ws.config().shell().warn("nothing to print.\n\n\
-        To find dependencies that require specific features or target platforms, \
-        try use options `--all-features` or `--target all` first, and then narrow your search scope accordingly.")?;
+        ws.config().shell().warn(
+            "nothing to print.\n\n\
+        To find dependencies that require specific target platforms, \
+        try use option `--target all` first, and then narrow your search scope accordingly.",
+        )?;
     } else {
         print(ws.config(), opts, root_indexes, &pkgs_to_prune, &graph)?;
     }

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -213,7 +213,13 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         })
         .collect::<CargoResult<Vec<PackageIdSpec>>>()?;
 
-    print(ws.config(), opts, root_indexes, &pkgs_to_prune, &graph)?;
+    if root_indexes.len() == 0 {
+        ws.config().shell().warn("nothing to print.\n\n\
+        To find dependencies that require specific features or target platforms, \
+        try use options `--all-features` or `--target all` first, and then narrow your search scope accordingly.")?;
+    } else {
+        print(ws.config(), opts, root_indexes, &pkgs_to_prune, &graph)?;
+    }
     Ok(())
 }
 

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -490,6 +490,62 @@ foo v0.1.0 ([..]/foo)
 }
 
 #[cargo_test]
+fn no_selected_target_dependency() {
+    // --target flag
+    if cross_compile::disabled() {
+        return;
+    }
+    Package::new("targetdep", "1.0.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [target.'{alt}'.dependencies]
+                targetdep = "1.0"
+
+                "#,
+                alt = alternate(),
+            ),
+        )
+        .file("src/lib.rs", "")
+        .file("build.rs", "fn main() {}")
+        .build();
+
+    p.cargo("tree")
+        .with_stdout(
+            "\
+foo v0.1.0 ([..]/foo)
+",
+        )
+        .run();
+
+    p.cargo("tree -i targetdep")
+        .with_stderr(
+            "\
+[WARNING] nothing to print.
+
+To find dependencies that require specific features or target platforms, \
+try use options `--all-features` or `--target all` first, and then narrow your search scope accordingly.
+",
+        )
+        .run();
+    p.cargo("tree -i targetdep --target all")
+        .with_stdout(
+            "\
+targetdep v1.0.0
+└── foo v0.1.0 ([..]/foo)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn dep_kinds() {
     Package::new("inner-devdep", "1.0.0").publish();
     Package::new("inner-builddep", "1.0.0").publish();

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -530,8 +530,8 @@ foo v0.1.0 ([..]/foo)
             "\
 [WARNING] nothing to print.
 
-To find dependencies that require specific features or target platforms, \
-try use options `--all-features` or `--target all` first, and then narrow your search scope accordingly.
+To find dependencies that require specific target platforms, \
+try use option `--target all` first, and then narrow your search scope accordingly.
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/11315

Add warning when `cargo tree -i <spec>` can not find packages.

### How should we test and review this PR?

Please run the unit test.
