### PR TITLE
gitoxide integration: fetch 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
           os: windows-latest
           rust: stable-msvc
           other: i686-pc-windows-msvc
-        - name: Windows x86_64 gnu nightly
+        - name: Windows x86_64 gnu nightly # runs out of space while trying to link the test suite
           os: windows-latest
           rust: nightly-gnu
           other: i686-pc-windows-gnu
@@ -102,7 +102,16 @@ jobs:
       if: "!contains(matrix.rust, 'stable')"
 
     - run: cargo test
-    # The testsuite generates a huge amount of data, and fetch-smoke-test was
+    - name: Clear intermediate test output
+      run: |
+          df -h
+          rm -rf target/tmp
+          df -h
+    - name: gitoxide tests (all git-related tests)
+      run: cargo test git
+      env:
+        __CARGO_USE_GITOXIDE_INSTEAD_OF_GIT2: 1
+      # The testsuite generates a huge amount of data, and fetch-smoke-test was
     # running out of disk space.
     - name: Clear test output
       run: |
@@ -156,6 +165,18 @@ jobs:
     - run: rustup update stable && rustup default stable
     - run: cargo test --manifest-path crates/resolver-tests/Cargo.toml
 
+  test_gitoxide:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update --no-self-update stable && rustup default stable
+      - run: rustup target add i686-unknown-linux-gnu
+      - run: sudo apt update -y && sudo apt install gcc-multilib libsecret-1-0 libsecret-1-dev -y
+      - run: rustup component add rustfmt || echo "rustfmt not available"
+      - run: cargo test
+        env:
+          __CARGO_USE_GITOXIDE_INSTEAD_OF_GIT2: 1
+
   build_std:
     runs-on: ubuntu-latest
     env:
@@ -196,7 +217,7 @@ jobs:
     permissions:
       contents: none
     name: bors build finished
-    needs: [docs, rustfmt, test, resolver, build_std]
+    needs: [docs, rustfmt, test, resolver, build_std, test_gitoxide]
     runs-on: ubuntu-latest
     if: "success() && github.event_name == 'push' && github.ref == 'refs/heads/auto-cargo'"
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 git2 = "0.16.0"
 git2-curl = "0.17.0"
+gix = { version = "0.38.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix-features-for-configuration-only = { version = "0.27.0", package = "gix-features", features = [ "parallel" ] }
 glob = "0.3.0"
 hex = "0.4"
 hmac = "0.12.1"

--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -247,3 +247,10 @@ pub fn tag(repo: &git2::Repository, name: &str) {
         false
     ));
 }
+
+/// Returns true if gitoxide is globally activated.
+///
+/// That way, tests that normally use `git2` can transparently use `gitoxide`.
+pub fn cargo_uses_gitoxide() -> bool {
+    std::env::var_os("__CARGO_USE_GITOXIDE_INSTEAD_OF_GIT2").map_or(false, |value| value == "1")
+}

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -52,7 +52,7 @@ mod cargo_uninstall;
 mod common_for_install_and_uninstall;
 mod fix;
 mod lockfile;
-mod registry;
+pub(crate) mod registry;
 mod resolve;
 pub mod tree;
 mod vendor;

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -619,9 +619,6 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
         handle.useragent(&format!("cargo {}", version()))?;
     }
 
-    // Empty string accept encoding expands to the encodings supported by the current libcurl.
-    handle.accept_encoding("")?;
-
     fn to_ssl_version(s: &str) -> CargoResult<SslVersion> {
         let version = match s {
             "default" => SslVersion::Default,
@@ -631,13 +628,15 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
             "tlsv1.2" => SslVersion::Tlsv12,
             "tlsv1.3" => SslVersion::Tlsv13,
             _ => bail!(
-                "Invalid ssl version `{}`,\
-                 choose from 'default', 'tlsv1', 'tlsv1.0', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3'.",
-                s
+                "Invalid ssl version `{s}`,\
+                 choose from 'default', 'tlsv1', 'tlsv1.0', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3'."
             ),
         };
         Ok(version)
     }
