### PR TITLE
add newline char to `cargo install .` error message for easier reading.

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -69,7 +69,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
             if name == "." {
                 bail!(
                     "To install the binaries for the package in current working \
-                     directory use `cargo install --path .`. \
+                     directory use `cargo install --path .`. \n\
                      Use `cargo build` if you want to simply build the package."
                 )
             }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -327,7 +327,7 @@ fn missing_current_working_directory() {
     cargo_process("install .")
         .with_status(101)
         .with_stderr(
-            "To install the binaries for the package in current working \
+            "error: To install the binaries for the package in current working \
             directory use `cargo install --path .`. \n\
             Use `cargo build` if you want to simply build the package.",
         )

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -327,11 +327,9 @@ fn missing_current_working_directory() {
     cargo_process("install .")
         .with_status(101)
         .with_stderr(
-            "\
-error: To install the binaries for the package in current working \
-directory use `cargo install --path .`. \n\ 
-Use `cargo build` if you want to simply build the package.
-",
+            "To install the binaries for the package in current working \
+            directory use `cargo install --path .`. \n\
+            Use `cargo build` if you want to simply build the package.",
         )
         .run();
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -329,8 +329,8 @@ fn missing_current_working_directory() {
         .with_stderr(
             "\
 error: To install the binaries for the package in current working \
-directory use `cargo install --path .`. Use `cargo build` if you \
-want to simply build the package.
+directory use `cargo install --path .`. \n\ 
+Use `cargo build` if you want to simply build the package.
 ",
         )
         .run();


### PR DESCRIPTION
I just noticed the `cargo install .` error message was not formatted very nicely.

Just added a newline char to make it cleaner.

Thanks