### PR TITLE
Crate checksum lookup query should match on semver build metadata

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -694,6 +694,7 @@ impl<'cfg> RegistrySource<'cfg> {
             .summaries(&package.name(), &req, &mut *self.ops)?
             .expect("a downloaded dep now pending!?")
             .map(|s| s.summary.clone())
+            .filter(|s| s.version() == package.version())
             .next()
             .expect("summary not found");
         if let Some(cksum) = summary_with_cksum.checksum() {


### PR DESCRIPTION
Since crates.io allows crate versions to differ only by build metadata, a query using `OptVersionReq::exact` + `next()` can return nondeterministic results.

This change fixes the issue by adding an additional `filter` that ensures the version is equal (including build metadata).

It still feels somewhat wrong that a query using `exact` can match multiple crates, so an alternative fix would be to add a new variant of `OptVersionReq` that also matched on build metadata.

Fixes #11412 