+
+    // Empty string accept encoding expands to the encodings supported by the current libcurl.
+    handle.accept_encoding("")?;
     if let Some(ssl_version) = &http.ssl_version {
         match ssl_version {
             SslVersionConfig::Single(s) => {

--- a/src/cargo/sources/git/mod.rs
+++ b/src/cargo/sources/git/mod.rs
@@ -1,5 +1,10 @@
 pub use self::source::GitSource;
 pub use self::utils::{fetch, GitCheckout, GitDatabase, GitRemote};
 mod known_hosts;
+mod oxide;
 mod source;
 mod utils;
+
+pub mod fetch {
+    pub type Error = gix::env::collate::fetch::Error<gix::refspec::parse::Error>;
+}

--- a/src/cargo/sources/git/oxide.rs
+++ b/src/cargo/sources/git/oxide.rs
@@ -1,0 +1,338 @@
+//! This module contains all code sporting `gitoxide` for operations on `git` repositories and it mirrors
+//! `utils` closely for now. One day it can be renamed into `utils` once `git2` isn't required anymore.
+
+use crate::ops::HttpTimeout;
+use crate::util::{human_readable_bytes, network, MetricsCounter, Progress};
+use crate::{CargoResult, Config};
+use cargo_util::paths;
+use gix::bstr::{BString, ByteSlice};
+use log::debug;
+use std::cell::RefCell;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant};
+
+/// For the time being, `repo_path` makes it easy to instantiate a gitoxide repo just for fetching.
+/// In future this may change to be the gitoxide repository itself.
+pub fn with_retry_and_progress(
+    repo_path: &std::path::Path,
+    config: &Config,
+    cb: &(dyn Fn(
+        &std::path::Path,
+        &AtomicBool,
+        &mut gix::progress::tree::Item,
+        &mut dyn FnMut(&gix::bstr::BStr),
+    ) -> Result<(), crate::sources::git::fetch::Error>
+          + Send
+          + Sync),
+) -> CargoResult<()> {
+    std::thread::scope(|s| {
+        let mut progress_bar = Progress::new("Fetch", config);
+        network::with_retry(config, || {
+            let progress_root: Arc<gix::progress::tree::Root> =
+                gix::progress::tree::root::Options {
+                    initial_capacity: 10,
+                    message_buffer_capacity: 10,
+                }
+                .into();
+            let root = Arc::downgrade(&progress_root);
+            let thread = s.spawn(move || {
+                let mut progress = progress_root.add_child("operation");
+                let mut urls = RefCell::new(Default::default());
+                let res = cb(
+                    &repo_path,
+                    &AtomicBool::default(),
+                    &mut progress,
+                    &mut |url| {
+                        *urls.borrow_mut() = Some(url.to_owned());
+                    },
+                );
+                amend_authentication_hints(res, urls.get_mut().take())
+            });
+            translate_progress_to_bar(&mut progress_bar, root)?;
+            thread.join().expect("no panic in scoped thread")
+        })
+    })
+}
+
+fn translate_progress_to_bar(
+    progress_bar: &mut Progress<'_>,
+    root: Weak<gix::progress::tree::Root>,
+) -> CargoResult<()> {
+    let read_pack_bytes: gix::progress::Id =
+        gix::odb::pack::bundle::write::ProgressId::ReadPackBytes.into();
+    let delta_index_objects: gix::progress::Id =
+        gix::odb::pack::index::write::ProgressId::IndexObjects.into();
+    let resolve_objects: gix::progress::Id =
+        gix::odb::pack::index::write::ProgressId::ResolveObjects.into();
+
+    // We choose `N=10` here to make a `300ms * 10slots ~= 3000ms`
+    // sliding window for tracking the data transfer rate (in bytes/s).
+    let mut last_update = Instant::now();
+    let mut counter = MetricsCounter::<10>::new(0, last_update);
+
+    let mut tasks = Vec::with_capacity(10);
+    let update_interval = std::time::Duration::from_millis(300);
+    let short_check_interval = Duration::from_millis(50);
+
+    while let Some(root) = root.upgrade() {
+        let not_yet = last_update.elapsed() < update_interval;
+        if not_yet {
+            std::thread::sleep(short_check_interval);
+        }
+        root.sorted_snapshot(&mut tasks);
+
+        fn progress_by_id(
+            id: gix::progress::Id,
+            task: &gix::progress::Task,
+        ) -> Option<&gix::progress::Value> {
+            (task.id == id).then(|| task.progress.as_ref()).flatten()
+        }
+        fn find_in<K>(
+            tasks: &[(K, gix::progress::Task)],
+            cb: impl Fn(&gix::progress::Task) -> Option<&gix::progress::Value>,
+        ) -> Option<&gix::progress::Value> {
+            tasks.iter().find_map(|(_, t)| cb(t))
+        }
+
+        if let Some(objs) = find_in(&tasks, |t| progress_by_id(resolve_objects, t)) {
+            // Resolving deltas.
+            let objects = objs.step.load(Ordering::Relaxed);
+            let total_objects = objs.done_at.expect("known amount of objects");
+            let msg = format!(", ({objects}/{total_objects}) resolving deltas");
+
+            progress_bar.tick(objects, total_objects, &msg)?;
+        } else if let Some((objs, read_pack)) =
+            find_in(&tasks, |t| progress_by_id(read_pack_bytes, t)).and_then(|read| {
+                find_in(&tasks, |t| progress_by_id(delta_index_objects, t))
+                    .map(|delta| (delta, read))
+            })
+        {
+            // Receiving objects.
+            let objects = objs.step.load(Ordering::Relaxed);
+            let total_objects = objs.done_at.expect("known amount of objects");
+            let received_bytes = read_pack.step.load(Ordering::Relaxed);
+
+            let now = Instant::now();
+            if !not_yet {
+                counter.add(received_bytes, now);
+                last_update = now;
+            }
+            let (rate, unit) = human_readable_bytes(counter.rate() as u64);
+            let msg = format!(", {rate:.2}{unit}/s");
+
+            progress_bar.tick(objects, total_objects, &msg)?;
+        }
+    }
+    Ok(())
+}
+
+fn amend_authentication_hints(
+    res: Result<(), crate::sources::git::fetch::Error>,
+    last_url_for_authentication: Option<gix::bstr::BString>,
+) -> CargoResult<()> {
+    let Err(err) = res else { return Ok(()) };
+    let e = match &err {
+        crate::sources::git::fetch::Error::PrepareFetch(
+            gix::remote::fetch::prepare::Error::RefMap(gix::remote::ref_map::Error::Handshake(err)),
+        ) => Some(err),
+        _ => None,
+    };
+    if let Some(e) = e {
+        use anyhow::Context;
+        let auth_message = match e {
+            gix::protocol::handshake::Error::Credentials(_) => {
+                "\n* attempted to find username/password via \
+                     git's `credential.helper` support, but failed"
+                    .into()
+            }
+            gix::protocol::handshake::Error::InvalidCredentials { .. } => {
+                "\n* attempted to find username/password via \
+                     `credential.helper`, but maybe the found \
+                     credentials were incorrect"
+                    .into()
+            }
+            gix::protocol::handshake::Error::Transport(_) => {
+                let msg = concat!(
+                    "network failure seems to have happened\n",
+                    "if a proxy or similar is necessary `net.git-fetch-with-cli` may help here\n",
+                    "https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli"
+                );
+                return Err(anyhow::Error::from(err)).context(msg);
+            }
+            _ => None,
+        };
+        if let Some(auth_message) = auth_message {
+            let mut msg = "failed to authenticate when downloading \
+                       repository"
+                .to_string();
+            if let Some(url) = last_url_for_authentication {
+                msg.push_str(": ");
+                msg.push_str(url.to_str_lossy().as_ref());
+            }
+            msg.push('\n');
+            msg.push_str(auth_message);
+            msg.push_str("\n\n");
+            msg.push_str("if the git CLI succeeds then `net.git-fetch-with-cli` may help here\n");
+            msg.push_str(
+                "https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli",
+            );
+            return Err(anyhow::Error::from(err)).context(msg);
+        }
+    }
+    Err(err.into())
+}
+
+/// The reason we are opening a git repository.
+///
+/// This can affect the way we open it and the cost associated with it.
+pub enum OpenMode {
+    /// We need `git_binary` configuration as well for being able to see credential helpers
+    /// that are configured with the `git` installation itself.
+    /// However, this is slow on windows (~150ms) and most people won't need it as they use the
+    /// standard index which won't ever need authentication, so we only enable this when needed.
+    ForFetch,
+}
+
+impl OpenMode {
+    /// Sometimes we don't need to pay for figuring out the system's git installation, and this tells
+    /// us if that is the case.
+    pub fn needs_git_binary_config(&self) -> bool {
+        match self {
+            OpenMode::ForFetch => true,
+        }
+    }
+}
+
+/// Produce a repository with everything pre-configured according to `config`. Most notably this includes
+/// transport configuration. Knowing its `purpose` helps to optimize the way we open the repository.
+/// Use `config_overrides` to configure the new repository.
+pub fn open_repo(
+    repo_path: &std::path::Path,
+    config_overrides: Vec<BString>,
+    purpose: OpenMode,
+) -> Result<gix::Repository, gix::open::Error> {
+    gix::open_opts(repo_path, {
+        let mut opts = gix::open::Options::default();
+        opts.permissions.config = gix::permissions::Config::all();
+        opts.permissions.config.git_binary = purpose.needs_git_binary_config();
+        opts.with(gix::sec::Trust::Full)
+            .config_overrides(config_overrides)
+    })
+}
+
+/// Convert `git` related cargo configuration into the respective `git` configuration which can be
+/// used when opening new repositories.
+pub fn cargo_config_to_gitoxide_overrides(config: &Config) -> CargoResult<Vec<BString>> {
+    use gix::config::tree::{gitoxide, Core, Http, Key};
+    let timeout = HttpTimeout::new(config)?;
+    let http = config.http_config()?;
+
+    let mut values = vec![
+        gitoxide::Http::CONNECT_TIMEOUT.validated_assignment_fmt(&timeout.dur.as_millis())?,
+        Http::LOW_SPEED_LIMIT.validated_assignment_fmt(&timeout.low_speed_limit)?,
+        Http::LOW_SPEED_TIME.validated_assignment_fmt(&timeout.dur.as_secs())?,
+        // Assure we are not depending on committer information when updating refs after cloning.
+        Core::LOG_ALL_REF_UPDATES.validated_assignment_fmt(&false)?,
+    ];
+    if let Some(proxy) = &http.proxy {
+        values.push(Http::PROXY.validated_assignment_fmt(proxy)?);
+    }
+    if let Some(check_revoke) = http.check_revoke {
+        values.push(Http::SCHANNEL_CHECK_REVOKE.validated_assignment_fmt(&check_revoke)?);
+    }
+    if let Some(cainfo) = &http.cainfo {
+        values.push(
+            Http::SSL_CA_INFO.validated_assignment_fmt(&cainfo.resolve_path(config).display())?,
+        );
+    }
+
+    values.push(if let Some(user_agent) = &http.user_agent {
+        Http::USER_AGENT.validated_assignment_fmt(user_agent)
+    } else {
+        Http::USER_AGENT.validated_assignment_fmt(&format!("cargo {}", crate::version()))
+    }?);
+    if let Some(ssl_version) = &http.ssl_version {
+        use crate::util::config::SslVersionConfig;
+        match ssl_version {
+            SslVersionConfig::Single(version) => {
+                values.push(Http::SSL_VERSION.validated_assignment_fmt(&version)?);
+            }
+            SslVersionConfig::Range(range) => {
+                values.push(
+                    gitoxide::Http::SSL_VERSION_MIN
+                        .validated_assignment_fmt(&range.min.as_deref().unwrap_or("default"))?,
+                );
+                values.push(
+                    gitoxide::Http::SSL_VERSION_MAX
+                        .validated_assignment_fmt(&range.max.as_deref().unwrap_or("default"))?,
+                );
+            }
+        }
+    } else if cfg!(windows) {
+        // This text is copied from https://github.com/rust-lang/cargo/blob/39c13e67a5962466cc7253d41bc1099bbcb224c3/src/cargo/ops/registry.rs#L658-L674 .
+        // This is a temporary workaround for some bugs with libcurl and
+        // schannel and TLS 1.3.
+        //
+        // Our libcurl on Windows is usually built with schannel.
+        // On Windows 11 (or Windows Server 2022), libcurl recently (late
+        // 2022) gained support for TLS 1.3 with schannel, and it now defaults
+        // to 1.3. Unfortunately there have been some bugs with this.
+        // https://github.com/curl/curl/issues/9431 is the most recent. Once
+        // that has been fixed, and some time has passed where we can be more
+        // confident that the 1.3 support won't cause issues, this can be
+        // removed.
+        //
+        // Windows 10 is unaffected. libcurl does not support TLS 1.3 on
+        // Windows 10. (Windows 10 sorta had support, but it required enabling
+        // an advanced option in the registry which was buggy, and libcurl
+        // does runtime checks to prevent it.)
+        values.push(gitoxide::Http::SSL_VERSION_MIN.validated_assignment_fmt(&"default")?);
+        values.push(gitoxide::Http::SSL_VERSION_MAX.validated_assignment_fmt(&"tlsv1.2")?);
+    }
+    if let Some(debug) = http.debug {
+        values.push(gitoxide::Http::VERBOSE.validated_assignment_fmt(&debug)?);
+    }
+    if let Some(multiplexing) = http.multiplexing {
+        let http_version = multiplexing.then(|| "HTTP/2").unwrap_or("HTTP/1.1");
+        // Note that failing to set the HTTP version in `gix-transport` isn't fatal,
+        // which is why we don't have to try to figure out if HTTP V2 is supported in the
+        // currently linked version (see `try_old_curl!()`)
+        values.push(Http::VERSION.validated_assignment_fmt(&http_version)?);
+    }
+
+    Ok(values)
+}
+
+pub fn reinitialize(git_dir: &Path) -> CargoResult<()> {
+    fn init(path: &Path, bare: bool) -> CargoResult<()> {
+        let mut opts = git2::RepositoryInitOptions::new();
+        // Skip anything related to templates, they just call all sorts of issues as
+        // we really don't want to use them yet they insist on being used. See #6240
+        // for an example issue that comes up.
+        opts.external_template(false);
+        opts.bare(bare);
+        git2::Repository::init_opts(&path, &opts)?;
+        Ok(())
+    }
+    // Here we want to drop the current repository object pointed to by `repo`,
+    // so we initialize temporary repository in a sub-folder, blow away the
+    // existing git folder, and then recreate the git repo. Finally we blow away
+    // the `tmp` folder we allocated.
+    debug!("reinitializing git repo at {:?}", git_dir);
+    let tmp = git_dir.join("tmp");
+    let bare = !git_dir.ends_with(".git");
+    init(&tmp, false)?;
+    for entry in git_dir.read_dir()? {
+        let entry = entry?;
+        if entry.file_name().to_str() == Some("tmp") {
+            continue;
+        }
+        let path = entry.path();
+        drop(paths::remove_file(&path).or_else(|_| paths::remove_dir_all(&path)));
+    }
+    init(git_dir, bare)?;
+    paths::remove_dir_all(&tmp)?;
+    Ok(())
+}

--- a/src/cargo/util/network.rs
+++ b/src/cargo/util/network.rs
@@ -79,6 +79,15 @@ fn maybe_spurious(err: &Error) -> bool {
             return true;
         }
     }
+
+    use gix::protocol::transport::IsSpuriousError;
+
+    if let Some(err) = err.downcast_ref::<crate::sources::git::fetch::Error>() {
+        if err.is_spurious() {
+            return true;
+        }
+    }
+
     false
 }
 

