### PR TITLE
fix(add): use the possessive in error message

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -256,7 +256,7 @@ fn parse_dependencies(config: &Config, matches: &ArgMatches) -> CargoResult<Vec<
                             )
                         })
                         .collect::<Vec<_>>();
-                    anyhow::bail!("feature `{feature}` must be qualified by the dependency its being activated for, like {}", candidates.join(", "));
+                    anyhow::bail!("feature `{feature}` must be qualified by the dependency it's being activated for, like {}", candidates.join(", "));
                 }
                 crates
                     .first_mut()


### PR DESCRIPTION
### What does this PR try to resolve?

While using `cargo add` to add some dependencies with features, I noticed this error message didn't use an apostrophe. A really minor issue, but it bugged me 😅 
