### PR TITLE
Display CPU info in CI

### DIFF
--- a/ci/dump-environment.sh
+++ b/ci/dump-environment.sh
@@ -11,3 +11,12 @@ echo
 echo "disk usage:"
 df -h
 echo
+
+echo "CPU info:"
+if [[ "${OSTYPE}" = "darwin"* ]]; then
+    system_profiler SPHardwareDataType || true
+    sysctl hw || true
+else
+    cat /proc/cpuinfo || true
+    cat /proc/meminfo || true
+fi


### PR DESCRIPTION
This displays the CPU information on the CI runners in the logs. This can be helpful for diagnosing CI issues and to better understand the environment they are running under.