--- a/src/doc/contrib/src/tests/running.md
+++ b/src/doc/contrib/src/tests/running.md
@@ -40,6 +40,16 @@ the `CARGO_RUN_BUILD_STD_TESTS=1` environment variable and running `cargo test
 `rust-src` component installed with `rustup component add rust-src
 --toolchain=nightly`.
 
+## Running with `gitoxide` as default git backend in tests
+
+By default, the `git2` backend is used for most git operations. As tests need to explicitly
+opt-in to use nightly features and feature flags, adjusting all tests to run with nightly
+and `-Zgitoxide` is unfeasible.
+
+This is why the private environment variable named `__CARGO_USE_GITOXIDE_INSTEAD_OF_GIT2` can be
+set while running tests to automatically enable the `-Zgitoxide` flag implicitly, allowing to
+test `gitoxide` for the entire cargo test suite.
+
 ## Running public network tests
 
 Some (very rare) tests involve connecting to the public internet.

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -100,6 +100,8 @@ Each new feature described below should explain how to use it.
     * [`cargo logout`](#cargo-logout) --- Adds the `logout` command to remove the currently saved registry token.
     * [publish-timeout](#publish-timeout) --- Controls the timeout between uploading the crate and being available in the index
     * [registry-auth](#registry-auth) --- Adds support for authenticated registries, and generate registry authentication tokens using asymmetric cryptography.
+* Other
+    * [gitoxide](#gitoxide) --- Use `gitoxide` instead of `git2` for a set of operations.
 
 ### allow-features
 
@@ -1276,6 +1278,21 @@ codegen-backend = true
 [profile.dev.package.foo]
 codegen-backend = "cranelift"
 ```
