### PR TITLE
Cargo by default saves credentials to `.cargo/credentials.toml`

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -320,7 +320,7 @@ impl RegistryBuilder {
         }
 
         if self.configure_token {
-            let credentials = paths::home().join(".cargo/credentials");
+            let credentials = paths::home().join(".cargo/credentials.toml");
             match &registry.token {
                 Token::Plaintext(token) => {
                     if let Some(alternative) = &self.alternative {

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2134,16 +2134,16 @@ pub fn save_credentials(
         Some(name)
     };
 
-    // If 'credentials.toml' exists, we should write to that, otherwise
-    // use the legacy 'credentials'. There's no need to print the warning
-    // here, because it would already be printed at load time.
+    // If 'credentials' exists, write to that for backward compatibility reasons.
+    // Otherwise write to 'credentials.toml'. There's no need to print the
+    // warning here, because it would already be printed at load time.
     let home_path = cfg.home_path.clone().into_path_unlocked();
     let filename = match cfg.get_file_path(&home_path, "credentials", false)? {
         Some(path) => match path.file_name() {
             Some(filename) => Path::new(filename).to_owned(),
-            None => Path::new("credentials").to_owned(),
+            None => Path::new("credentials.toml").to_owned(),
         },
-        None => Path::new("credentials").to_owned(),
+        None => Path::new("credentials.toml").to_owned(),
     };
 
     let mut file = {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -912,7 +912,7 @@ a new `cargo logout` command.
 
 To use this feature, you must pass the `-Z credential-process` flag on the
 command-line. Additionally, you must remove any current tokens currently saved
-in the [`credentials` file] (which can be done with the new `logout` command).
+in the [`credentials.toml` file] (which can be done with the new `logout` command).
 
 #### `credential-process` Configuration
 
@@ -1049,10 +1049,10 @@ The following environment variables will be provided to the executed command:
 #### `cargo logout`
 
 A new `cargo logout` command has been added to make it easier to remove a
-token from storage. This supports both [`credentials` file] tokens and
+token from storage. This supports both [`credentials.toml` file] tokens and
 `credential-process` tokens.
 
-When used with `credentials` file tokens, it needs the `-Z unstable-options`
+When used with `credentials.toml` file tokens, it needs the `-Z unstable-options`
 command-line option:
 
 ```console
@@ -1071,7 +1071,7 @@ cargo logout -Z credential-process
 [`cargo publish`]: ../commands/cargo-publish.md
 [`cargo owner`]: ../commands/cargo-owner.md
 [`cargo yank`]: ../commands/cargo-yank.md
-[`credentials` file]: config.md#credentials
+[`credentials.toml` file]: config.md#credentials
 [crates.io]: https://crates.io/
 [config file]: config.md
 

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -399,7 +399,7 @@ fn block_publish_due_to_no_token() {
     registry::alt_init();
     let p = project().file("src/lib.rs", "").build();
 
-    fs::remove_file(paths::home().join(".cargo/credentials")).unwrap();
+    fs::remove_file(paths::home().join(".cargo/credentials.toml")).unwrap();
 
     // Now perform the actual publish
     p.cargo("publish --registry alternative")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2893,7 +2893,7 @@ fn credentials_is_unreadable() {
         .file("src/lib.rs", "")
         .build();
 
-    let credentials = home().join(".cargo/credentials");
+    let credentials = home().join(".cargo/credentials.toml");
     t!(fs::create_dir_all(credentials.parent().unwrap()));
     t!(fs::write(
         &credentials,

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -24,7 +24,7 @@ the `cargo logout` command.
 
 /// Checks whether or not the token is set for the given token.
 fn check_config_token(registry: Option<&str>, should_be_set: bool) {
-    let credentials = cargo_home().join("credentials");
+    let credentials = cargo_home().join("credentials.toml");
     let contents = fs::read_to_string(&credentials).unwrap();
     let toml: toml::Value = contents.parse().unwrap();
     if let Some(registry) = registry {


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Cargo team discussed this in the triage meeting and agree that it has been long enough to write to `.cargo/credentials.toml` by default.

Fixes #11509.

cc rust-lang/crates.io#5730 rust-lang/crates.io#5732

### How should we test and review this PR?

Integration tests included.

### Additional information

We also talked about theoretically dropping the support of the old `credentials` for any new features. That might “force” people to migrate, though doing that has low benefits.
<!-- homu-ignore:end -->
