### PR TITLE
temporarily disable test `lto::test_profile`

### DIFF
--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -625,6 +625,10 @@ fn dylib() {
 }
 
 #[cargo_test]
+#[cfg_attr(
+    all(target_os = "windows", target_env = "gnu"),
+    ignore = "thinLTO is broken. Tracking in rust-lang/rust#104852"
+)]
 fn test_profile() {
     Package::new("bar", "0.0.1")
         .file("src/lib.rs", "pub fn foo() -> i32 { 123 } ")


### PR DESCRIPTION
- CI failing
  - <https://github.com/rust-lang/cargo/actions/runs/3542820690/jobs/5948722067>
  - <https://github.com/rust-lang/cargo/actions/runs/3535399031/jobs/5933377592>
- Tracking in <https://github.com/rust-lang/rust/issues/104852>
- Discussing in <https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/windows.20gnu.20LTO.20CI.20error>