### PR TITLE
core::compiler: remove Executor trait

### DIFF
--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -18,9 +18,7 @@ use super::job_queue::JobQueue;
 use super::layout::Layout;
 use super::lto::Lto;
 use super::unit_graph::UnitDep;
-use super::{
-    BuildContext, Compilation, CompileKind, CompileMode, Executor, FileFlavor, RustDocFingerprint,
-};
+use super::{BuildContext, Compilation, CompileKind, CompileMode, FileFlavor, RustDocFingerprint};
 
 mod compilation_files;
 use self::compilation_files::CompilationFiles;
@@ -126,7 +124,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
 
     /// Starts compilation, waits for it to finish, and returns information
     /// about the result of compilation.
-    pub fn compile(mut self, exec: &Arc<dyn Executor>) -> CargoResult<Compilation<'cfg>> {
+    pub fn compile(mut self) -> CargoResult<Compilation<'cfg>> {
         let mut queue = JobQueue::new(self.bcx);
         let mut plan = BuildPlan::new();
         let build_plan = self.bcx.build_config.build_plan;
@@ -156,7 +154,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
             // function which will run everything in order with proper
             // parallelism.
             let force_rebuild = self.bcx.build_config.force_rebuild;
-            super::compile(&mut self, &mut queue, &mut plan, unit, exec, force_rebuild)?;
+            super::compile(&mut self, &mut queue, &mut plan, unit, force_rebuild)?;
         }
 
         // Now that we've got the full job queue and we've done all our

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -1,9 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::{env, fs};
 
-use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, Freshness, UnitOutput};
+use crate::core::compiler::{CompileKind, Freshness, UnitOutput};
 use crate::core::{Dependency, Edition, Package, PackageId, Source, SourceId, Workspace};
 use crate::ops::CompileFilter;
 use crate::ops::{common_for_install_and_uninstall::*, FilterRule};
@@ -296,8 +295,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
 
         self.check_yanked_install()?;
 
-        let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
-        let compile = ops::compile_ws(&self.ws, self.opts, &exec).with_context(|| {
+        let compile = ops::compile_ws(&self.ws, self.opts).with_context(|| {
             if let Some(td) = td_opt.take() {
                 // preserve the temporary directory, so the user can inspect it
                 td.into_path();

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -4,10 +4,9 @@ use std::io::prelude::*;
 use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::sync::Arc;
 use std::task::Poll;
 
-use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};
+use crate::core::compiler::{BuildConfig, CompileMode};
 use crate::core::resolver::CliFeatures;
 use crate::core::{Feature, Shell, Verbosity, Workspace};
 use crate::core::{Package, PackageId, PackageSet, Resolve, SourceId};
@@ -835,8 +834,7 @@ fn run_verify(
         None
     };
 
-    let exec: Arc<dyn Executor> = Arc::new(DefaultExecutor);
-    ops::compile_with_exec(
+    ops::compile(
         &ws,
         &ops::CompileOptions {
             build_config: BuildConfig::new(
@@ -857,7 +855,6 @@ fn run_verify(
             rustdoc_document_private_items: false,
             honor_rust_version: true,
         },
-        &exec,
     )?;
 
     // Check that `build.rs` didn't modify any files in the `src` directory.

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -2,7 +2,7 @@ use crate::sources::CRATES_IO_DOMAIN;
 
 pub use self::cargo_clean::{clean, CleanOptions};
 pub use self::cargo_compile::{
-    compile, compile_with_exec, compile_ws, create_bcx, print, resolve_all_features, CompileOptions,
+    compile, compile_ws, create_bcx, print, resolve_all_features, CompileOptions,
 };
 pub use self::cargo_compile::{CompileFilter, FilterRule, LibRule, Packages};
 pub use self::cargo_doc::{doc, DocOptions};


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This PR remove the Executor trait and thus simplifies some code. I added this trait for the RLS and it was never advertised as a publicly available API. The RLS is dead now and I think this API is not the best way to achieve its goals, therefore I think it should be removed.

### How should we test and review this PR?

Change is trivial refactoring, so existing tests should be fine. Eyeball review should be fine.

### Additional information

r? @arlosi 
<!-- homu-ignore:end -->
