### PR TITLE
Add gitlab.com ssh host keys as builtin

### DIFF
--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -29,18 +29,22 @@ use std::path::{Path, PathBuf};
 
 /// These are host keys that are hard-coded in cargo to provide convenience.
 ///
-/// If GitHub ever publishes new keys, the user can add them to their own
-/// configuration file to use those instead.
+/// If the hosts ever publish new keys, the user can add them to their own
+/// configuration file to use those instead. In that instance, the builtin hosts
+/// will be ignored.
 ///
 /// The GitHub keys are sourced from <https://api.github.com/meta> or
 /// <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints>.
 ///
-/// These will be ignored if the user adds their own entries for `github.com`,
-/// which can be useful if GitHub ever revokes their old keys.
+/// The GitLab keys are sourced from
+/// <https://docs.gitlab.com/ee/user/gitlab_com/#ssh-known_hosts-entries>.
 static BUNDLED_KEYS: &[(&str, &str, &str)] = &[
     ("github.com", "ssh-ed25519", "AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"),
     ("github.com", "ecdsa-sha2-nistp256", "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="),
     ("github.com", "ssh-rsa", "AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=="),
+    ("gitlab.com", "ssh-ed25519", "AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf"),
+    ("gitlab.com", "ssh-rsa", "AAAAB3NzaC1yc2EAAAADAQABAAABAQCsj2bNKTBSpIYDEGk9KxsGh3mySTRgMtXL583qmBpzeQ+jqCMRgBqB98u3z++J1sKlXHWfM9dyhSevkMwSbhoR8XIq/U0tCNyokEi/ueaBMCvbcTHhO7FcwzY92WK4Yt0aGROY5qX2UKSeOvuP4D6TPqKF1onrSzH9bx9XUf2lEdWT/ia1NEKjunUqu1xOB/StKDHMoX4/OKyIzuS0q/T1zOATthvasJFoPrAjkohTyaDUz2LN5JoH839hViyEG82yB+MjcFV5MU3N1l1QL3cVUCh93xSaua1N85qivl+siMkPGbO5xR/En4iEY6K2XPASUEMaieWVNTRCtJ4S8H+9"),
+    ("gitlab.com", "ecdsa-sha2-nistp256", "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFSMqzJeV9rUzU4kWitGjeR4PWSa29SPqJ1fVkhtj3Hw9xjLVXVYrU9QlYWrOLXBpQ6KWjbjTDTdDkoohFzgbEY="),
 ];
 
 enum KnownHostError {

--- a/src/doc/src/appendix/git-authentication.md
+++ b/src/doc/src/appendix/git-authentication.md
@@ -78,8 +78,9 @@ the fingerprint by running `ssh-keygen` against the public key (for example,
 publish their fingerprints on the web; for example GitHub posts theirs at
 <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints>.
 
-Cargo comes with the host keys for [github.com](https://github.com) built-in.
-If those ever change, you can add the new keys to the config or known_hosts file.
+Cargo comes with the host keys for [github.com](https://github.com) and
+[gitlab.com](https://gitlab.com) built-in. If those ever change, you can add
+the new keys to the config or known_hosts file.
 
 [`credential.helper`]: https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
 [`net.git-fetch-with-cli`]: ../reference/config.md#netgit-fetch-with-cli


### PR DESCRIPTION
PR #11556 has added github.com ssh host keys as builtin. This adds gitlab.com ssh host keys.

The "unknown SSH host key" error is quite annoying as, unlike ssh, it does not allow you to press `y` and continue. Instead you are asked to manually edit config files.

I've tested it locally and I've confirmed both the error with latest master, as well as that the builtin key works with this PR applied.

The keys can be found in [this](https://docs.gitlab.com/ee/user/gitlab_com/#ssh-known_hosts-entries) URL.

r? @ehuss