### PR TITLE
Reasons for rebuilding

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1,4 +1,4 @@
-use super::job::{Freshness, Job, Work};
+use super::job::{Job, Work};
 use super::{fingerprint, Context, LinkType, Unit};
 use crate::core::compiler::artifact;
 use crate::core::compiler::context::Metadata;
@@ -484,11 +484,11 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     });
 
     let mut job = if cx.bcx.build_config.build_plan {
-        Job::new_dirty(Work::noop())
+        Job::new_dirty(Work::noop(), None)
     } else {
         fingerprint::prepare_target(cx, unit, false)?
     };
-    if job.freshness() == Freshness::Dirty {
+    if job.freshness().is_dirty() {
         job.before(dirty);
     } else {
         job.before(fresh);

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -856,13 +856,13 @@ impl Fingerprint {
     /// an error, it will never return success.
     fn compare(&self, old: &Fingerprint) -> DirtyReason {
         if self.rustc != old.rustc {
-            return DirtyReason::RustcChanged
+            return DirtyReason::RustcChanged;
         }
         if self.features != old.features {
             return DirtyReason::FeaturesChanged {
                 old: old.features.clone(),
                 new: self.features.clone(),
-            }
+            };
         }
         if self.target != old.target {
             return DirtyReason::TargetConfigurationChanged;
@@ -961,10 +961,12 @@ impl Fingerprint {
                         };
                     }
                 }
-                (a, b) => return DirtyReason::LocalFingerprintTypeChanged {
-                    old: b.kind(),
-                    new: a.kind(),
-                },
+                (a, b) => {
+                    return DirtyReason::LocalFingerprintTypeChanged {
+                        old: b.kind(),
+                        new: a.kind(),
+                    }
+                }
             }
         }
 
@@ -1700,21 +1702,21 @@ fn compare_old_fingerprint(
 
 fn log_compare(unit: &Unit, compare: &CargoResult<Option<DirtyReason>>) {
     match compare {
-        Ok(None) => {},
+        Ok(None) => {}
         Ok(Some(reason)) => {
             info!(
                 "fingerprint dirty for {}/{:?}/{:?}",
                 unit.pkg, unit.mode, unit.target,
             );
             info!("    dirty: {reason:?}");
-        },
+        }
         Err(e) => {
             info!(
                 "fingerprint error for {}/{:?}/{:?}",
                 unit.pkg, unit.mode, unit.target,
             );
             info!("    err: {e:?}");
-        },
+        }
     }
 }
 

--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -312,7 +312,10 @@
 //! See the `A-rebuild-detection` flag on the issue tracker for more:
 //! <https://github.com/rust-lang/cargo/issues?q=is%3Aissue+is%3Aopen+label%3AA-rebuild-detection>
 
+mod dirty_reason;
+
 use std::collections::hash_map::{Entry, HashMap};
+
 use std::env;
 use std::hash::{self, Hash, Hasher};
 use std::io;
@@ -340,6 +343,8 @@ use crate::CARGO_ENV;
 use super::custom_build::BuildDeps;
 use super::job::{Job, Work};
 use super::{BuildContext, Context, FileFlavor, Unit};
+
+pub use dirty_reason::DirtyReason;
 
 /// Determines if a `unit` is up-to-date, and if not prepares necessary work to
 /// update the persisted fingerprint.
@@ -393,9 +398,16 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
         source.verify(unit.pkg.package_id())?;
     }
 
-    if compare.is_ok() && !force {
-        return Ok(Job::new_fresh());
-    }
+    let dirty_reason = match compare {
+        Ok(_) => {
+            if force {
+                Some(DirtyReason::Forced)
+            } else {
+                return Ok(Job::new_fresh());
+            }
+        }
+        Err(e) => e.downcast::<DirtyReason>().ok(),
+    };
 
     // Clear out the old fingerprint file if it exists. This protects when
     // compilation is interrupted leaving a corrupt file. For example, a
@@ -466,7 +478,7 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
         Work::new(move |_| write_fingerprint(&loc, &fingerprint))
     };
 
-    Ok(Job::new_dirty(write_fingerprint))
+    Ok(Job::new_dirty(write_fingerprint, dirty_reason))
 }
 
 /// Dependency edge information for fingerprints. This is generated for each
@@ -559,13 +571,27 @@ pub struct Fingerprint {
 }
 
 /// Indication of the status on the filesystem for a particular unit.
