### PR TITLE
Suggest cargo add when installing library crate

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -209,8 +209,8 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
             bail!(
                 "there is nothing to install in `{}`, because it has no binaries\n\
                  `cargo install` is only for installing programs, and can't be used with libraries.\n\
-                 To use a library crate, add it as a dependency in a Cargo project instead.",
-                pkg
+                 To use a library crate, add it as a dependency to a Cargo project with `cargo add`.",
+                pkg,
             );
         }
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -730,7 +730,7 @@ fn no_binaries() {
             "\
 [ERROR] there is nothing to install in `foo v0.0.1 ([..])`, because it has no binaries[..]
 [..]
-[..]",
+To use a library crate, add it as a dependency to a Cargo project with `cargo add`.",
         )
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

When using `cargo install` instead of `cargo use` the error message is the following:
```
error: there is nothing to install in `foo v0.0.1`, because it has no binaries
`cargo install` is only for installing programs, and can't be used with libraries.
To use a library crate, add it as a dependency in a Cargo project instead.
```
It would be good to suggest to the user to use `cargo add`.

### How should we test and review this PR?

The `no_binaries` test from `tests/testsuite/install.rs` covers that case.