### PR TITLE
Don't scrape examples from library targets by default

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -224,7 +224,7 @@ fn make_failed_scrape_diagnostic(
         "\
 {top_line}
     Try running with `--verbose` to see the error message.
-    If an example or library should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` or `[lib]` definition in {}",
+    If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in {}",
         relative_manifest_path.display()
     )
 }

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -33,7 +33,6 @@ use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use crate::core::compiler::rustdoc::RustdocScrapeExamples;
 use crate::core::compiler::unit_dependencies::build_unit_dependencies;
 use crate::core::compiler::unit_graph::{self, UnitDep, UnitGraph};
 use crate::core::compiler::{standard_lib, CrateType, TargetInfo};
@@ -371,19 +370,11 @@ pub fn create_bcx<'a, 'cfg>(
 
     let should_scrape = build_config.mode.is_doc() && config.cli_unstable().rustdoc_scrape_examples;
     let mut scrape_units = if should_scrape {
-        let scrape_generator = UnitGenerator {
+        UnitGenerator {
             mode: CompileMode::Docscrape,
             ..generator
-        };
-        let mut scrape_units = scrape_generator.generate_root_units()?;
-        scrape_units.retain(|unit| {
-            ws.unit_needs_doc_scrape(unit)
-                && !matches!(
-                    unit.target.doc_scrape_examples(),
-                    RustdocScrapeExamples::Disabled
-                )
-        });
-        scrape_units
+        }
+        .generate_scrape_units(&units)?
     } else {
         Vec::new()
     };

--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -680,8 +680,10 @@ impl<'a> UnitGenerator<'a, '_> {
 
     /// Generates units specfically for doc-scraping.
     ///
-    /// This requires a separate entrypoint from `generate_root_units` because it
+    /// This requires a separate entrypoint from [`generate_root_units`] because it
     /// takes the documented units as input.
+    ///
+    /// [`generate_root_units`]: Self::generate_root_units
     pub fn generate_scrape_units(&self, doc_units: &[Unit]) -> CargoResult<Vec<Unit>> {
         let scrape_proposals = self.create_docscrape_proposals(&doc_units)?;
         let scrape_units = self.proposals_to_units(scrape_proposals)?;

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1162,34 +1162,35 @@ like this:
 cargo doc -Z unstable-options -Z rustdoc-scrape-examples
 ```
 
-By default, Cargo will scrape from the packages that are being documented, as well as scrape from
-examples for the packages (i.e. those corresponding to the `--examples` flag). You can individually
-enable or disable targets from being scraped with the `doc-scrape-examples` flag, such as:
+By default, Cargo will scrape examples from the example targets of packages being documented. 
+You can individually enable or disable targets from being scraped with the `doc-scrape-examples` flag, such as:
 
 ```toml
-# Disable scraping examples from a library
+# Enable scraping examples from a library
 [lib]
-doc-scrape-examples = false
-
-# Enable scraping examples from a binary
-[[bin]]
-name = "my-bin"
 doc-scrape-examples = true
+
+# Disable scraping examples from an example target
+[[example]]
+name = "my-example"
+doc-scrape-examples = false
 ```
 
 **Note on tests:** enabling `doc-scrape-examples` on test targets will not currently have any effect. Scraping
 examples from tests is a work-in-progress.
 
 **Note on dev-dependencies:** documenting a library does not normally require the crate's dev-dependencies. However,
-example units do require dev-deps. For backwards compatibility, `-Z rustdoc-scrape-examples` will *not* introduce a 
+example targets require dev-deps. For backwards compatibility, `-Z rustdoc-scrape-examples` will *not* introduce a 
 dev-deps requirement for `cargo doc`. Therefore examples will *not* be scraped from example targets under the 
 following conditions:
 
 1. No target being documented requires dev-deps, AND
-2. At least one crate being documented requires dev-deps, AND
-3. The `doc-scrape-examples` parameter is unset for `[[example]]` targets.
+2. At least one crate with targets being documented has dev-deps, AND
+3. The `doc-scrape-examples` parameter is unset or false for all `[[example]]` targets.
 
 If you want examples to be scraped from example targets, then you must not satisfy one of the above conditions.
+For example, you can set `doc-scrape-examples` to true for one example target, and that signals to Cargo that
+you are ok with dev-deps being build for `cargo doc`.
 
 
 ### check-cfg

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -350,15 +350,15 @@ fn no_fail_bad_lib() {
 [SCRAPING] foo v0.0.1 ([CWD])
 warning: failed to check lib in package `foo` as a prerequisite for scraping examples from: example \"ex\", example \"ex2\"
     Try running with `--verbose` to see the error message.
-    If an example or library should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` or `[lib]` definition in Cargo.toml
+    If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (lib) generated 1 warning
 warning: failed to scan example \"ex\" in package `foo` for example code usage
     Try running with `--verbose` to see the error message.
-    If an example or library should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` or `[lib]` definition in Cargo.toml
+    If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex\") generated 1 warning
 warning: failed to scan example \"ex2\" in package `foo` for example code usage
     Try running with `--verbose` to see the error message.
-    If an example or library should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` or `[lib]` definition in Cargo.toml
+    If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex2\") generated 1 warning
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
@@ -391,7 +391,7 @@ fn no_fail_bad_example() {
 [SCRAPING] foo v0.0.1 ([CWD])
 warning: failed to scan example \"ex1\" in package `foo` for example code usage
     Try running with `--verbose` to see the error message.
-    If an example or library should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` or `[lib]` definition in Cargo.toml
+    If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex1\") generated 1 warning
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",


### PR DESCRIPTION
### What does this PR try to resolve?

Based on some [early feedback](https://www.reddit.com/r/rust/comments/zosle6/feedback_requested_rustdocs_scraped_examples/) about the scrape-examples feature, both documentation authors and consumers did not consider examples useful if they are scraped from a library's internals, at least in the common case. Therefore this PR changes the default behavior of `-Zrustdoc-scrape-examples` to *only* scrape from example targets, although library targets can still be configured for scraping. 

### How should we test and review this PR?

I have updated the `docscrape` tests to reflect this new policy, as well as the Unstable Options page in the Cargo book.

r? @weihanglo 