### PR TITLE
Less cryptic panic! for when std_roots index fails in attach_std_deps()

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -173,7 +173,13 @@ fn attach_std_deps(
     let mut found = false;
     for (unit, deps) in state.unit_dependencies.iter_mut() {
         if !unit.kind.is_host() && !unit.mode.is_run_custom_build() {
-            deps.extend(std_roots[&unit.kind].iter().map(|unit| UnitDep {
+            let Some(unit_target) = std_roots.get(&unit.kind) else {
+                // TODO: Handle error without a panic?
+                // Is this a bug within Cargo? If so, it should be specified within the message.
+                panic!("Could not find std root for unit kind: {:?}", unit.kind);
+            };
+
+            deps.extend(unit_target.iter().map(|unit| UnitDep {
                 unit: unit.clone(),
                 unit_for: UnitFor::new_normal(unit.kind),
                 extern_crate_name: unit.pkg.name(),


### PR DESCRIPTION
Sometimes, Cargo panics with a cryptic `thread 'main' panicked at 'no entry found for key', src/tools/cargo/src/cargo/core/compiler/unit_dependencies.rs:176:25` panic message. This commit replaces it with a less-terrible alternative, until whatever is causing it can be fixed...

If you are more experienced with the code-base, I ask that you put in a better `panic!` message (or convert it into a user-facing error with `Result` if this is intended).

This error is caused when using workspaces with a correctly defined submodule, compiling for a bare-metal (`x86_64-unknown-none`) target.

I ran into this error when working on a hobby project. I preserved the code that causes this error in this [branch](https://github.com/T-O-R-U-S/sprinkles_os/tree/peculiar-bug).

** I couldn't find a corresponding issue for this bug.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
