### PR TITLE
Fix collision_doc_profile test error

### DIFF
--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -355,8 +355,10 @@ fn collision_doc_profile_split() {
         .build();
 
     // Just to verify that common is normally built twice.
+    // This is unordered because in rare cases `pm` may start
+    // building in-between the two `common`.
     p.cargo("build -v")
-        .with_stderr(
+        .with_stderr_unordered(
             "\
 [UPDATING] [..]
 [DOWNLOADING] crates ...


### PR DESCRIPTION
This fixes the `collision_doc_profile` test which was sporadically failing on CI. My theory is that the first `common` build finishes quickly (or the other job slot is delayed). The proc-macro `pm` starts (likely very quickly due to pipelining), and it can jump ahead before the second `common` build starts (or at least before the `Message::Run` message gets delivered).

The order isn't really important or relevant to this test (all that matters is that "common" shows up twice), so this ignores the order of the messages.

cc #11334
