### PR TITLE
fix: deduplicate dependencies by artifact target

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -214,6 +214,7 @@ pub fn generate_std_roots(
                 /*is_std*/ true,
                 /*dep_hash*/ 0,
                 IsArtifact::No,
+                None,
             ));
         }
     }

--- a/src/cargo/core/compiler/unit.rs
+++ b/src/cargo/core/compiler/unit.rs
@@ -1,6 +1,8 @@
-use crate::core::compiler::{unit_dependencies::IsArtifact, CompileKind, CompileMode, CrateType};
+use crate::core::compiler::unit_dependencies::IsArtifact;
+use crate::core::compiler::{CompileKind, CompileMode, CompileTarget, CrateType};
 use crate::core::manifest::{Target, TargetKind};
-use crate::core::{profiles::Profile, Package};
+use crate::core::profiles::Profile;
+use crate::core::Package;
 use crate::util::hex::short_hash;
 use crate::util::interning::InternedString;
 use crate::util::Config;
@@ -72,6 +74,12 @@ pub struct UnitInner {
     /// This value initially starts as 0, and then is filled in via a
     /// second-pass after all the unit dependencies have been computed.
     pub dep_hash: u64,
+
+    /// This is used for target-dependent feature resolution and is copied from
+    /// [`FeaturesFor::ArtifactDep`], if the enum matches the variant.
+    ///
+    /// [`FeaturesFor::ArtifactDep`]: crate::core::resolver::features::FeaturesFor::ArtifactDep
+    pub artifact_target_for_features: Option<CompileTarget>,
 }
 
 impl UnitInner {
@@ -139,6 +147,10 @@ impl fmt::Debug for Unit {
             .field("mode", &self.mode)
             .field("features", &self.features)
             .field("artifact", &self.artifact.is_true())
+            .field(
+                "artifact_target_for_features",
+                &self.artifact_target_for_features,
+            )
             .field("is_std", &self.is_std)
             .field("dep_hash", &self.dep_hash)
             .finish()
@@ -184,6 +196,7 @@ impl UnitInterner {
         is_std: bool,
         dep_hash: u64,
         artifact: IsArtifact,
+        artifact_target_for_features: Option<CompileTarget>,
     ) -> Unit {
         let target = match (is_std, target.kind()) {
             // This is a horrible hack to support build-std. `libstd` declares
@@ -216,6 +229,7 @@ impl UnitInterner {
             is_std,
             dep_hash,
             artifact,
+            artifact_target_for_features,
         });
         Unit { inner }
     }

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -885,6 +885,10 @@ fn new_unit_dep_with_profile(
         .resolve()
         .is_public_dep(parent.pkg.package_id(), pkg.package_id());
     let features_for = unit_for.map_to_features_for(artifact);
+    let artifact_target = match features_for {
+        FeaturesFor::ArtifactDep(target) => Some(target),
+        _ => None,
+    };
     let features = state.activated_features(pkg.package_id(), features_for);
     let unit = state.interner.intern(
         pkg,
@@ -896,6 +900,7 @@ fn new_unit_dep_with_profile(
         state.is_std,
         /*dep_hash*/ 0,
         artifact.map_or(IsArtifact::No, |_| IsArtifact::Yes),
+        artifact_target,
     );
     Ok(UnitDep {
         unit,

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -630,6 +630,9 @@ fn traverse_and_share(
         unit.is_std,
         new_dep_hash,
         unit.artifact,
+        // Since `dep_hash` is now filled in, there's no need to specify the artifact target
+        // for target-dependent feature resolution
+        None,
     );
     assert!(memo.insert(unit.clone(), new_unit.clone()).is_none());
     new_graph.entry(new_unit.clone()).or_insert(new_deps);
@@ -788,6 +791,7 @@ fn override_rustc_crate_types(
             unit.is_std,
             unit.dep_hash,
             unit.artifact,
+            unit.artifact_target_for_features,
         )
     };
     units[0] = match unit.target.kind() {

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -171,6 +171,7 @@ impl<'a> UnitGenerator<'a, '_> {
                     /*is_std*/ false,
                     /*dep_hash*/ 0,
                     IsArtifact::No,
+                    None,
                 )
             })
             .collect()

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2447,3 +2447,226 @@ fn with_assumed_host_target_and_optional_build_dep() {
         )
         .run();
 }
+
+#[cargo_test]
+fn decouple_same_target_transitive_dep_from_artifact_dep() {
+    // See https://github.com/rust-lang/cargo/issues/11463
+    let target = rustc_host();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                a = {{ path = "a" }}
+                bar = {{ path = "bar", artifact = "bin", target = "{target}" }}
+            "#
+            ),
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {}
+            "#,
+        )
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+
+                [dependencies]
+                a = { path = "../a", features = ["feature"] }
+            "#,
+        )
+        .file(
+            "bar/src/main.rs",
+            r#"
+                fn main() {}
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                b = { path = "../b" }
+                c = { path = "../c" }
+
+                [features]
+                feature = ["c/feature"]
+            "#,
+        )
+        .file(
+            "a/src/lib.rs",
+            r#"
+                use b::Trait as _;
+
+                pub fn use_b_trait(x: &impl c::Trait) {
+                    x.b();
+                }
+            "#,
+        )
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+
+                [dependencies]
+                c = { path = "../c" }
+            "#,
+        )
+        .file(
+            "b/src/lib.rs",
+            r#"
+                pub trait Trait {
+                    fn b(&self) {}
+                }
+
+                impl<T: c::Trait> Trait for T {}
+            "#,
+        )
+        .file(
+            "c/Cargo.toml",
+            r#"
+                [package]
+                name = "c"
+                version = "0.1.0"
+
+                [features]
+                feature = []
+            "#,
+        )
+        .file(
+            "c/src/lib.rs",
+            r#"
+                pub trait Trait {}
+            "#,
+        )
+        .build();
+    p.cargo("build -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr(
+            "\
+[COMPILING] c v0.1.0 ([CWD]/c)
+[COMPILING] b v0.1.0 ([CWD]/b)
+[COMPILING] a v0.1.0 ([CWD]/a)
+[COMPILING] bar v0.1.0 ([CWD]/bar)
+[COMPILING] foo v0.1.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
+    // See https://github.com/rust-lang/cargo/issues/10837
+    let target = rustc_host();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                a = {{ path = "a" }}
+                b = {{ path = "b", features = ["feature"] }}
+                bar = {{ path = "bar", artifact = "bin", lib = true, target = "{target}" }}
+            "#
+            ),
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                a = { path = "../a", features = ["b"] }
+                b = { path = "../b" }
+            "#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file(
+            "bar/src/main.rs",
+            r#"
+                use b::Trait;
+
+                fn main() {
+                    a::A.b()
+                }
+            "#,
+        )
+        .file(
+            "a/Cargo.toml",
+            r#"
+                [package]
+                name = "a"
+                version = "0.1.0"
+
+                [dependencies]
+                b = { path = "../b", optional = true }
+            "#,
+        )
+        .file(
+            "a/src/lib.rs",
+            r#"
+                pub struct A;
+
+                #[cfg(feature = "b")]
+                impl b::Trait for A {}
+            "#,
+        )
+        .file(
+            "b/Cargo.toml",
+            r#"
+                [package]
+                name = "b"
+                version = "0.1.0"
+
+                [features]
+                feature = []
+            "#,
+        )
+        .file(
+            "b/src/lib.rs",
+            r#"
+                pub trait Trait {
+                    fn b(&self) {}
+                }
+            "#,
+        )
+        .build();
+    p.cargo("build -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr(
+            "\
+[COMPILING] b v0.1.0 ([CWD]/b)
+[COMPILING] a v0.1.0 ([CWD]/a)
+[COMPILING] bar v0.1.0 ([CWD]/bar)
+[COMPILING] foo v0.1.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

In cases when a compile target is specified for a bindep and the crate depending on it, cargo fails to deduplicate the crate dependencies and attempts to build the dependent crate only once with non-deterministic feature set, which breaks e.g. https://github.com/rvolosatovs/musl-bindep-feature-bug

Fix the issue by including the optional artifact compile target in the `Unit` in order to avoid wrongfully deduplicating the dependent crates

Fixes https://github.com/rust-lang/cargo/issues/11463 
Fixes https://github.com/rust-lang/cargo/issues/10837
Fixes https://github.com/rust-lang/cargo/issues/10525

Note, that this issue is already accounted for by `cargo`, but in different context a similar situation can occur while building the build script, which:
1. may be built for different target than the actual package target
2. may contain dependencies with different feature sets than the same dependencies in the dependency graph of the package itself

That's why this PR is simply reusing the existing functionality for deduplication

### How should we test and review this PR?

Build https://github.com/rvolosatovs/musl-bindep-feature-bug

### Additional information

This is based on analysis by @weihanglo in https://github.com/rust-lang/cargo/issues/10837#issuecomment-1339365374
I experimented with adding the whole `UnitFor` to the internal unit struct, but that seems unnecessary.

It would probably be nicer to refactor `IsArtifact` and instead turn it into a 3-variant enum with a possible compile target, but I decided against that to minimize the diff. Perhaps it's worth a follow-up?
