### PR TITLE
Register .dwp files as debuginfo artifacts so they get uplifted

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -462,6 +462,16 @@ impl TargetInfo {
                     // preserved.
                     should_replace_hyphens: true,
                 })
+            } else {
+                ret.push(FileType {
+                    suffix: ".dwp".to_string(),
+                    prefix: prefix.clone(),
+                    flavor: FileFlavor::DebugInfo,
+                    crate_type: Some(crate_type),
+                    // Currently no known reason to prefer one naming scheme
+                    // over the other, but the macos approach seems friendlier.
+                    should_replace_hyphens: false,
+                })
             }
         }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4788,9 +4788,14 @@ fn cdylib_final_outputs() {
 }
 
 #[cargo_test]
-// NOTE: Windows MSVC and wasm32-unknown-emscripten do not use metadata. Skip them.
+// NOTE: Windows MSVC and wasm32-unknown-emscripten do not use metadata.
 // See <https://github.com/rust-lang/cargo/issues/9325#issuecomment-1030662699>
-#[cfg(not(all(target_os = "windows", target_env = "msvc")))]
+//
+// We skip both msvc windows and gnu windows (mingw) because their naming schemes for
+// debuginfo files results in conflicts in this case. msvc makes two `foo.pdb` files
+// while mingw makes two `foo.dwp` files. These files clobber eachother,
+// corrupting the build output.
+#[cfg(not(target_os = "windows"))]
 fn no_dep_info_collision_when_cdylib_and_bin_coexist() {
     let p = project()
         .file(


### PR DESCRIPTION
### What does this PR try to resolve?

With this change linux split-debuginfo=packed builds will place the final .dwp in the top level target dir alongside the binary and report it as a file in the json messages. This puts it on equal footing with .pdb and .dysm files.

### How should we test and review this PR?

Step 0: be on linux with the latest rustc stable release.

Step 1: Add this profile to any project that emits a binary:

```
[profile.dist]
inherits = "release"
split-debuginfo = "packed"
debug = true
```

Step 2: Run `cargo build --profile=dist --message-format=json`

Before:

* .dwp file doesn't end up in the top level of `target/dist/`
* json message doesn't include .dwp file in `files` for the binary's build

After:

* Both of those things now happen, establishing parity.

### Additional information

I am uncertain on:

* exactly under what conditions this file type should get pushed (currently "not windows-msvc AND not apple")
* what the right default is for the hyphen-renaming flag
* whether moving (copying?) the file will break any existing tooling anyone has written (unclear to me if any exists)