### PR TITLE
fix(docs): fix typo learm => learn in cargo tree docs

### DIFF
--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -67,7 +67,7 @@ of what `cargo test` does, `cargo tree` is pretty close. However, it doesn't
 guarantee the exact equivalence to what Cargo is going to build, since a
 compilation is complex and depends on lots of different factors.
 
-To learm more about feature unification, check out this
+To learn more about feature unification, check out this
 [dedicated section](../reference/features.html#feature-unification).
 
 ## OPTIONS

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -59,7 +59,7 @@ DESCRIPTION
        build, since a compilation is complex and depends on lots of different
        factors.
 
-       To learm more about feature unification, check out this dedicated
+       To learn more about feature unification, check out this dedicated
        section
        <https://doc.rust-lang.org/cargo/reference/features.html#feature-unification>.
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -67,7 +67,7 @@ of what `cargo test` does, `cargo tree` is pretty close. However, it doesn't
 guarantee the exact equivalence to what Cargo is going to build, since a
 compilation is complex and depends on lots of different factors.
 
-To learm more about feature unification, check out this
+To learn more about feature unification, check out this
 [dedicated section](../reference/features.html#feature-unification).
 
 ## OPTIONS

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -65,7 +65,7 @@ of what \fBcargo test\fR does, \fBcargo tree\fR is pretty close. However, it doe
 guarantee the exact equivalence to what Cargo is going to build, since a
 compilation is complex and depends on lots of different factors.
 .sp
-To learm more about feature unification, check out this
+To learn more about feature unification, check out this
 \fIdedicated section\fR <https://doc.rust\-lang.org/cargo/reference/features.html#feature\-unification>\&.
 .SH "OPTIONS"
 .SS "Tree Options"


### PR DESCRIPTION
Fix a typo in the `cargo tree` docs.