### PR TITLE
fix(docs): add required "inherits" option to example profile

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -121,6 +121,7 @@ known-hosts = ["..."]       # known SSH host keys
 # Same keys as for [patch] in Cargo.toml
 
 [profile.<name>]         # Modify profile settings via config.
+inherits = "dev"         # Inherits settings from [profile.dev].
 opt-level = 0            # Optimization level.
 debug = true             # Include debug info.
 split-debuginfo = '...'  # Debug info splitting behavior.


### PR DESCRIPTION
## What does this PR try to resolve?

I copy-pasted then modified the example [profile.<name>] section in Cargo's docs. I was met with the following error:

> error: profile quick-build-incremental is missing an inherits directive (inherits is required for all profiles except dev or release)

## How should we test and review this PR?

Copy-paste the new docs into a `Cargo.toml` file, tweak, then try to use the new profile (`cargo build --profile mynewprofile`).

## Additional information

None
