### PR TITLE
Fix doc credentials file location

### DIFF
--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -12,7 +12,7 @@ cargo-login - Save an API token from the registry locally
 
 This command will save the API token to disk so that commands that require
 authentication, such as [cargo-publish(1)](cargo-publish.html), will be automatically
-authenticated. The token is saved in `$CARGO_HOME/credentials.toml`. `CARGO_HOME`
+authenticated. The token is saved in `$CARGO_HOME/credentials`. `CARGO_HOME`
 defaults to `.cargo` in your home directory.
 
 If the _token_ argument is not specified, it will be read from stdin.


### PR DESCRIPTION
### What does this PR try to resolve?

Fix outdated(?) cargo credentials file location. In my local, the file doesn't have toml extension

<img width="333" alt="Screen Shot 2023-01-06 at 4 53 17 PM" src="https://user-images.githubusercontent.com/7658554/210976561-fd4f041b-f5e4-4e5c-af40-993b68857fd2.png">

Please ignore and close this PR if *.toml was the correct extension 🙏🏻  Thanks!
