### PR TITLE
Fixes #11383: cargo package doesn't include build script if this has a custom path

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -747,8 +747,8 @@ fn exclude_from_time_machine(path: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_path, join_paths};
-    use std::path::{PathBuf, Path};
+    use super::{join_paths, normalize_path};
+    use std::path::{Path, PathBuf};
 
     #[test]
     fn join_paths_lists_paths_on_error() {
@@ -789,10 +789,7 @@ mod tests {
     #[test]
     fn normalize_path_works() {
         let path = Path::new("../cargo");
-        assert_eq!(
-            normalize_path(&path),
-            PathBuf::from("cargo")
-        );
+        assert_eq!(normalize_path(&path), PathBuf::from("cargo"));
 
         let path = Path::new("C:\\Users\\user_name\\..\\user_name\\folder");
         assert_eq!(

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -747,7 +747,8 @@ fn exclude_from_time_machine(path: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::join_paths;
+    use super::{normalize_path, join_paths};
+    use std::path::{PathBuf, Path};
 
     #[test]
     fn join_paths_lists_paths_on_error() {
@@ -783,5 +784,20 @@ mod tests {
              "
             );
         }
+    }
+
+    #[test]
+    fn normalize_path_works() {
+        let path = Path::new("../cargo");
+        assert_eq!(
+            normalize_path(&path),
+            PathBuf::from("cargo")
+        );
+
+        let path = Path::new("C:\\Users\\user_name\\..\\user_name\\folder");
+        assert_eq!(
+            normalize_path(&path),
+            PathBuf::from("C:\\Users\\user_name\\folder")
+        );
     }
 }

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -352,6 +352,11 @@ pub fn bytes2path(bytes: &[u8]) -> Result<PathBuf> {
     }
 }
 
+/// Check if a path is outside the package root path
+pub fn is_outsider(path: &Path, pkg_root: &Path) -> bool {
+    !path.ancestors().any(|ancestor| ancestor == pkg_root)
+}
+
 /// Returns an iterator that walks up the directory hierarchy towards the root.
 ///
 /// Each item is a [`Path`]. It will start with the given path, finishing at
@@ -747,7 +752,7 @@ fn exclude_from_time_machine(path: &Path) {
 
 #[cfg(test)]
 mod tests {
-    use super::{join_paths, normalize_path};
+    use super::{is_outsider, join_paths, normalize_path};
     use std::path::{Path, PathBuf};
 
     #[test]
@@ -796,5 +801,16 @@ mod tests {
             normalize_path(&path),
             PathBuf::from("C:\\Users\\user_name\\folder")
         );
+    }
+
+    #[test]
+    fn check_outsider() {
+        let pkg_root = Path::new("C:\\Users\\user_name\\project");
+        let path = Path::new("C:\\Users\\user_name\\project\\src\\module");
+        assert!(is_outsider(path, pkg_root) == false);
+
+        let path = Path::new("C:\\Users");
+        assert!(is_outsider(path, pkg_root) == true);
+        assert!(is_outsider(pkg_root, pkg_root) == false);
     }
 }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -42,6 +42,7 @@ impl EitherManifest {
 pub struct Manifest {
     summary: Summary,
     targets: Vec<Target>,
+    build_script: Option<PathBuf>,
     default_kind: Option<CompileKind>,
     forced_kind: Option<CompileKind>,
     links: Option<String>,
@@ -384,6 +385,7 @@ impl Manifest {
         default_kind: Option<CompileKind>,
         forced_kind: Option<CompileKind>,
         targets: Vec<Target>,
+        build_script: Option<PathBuf>,
         exclude: Vec<String>,
         include: Vec<String>,
         links: Option<String>,
@@ -408,6 +410,7 @@ impl Manifest {
             default_kind,
             forced_kind,
             targets,
+            build_script,
             warnings: Warnings::new(),
             exclude,
             include,
@@ -497,6 +500,10 @@ impl Manifest {
 
     pub fn workspace_config(&self) -> &WorkspaceConfig {
         &self.workspace
+    }
+
+    pub fn build_script(&self) -> Option<&PathBuf> {
+        self.build_script.as_ref()
     }
 
     /// Unstable, nightly features that are enabled in this manifest.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -278,7 +278,7 @@ fn build_ar_list(
         });
     }
 
-    // Process special files that may need to be moved/modified like the 
+    // Process special files that may need to be moved/modified like the
     // license, the readme and the build script (build.rs)
     if let Some(license_file) = &pkg.manifest().metadata().license_file {
         let license_path = Path::new(license_file);
@@ -312,14 +312,7 @@ fn build_ar_list(
         let readme_path = Path::new(readme);
         let abs_file_path = paths::normalize_path(&pkg.root().join(readme_path));
         if abs_file_path.exists() {
-            check_for_file_and_add(
-                "readme",
-                readme_path, 
-                abs_file_path, 
-                pkg,
-                &mut result,
-                ws
-            )?;
+            check_for_file_and_add("readme", readme_path, abs_file_path, pkg, &mut result, ws)?;
         }
     }
     if let Some(build_script_path) = pkg.manifest().build_script() {
@@ -329,9 +322,9 @@ fn build_ar_list(
                 "build-script",
                 build_script_path,
                 abs_build_script_path,
-                pkg, 
+                pkg,
                 &mut result,
-                ws
+                ws,
             )?;
         } else {
             unreachable!();
@@ -344,14 +337,14 @@ fn build_ar_list(
 
 /// Check for special files that have to be archived, but may be on external paths to the
 /// package root
-/// 
+///
 /// ### Parameters
 /// * `label` - The human readable name of the type of file
-/// * `file_path` - The relative file path of the file (used just for 
+/// * `file_path` - The relative file path of the file (used just for
 ///                 human readable logging)
 /// * `abs_file_path` - The absolute file path of the file
 /// * `pkg` - The current package that issues this file
-/// * `files` - The files to be archived 
+/// * `files` - The files to be archived
 /// * `ws` - The workspace (used just for logging)
 fn check_for_file_and_add(
     label: &str,
@@ -363,7 +356,7 @@ fn check_for_file_and_add(
 ) -> CargoResult<()> {
     // Get the relative path of the file from the package root
     if let Ok(rel_file_path) = abs_file_path.strip_prefix(&pkg.root()) {
-        // If the files isn't already included on the arhived files, 
+        // If the files isn't already included on the arhived files,
         // include it
         if !files.iter().any(|ar| ar.rel_path == rel_file_path) {
             files.push(ArchiveFile {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1445,7 +1445,7 @@ impl TomlManifest {
             }
         }
         if let Some(_) = &package.build {
-            // This entry if omitted will result in cargo to look for a `build.rs` on the 
+            // This entry if omitted will result in cargo to look for a `build.rs` on the
             // root of the package, if there is a `build.rs` at has been packaged on the root
             // even if it was on a custom path before
             package.build = None;
@@ -2381,7 +2381,6 @@ impl TomlManifest {
         }
         Ok(patch)
     }
-
 
     pub fn has_profiles(&self) -> bool {
         self.profile.is_some()

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -15,7 +15,7 @@ use std::fs::{self, DirEntry};
 use std::path::{Path, PathBuf};
 
 use super::{
-    PathValue, StringOrBool, StringOrVec, TomlBenchTarget, TomlBinTarget, TomlExampleTarget,
+    PathValue, StringOrVec, TomlBenchTarget, TomlBinTarget, TomlExampleTarget,
     TomlLibTarget, TomlManifest, TomlTarget, TomlTestTarget,
 };
 use crate::core::compiler::CrateType;
@@ -36,7 +36,6 @@ pub fn targets(
     package_name: &str,
     package_root: &Path,
     edition: Edition,
-    custom_build: &Option<StringOrBool>,
     metabuild: &Option<StringOrVec>,
     warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
@@ -104,7 +103,7 @@ pub fn targets(
     )?);
 
     // processing the custom build script
-    if let Some(custom_build) = manifest.maybe_custom_build(custom_build, package_root) {
+    if let Some(custom_build) = package.build_script_path(package_root) {
         if metabuild.is_some() {
             anyhow::bail!("cannot specify both `metabuild` and `build`");
         }

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -15,8 +15,8 @@ use std::fs::{self, DirEntry};
 use std::path::{Path, PathBuf};
 
 use super::{
-    PathValue, StringOrVec, TomlBenchTarget, TomlBinTarget, TomlExampleTarget,
-    TomlLibTarget, TomlManifest, TomlTarget, TomlTestTarget,
+    PathValue, StringOrVec, TomlBenchTarget, TomlBinTarget, TomlExampleTarget, TomlLibTarget,
+    TomlManifest, TomlTarget, TomlTestTarget,
 };
 use crate::core::compiler::CrateType;
 use crate::core::{Edition, Feature, Features, Target};

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -2813,7 +2813,13 @@ src/main.rs
     validate_crate_contents(
         f,
         "foo-0.0.1.crate",
-        &["Cargo.lock", "Cargo.toml", "Cargo.toml.orig", "src/main.rs", "build.rs"],
+        &[
+            "Cargo.lock",
+            "Cargo.toml",
+            "Cargo.toml.orig",
+            "src/main.rs",
+            "build.rs",
+        ],
         &[],
     );
 }

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -2764,7 +2764,7 @@ src/main.rs.bak
 }
 
 #[cargo_test]
-fn external_build_script() {
+fn outsider_build_script() {
     let p = project()
         .file(
             "Cargo.toml",
@@ -2783,43 +2783,12 @@ fn external_build_script() {
         .build();
 
     p.cargo("package")
+        .with_status(-1)
         .with_stderr(
             "\
 [WARNING] manifest has no documentation[..]
 See [..]
-[PACKAGING] foo v0.0.1 ([CWD])
-[VERIFYING] foo v0.0.1 ([CWD])
-[COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[PACKAGED] 5 files, [..] ([..] compressed)
-",
+[ERROR] the build script[..]",
         )
         .run();
-    assert!(p.root().join("target/package/foo-0.0.1.crate").is_file());
-    p.cargo("package -l")
-        .with_stdout(
-            "\
-Cargo.lock
-Cargo.toml
-Cargo.toml.orig
-build.rs
-src/main.rs
-",
-        )
-        .run();
-    p.cargo("package").with_stdout("").run();
-
-    let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
-    validate_crate_contents(
-        f,
-        "foo-0.0.1.crate",
-        &[
-            "Cargo.lock",
-            "Cargo.toml",
-            "Cargo.toml.orig",
-            "src/main.rs",
-            "build.rs",
-        ],
-        &[],
-    );
 }


### PR DESCRIPTION
Given the problem at #11383 here is the proposed solution:

If a referenced build script on the package manifest is outside the package, for example:
```toml
[package]
build = "../folder/build.rs"
```

I copy that `build.rs` to the root of the package and modify the package `Cargo.toml` to not reference any `build.rs` so it uses the default behavior of looking at the root