+
+### gitoxide
+
+With the 'gitoxide' unstable feature, all or the the specified git operations will be performed by 
+the `gitoxide` crate instead of `git2`.
+
+While `-Zgitoxide` enables all currently implemented features, one can individually select git operations
+to run with `gitoxide` with the `-Zgitoxide=operation[,operationN]` syntax.
+
+Valid operations are the following:
+
+* `fetch` - All fetches are done with `gitoxide`, which includes git dependencies as well as the crates index.
+* `shallow-index` *(planned)* - perform a shallow clone of the index.
+* `shallow-deps` *(planned)* - perform a shallow clone of git dependencies.
+* `checkout` *(planned)* - checkout the worktree, with support for filters and submodules.
 
 ## Stabilized and removed features
 

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
+use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::paths;
 use cargo_test_support::{basic_manifest, project};
 
@@ -157,8 +158,7 @@ Caused by:
   https://[..]
 
 Caused by:
-",
-            addr = addr
+"
         ))
         .run();
 
@@ -206,15 +206,16 @@ fn https_something_happens() {
     p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains(&format!(
-            "[UPDATING] git repository `https://{addr}/foo/bar`",
-            addr = addr
+            "[UPDATING] git repository `https://{addr}/foo/bar`"
         ))
         .with_stderr_contains(&format!(
             "\
 Caused by:
   {errmsg}
 ",
-            errmsg = if cfg!(windows) {
+            errmsg = if cargo_uses_gitoxide() {
+                "[..]SSL connect error [..]"
+            } else if cfg!(windows) {
                 "[..]failed to send request: [..]"
             } else if cfg!(target_os = "macos") {
                 // macOS is difficult to tests as some builds may use Security.framework,
@@ -258,18 +259,40 @@ fn ssh_something_happens() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("check -v")
-        .with_status(101)
-        .with_stderr_contains(&format!(
-            "[UPDATING] git repository `ssh://{addr}/foo/bar`",
-            addr = addr
-        ))
-        .with_stderr_contains(
+    let (expected_ssh_message, expected_update) = if cargo_uses_gitoxide() {
+        // Due to the usage of `ssh` and `ssh.exe` respectively, the messages change.
+        // This will be adjusted to use `ssh2` to get rid of this dependency and have uniform messaging.
+        let message = if cfg!(windows) {
+            // The order of multiple possible messages isn't deterministic within `ssh`, and `gitoxide` detects both
+            // but gets to report only the first. Thus this test can flip-flop from one version of the error to the other
+            // and we can't test for that.
+            // We'd want to test for:
+            // "[..]ssh: connect to host 127.0.0.1 [..]"
+            //   ssh: connect to host example.org port 22: No route to host
+            // "[..]banner exchange: Connection to 127.0.0.1 [..]"
+            //   banner exchange: Connection to 127.0.0.1 port 62250: Software caused connection abort
+            // But since there is no common meaningful sequence or word, we can only match a small telling sequence of characters.
+            "[..]onnect[..]"
+        } else {
+            "[..]Connection [..] by [..]"
+        };
+        (
+            message,
+            format!("[..]Unable to update ssh://{addr}/foo/bar"),
+        )
+    } else {
+        (
             "\
 Caused by:
   [..]failed to start SSH session: Failed getting banner[..]
 ",
+            format!("[UPDATING] git repository `ssh://{addr}/foo/bar`"),
         )
+    };
+    p.cargo("check -v")
+        .with_status(101)
+        .with_stderr_contains(&expected_update)
+        .with_stderr_contains(expected_ssh_message)
         .run();
     t.join().ok().unwrap();
 }
@@ -294,7 +317,7 @@ fn net_err_suggests_fetch_with_cli() {
 
     p.cargo("check -v")
         .with_status(101)
-        .with_stderr(
+        .with_stderr(format!(
             "\
 [UPDATING] git repository `ssh://needs-proxy.invalid/git`
 warning: spurious network error[..]
@@ -316,9 +339,14 @@ Caused by:
   https://[..]
 
 Caused by:
-  failed to resolve address for needs-proxy.invalid[..]
+  {trailer}
 ",
-        )
+            trailer = if cargo_uses_gitoxide() {
+                "An IO error occurred when talking to the server\n\nCaused by:\n  ssh: Could not resolve hostname needs-proxy.invalid[..]"
+            } else {
+                "failed to resolve address for needs-proxy.invalid[..]"
+            }
+        ))
         .run();
 
     p.change_file(
@@ -389,8 +417,8 @@ Caused by:
 
 Caused by:
   [..]
-",
-            addr = addr
+{trailer}",
+            trailer = if cargo_uses_gitoxide() { "\nCaused by:\n  [..]" } else { "" }
         ))
         .run();
 

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -5,6 +5,7 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 
 use cargo_test_support::git;
+use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::paths;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
@@ -96,6 +97,11 @@ fn use_git_gc() {
 
 #[cargo_test]
 fn avoid_using_git() {
+    if cargo_uses_gitoxide() {
+        // file protocol without git binary is currently not possible - needs built-in upload-pack.
+        // See https://github.com/Byron/gitoxide/issues/734 (support for the file protocol) progress updates.
+        return;
+    }
     let path = env::var_os("PATH").unwrap_or_default();
     let mut paths = env::split_paths(&path).collect::<Vec<_>>();
     let idx = paths


### PR DESCRIPTION
This PR is the first step towards resolving #1171.

In order to get there, we integrate `gitoxide` into `cargo` in such a way that one can control its usage in nightly via `-Zgitoxide` or `Zgitoxide=<feature>[,featureN]`.

Planned features are:

* **fetch** - all fetches are done with `gitxide` (this PR)
* **shallow_index** - the crates index will be a shallow clone (_planned_)
* **shallow_deps** - git dependencies will be a shallow clone (_planned_)
* **checkout** - plain checkouts with `gitoxide` (_planned_)

The above list is a prediction and might change as we understand the requirements better.

### Testing and Transitioning

By default, everything stays as is. However, relevant tests can be re-runwith `gitoxide` using 

```
RUSTFLAGS='--cfg always_test_gitoxide' cargo test git
```

There are about 200 tests with 'git' in their name and I plan to enable them one by one. That way the costs for CI stay managable (my first measurement with one test was 2min 30s), while allowing to take one step at a time.

Custom tests shall be added once we realize that more coverage is needed.

That way we should be able to maintain running `git2` and `gitoxide` side by side until we are willing to switch over to `gitoxide` entirely on stable cargo. Then turning on `git2` might be a feature toggle for a while until we finally remove it from the codebase.

_Please see the above paragraph as invitation for discussion, it's merely a basis to explore from and improve upon._

### Tasks

* [x] add feature toggle
* [x] setup test system with one currently successful test
* [x] implement fetch with `gitoxide` (MVP)
* [x] fetch progress
* [x] detect spurious errors
* [x] enable as many git tests as possible (and ignore what's not possible)
* [x] fix all git-related test failures (except for 1: built-in upload-pack, skipped for now)
* [x] validate that all HTTP handle options that come from `cargo` specific values are passed to `gitoxide`
* [x] a test to validate `git2` code can handle crates-index clones created with `gitoxide` and vice-versa
* [x] remove patches that enabled `gitoxide` enabled testing - it's not used anymore
* [x] ~~remove all TODOs and use crates-index version of `git-repository`~~ The remaining 2 TODO's are more like questions for the reviewer.
* [x] run all tests with gitoxide on the fastest platform as another parallel task
* [x] switch to released version
* [x] [Tasks from first review round](https://github.com/rust-lang/cargo/pull/11448#issuecomment-1374421517)
* [x] create a new `gitoxide` release and refer to the latest version from crates.io (instead of git-dependency)
* [x] [address 2nd review round comments](https://github.com/rust-lang/cargo/pull/11448#issuecomment-1426326996)

### Postponed Tasks

I suggest to go breadth-first and implement the most valuable features first, and then aim for a broad replacement of `git2`. What's left is details and improved compatibility with the `git2` implementation that will be required once `gitoxide` should become the default implementation on stable to complete the transition.

* **built-in support for serving the `file` protocol** (i.e. without using `git`). Simple cases like `clone` can probably be supported quickly, `fetch` needs more work though due to negotiation.
* SSH name fallbacks via a native (probably ~~libssh~~ (avoid LGPL) `libssh2` based) transport. Look at [this issue](https://github.com/rust-lang/cargo/issues/2399) for some history.
* additional tasks from [this tracking issue](https://github.com/Byron/gitoxide/issues/450#issue-1290858067)

### Proposed Workflow

I am now using [stacked git](https://stacked-git.github.io) to keep commits meaningful during development. This will also mean that before reviews I will force-push a lot as changes will be bucketed into their respective commits.

Once review officially begins I will stop force-pushing and create small commits to address review comments. That way it should be easier to understand how things change over time.

Those review-comments can certainly be squashed into one commit before merging.

_Please let me know if this is feasible or if there are other ways of working you prefer._

### Development notes

* unrelated: [this line](https://github.com/rust-lang/cargo/blob/9827412fee4f5a88ac85e013edd954b2b63f399b/src/cargo/ops/registry.rs#L620) refers to an issue that has since been resolved in `curl`.
* Additional tasks related to a correct fetch implementation are collected in this [tracking issue](https://github.com/Byron/gitoxide/issues/450). **These affect how well the HTTP transport can be configured, needs work**
* _authentication_ [is quite complex](https://github.com/rust-lang/cargo/blob/37cad5bd7f7dcd2f6d3e45312a99a9d3eec1e2a0/src/cargo/sources/git/utils.rs#L490) and centred around making SSH connections work. This feature is currently the weakest in `gitoxide` as it simply uses `ssh` (the program) and calls it a day.  No authentication flows are supported there yet and the goal would be to match `git` there at least (which it might already do by just calling `ssh`). Needs investigation. Once en-par with `git` I think `cargo` can restart the whole fetch operation to try different user names like before.
   - the built-in `ssh`-program based transport can now understand permission-denied errors, but the capability isn't used after all since a builtin ssh transport is required.
* It would be possible to implement `git::Progress` and just ignore most of the calls, but that's known to be too slow as the implementation assumes a `Progress::inc()` call is as fast as an atomic increment and makes no attempt to reduce its calls to it.
* learning about [a way to get custom traits in `thiserror`](https://github.com/dtolnay/thiserror/issues/212) could make spurious error checks nicer and less error prone during maintenance. It's not a problem though.
* I am using `RUSTFLAGS=--cfg` to influence the entire build and unit-tests as environment variables didn't get through to the binary built and run for tests.

### Questions

* The way `gitoxide` is configured the user has the opportunity to override these values using more specific git options, for example using url specific http settings. This looks like a feature to me, but if it's not `gitoxide` needs to provide a way to disable applying these overrides. Please let me know what's desired here - my preference is to allow overrides.
* `gitoxide` currently opens repositories similar to how `git` does which respects git specific environment variables. This might be a deviation from how it was before and can be turned off. My preference is to see it as a feature.

### Prerequisite PRs

* https://github.com/rust-lang/cargo/pull/11602 