### PR TITLE
Emit progress state escape codes

### DIFF
--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -40,6 +40,9 @@ struct Format {
     max_print: usize,
 }
 
+/// Which escape code to use for progress reporting.
+/// 
+/// There is more codes, but we only use these two.
 enum ProgressCode {
     None,
     Normal(u8),
@@ -101,7 +104,7 @@ impl<'cfg> Progress<'cfg> {
                 throttle: Throttle::new(),
                 last_line: None,
                 fixed_width: progress_config.width,
-                last_pbar: 255,
+                last_pbar: u8::MAX,
             }),
         }
     }

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -41,7 +41,7 @@ struct Format {
 }
 
 /// Which escape code to use for progress reporting.
-/// 
+///
 /// There is more codes, but we only use these two.
 enum ProgressCode {
     None,
@@ -50,13 +50,9 @@ enum ProgressCode {
 
 impl std::fmt::Display for ProgressCode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let progress = match self {
-            Self::None => 0,
-            Self::Normal(v) => *v,
-        };
-        let state = match self {
-            Self::None => 0,
-            Self::Normal(_) => 1,
+        let (state, progress) = match self {
+            Self::None => (0, 0),
+            Self::Normal(v) => (1, *v),
         };
         write!(f, "\x1b]9;4;{state};{progress}\x1b\\")
     }
@@ -262,6 +258,8 @@ impl<'cfg> State<'cfg> {
         if self.last_line.is_some() && !self.config.shell().is_cleared() {
             self.config.shell().err_erase_line();
             self.last_line = None;
+            let _ = write!(self.config.shell().err(), "{}", ProgressCode::None);
+            self.last_pbar = u8::MAX;
         }
     }
 


### PR DESCRIPTION
Emit progress state escape codes when drawing progress bar.

Fixes #11432

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
