### PR TITLE
test: revive nightly plugin tests to work

### DIFF
--- a/tests/testsuite/plugins.rs
+++ b/tests/testsuite/plugins.rs
@@ -361,6 +361,7 @@ fn panic_abort_plugins() {
             r#"
                 #![feature(rustc_private)]
                 extern crate rustc_ast;
+                extern crate rustc_driver;
             "#,
         )
         .build();
@@ -408,6 +409,7 @@ fn shared_panic_abort_plugins() {
             r#"
                 #![feature(rustc_private)]
                 extern crate rustc_ast;
+                extern crate rustc_driver;
                 extern crate baz;
             "#,
         )


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

CI is failing: https://github.com/rust-lang/cargo/actions/runs/3837241733/jobs/6532317777

```
   Compiling baz v0.0.1 (/home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/baz)
     Running `rustc --crate-name baz baz/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C metadata=04ecbc4d503298d3 -C extra-filename=-04ecbc4d503298d3 --out-dir /home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps -L dependency=/home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps`
     Running `rustc --crate-name baz baz/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C panic=abort -C embed-bitcode=no -C debuginfo=2 -C metadata=a079e75a1240be9f -C extra-filename=-a079e75a1240be9f --out-dir /home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps -L dependency=/home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps`
   Compiling bar v0.0.1 (/home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/bar)
error: test failed, to rerun pass `--test testsuite`
     Running `rustc --crate-name bar bar/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type dylib --emit=dep-info,link -C prefer-dynamic -C embed-bitcode=no -C debuginfo=2 -C metadata=26cdd1af49fe33b5 --out-dir /home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps -L dependency=/home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps --extern baz=/home/runner/work/cargo/cargo/target/tmp/cit/t1911/foo/target/debug/deps/libbaz-04ecbc4d503298d3.rlib`
error: crate `rustc_ast` required to be available in rlib format, but was not found in this form
  |
  = help: try adding `extern crate rustc_driver;` at the top level of this crate

error: crate `tracing` required to be available in rlib format, but was not found in this form
```

### How should we test and review this PR?

Although I don't understand the internals of plugin mechanism, these additional `extern crate` should be fine to add.
<!-- homu-ignore:end -->
