### PR TITLE
Proxy auth with custom HTTP transport

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -560,6 +560,9 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
     if let Some(proxy) = http_proxy(config)? {
         handle.proxy(&proxy)?;
     }
+    handle.proxy_auth(&http.proxy_auth.to_easy())?;
+    handle.proxy_username(&http.proxy_username)?;
+    handle.proxy_password(&http.proxy_password)?;
     if let Some(cainfo) = &http.cainfo {
         let cainfo = cainfo.resolve_path(config);
         handle.cainfo(&cainfo)?;

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -561,8 +561,8 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
         handle.proxy(&proxy)?;
     }
     handle.proxy_auth(&http.proxy_auth.to_easy())?;
-    handle.proxy_username(&http.proxy_username)?;
-    handle.proxy_password(&http.proxy_password)?;
+    handle.proxy_username(http.proxy_username.as_deref().unwrap_or(""))?;
+    handle.proxy_password(http.proxy_password.as_deref().unwrap_or(""))?;
     if let Some(cainfo) = &http.cainfo {
         let cainfo = cainfo.resolve_path(config);
         handle.cainfo(&cainfo)?;

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2229,16 +2229,16 @@ pub enum CargoHttpProxyAuth {
 
 impl CargoHttpProxyAuth {
     pub fn to_easy(&self) -> Auth {
-        let mut easy = Auth::new();
-        let easy = match self {
-            Self::Auto => easy.basic(true).digest(true).gssnegotiate(true).ntlm(true),
-            Self::Disable => &mut easy,
-            Self::Basic => easy.basic(true),
-            Self::Digest => easy.digest(true),
-            Self::Gss => easy.gssnegotiate(true),
-            Self::Ntlm => easy.ntlm(true),
+        let mut auth = Auth::new();
+        match self {
+            Self::Auto => auth.basic(true).digest(true).gssnegotiate(true).ntlm(true),
+            Self::Disable => &auth,
+            Self::Basic => auth.basic(true),
+            Self::Digest => auth.digest(true),
+            Self::Gss => auth.gssnegotiate(true),
+            Self::Ntlm => auth.ntlm(true),
         };
-        easy.clone()
+        auth
     }
 }
 

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2248,10 +2248,8 @@ pub struct CargoHttpConfig {
     pub proxy: Option<String>,
     #[serde(default)]
     pub proxy_auth: CargoHttpProxyAuth,
-    #[serde(default)]
-    pub proxy_username: String,
-    #[serde(default)]
-    pub proxy_password: String,
+    pub proxy_username: Option<String>,
+    pub proxy_password: Option<String>,
     pub low_speed_limit: Option<u32>,
     pub timeout: Option<u64>,
     pub cainfo: Option<ConfigRelativePath>,

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -96,6 +96,9 @@ vcs = "none"              # VCS to use ('git', 'hg', 'pijul', 'fossil', 'none')
 [http]
 debug = false               # HTTP debugging
 proxy = "host:port"         # HTTP proxy in libcurl format
+proxy-auth = "auto"         # HTTP proxy authentication mechanism
+proxy-username = ""         # HTTP proxy username
+proxy-password = ""         # HTTP proxy password
 ssl-version = "tlsv1.3"     # TLS version to use
 ssl-version.max = "tlsv1.3" # maximum TLS version
 ssl-version.min = "tlsv1.1" # minimum TLS version
@@ -626,6 +629,28 @@ Sets an HTTP and HTTPS proxy to use. The format is in [libcurl format] as in
 setting in your global git configuration. If none of those are set, the
 `HTTPS_PROXY` or `https_proxy` environment variables set the proxy for HTTPS
 requests, and `http_proxy` sets it for HTTP requests.
+
+##### `http.proxy-auth`
+* Type: string
+* Default: "auto"
+* Environment: `CARGO_HTTP_PROXY_AUTH`
+
+Sets a mechanism to authenticate against the proxy.
+Possible values are: "auto", "disable", "basic", "digest", "gss" and "ntlm".
+
+##### `http.proxy-username`
+* Type: string
+* Default: ""
+* Environment: `CARGO_HTTP_PROXY_USERNAME`
+
+Authenticate against the proxy using the given username.
+
+##### `http.proxy-password`
+* Type: string
+* Default: ""
+* Environment: `CARGO_HTTP_PROXY_PASSWORD`
+
+Authenticate against the proxy using the given password.
 
 ##### `http.timeout`
 * Type: integer

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -640,14 +640,14 @@ Possible values are: "auto", "disable", "basic", "digest", "gss" and "ntlm".
 
 ##### `http.proxy-username`
 * Type: string
-* Default: ""
+* Default: none
 * Environment: `CARGO_HTTP_PROXY_USERNAME`
 
 Authenticate against the proxy using the given username.
 
 ##### `http.proxy-password`
 * Type: string
-* Default: ""
+* Default: none
 * Environment: `CARGO_HTTP_PROXY_PASSWORD`
 
 Authenticate against the proxy using the given password.

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -101,6 +101,9 @@ In summary, the supported environment variables are:
 * `CARGO_FUTURE_INCOMPAT_REPORT_FREQUENCY` - How often we should generate a future incompat report notification, see [`future-incompat-report.frequency`].
 * `CARGO_HTTP_DEBUG` — Enables HTTP debugging, see [`http.debug`].
 * `CARGO_HTTP_PROXY` — Enables HTTP proxy, see [`http.proxy`].
+* `CARGO_HTTP_PROXY_AUTH` — The proxy authentication mechanism, see [`http.proxy-auth`].
+* `CARGO_HTTP_PROXY_USERNAME` — The proxy username, see [`http.proxy-username`].
+* `CARGO_HTTP_PROXY_PASSWORD` — The proxy password, see [`http.proxy-password`].
 * `CARGO_HTTP_TIMEOUT` — The HTTP timeout, see [`http.timeout`].
 * `CARGO_HTTP_CAINFO` — The TLS certificate Certificate Authority file, see [`http.cainfo`].
 * `CARGO_HTTP_CHECK_REVOKE` — Disables TLS certificate revocation checks, see [`http.check-revoke`].
@@ -163,6 +166,9 @@ In summary, the supported environment variables are:
 [`future-incompat-report.frequency`]: config.md#future-incompat-reportfrequency
 [`http.debug`]: config.md#httpdebug
 [`http.proxy`]: config.md#httpproxy
+[`http.proxy-auth`]: config.md#httpproxy-auth
+[`http.proxy-username`]: config.md#httpproxy-username
+[`http.proxy-password`]: config.md#httpproxy-password
 [`http.timeout`]: config.md#httptimeout
 [`http.cainfo`]: config.md#httpcainfo
 [`http.check-revoke`]: config.md#httpcheck-revoke


### PR DESCRIPTION
### What does this PR try to resolve?

This PR makes cargo authenticate against proxies when needed.
Closes https://github.com/rust-lang/cargo/issues/7330

Add three settings:
- http.proxy-auth
- http.proxy-username
- http.proxy-password

proxy-auth defaults to "auto" so that most use cases work out of the box. I don't know why you would disable authentication support, but I added a "disable" option in this case. You can also force the use of a mechanism and abort if the proxy doesn't advertise it.

proxy-username and proxy-password: `String` vs `Option<String>`?
curl doesn't negotiate (SPNEGO, here "gss") if handle.proxy_username and handle.proxy_password aren't called. This authentication mechanism doesn't require a user/pass in cargo config. This shouldn't hurt (?) when the proxy doesn't require authentication.

About curl-rust's spnego and ntlm features:
https://github.com/alexcrichton/curl-rust/blob/b50c5d355aab69483752db51815c5a679b29d6c4/curl-sys/Cargo.toml#L54-L60
**This is the last blocker I think.** If we require those features, then vendored curl builds will require "a suitable GSS-API library or SSPI on Windows" [0] for the "gss" setting to work (which is what corporate proxies are using most of the time). I think this PR is blocked until we can either  vendor those dependencies, or we change the official cargo builds to link dynamically to libcurl.

The official cargo builds seems to be made with vendored curl.

### How should we test and review this PR?

Complete testing is a bit tedious since you'd need e.g. squid [1] to test each authentication mechanism. With such proxy, run `cargo update` with http-proxy environment variables (plus `--config http.proxy-{username,password}=` if needed).

[0] https://docs.rs/curl/0.4/curl/easy/struct.Auth.html#method.gssnegotiate
[1] http://www.squid-cache.org/