### PR TITLE
chore: Upgrade miow

### DIFF
--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -24,5 +24,5 @@ walkdir = "2.3.1"
 core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
-miow = "0.4.0"
+miow = "0.5.0"
 winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }


### PR DESCRIPTION
Upgrade `miow` to the latest release.

The main change from miow is the upgrade of transitive dependency `windows-sys` from 0.28 to 0.42, which removes a duplicate dependency for cargo.