### PR TITLE
Support `codegen-backend` and `rustflags` in profiles in config file

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -667,6 +667,7 @@ unstable_cli_options!(
     #[serde(deserialize_with = "deserialize_build_std")]
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
+    codegen_backend: bool = ("Enable the `codegen-backend` option in profiles in .cargo/config.toml file"),
     config_include: bool = ("Enable the `include` key in config files"),
     credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
     #[serde(deserialize_with = "deserialize_check_cfg")]
@@ -680,6 +681,7 @@ unstable_cli_options!(
     mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
     no_index_update: bool = ("Do not update the registry index even if the cache is outdated"),
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
+    profile_rustflags: bool = ("Enable the `rustflags` option in profiles in .cargo/config.toml file"),
     host_config: bool = ("Enable the [host] section in the .cargo/config.toml file"),
     sparse_registry: bool = ("Support plain-HTTP-based crate registries"),
     registry_auth: bool = ("Authentication for alternative registries, and generate registry authentication tokens using asymmetric cryptography"),
@@ -969,6 +971,8 @@ impl CliUnstable {
                 stabilized_warn(k, "1.59.0", STABILIZED_FUTURE_INCOMPAT_REPORT)
             }
             "timings" => stabilized_warn(k, "1.60", STABILIZED_TIMINGS),
+            "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,
+            "profile-rustflags" => self.profile_rustflags = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -1115,7 +1115,12 @@ fn get_config_profile(ws: &Workspace<'_>, name: &str) -> CargoResult<Option<Toml
     let mut warnings = Vec::new();
     profile
         .val
-        .validate(name, ws.unstable_features(), &mut warnings)
+        .validate(
+            name,
+            ws.config().cli_unstable(),
+            ws.unstable_features(),
+            &mut warnings,
+        )
         .with_context(|| {
             format!(
                 "config profile `{}` is not valid (defined in `{}`)",

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -681,6 +681,18 @@ cargo-features = ["profile-rustflags"]
 rustflags = [ "-C", "..." ]
 ```
 
+To set this in a profile in Cargo configuration, you need to use either
+`-Z profile-rustflags` or `[unstable]` table to enable it. For example,
+
+```toml
+# .cargo/config.toml
+[unstable]
+profile-rustflags = true
+
+[profile.release]
+rustflags = [ "-C", "..." ]
+```
+
 ### rustdoc-map
 * Tracking Issue: [#8296](https://github.com/rust-lang/cargo/issues/8296)
 
@@ -1373,6 +1385,18 @@ name = "foo"
 
 [dependencies]
 serde = "1.0.117"
+
+[profile.dev.package.foo]
+codegen-backend = "cranelift"
+```
+
+To set this in a profile in Cargo configuration, you need to use either
+`-Z codegen-backend` or `[unstable]` table to enable it. For example,
+
+```toml
+# .cargo/config.toml
+[unstable]
+codegen-backend = true
 
 [profile.dev.package.foo]
 codegen-backend = "cranelift"

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -85,6 +85,7 @@ Each new feature described below should explain how to use it.
     * [rustdoc-map](#rustdoc-map) — Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
 * `Cargo.toml` extensions
     * [Profile `rustflags` option](#profile-rustflags-option) — Passed directly to rustc.
+    * [codegen-backend](#codegen-backend) — Select the codegen backend used by rustc.
     * [per-package-target](#per-package-target) — Sets the `--target` to use for each individual package.
     * [artifact dependencies](#artifact-dependencies) - Allow build artifacts to be included into other build artifacts and build them for different targets.
 * Information and metadata


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Add two `-Z` flags

- `profile-rustflags`
- `codegen-backend`

to support configuring them in `.cargo/config.toml` without touching `Cargo.toml`.

### How should we test and review this PR?

A test is added for `-Zprofile-rustflags`. There is no test around `codegen-backend`. I followed that.

### Additional information

Was trying to write an instruction for this fix but accidentally finished it…

Fixes #11552
Fixes #9926

<!-- homu-ignore:end -->
