### PR TITLE
fix: Move off atty to resolve soundness issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
-atty = "0.2"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.3" }
@@ -37,6 +36,7 @@ http-auth = { version = "0.1.6", default-features = false }
 humantime = "2.0.0"
 indexmap = "1"
 ignore = "0.4.7"
+is-terminal = "0.4.0"
 lazy_static = "1.2.0"
 jobserver = "0.1.24"
 lazycell = "1.2.0"

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -9,4 +9,4 @@ cargo-util = { path = "../cargo-util" }
 proptest = "0.9.1"
 lazy_static = "1.3.0"
 varisat = "0.2.1"
-atty = "0.2.11"
+is-terminal = "0.4.0"

--- a/crates/resolver-tests/tests/resolve.rs
+++ b/crates/resolver-tests/tests/resolve.rs
@@ -21,7 +21,7 @@ use proptest::prelude::*;
 proptest! {
     #![proptest_config(ProptestConfig {
         max_shrink_iters:
-            if is_ci() || !atty::is(atty::Stream::Stderr) {
+            if is_ci() || !is_terminal::IsTerminal::is_terminal(&std::io::stderr()){
                 // This attempts to make sure that CI will fail fast,
                 0
             } else {


### PR DESCRIPTION
There is a soundness issue with atty when building on Windows with a custom allocator.

This PR switches direct dependencies on atty to is-terminal.  New semver compatible versions of clap and snapbox remove atty. #11417 upgrades env_logger to remove it from there.

Fixes #11416

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