-#[derive(Default)]
-enum FsStatus {
+#[derive(Clone, Default, Debug)]
+pub enum FsStatus {
     /// This unit is to be considered stale, even if hash information all
-    /// matches. The filesystem inputs have changed (or are missing) and the
-    /// unit needs to subsequently be recompiled.
+    /// matches.
     #[default]
     Stale,
+
+    /// File system inputs have changed (or are missing), or there were
+    /// changes to the environment variables that affect this unit. See
+    /// the variants of [`StaleItem`] for more information.
+    StaleItem(StaleItem),
+
+    /// A dependency was stale.
+    StaleDependency {
+        name: InternedString,
+        dep_mtime: FileTime,
+        max_mtime: FileTime,
+    },
+
+    /// A dependency was stale.
+    StaleDepFingerprint { name: InternedString },
 
     /// This unit is up-to-date. All outputs and their corresponding mtime are
     /// listed in the payload here for other dependencies to compare against.
@@ -576,7 +602,10 @@ impl FsStatus {
     fn up_to_date(&self) -> bool {
         match self {
             FsStatus::UpToDate { .. } => true,
-            FsStatus::Stale => false,
+            FsStatus::Stale
+            | FsStatus::StaleItem(_)
+            | FsStatus::StaleDependency { .. }
+            | FsStatus::StaleDepFingerprint { .. } => false,
         }
     }
 }
@@ -677,7 +706,8 @@ enum LocalFingerprint {
     RerunIfEnvChanged { var: String, val: Option<String> },
 }
 
-enum StaleItem {
+#[derive(Clone, Debug)]
+pub enum StaleItem {
     MissingFile(PathBuf),
     ChangedFile {
         reference: PathBuf,
@@ -823,56 +853,53 @@ impl Fingerprint {
     /// The purpose of this is exclusively to produce a diagnostic message
     /// indicating why we're recompiling something. This function always returns
     /// an error, it will never return success.
-    fn compare(&self, old: &Fingerprint) -> CargoResult<()> {
+    fn compare(&self, old: &Fingerprint) -> Result<(), DirtyReason> {
         if self.rustc != old.rustc {
-            bail!("rust compiler has changed")
+            Err(DirtyReason::RustcChanged)?
         }
         if self.features != old.features {
-            bail!(
-                "features have changed: previously {}, now {}",
-                old.features,
-                self.features
-            )
+            Err(DirtyReason::FeaturesChanged {
+                old: old.features.clone(),
+                new: self.features.clone(),
+            })?
         }
         if self.target != old.target {
-            bail!("target configuration has changed")
+            Err(DirtyReason::TargetConfigurationChanged)?
         }
         if self.path != old.path {
-            bail!("path to the source has changed")
+            Err(DirtyReason::PathToSourceChanged)?
         }
         if self.profile != old.profile {
-            bail!("profile configuration has changed")
+            Err(DirtyReason::ProfileConfigurationChanged)?
         }
         if self.rustflags != old.rustflags {
-            bail!(
-                "RUSTFLAGS has changed: previously {:?}, now {:?}",
-                old.rustflags,
-                self.rustflags
-            )
+            Err(DirtyReason::RustflagsChanged {
+                old: old.rustflags.clone(),
+                new: self.rustflags.clone(),
+            })?
         }
         if self.metadata != old.metadata {
-            bail!("metadata changed")
+            Err(DirtyReason::MetadataChanged)?
         }
         if self.config != old.config {
-            bail!("configuration settings have changed")
+            Err(DirtyReason::ConfigSettingsChanged)?
         }
         if self.compile_kind != old.compile_kind {
-            bail!("compile kind (rustc target) changed")
+            Err(DirtyReason::CompileKindChanged)?
         }
         let my_local = self.local.lock().unwrap();
         let old_local = old.local.lock().unwrap();
         if my_local.len() != old_local.len() {
-            bail!("local lens changed");
+            Err(DirtyReason::LocalLengthsChanged)?
         }
         for (new, old) in my_local.iter().zip(old_local.iter()) {
             match (new, old) {
                 (LocalFingerprint::Precalculated(a), LocalFingerprint::Precalculated(b)) => {
                     if a != b {
-                        bail!(
-                            "precalculated components have changed: previously {}, now {}",
-                            b,
-                            a
-                        )
+                        Err(DirtyReason::PrecalculatedComponentsChanged {
+                            old: b.to_string(),
+                            new: a.to_string(),
+                        })?
                     }
                 }
                 (
@@ -880,11 +907,10 @@ impl Fingerprint {
                     LocalFingerprint::CheckDepInfo { dep_info: bdep },
                 ) => {
                     if adep != bdep {
-                        bail!(
-                            "dep info output changed: previously {:?}, now {:?}",
-                            bdep,
-                            adep
-                        )
+                        Err(DirtyReason::DepInfoOutputChanged {
+                            old: bdep.clone(),
+                            new: adep.clone(),
+                        })?
                     }
                 }
                 (
@@ -898,18 +924,16 @@ impl Fingerprint {
                     },
                 ) => {
                     if aout != bout {
-                        bail!(
-                            "rerun-if-changed output changed: previously {:?}, now {:?}",
-                            bout,
-                            aout
-                        )
+                        Err(DirtyReason::RerunIfChangedOutputFileChanged {
+                            old: bout.clone(),
+                            new: aout.clone(),
+                        })?
                     }
                     if apaths != bpaths {
-                        bail!(
-                            "rerun-if-changed output changed: previously {:?}, now {:?}",
-                            bpaths,
-                            apaths,
-                        )
+                        Err(DirtyReason::RerunIfChangedOutputPathsChanged {
+                            old: bpaths.clone(),
+                            new: apaths.clone(),
+                        })?
                     }
                 }
                 (
@@ -923,57 +947,59 @@ impl Fingerprint {
                     },
                 ) => {
                     if *akey != *bkey {
-                        bail!("env vars changed: previously {}, now {}", bkey, akey);
+                        Err(DirtyReason::EnvVarsChanged {
+                            old: bkey.clone(),
+                            new: akey.clone(),
+                        })?
                     }
                     if *avalue != *bvalue {
-                        bail!(
-                            "env var `{}` changed: previously {:?}, now {:?}",
-                            akey,
-                            bvalue,
-                            avalue
-                        )
+                        Err(DirtyReason::EnvVarChanged {
+                            name: akey.clone(),
+                            old_value: bvalue.clone(),
+                            new_value: avalue.clone(),
+                        })?
                     }
                 }
-                (a, b) => bail!(
-                    "local fingerprint type has changed ({} => {})",
-                    b.kind(),
-                    a.kind()
-                ),
+                (a, b) => Err(DirtyReason::LocalFingerprintTypeChanged {
+                    old: b.kind(),
+                    new: a.kind(),
+                })?,
             }
         }
 
         if self.deps.len() != old.deps.len() {
-            bail!("number of dependencies has changed")
+            Err(DirtyReason::NumberOfDependenciesChanged {
+                old: old.deps.len(),
+                new: self.deps.len(),
+            })?
         }
         for (a, b) in self.deps.iter().zip(old.deps.iter()) {
             if a.name != b.name {
-                let e = format_err!("`{}` != `{}`", a.name, b.name)
-                    .context("unit dependency name changed");
-                return Err(e);
+                Err(DirtyReason::UnitDependencyNameChanged {
+                    old: b.name.clone(),
+                    new: a.name.clone(),
+                })?
             }
 
             if a.fingerprint.hash_u64() != b.fingerprint.hash_u64() {
-                let e = format_err!(
-                    "new ({}/{:x}) != old ({}/{:x})",
-                    a.name,
-                    a.fingerprint.hash_u64(),
-                    b.name,
-                    b.fingerprint.hash_u64()
-                )
-                .context("unit dependency information changed");
-                return Err(e);
+                Err(DirtyReason::UnitDependencyInfoChanged {
+                    new_name: a.name.clone(),
+                    new_fingerprint: a.fingerprint.hash_u64(),
+                    old_name: b.name.clone(),
+                    old_fingerprint: b.fingerprint.hash_u64(),
+                })?
             }
         }
 
         if !self.fs_status.up_to_date() {
-            bail!("current filesystem status shows we're outdated");
+            Err(DirtyReason::FsStatusOutdated(self.fs_status.clone()))?
         }
 
         // This typically means some filesystem modifications happened or
         // something transitive was odd. In general we should strive to provide
         // a better error message than this, so if you see this message a lot it
         // likely means this method needs to be updated!
-        bail!("two fingerprint comparison turned up nothing obvious");
+        Err(DirtyReason::NothingObvious)
     }
 
     /// Dynamically inspect the local filesystem to update the `fs_status` field
@@ -1034,7 +1060,15 @@ impl Fingerprint {
             let dep_mtimes = match &dep.fingerprint.fs_status {
                 FsStatus::UpToDate { mtimes } => mtimes,
                 // If our dependency is stale, so are we, so bail out.
-                FsStatus::Stale => return Ok(()),
+                FsStatus::Stale
+                | FsStatus::StaleItem(_)
+                | FsStatus::StaleDependency { .. }
+                | FsStatus::StaleDepFingerprint { .. } => {
+                    self.fs_status = FsStatus::StaleDepFingerprint {
+                        name: dep.name.clone(),
+                    };
+                    return Ok(());
+                }
             };
 
             // If our dependency edge only requires the rmeta file to be present
@@ -1072,6 +1106,13 @@ impl Fingerprint {
                     "dependency on `{}` is newer than we are {} > {} {:?}",
                     dep.name, dep_mtime, max_mtime, pkg_root
                 );
+
+                self.fs_status = FsStatus::StaleDependency {
+                    name: dep.name.clone(),
+                    dep_mtime: *dep_mtime,
+                    max_mtime: *max_mtime,
+                };
+
                 return Ok(());
             }
         }
@@ -1085,6 +1126,7 @@ impl Fingerprint {
                 local.find_stale_item(mtime_cache, pkg_root, target_root, cargo_exe)?
             {
                 item.log();
+                self.fs_status = FsStatus::StaleItem(item);
                 return Ok(());
             }
         }
@@ -1652,8 +1694,10 @@ fn compare_old_fingerprint(
         );
     }
     let result = new_fingerprint.compare(&old_fingerprint);
-    assert!(result.is_err());
-    result
+    match result {
+        Ok(_) => panic!("compare should not return Ok"),
+        Err(e) => Err(e.into()),
+    }
 }
 
 fn log_compare(unit: &Unit, compare: &CargoResult<()>) {

--- a/src/cargo/core/compiler/fingerprint/dirty_reason.rs
+++ b/src/cargo/core/compiler/fingerprint/dirty_reason.rs
@@ -1,8 +1,8 @@
-use super::*;
-use crate::core::Shell;
-
 use std::fmt;
 use std::fmt::Debug;
+
+use super::*;
+use crate::core::Shell;
 
 #[derive(Clone, Debug)]
 pub enum DirtyReason {
@@ -135,9 +135,7 @@ impl DirtyReason {
         match self {
             DirtyReason::RustcChanged => s.dirty_because(unit, "the toolchain changed"),
             DirtyReason::FeaturesChanged { .. } => {
-                s.dirty_because(unit, "the list of features changed")?;
-
-                Ok(())
+                s.dirty_because(unit, "the list of features changed")
             }
             DirtyReason::TargetConfigurationChanged => {
                 s.dirty_because(unit, "the target configuration changed")
@@ -148,11 +146,7 @@ impl DirtyReason {
             DirtyReason::ProfileConfigurationChanged => {
                 s.dirty_because(unit, "the profile configuration changed")
             }
-            DirtyReason::RustflagsChanged { .. } => {
-                s.dirty_because(unit, "the rustflags changed")?;
-
-                Ok(())
-            }
+            DirtyReason::RustflagsChanged { .. } => s.dirty_because(unit, "the rustflags changed"),
             DirtyReason::MetadataChanged => s.dirty_because(unit, "the metadata changed"),
             DirtyReason::ConfigSettingsChanged => {
                 s.dirty_because(unit, "the config settings changed")
@@ -169,37 +163,25 @@ impl DirtyReason {
                 Ok(())
             }
             DirtyReason::PrecalculatedComponentsChanged { .. } => {
-                s.dirty_because(unit, "the precalculated components changed")?;
-
-                Ok(())
+                s.dirty_because(unit, "the precalculated components changed")
             }
             DirtyReason::DepInfoOutputChanged { .. } => {
                 s.dirty_because(unit, "the dependency info output changed")
             }
             DirtyReason::RerunIfChangedOutputFileChanged { .. } => {
-                s.dirty_because(unit, "rerun-if-changed output file path changed")?;
-
-                Ok(())
+                s.dirty_because(unit, "rerun-if-changed output file path changed")
             }
             DirtyReason::RerunIfChangedOutputPathsChanged { .. } => {
-                s.dirty_because(unit, "the rerun-if-changed instructions changed")?;
-
-                Ok(())
+                s.dirty_because(unit, "the rerun-if-changed instructions changed")
             }
             DirtyReason::EnvVarsChanged { .. } => {
-                s.dirty_because(unit, "the environment variables changed")?;
-
-                Ok(())
+                s.dirty_because(unit, "the environment variables changed")
             }
             DirtyReason::EnvVarChanged { name, .. } => {
-                s.dirty_because(unit, format_args!("the env variable {name} changed"))?;
-
-                Ok(())
+                s.dirty_because(unit, format_args!("the env variable {name} changed"))
             }
             DirtyReason::LocalFingerprintTypeChanged { .. } => {
-                s.dirty_because(unit, "the local fingerprint type changed")?;
-
-                Ok(())
+                s.dirty_because(unit, "the local fingerprint type changed")
             }
             DirtyReason::NumberOfDependenciesChanged { old, new } => s.dirty_because(
                 unit,
@@ -235,13 +217,10 @@ impl DirtyReason {
                             format_args!("the file `{}` has changed ({after})", file.display()),
                         )
                     }
-                    StaleItem::ChangedEnv { var, .. } => {
-                        s.dirty_because(
-                            unit,
-                            format_args!("the environment variable {var} changed"),
-                        )?;
-                        Ok(())
-                    }
+                    StaleItem::ChangedEnv { var, .. } => s.dirty_because(
+                        unit,
+                        format_args!("the environment variable {var} changed"),
+                    ),
                 },
                 FsStatus::StaleDependency {
                     name,

--- a/src/cargo/core/compiler/fingerprint/dirty_reason.rs
+++ b/src/cargo/core/compiler/fingerprint/dirty_reason.rs
@@ -1,0 +1,281 @@
+use super::*;
+use crate::core::Shell;
+
+use std::fmt;
+use std::fmt::Debug;
+
+#[derive(Clone, Debug)]
+pub enum DirtyReason {
+    RustcChanged,
+    FeaturesChanged {
+        old: String,
+        new: String,
+    },
+    TargetConfigurationChanged,
+    PathToSourceChanged,
+    ProfileConfigurationChanged,
+    RustflagsChanged {
+        old: Vec<String>,
+        new: Vec<String>,
+    },
+    MetadataChanged,
+    ConfigSettingsChanged,
+    CompileKindChanged,
+    LocalLengthsChanged,
+    PrecalculatedComponentsChanged {
+        old: String,
+        new: String,
+    },
+    DepInfoOutputChanged {
+        old: PathBuf,
+        new: PathBuf,
+    },
+    RerunIfChangedOutputFileChanged {
+        old: PathBuf,
+        new: PathBuf,
+    },
+    RerunIfChangedOutputPathsChanged {
+        old: Vec<PathBuf>,
+        new: Vec<PathBuf>,
+    },
+    EnvVarsChanged {
+        old: String,
+        new: String,
+    },
+    EnvVarChanged {
+        name: String,
+        old_value: Option<String>,
+        new_value: Option<String>,
+    },
+    LocalFingerprintTypeChanged {
+        old: &'static str,
+        new: &'static str,
+    },
+    NumberOfDependenciesChanged {
+        old: usize,
+        new: usize,
+    },
+    UnitDependencyNameChanged {
+        old: InternedString,
+        new: InternedString,
+    },
+    UnitDependencyInfoChanged {
+        old_name: InternedString,
+        old_fingerprint: u64,
+
+        new_name: InternedString,
+        new_fingerprint: u64,
+    },
+    FsStatusOutdated(FsStatus),
+    NothingObvious,
+    Forced,
+}
+
+// still need to implement Display for Error
+impl fmt::Display for DirtyReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "dirty")
+    }
+}
+
+impl std::error::Error for DirtyReason {}
+
+trait ShellExt {
+    fn dirty_because(&mut self, unit: &Unit, s: impl fmt::Display) -> CargoResult<()>;
+}
+
+impl ShellExt for Shell {
+    fn dirty_because(&mut self, unit: &Unit, s: impl fmt::Display) -> CargoResult<()> {
+        self.status("Dirty", format_args!("{}: {s}", &unit.pkg))
+    }
+}
+
+struct FileTimeDiff {
+    old_time: FileTime,
+    new_time: FileTime,
+}
+
+impl fmt::Display for FileTimeDiff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s_diff = self.new_time.seconds() - self.old_time.seconds();
+        if s_diff >= 1 {
+            fmt::Display::fmt(
+                &humantime::Duration::from(std::time::Duration::from_secs(s_diff as u64)),
+                f,
+            )
+        } else {
+            // format nanoseconds as it is, humantime would display ms, us and ns
+            let ns_diff = self.new_time.nanoseconds() - self.old_time.nanoseconds();
+            write!(f, "{ns_diff}ns")
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+struct After {
+    old_time: FileTime,
+    new_time: FileTime,
+    what: &'static str,
+}
+
+impl fmt::Display for After {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            old_time,
+            new_time,
+            what,
+        } = *self;
+        let diff = FileTimeDiff { old_time, new_time };
+
+        write!(f, "{new_time}, {diff} after {what} at {old_time}")
+    }
+}
+
+impl DirtyReason {
+    fn after(old_time: FileTime, new_time: FileTime, what: &'static str) -> After {
+        After {
+            old_time,
+            new_time,
+            what,
+        }
+    }
+
+    pub fn present_to(&self, s: &mut Shell, unit: &Unit, root: &Path) -> CargoResult<()> {
+        match self {
+            DirtyReason::RustcChanged => s.dirty_because(unit, "the toolchain changed"),
+            DirtyReason::FeaturesChanged { .. } => {
+                s.dirty_because(unit, "the list of features changed")?;
+
+                Ok(())
+            }
+            DirtyReason::TargetConfigurationChanged => {
+                s.dirty_because(unit, "the target configuration changed")
+            }
+            DirtyReason::PathToSourceChanged => {
+                s.dirty_because(unit, "the path to the source changed")
+            }
+            DirtyReason::ProfileConfigurationChanged => {
+                s.dirty_because(unit, "the profile configuration changed")
+            }
+            DirtyReason::RustflagsChanged { .. } => {
+                s.dirty_because(unit, "the rustflags changed")?;
+
+                Ok(())
+            }
+            DirtyReason::MetadataChanged => s.dirty_because(unit, "the metadata changed"),
+            DirtyReason::ConfigSettingsChanged => {
+                s.dirty_because(unit, "the config settings changed")
+            }
+            DirtyReason::CompileKindChanged => {
+                s.dirty_because(unit, "the rustc compile kind changed")
+            }
+            DirtyReason::LocalLengthsChanged => {
+                s.dirty_because(unit, "the local lengths changed")?;
+                s.note(
+                    "This could happen because of added/removed `cargo:rerun-if` instructions in the build script",
+                )?;
+
+                Ok(())
+            }
+            DirtyReason::PrecalculatedComponentsChanged { .. } => {
+                s.dirty_because(unit, "the precalculated components changed")?;
+
+                Ok(())
+            }
+            DirtyReason::DepInfoOutputChanged { .. } => {
+                s.dirty_because(unit, "the dependency info output changed")
+            }
+            DirtyReason::RerunIfChangedOutputFileChanged { .. } => {
+                s.dirty_because(unit, "rerun-if-changed output file path changed")?;
+
+                Ok(())
+            }
+            DirtyReason::RerunIfChangedOutputPathsChanged { .. } => {
+                s.dirty_because(unit, "the rerun-if-changed instructions changed")?;
+
+                Ok(())
+            }
+            DirtyReason::EnvVarsChanged { .. } => {
+                s.dirty_because(unit, "the environment variables changed")?;
+
+                Ok(())
+            }
+            DirtyReason::EnvVarChanged { name, .. } => {
+                s.dirty_because(unit, format_args!("the env variable {name} changed"))?;
+
+                Ok(())
+            }
+            DirtyReason::LocalFingerprintTypeChanged { .. } => {
+                s.dirty_because(unit, "the local fingerprint type changed")?;
+
+                Ok(())
+            }
+            DirtyReason::NumberOfDependenciesChanged { old, new } => s.dirty_because(
+                unit,
+                format_args!("number of dependencies changed ({old} => {new})",),
+            ),
+            DirtyReason::UnitDependencyNameChanged { old, new } => s.dirty_because(
+                unit,
+                format_args!("name of dependency changed ({old} => {new})"),
+            ),
+            DirtyReason::UnitDependencyInfoChanged { .. } => {
+                s.dirty_because(unit, "dependency info changed")
+            }
+            DirtyReason::FsStatusOutdated(status) => match status {
+                FsStatus::Stale => s.dirty_because(unit, "stale, unknown reason"),
+                FsStatus::StaleItem(item) => match item {
+                    StaleItem::MissingFile(missing_file) => {
+                        let file = missing_file.strip_prefix(root).unwrap_or(&missing_file);
+                        s.dirty_because(
+                            unit,
+                            format_args!("the file `{}` is missing", file.display()),
+                        )
+                    }
+                    StaleItem::ChangedFile {
+                        stale,
+                        stale_mtime,
+                        reference_mtime,
+                        ..
+                    } => {
+                        let file = stale.strip_prefix(root).unwrap_or(&stale);
+                        let after = Self::after(*reference_mtime, *stale_mtime, "last build");
+                        s.dirty_because(
+                            unit,
+                            format_args!("the file `{}` has changed ({after})", file.display()),
+                        )
+                    }
+                    StaleItem::ChangedEnv { var, .. } => {
+                        s.dirty_because(
+                            unit,
+                            format_args!("the environment variable {var} changed"),
+                        )?;
+                        Ok(())
+                    }
+                },
+                FsStatus::StaleDependency {
+                    name,
+                    dep_mtime,
+                    max_mtime,
+                    ..
+                } => {
+                    let after = Self::after(*max_mtime, *dep_mtime, "last build");
+                    s.dirty_because(
+                        unit,
+                        format_args!("the dependency {name} was rebuilt ({after})"),
+                    )
+                }
+                FsStatus::StaleDepFingerprint { name } => {
+                    s.dirty_because(unit, format_args!("the dependency {name} was rebuilt"))
+                }
+                FsStatus::UpToDate { .. } => {
+                    unreachable!()
+                }
+            },
+            DirtyReason::NothingObvious => {
+                // See comment in fingerprint compare method.
+                s.dirty_because(unit, "the fingerprint comparison turned up nothing obvious")
+            }
+            DirtyReason::Forced => s.dirty_because(unit, "forced"),
+        }
+    }
+}

--- a/src/cargo/core/compiler/fingerprint/dirty_reason.rs
+++ b/src/cargo/core/compiler/fingerprint/dirty_reason.rs
@@ -71,15 +71,6 @@ pub enum DirtyReason {
     Forced,
 }
 
-// still need to implement Display for Error
-impl fmt::Display for DirtyReason {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "dirty")
-    }
-}
-
-impl std::error::Error for DirtyReason {}
-
 trait ShellExt {
     fn dirty_because(&mut self, unit: &Unit, s: impl fmt::Display) -> CargoResult<()>;
 }

--- a/src/cargo/core/compiler/job.rs
+++ b/src/cargo/core/compiler/job.rs
@@ -1,8 +1,8 @@
-use crate::core::compiler::fingerprint::DirtyReason;
 use std::fmt;
 use std::mem;
 
 use super::job_queue::JobState;
+use crate::core::compiler::fingerprint::DirtyReason;
 use crate::util::CargoResult;
 
 pub struct Job {

--- a/src/cargo/core/compiler/job.rs
+++ b/src/cargo/core/compiler/job.rs
@@ -1,3 +1,4 @@
+use crate::core::compiler::fingerprint::DirtyReason;
 use std::fmt;
 use std::mem;
 
@@ -49,10 +50,10 @@ impl Job {
     }
 
     /// Creates a new job representing a unit of work.
-    pub fn new_dirty(work: Work) -> Job {
+    pub fn new_dirty(work: Work, dirty_reason: Option<DirtyReason>) -> Job {
         Job {
             work,
-            fresh: Freshness::Dirty,
+            fresh: Freshness::Dirty(dirty_reason),
         }
     }
 
@@ -65,8 +66,8 @@ impl Job {
     /// Returns whether this job was fresh/dirty, where "fresh" means we're
     /// likely to perform just some small bookkeeping where "dirty" means we'll
     /// probably do something slow like invoke rustc.
-    pub fn freshness(&self) -> Freshness {
-        self.fresh
+    pub fn freshness(&self) -> &Freshness {
+        &self.fresh
     }
 
     pub fn before(&mut self, next: Work) {
@@ -85,8 +86,18 @@ impl fmt::Debug for Job {
 ///
 /// A fresh package does not necessarily need to be rebuilt (unless a dependency
 /// was also rebuilt), and a dirty package must always be rebuilt.
-#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum Freshness {
     Fresh,
-    Dirty,
+    Dirty(Option<DirtyReason>),
+}
+
+impl Freshness {
+    pub fn is_dirty(&self) -> bool {
+        matches!(self, Freshness::Dirty(_))
+    }
+
+    pub fn is_fresh(&self) -> bool {
+        matches!(self, Freshness::Fresh)
+    }
 }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -164,11 +164,11 @@ fn compile<'cfg>(
         // We run these targets later, so this is just a no-op for now.
         Job::new_fresh()
     } else if build_plan {
-        Job::new_dirty(rustc(cx, unit, &exec.clone())?)
+        Job::new_dirty(rustc(cx, unit, &exec.clone())?, None)
     } else {
         let force = exec.force_rebuild(unit) || force_rebuild;
         let mut job = fingerprint::prepare_target(cx, unit, force)?;
-        job.before(if job.freshness() == Freshness::Dirty {
+        job.before(if job.freshness().is_dirty() {
             let work = if unit.mode.is_doc() || unit.mode.is_doc_scrape() {
                 rustdoc(cx, unit)?
             } else {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -45,6 +45,7 @@ pub use self::compile_kind::{CompileKind, CompileTarget};
 pub use self::context::{Context, Metadata};
 pub use self::crate_type::CrateType;
 pub use self::custom_build::{BuildOutput, BuildScriptOutputs, BuildScripts};
+pub(crate) use self::fingerprint::DirtyReason;
 pub use self::job::Freshness;
 use self::job::{Job, Work};
 use self::job_queue::{JobQueue, JobState};

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::{env, fs};
 
-use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, Freshness, UnitOutput};
+use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, UnitOutput};
 use crate::core::{Dependency, Edition, Package, PackageId, Source, SourceId, Workspace};
 use crate::ops::CompileFilter;
 use crate::ops::{common_for_install_and_uninstall::*, FilterRule};
@@ -683,7 +683,7 @@ fn is_installed(
     let tracker = InstallTracker::load(config, root)?;
     let (freshness, _duplicates) =
         tracker.check_upgrade(dst, pkg, force, opts, target, &rustc.verbose_version)?;
-    Ok(freshness == Freshness::Fresh)
+    Ok(freshness.is_fresh())
 }
 
 /// Checks if vers can only be satisfied by exactly one version of a package in a registry, and it's

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -170,7 +170,7 @@ impl InstallTracker {
         // Check if any tracked exe's are already installed.
         let duplicates = self.find_duplicates(dst, &exes);
         if force || duplicates.is_empty() {
-            return Ok((Freshness::Dirty, duplicates));
+            return Ok((Freshness::Dirty(None), duplicates));
         }
         // Check if all duplicates come from packages of the same name. If
         // there are duplicates from other packages, then --force will be
@@ -200,7 +200,7 @@ impl InstallTracker {
             let source_id = pkg.package_id().source_id();
             if source_id.is_path() {
                 // `cargo install --path ...` is always rebuilt.
-                return Ok((Freshness::Dirty, duplicates));
+                return Ok((Freshness::Dirty(None), duplicates));
             }
             let is_up_to_date = |dupe_pkg_id| {
                 let info = self
@@ -224,7 +224,7 @@ impl InstallTracker {
             if matching_duplicates.iter().all(is_up_to_date) {
                 Ok((Freshness::Fresh, duplicates))
             } else {
-                Ok((Freshness::Dirty, duplicates))
+                Ok((Freshness::Dirty(None), duplicates))
             }
         } else {
             // Format the error message.

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2321,8 +2321,10 @@ fn calc_bin_artifact_fingerprint() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
+[DIRTY] bar v0.5.0 ([CWD]/bar): the file `bar/src/main.rs` has changed ([..])
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [RUNNING] `rustc --crate-name bar [..]`
+[DIRTY] foo v0.1.0 ([CWD]): the dependency bar was rebuilt
 [CHECKING] foo v0.1.0 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -74,6 +74,7 @@ fn works_with_cli() {
         .masquerade_as_nightly_cargo(&["config-include"])
         .with_stderr(
             "\
+[DIRTY] foo v0.0.1 ([..]): the rustflags changed
 [COMPILING] foo v0.0.1 [..]
 [RUNNING] `rustc [..]-W unsafe-code -W unused`
 [FINISHED] [..]

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -480,11 +480,14 @@ fn no_feature_doesnt_build() {
         .run();
     p.process(&p.bin("foo")).with_stdout("").run();
 
-    p.cargo("build --features bar")
+    p.cargo("build --features bar -v")
         .with_stderr(
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
+[RUNNING] `rustc --crate-name bar [..]
+[DIRTY-MSVC] foo v0.0.1 ([CWD]): the list of features changed
 [COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -537,10 +540,12 @@ fn default_feature_pulled_in() {
         .run();
     p.process(&p.bin("foo")).with_stdout("bar\n").run();
 
-    p.cargo("build --no-default-features")
+    p.cargo("build --no-default-features -v")
         .with_stderr(
             "\
+[DIRTY-MSVC] foo v0.0.1 ([CWD]): the list of features changed
 [COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `rustc --crate-name foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2521,6 +2521,7 @@ fn include_overrides_gitignore() {
     p.cargo("build -v")
         .with_stderr(
             "\
+[DIRTY] foo v0.5.0 ([..]): the precalculated components changed
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]`

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -595,6 +595,7 @@ fn dylib() {
 [COMPILING] registry-shared v0.0.1
 [FRESH] registry v0.0.1
 [RUNNING] `rustc --crate-name registry_shared [..]-C embed-bitcode=no[..]
+[DIRTY] bar v0.0.0 ([..]): dependency info changed
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar [..]--crate-type dylib [..]-C embed-bitcode=no[..]
 [FINISHED] [..]
@@ -612,6 +613,7 @@ fn dylib() {
 [FRESH] registry-shared v0.0.1
 [COMPILING] registry v0.0.1
 [RUNNING] `rustc --crate-name registry [..]
+[DIRTY] bar v0.0.0 ([..]): dependency info changed
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar [..]--crate-type dylib [..]-C embed-bitcode=no[..]
 [RUNNING] `rustc --crate-name bar [..]-C lto [..]--test[..]

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -639,6 +639,7 @@ fn rustc_fingerprint() {
         .with_stderr_does_not_contain("-C debug-assertions")
         .with_stderr(
             "\
+[DIRTY] foo [..]: the profile configuration changed
 [COMPILING] foo [..]
 [RUNNING] `rustc [..]
 [FINISHED] [..]

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -2661,6 +2661,7 @@ fn bin_does_not_rebuild_tests() {
     p.cargo("test -v --no-run")
         .with_stderr(
             "\
+[DIRTY] foo v0.0.1 ([..]): the file `src/main.rs` has changed ([..])
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] src/main.rs [..]`
 [RUNNING] `rustc [..] src/main.rs [..]`


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Attempts to provide some reasons for why crates are rebuilt (issue #2904 has been around for a very long time).

Basically adds an `Option<DirtyReason>` to `Job`, returned by the `Fingerprint::compare` method, and displays it in `DrainState::note_working_on`, almost analogous to displaying `Fresh`, ~but unlike `Fresh`, it is displayed regardless of verbosity, though with `-v` it gives a few more details~ Edit: now only displayed with `--verbose`. Also needed to add a few `FsStatus` variants to track why it was stale, to be able to display that information.

### How should we test and review this PR?

I updated the freshness tests with the correct outputs after the change. ~Unsure if any of the other tests need to be changed.~ Edit: turns out quite a few did.

### Additional information

[Topic on zulip](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Questions.20for.20implementation.20of.20.232904.3F).

As for the actual presentation, it definitely can be improved, and I would love to hear some other thoughts on it. There are some variants that seem pretty enigmatic, and that I have few ideas how to actually present in any meaningful way (specifically: `CompileKindChanged`, `LocalLengthsChanged`, `PrecalculatedComponentsChanged`, `DepInfoOutputChanged`, `LocalFingerprintTypeChanged`, and `NothingObvious`).

Fixes #2904

<!-- homu-ignore:end -->
