### PR TITLE
Store the sparse+ prefix in the SourceId for sparse registries

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -177,7 +177,7 @@ impl<'cfg> HttpRegistry<'cfg> {
             cache_path: config.registry_cache_path().join(name),
             source_id,
             config,
-            url: url,
+            url,
             multi: Multi::new(),
             multiplexing: false,
             downloads: Downloads {

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -163,15 +163,21 @@ impl<'cfg> HttpRegistry<'cfg> {
         let url = source_id.url().as_str();
         // Ensure the url ends with a slash so we can concatenate paths.
         if !url.ends_with('/') {
-            anyhow::bail!("sparse registry url must end in a slash `/`: sparse+{url}")
+            anyhow::bail!("sparse registry url must end in a slash `/`: {url}")
         }
+        assert!(source_id.is_sparse());
+        let url = url
+            .strip_prefix("sparse+")
+            .expect("sparse registry needs sparse+ prefix")
+            .into_url()
+            .expect("a url with the sparse+ stripped should still be valid");
 
         Ok(HttpRegistry {
             index_path: config.registry_index_path().join(name),
             cache_path: config.registry_cache_path().join(name),
             source_id,
             config,
-            url: source_id.url().to_owned(),
+            url: url,
             multi: Multi::new(),
             multiplexing: false,
             downloads: Downloads {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -188,7 +188,7 @@ use crate::util::{
 
 const PACKAGE_SOURCE_LOCK: &str = ".cargo-ok";
 pub const CRATES_IO_INDEX: &str = "https://github.com/rust-lang/crates.io-index";
-pub const CRATES_IO_HTTP_INDEX: &str = "https://index.crates.io/";
+pub const CRATES_IO_HTTP_INDEX: &str = "sparse+https://index.crates.io/";
 pub const CRATES_IO_REGISTRY: &str = "crates-io";
 pub const CRATES_IO_DOMAIN: &str = "crates.io";
 const CRATE_TEMPLATE: &str = "{crate}";


### PR DESCRIPTION
#11209 added a new `SourceKind::SparseRegistry` and removed the `sparse+` prefix from the URLs stored in the `SourceId`.

The removal of the `sparse+` prefix from the URLs in the `SourceId` has led to several bugs, since registry URLs no longer round-trip through a `SourceId`. The most recent one I found was that the example configuration generated by `cargo vendor` did not include the `sparse+` prefix. Any place that calls the `.url()` method on a `SourceId` potentially has this bug.

This change puts the `sparse+` prefix back in the URL stored in the `SourceId`, but keeps the new `SourceKind::SparseRegistry`.

A test is added for doing `cargo vendor` on an alternative registry using the sparse protocol.