### PR TITLE
Fix examples of proc-macro crates being scraped for examples

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1515,7 +1515,7 @@ impl<'cfg> Workspace<'cfg> {
         // (not documented) or proc macros (have no scrape-able exports). Additionally,
         // naively passing a proc macro's unit_for to new_unit_dep will currently cause
         // Cargo to panic, see issue #10545.
-        self.is_member(&unit.pkg) && !unit.target.for_host()
+        self.is_member(&unit.pkg) && !(unit.target.for_host() || unit.pkg.proc_macro())
     }
 }
 

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -375,19 +375,15 @@ pub fn create_bcx<'a, 'cfg>(
             mode: CompileMode::Docscrape,
             ..generator
         };
-        let all_units = scrape_generator.generate_root_units()?;
-
-        let valid_units = all_units
-            .into_iter()
-            .filter(|unit| {
-                ws.unit_needs_doc_scrape(unit)
-                    && !matches!(
-                        unit.target.doc_scrape_examples(),
-                        RustdocScrapeExamples::Disabled
-                    )
-            })
-            .collect::<Vec<_>>();
-        valid_units
+        let mut scrape_units = scrape_generator.generate_root_units()?;
+        scrape_units.retain(|unit| {
+            ws.unit_needs_doc_scrape(unit)
+                && !matches!(
+                    unit.target.doc_scrape_examples(),
+                    RustdocScrapeExamples::Disabled
+                )
+        });
+        scrape_units
     } else {
         Vec::new()
     };

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -595,3 +595,27 @@ fn only_scrape_documented_targets() {
     // be scraped.
     run_with_config("doc = false\ndoc-scrape-examples = true", true);
 }
+
+#[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]
+fn issue_11496() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "repro"
+                version = "0.1.0"
+                edition = "2021"
+                
+                [lib]
+                proc-macro = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("examples/ex.rs", "fn main(){}")
+        .build();
+
+    p.cargo("doc -Zunstable-options -Zrustdoc-scrape-examples")
+        .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
+        .run();
+}


### PR DESCRIPTION
This PR fixes #11496, where examples in proc-macro crates would crash the build with `-Zrustdoc-scrape-examples`. The fix is to change `unit_needs_doc_scrape` to check if a unit is coming from a `proc-macro` package. I added a test to ensure the simple example passes. I also ensured that [automod](https://github.com/dtolnay/automod) also documents correctly.

r? @weihanglo 
