### PR TITLE
Add warning if potentially-scrapable examples are skipped due to dev-dependencies

### DIFF
--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -459,7 +459,7 @@ impl<'a> UnitGenerator<'a, '_> {
             .map(|u| &u.pkg)
             .collect::<HashSet<_>>();
 
-        let skipped_examples: RefCell<Vec<Target>> = RefCell::new(Vec::new());
+        let skipped_examples = RefCell::new(Vec::new());
         let can_scrape = |target: &Target| {
             match (target.doc_scrape_examples(), target.is_example()) {
                 // Targets configured by the user to not be scraped should never be scraped
@@ -470,7 +470,9 @@ impl<'a> UnitGenerator<'a, '_> {
                 // it's guaranteed not to break the build
                 (RustdocScrapeExamples::Unset, true) => {
                     if !safe_to_scrape_example_targets {
-                        skipped_examples.borrow_mut().push(target.clone());
+                        skipped_examples
+                            .borrow_mut()
+                            .push(target.name().to_string());
                     }
                     safe_to_scrape_example_targets
                 }
@@ -485,11 +487,7 @@ impl<'a> UnitGenerator<'a, '_> {
         let skipped_examples = skipped_examples.into_inner();
         if !skipped_examples.is_empty() {
             let mut shell = self.ws.config().shell();
-            let example_str = skipped_examples
-                .into_iter()
-                .map(|t| t.description_named())
-                .collect::<Vec<_>>()
-                .join(", ");
+            let example_str = skipped_examples.join(", ");
             shell.warn(format!(
                 "\
 Rustdoc did not scrape the following examples because they require dev-dependencies: {example_str}

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -464,7 +464,7 @@ fn no_scrape_with_dev_deps() {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr(
             "\
-warning: Rustdoc did not scrape the following examples because they require dev-dependencies: example \"ex\"
+warning: Rustdoc did not scrape the following examples because they require dev-dependencies: ex
     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
     to the [[example]] target configuration of at least one example.
 [DOCUMENTING] foo v0.0.1 ([CWD])


### PR DESCRIPTION
### What does this PR try to resolve?

Another point of feedback I've received on the scrape-examples feature is that the dev-dependency situation is quite confusing and subtle. To make users more aware of the issue, I added a warning where Cargo will alert users when examples are skipped due to a dev-dependency requirement, along with proposing a fix.

### How should we test and review this PR?

The test `docscrape::no_scrape_with_dev_deps` has been updated to reflect this new warning.

r? @weihanglo

(PS thank you for the reviews Weihang. I know I'm doing lots of little patches right now to get this feature finalized. If you want to share the reviewing burden on scrape-examples with anyone else, let me know!)