### PR TITLE
Revert "temporarily disable test `lto::test_profile`"

### DIFF
--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -625,10 +625,6 @@ fn dylib() {
 }
 
 #[cargo_test]
-#[cfg_attr(
-    all(target_os = "windows", target_env = "gnu"),
-    ignore = "thinLTO is broken. Tracking in rust-lang/rust#104852"
-)]
 fn test_profile() {
     Package::new("bar", "0.0.1")
         .file("src/lib.rs", "pub fn foo() -> i32 { 123 } ")


### PR DESCRIPTION
This reverts commit d5cac16d07ab44dff51af8bece6d916059d91439. The broken change in rustc has been reverted.