### PR TITLE
Show `--help` if there is no man page for subcommand

### DIFF
--- a/src/bin/cargo/commands/config.rs
+++ b/src/bin/cargo/commands/config.rs
@@ -4,7 +4,6 @@ use cargo::ops::cargo_config;
 pub fn cli() -> Command {
     subcommand("config")
         .about("Inspect configuration values")
-        .after_help("Run `cargo help config` for more detailed information.\n")
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -22,11 +22,21 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let subcommand = args.get_one::<String>("COMMAND");
     if let Some(subcommand) = subcommand {
         if !try_help(config, subcommand)? {
-            crate::execute_external_subcommand(
-                config,
-                subcommand,
-                &[OsStr::new(subcommand), OsStr::new("--help")],
-            )?;
+            match check_builtin(&subcommand) {
+                Some(s) => {
+                    crate::execute_internal_subcommand(
+                        config,
+                        &[OsStr::new(s), OsStr::new("--help")],
+                    )?;
+                }
+                None => {
+                    crate::execute_external_subcommand(
+                        config,
+                        subcommand,
+                        &[OsStr::new(subcommand), OsStr::new("--help")],
+                    )?;
+                }
+            }
         }
     } else {
         let mut cmd = crate::cli::cli();

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -189,9 +189,22 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&OsStr]) -> C
             return Err(CliError::new(err, 101));
         }
     };
+    execute_subcommand(config, Some(&command), args)
+}
 
+fn execute_internal_subcommand(config: &Config, args: &[&OsStr]) -> CliResult {
+    execute_subcommand(config, None, args)
+}
+
+// This function is used to execute a subcommand. It is used to execute both
+// internal and external subcommands.
+// If `cmd_path` is `None`, then the subcommand is an internal subcommand.
+fn execute_subcommand(config: &Config, cmd_path: Option<&PathBuf>, args: &[&OsStr]) -> CliResult {
     let cargo_exe = config.cargo_exe()?;
-    let mut cmd = ProcessBuilder::new(&command);
+    let mut cmd = match cmd_path {
+        Some(cmd_path) => ProcessBuilder::new(cmd_path),
+        None => ProcessBuilder::new(&cargo_exe),
+    };
     cmd.env(cargo::CARGO_ENV, cargo_exe).args(args);
     if let Some(client) = config.jobserver_from_env() {
         cmd.inherit_jobserver(client);


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

part of https://github.com/rust-lang/cargo/issues/11408

- Show `--help` if there is no man page for the subcommand
- Do not suggest `cargo help config` until we add a man page.

### How should we test and review this PR?
1. build cargo
2. try `cargo help config`
3. see:
```sh
➜  cargo git:(master) ✗ ./target/debug/cargo help config
Inspect configuration values

Usage: cargo config [OPTIONS] <COMMAND>

Commands:
  get  

Options:
  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
      --color <WHEN>        Coloring: auto, always, never
      --frozen              Require Cargo.lock and cache are up to date
      --locked              Require Cargo.lock is up to date
      --offline             Run without accessing the network
      --config <KEY=VALUE>  Override a configuration value
  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
  -h, --help                Print help information
```

### Additional information
I am not sure I should add a test for it because I think we will add a man page for config. 
<!-- homu-ignore:end -->