### PR TITLE
Add error message when `cargo fix` on an empty repo

### DIFF
--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -175,6 +175,20 @@ where
     (git_project, repo)
 }
 
+/// Create a new git repository with a project.
+/// Returns both the Project and the git Repository but does not commit.
+pub fn new_repo_without_add_and_commit<F>(name: &str, callback: F) -> (Project, git2::Repository)
+where
+    F: FnOnce(ProjectBuilder) -> ProjectBuilder,
+{
+    let mut git_project = project().at(name);
+    git_project = callback(git_project);
+    let git_project = git_project.build();
+
+    let repo = init(&git_project.root());
+    (git_project, repo)
+}
+
 /// Add all files in the working directory to the git index.
 pub fn add(repo: &git2::Repository) {
     // FIXME(libgit2/libgit2#2514): apparently, `add_all` will add all submodules

--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -175,20 +175,6 @@ where
     (git_project, repo)
 }
 
-/// Create a new git repository with a project.
-/// Returns both the Project and the git Repository but does not commit.
-pub fn new_repo_without_add_and_commit<F>(name: &str, callback: F) -> (Project, git2::Repository)
-where
-    F: FnOnce(ProjectBuilder) -> ProjectBuilder,
-{
-    let mut git_project = project().at(name);
-    git_project = callback(git_project);
-    let git_project = git_project.build();
-
-    let repo = init(&git_project.root());
-    (git_project, repo)
-}
-
 /// Add all files in the working directory to the git index.
 pub fn add(repo: &git2::Repository) {
     // FIXME(libgit2/libgit2#2514): apparently, `add_all` will add all submodules

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -154,11 +154,11 @@ fn check_version_control(config: &Config, opts: &FixOptions) -> CargoResult<()> 
     if let Ok(repo) = git2::Repository::discover(config.cwd()) {
         let mut repo_opts = git2::StatusOptions::new();
         repo_opts.include_ignored(false);
-        if repo.is_empty()? {
+        if repo.is_empty()? && !opts.allow_dirty {
             bail!(
                 "no commits found in the git repository, and \
                 `cargo fix` can potentially perform destructive changes; if you'd \
-                like to suppress this error pass `--allow-dirty`, `--allow-staged`, \
+                like to suppress this error pass `--allow-dirty`, \
                 or commit your changes"
             )
         }

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -154,14 +154,7 @@ fn check_version_control(config: &Config, opts: &FixOptions) -> CargoResult<()> 
     if let Ok(repo) = git2::Repository::discover(config.cwd()) {
         let mut repo_opts = git2::StatusOptions::new();
         repo_opts.include_ignored(false);
-        if repo.is_empty()? && !opts.allow_dirty {
-            bail!(
-                "no commits found in the git repository, and \
-                `cargo fix` can potentially perform destructive changes; if you'd \
-                like to suppress this error pass `--allow-dirty`, \
-                or commit your changes"
-            )
-        }
+        repo_opts.include_untracked(true);
         for status in repo.statuses(Some(&mut repo_opts))?.iter() {
             if let Some(path) = status.path() {
                 match status.status() {

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -154,6 +154,14 @@ fn check_version_control(config: &Config, opts: &FixOptions) -> CargoResult<()> 
     if let Ok(repo) = git2::Repository::discover(config.cwd()) {
         let mut repo_opts = git2::StatusOptions::new();
         repo_opts.include_ignored(false);
+        if repo.is_empty()? {
+            bail!(
+                "no commits found in the git repository, and \
+                `cargo fix` can potentially perform destructive changes; if you'd \
+                like to suppress this error pass `--allow-dirty`, `--allow-staged`, \
+                or commit your changes"
+            )
+        }
         for status in repo.statuses(Some(&mut repo_opts))?.iter() {
             if let Some(path) = status.path() {
                 match status.status() {

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1431,7 +1431,7 @@ fn fix_in_existing_repo_weird_ignore() {
     let p = git::new("foo", |project| {
         project
             .file("src/lib.rs", "")
-            .file(".gitignore", "foo\ninner\n")
+            .file(".gitignore", "foo\ninner\nCargo.lock\ntarget\n")
             .file("inner/file", "")
     });
 

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2,7 +2,7 @@
 
 use cargo::core::Edition;
 use cargo_test_support::compare::assert_match_exact;
-use cargo_test_support::git;
+use cargo_test_support::git::{self, init};
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::tools;
@@ -773,8 +773,10 @@ commit the changes to these files:
 
 #[cargo_test]
 fn errors_on_empty_repo() {
-    let (p, _) =
-        git::new_repo_without_add_and_commit("foo", |p| p.file("src/lib.rs", "pub fn foo() {}"));
+    let mut git_project = project().at("foo");
+    git_project = git_project.file("src/lib.rs", "pub fn foo() {}");
+    let p = git_project.build();
+    let _ = init(&p.root());
 
     p.cargo("fix")
         .with_status(101)

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -772,7 +772,7 @@ commit the changes to these files:
 }
 
 #[cargo_test]
-fn errors_on_empty_repo() {
+fn errors_about_untracked_files() {
     let mut git_project = project().at("foo");
     git_project = git_project.file("src/lib.rs", "pub fn foo() {}");
     let p = git_project.build();
@@ -782,10 +782,15 @@ fn errors_on_empty_repo() {
         .with_status(101)
         .with_stderr(
             "\
-error: no commits found in the git repository, \
-and `cargo fix` can potentially perform destructive changes; \
-if you'd like to suppress this error pass `--allow-dirty`, \
-or commit your changes
+error: the working directory of this package has uncommitted changes, \
+and `cargo fix` can potentially perform destructive changes; if you'd \
+like to suppress this error pass `--allow-dirty`, `--allow-staged`, or \
+commit the changes to these files:
+
+  * Cargo.toml (dirty)
+  * src/ (dirty)
+
+
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/11380

Add error message when `cargo fix` on an empty repo.

### How should we test and review this PR?

- [x] unit test

```sh
set -eux

cargo +nightly new repro
cd repro
echo "fn main() { let _ = 0.clone(); }" > src/main.rs
cargo fix
```
