### PR TITLE
Enable triagebot's relabel functionality

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,3 +1,17 @@
+[relabel]
+allow-unauthenticated = [
+    "A-*",
+    "C-*",
+    "Command-*",
+    "E-*",
+    "O-*",
+    "S-*",
+    "Z-*",
+    "needs-mcve",
+    "regression-*",
+    "relnotes",
+]
+
 [ping.windows]
 message = """\
 Hey Windows Group! This bug has been identified as a good "Windows candidate".


### PR DESCRIPTION
### What does this PR try to resolve?

This fixes the following failure that rustbot currently posts whenever someone tries to use "<b>@</b><b>rustbot</b> label" in this repository.

> **Error**: The feature `relabel` is not enabled in this repository.
> To enable it add its section in the `triagebot.toml` in the root of the repository.

Unauthenticated relabel has been enabled in rust-lang/rust for nearly 4 years. People overwhelmingly use it in good faith.

<br>

### How should we test and review this PR?

Compare against https://github.com/rust-lang/rust/blob/1.66.0/triagebot.toml.

Also skim through the 7 pages of labels on https://github.com/rust-lang/cargo/labels, whether it makes sense the ones I decided to allow arbitrary GitHub users to apply.

<br>

### Additional information

Attempted uses of "<b>@</b><b>rustbot</b> label", that failed, but this PR would allow:

- https://github.com/rust-lang/cargo/pull/10343#issuecomment-1200345112
- https://github.com/rust-lang/cargo/pull/10243#issuecomment-1013842215
- https://github.com/rust-lang/cargo/pull/9982#issuecomment-952099226
- https://github.com/rust-lang/cargo/pull/9128#issuecomment-778806343
- https://github.com/rust-lang/cargo/pull/9067#issuecomment-759082349
- https://github.com/rust-lang/cargo/pull/8441#issuecomment-724064074
- https://github.com/rust-lang/cargo/issues/11432#issuecomment-1328715596
- https://github.com/rust-lang/cargo/issues/8841#issuecomment-723649692
- https://github.com/rust-lang/cargo/issues/10820#issuecomment-1176533061
- https://github.com/rust-lang/cargo/issues/10572#issuecomment-1101419326
- https://github.com/rust-lang/cargo/issues/9114#issuecomment-770212444
- https://github.com/rust-lang/cargo/issues/8980#issuecomment-745963184
- https://github.com/rust-lang/cargo/issues/9064#issuecomment-758120957
- https://github.com/rust-lang/cargo/issues/8726#issuecomment-697074328
- https://github.com/rust-lang/cargo/issues/8089#issuecomment-611213914