### PR TITLE
feat: stabilize auto fix note

### DIFF
--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -1281,7 +1281,7 @@ impl<'cfg> DrainState<'cfg> {
             n => drop(write!(message, " ({} duplicates)", n)),
         }
         // Only show the `cargo fix` message if its a local `Unit`
-        if unit.is_local() && config.nightly_features_allowed {
+        if unit.is_local() {
             // Do not show this if there are any errors or no fixable warnings
             if let FixableWarnings::Positive(fixable) = count.fixable {
                 // `cargo fix` doesnt have an option for custom builds

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1193,36 +1193,8 @@ fn check_fixable_warning() {
         .build();
 
     foo.cargo("check")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo fix --lib -p foo` to apply 1 suggestion)")
         .run();
-}
-
-#[cargo_test]
-fn check_fixable_not_nightly() {
-    let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-            "#,
-        )
-        .file("src/lib.rs", "use std::io;")
-        .build();
-
-    let rustc_message = raw_rustc_output(&foo, "src/lib.rs", &[]);
-    let expected_output = format!(
-        "\
-[CHECKING] foo v0.0.1 ([..])
-{}\
-[WARNING] `foo` (lib) generated 1 warning
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-",
-        rustc_message
-    );
-    foo.cargo("check").with_stderr(expected_output).run();
 }
 
 #[cargo_test]
@@ -1250,7 +1222,6 @@ mod tests {
         .build();
 
     foo.cargo("check --all-targets")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo fix --lib -p foo --tests` to apply 1 suggestion)")
         .run();
     foo.cargo("fix --lib -p foo --tests --allow-no-vcs").run();
@@ -1285,7 +1256,6 @@ fn check_fixable_error_no_fix() {
         rustc_message
     );
     foo.cargo("check")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_status(101)
         .with_stderr(expected_output)
         .run();
@@ -1325,7 +1295,6 @@ fn check_fixable_warning_workspace() {
         .build();
 
     p.cargo("check")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo fix --lib -p foo` to apply 1 suggestion)")
         .with_stderr_contains("[..] (run `cargo fix --lib -p bar` to apply 1 suggestion)")
         .run();
@@ -1350,7 +1319,6 @@ fn check_fixable_example() {
         .file("examples/ex1.rs", "use std::fmt; fn main() {}")
         .build();
     p.cargo("check --all-targets")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo fix --example \"ex1\"` to apply 1 suggestion)")
         .run();
 }
@@ -1393,7 +1361,6 @@ fn check_fixable_bench() {
         )
         .build();
     p.cargo("check --all-targets")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo fix --bench \"bench\"` to apply 1 suggestion)")
         .run();
 }
@@ -1441,7 +1408,6 @@ fn check_fixable_mixed() {
         )
         .build();
     p.cargo("check --all-targets")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo fix --bin \"foo\" --tests` to apply 2 suggestions)")
         .with_stderr_contains("[..] (run `cargo fix --example \"ex1\"` to apply 1 suggestion)")
         .with_stderr_contains("[..] (run `cargo fix --bench \"bench\"` to apply 1 suggestion)")
@@ -1490,7 +1456,6 @@ fn check_fixable_warning_for_clippy() {
             "RUSTC_WORKSPACE_WRAPPER",
             clippy_driver.bin("clippy-driver"),
         )
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr_contains("[..] (run `cargo clippy --fix --lib -p foo` to apply 1 suggestion)")
         .run();
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2045,7 +2045,6 @@ fn no_auto_fix_note() {
     // This is checked by matching the full output as `with_stderr_does_not_contain`
     // can be brittle
     cargo_process("install auto_fix")
-        .masquerade_as_nightly_cargo(&["auto-fix note"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -60,7 +60,7 @@ fn deduplicate_messages_basic() {
     let rustc_message = raw_rustc_output(&p, "src/lib.rs", &[]);
     let expected_output = format!(
         "{}\
-warning: `foo` (lib) generated 1 warning
+warning: `foo` (lib) generated 1 warning (run `cargo fix --lib -p foo` to apply 1 suggestion)
 warning: `foo` (lib test) generated 1 warning (1 duplicate)
 [FINISHED] [..]
 [EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[..][EXE])
@@ -103,7 +103,7 @@ fn deduplicate_messages_mismatched_warnings() {
     let expected_output = format!(
         "\
 {}\
-warning: `foo` (lib) generated 1 warning
+warning: `foo` (lib) generated 1 warning (run `cargo fix --lib -p foo` to apply 1 suggestion)
 {}\
 warning: `foo` (lib test) generated 2 warnings (1 duplicate)
 [FINISHED] [..]


### PR DESCRIPTION
A note that some warnings could be fixed by running a `cargo fix` command was added in #10989 and made to work with `clippy` in #11399. It has only been turned on for `nightly` builds so far; this PR would make it show on `stable`.

The original motivation for making this note `nightly` only, was to [allow for iteration](https://github.com/rust-lang/cargo/issues/10976#issuecomment-1289297978) on the message output. There has yet to be any feedback on the message format in the time that it has been on `nightly`. This was brought up in a recent cargo team meeting and it was thought that we should move forward with showing this on `stable`.


close #10976 