### PR TITLE
refactor(toml): Move `TomlWorkspaceDependency` out of `TomlDependency`

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -131,14 +131,6 @@ pub fn read_manifest_from_str(
                     name
                 );
             }
-            if let TomlDependency::Workspace(_) = dep {
-                bail!(
-                    "{} was specified as `workspace.dependencies.{}.workspace = true`, but \
-                    workspace dependencies cannot specify `workspace = true`",
-                    name,
-                    name
-                );
-            }
         }
     }
     return if manifest.project.is_some() || manifest.package.is_some() {
@@ -229,8 +221,6 @@ pub enum TomlDependency<P: Clone = String> {
     /// In the simple format, only a version is specified, eg.
     /// `package = "<version>"`
     Simple(String),
-    /// `package.workspace = true`
-    Workspace(TomlWorkspaceDependency),
     /// The simple format is equivalent to a detailed dependency
     /// specifying only a version, eg.
     /// `package = { version = "<version>" }`
@@ -266,43 +256,9 @@ impl<'de, P: Deserialize<'de> + Clone> de::Deserialize<'de> for TomlDependency<P
                 V: de::MapAccess<'de>,
             {
                 let mvd = de::value::MapAccessDeserializer::new(map);
-                let details: IntermediateDependency<P> = IntermediateDependency::deserialize(mvd)?;
-                if let Some(workspace) = details.workspace {
-                    if workspace {
-                        Ok(TomlDependency::Workspace(TomlWorkspaceDependency {
-                            workspace: true,
-                            features: details.features,
-                            default_features: details.default_features,
-                            default_features2: details.default_features2,
-                            optional: details.optional,
-                        }))
-                    } else {
-                        return Err(de::Error::custom("workspace cannot be false"));
-                    }
-                } else {
-                    Ok(TomlDependency::Detailed(DetailedTomlDependency {
-                        version: details.version,
-                        registry: details.registry,
-                        registry_index: details.registry_index,
-                        path: details.path,
-                        git: details.git,
-                        branch: details.branch,
-                        tag: details.tag,
-                        rev: details.rev,
-                        features: details.features,
-                        optional: details.optional,
-                        default_features: details.default_features,
-                        default_features2: details.default_features2,
-                        package: details.package,
-                        public: details.public,
-                        artifact: details.artifact,
-                        lib: details.lib,
-                        target: details.target,
-                    }))
-                }
+                DetailedTomlDependency::deserialize(mvd).map(TomlDependency::Detailed)
             }
         }
-
         deserializer.deserialize_any(TomlDependencyVisitor(PhantomData))
     }
 }
@@ -321,43 +277,6 @@ impl ResolveToPath for ConfigRelativePath {
     fn resolve(&self, c: &Config) -> PathBuf {
         self.resolve_path(c)
     }
-}
-
-// This is here due to parsing of TomlDependency works.
-// At the time of writing it can not be derived in anyway I could find.
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "kebab-case")]
-pub struct IntermediateDependency<P = String> {
-    workspace: Option<bool>,
-    version: Option<String>,
-    registry: Option<String>,
-    registry_index: Option<String>,
-    path: Option<P>,
-    git: Option<String>,
-    branch: Option<String>,
-    tag: Option<String>,
-    rev: Option<String>,
-    features: Option<Vec<String>>,
-    optional: Option<bool>,
-    default_features: Option<bool>,
-    #[serde(rename = "default_features")]
-    default_features2: Option<bool>,
-    package: Option<String>,
-    public: Option<bool>,
-    artifact: Option<StringOrVec>,
-    lib: Option<bool>,
-    target: Option<String>,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug)]
-#[serde(rename_all = "kebab-case")]
-pub struct TomlWorkspaceDependency {
-    workspace: bool,
-    features: Option<Vec<String>>,
-    default_features: Option<bool>,
-    #[serde(rename = "default_features")]
-    default_features2: Option<bool>,
-    optional: Option<bool>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
@@ -433,19 +352,19 @@ pub struct TomlManifest {
     example: Option<Vec<TomlExampleTarget>>,
     test: Option<Vec<TomlTestTarget>>,
     bench: Option<Vec<TomlTestTarget>>,
-    dependencies: Option<BTreeMap<String, TomlDependency>>,
-    dev_dependencies: Option<BTreeMap<String, TomlDependency>>,
+    dependencies: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
+    dev_dependencies: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     #[serde(rename = "dev_dependencies")]
-    dev_dependencies2: Option<BTreeMap<String, TomlDependency>>,
-    build_dependencies: Option<BTreeMap<String, TomlDependency>>,
+    dev_dependencies2: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
+    build_dependencies: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     #[serde(rename = "build_dependencies")]
-    build_dependencies2: Option<BTreeMap<String, TomlDependency>>,
+    build_dependencies2: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     features: Option<BTreeMap<InternedString, Vec<InternedString>>>,
     target: Option<BTreeMap<String, TomlPlatform>>,
     replace: Option<BTreeMap<String, TomlDependency>>,
     patch: Option<BTreeMap<String, BTreeMap<String, TomlDependency>>>,
     workspace: Option<TomlWorkspace>,
-    badges: Option<MaybeWorkspace<BTreeMap<String, BTreeMap<String, String>>>>,
+    badges: Option<MaybeWorkspaceField<BTreeMap<String, BTreeMap<String, String>>>>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -1008,14 +927,14 @@ impl<'de> de::Deserialize<'de> for VecStringOrBool {
 
 fn version_trim_whitespace<'de, D>(
     deserializer: D,
-) -> Result<MaybeWorkspace<semver::Version>, D::Error>
+) -> Result<MaybeWorkspaceField<semver::Version>, D::Error>
 where
     D: de::Deserializer<'de>,
 {
     struct Visitor;
 
     impl<'de> de::Visitor<'de> for Visitor {
-        type Value = MaybeWorkspace<semver::Version>;
+        type Value = MaybeWorkspaceField<semver::Version>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("SemVer version")
@@ -1043,52 +962,87 @@ where
     deserializer.deserialize_any(Visitor)
 }
 
-/// Enum that allows for the parsing of `field.workspace = true` in a Cargo.toml
+/// This Trait exists to make [`MaybeWorkspace::Workspace`] generic. It makes deserialization of
+/// [`MaybeWorkspace`] much easier, as well as making error messages for
+/// [`MaybeWorkspace::resolve`] much nicer
 ///
-/// It allows for things to be inherited from a workspace or defined as needed
-#[derive(Serialize, Clone, Debug)]
-#[serde(untagged)]
-pub enum MaybeWorkspace<T> {
-    Workspace(TomlWorkspaceField),
-    Defined(T),
+/// Implementors should have a field `workspace` with the type of `bool`. It is used to ensure
+/// `workspace` is not `false` in a `Cargo.toml`
+pub trait WorkspaceInherit {
+    /// This is the workspace table that is being inherited from.
+    /// For example `[workspace.dependencies]` would be the table "dependencies"
+    fn inherit_toml_table(&self) -> &str;
+
+    /// This is used to output the value of the implementors `workspace` field
+    fn workspace(&self) -> bool;
 }
 
-impl<'de, T: Deserialize<'de>> de::Deserialize<'de> for MaybeWorkspace<T> {
-    fn deserialize<D>(deserializer: D) -> Result<MaybeWorkspace<T>, D::Error>
+/// An enum that allows for inheriting keys from a workspace in a Cargo.toml.
+#[derive(Serialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum MaybeWorkspace<T, W: WorkspaceInherit> {
+    /// The "defined" type, or the type that that is used when not inheriting from a workspace.
+    Defined(T),
+    /// The type when inheriting from a workspace.
+    Workspace(W),
+}
+
+impl<'de, T: Deserialize<'de>, W: WorkspaceInherit + de::Deserialize<'de>> de::Deserialize<'de>
+    for MaybeWorkspace<T, W>
+{
+    fn deserialize<D>(deserializer: D) -> Result<MaybeWorkspace<T, W>, D::Error>
     where
         D: de::Deserializer<'de>,
     {
         let value = serde_value::Value::deserialize(deserializer)?;
-        if let Ok(workspace) = TomlWorkspaceField::deserialize(serde_value::ValueDeserializer::<
-            D::Error,
-        >::new(value.clone()))
-        {
-            return Ok(MaybeWorkspace::Workspace(workspace));
+
+        if let Ok(w) = W::deserialize(serde_value::ValueDeserializer::<D::Error>::new(
+            value.clone(),
+        )) {
+            return if w.workspace() {
+                Ok(MaybeWorkspace::Workspace(w))
+            } else {
+                Err(de::Error::custom("`workspace` cannot be false"))
+            };
         }
         T::deserialize(serde_value::ValueDeserializer::<D::Error>::new(value))
             .map(MaybeWorkspace::Defined)
     }
 }
 
-impl<T> MaybeWorkspace<T> {
+impl<T, W: WorkspaceInherit> MaybeWorkspace<T, W> {
     fn resolve<'a>(
         self,
         label: &str,
-        get_ws_field: impl FnOnce() -> CargoResult<T>,
+        get_ws_inheritable: impl FnOnce() -> CargoResult<T>,
     ) -> CargoResult<T> {
         match self {
             MaybeWorkspace::Defined(value) => Ok(value),
-            MaybeWorkspace::Workspace(TomlWorkspaceField { workspace: true }) => get_ws_field()
-                .context(format!(
-                    "error inheriting `{}` from workspace root manifest's `workspace.package.{}`",
-                    label, label
-                )),
-            MaybeWorkspace::Workspace(TomlWorkspaceField { workspace: false }) => Err(anyhow!(
-                "`workspace=false` is unsupported for `package.{}`",
-                label,
-            )),
+            MaybeWorkspace::Workspace(w) => get_ws_inheritable().with_context(|| {
+                format!(
+                "error inheriting `{label}` from workspace root manifest's `workspace.{}.{label}`",
+                w.inherit_toml_table(),
+            )
+            }),
         }
     }
+
+    fn resolve_with_self<'a>(
+        self,
+        label: &str,
+        get_ws_inheritable: impl FnOnce(&W) -> CargoResult<T>,
+    ) -> CargoResult<T> {
+        match self {
+            MaybeWorkspace::Defined(value) => Ok(value),
+            MaybeWorkspace::Workspace(w) => get_ws_inheritable(&w).with_context(|| {
+                format!(
+                "error inheriting `{label}` from workspace root manifest's `workspace.{}.{label}`",
+                w.inherit_toml_table(),
+            )
+            }),
+        }
+    }
+
     fn as_defined(&self) -> Option<&T> {
         match self {
             MaybeWorkspace::Workspace(_) => None,
@@ -1097,9 +1051,117 @@ impl<T> MaybeWorkspace<T> {
     }
 }
 
+type MaybeWorkspaceDependency = MaybeWorkspace<TomlDependency, TomlWorkspaceDependency>;
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(rename_all = "kebab-case")]
+pub struct TomlWorkspaceDependency {
+    workspace: bool,
+    features: Option<Vec<String>>,
+    default_features: Option<bool>,
+    #[serde(rename = "default_features")]
+    default_features2: Option<bool>,
+    optional: Option<bool>,
+}
+
+impl WorkspaceInherit for TomlWorkspaceDependency {
+    fn inherit_toml_table(&self) -> &str {
+        "dependencies"
+    }
+
+    fn workspace(&self) -> bool {
+        self.workspace
+    }
+}
+
+impl TomlWorkspaceDependency {
+    fn resolve<'a>(
+        &self,
+        name: &str,
+        inheritable: impl FnOnce() -> CargoResult<&'a InheritableFields>,
+        cx: &mut Context<'_, '_>,
+    ) -> CargoResult<TomlDependency> {
+        fn default_features_msg(label: &str, ws_def_feat: Option<bool>, cx: &mut Context<'_, '_>) {
+            let ws_def_feat = match ws_def_feat {
+                Some(true) => "true",
+                Some(false) => "false",
+                None => "not specified",
+            };
+            cx.warnings.push(format!(
+                "`default-features` is ignored for {label}, since `default-features` was \
+                {ws_def_feat} for `workspace.dependencies.{label}`, \
+                this could become a hard error in the future"
+            ))
+        }
+        if self.default_features.is_some() && self.default_features2.is_some() {
+            warn_on_deprecated("default-features", name, "dependency", cx.warnings);
+        }
+        inheritable()?.get_dependency(name, cx.root).map(|d| {
+            match d {
+                TomlDependency::Simple(s) => {
+                    if let Some(false) = self.default_features.or(self.default_features2) {
+                        default_features_msg(name, None, cx);
+                    }
+                    if self.optional.is_some() || self.features.is_some() {
+                        TomlDependency::Detailed(DetailedTomlDependency {
+                            version: Some(s),
+                            optional: self.optional,
+                            features: self.features.clone(),
+                            ..Default::default()
+                        })
+                    } else {
+                        TomlDependency::Simple(s)
+                    }
+                }
+                TomlDependency::Detailed(d) => {
+                    let mut d = d.clone();
+                    match (
+                        self.default_features.or(self.default_features2),
+                        d.default_features.or(d.default_features2),
+                    ) {
+                        // member: default-features = true and
+                        // workspace: default-features = false should turn on
+                        // default-features
+                        (Some(true), Some(false)) => {
+                            d.default_features = Some(true);
+                        }
+                        // member: default-features = false and
+                        // workspace: default-features = true should ignore member
+                        // default-features
+                        (Some(false), Some(true)) => {
+                            default_features_msg(name, Some(true), cx);
+                        }
+                        // member: default-features = false and
+                        // workspace: dep = "1.0" should ignore member default-features
+                        (Some(false), None) => {
+                            default_features_msg(name, None, cx);
+                        }
+                        _ => {}
+                    }
+                    d.add_features(self.features.clone());
+                    d.update_optional(self.optional);
+                    TomlDependency::Detailed(d)
+                }
+            }
+        })
+    }
+}
+
+type MaybeWorkspaceField<T> = MaybeWorkspace<T, TomlWorkspaceField>;
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct TomlWorkspaceField {
     workspace: bool,
+}
+
+impl WorkspaceInherit for TomlWorkspaceField {
+    fn inherit_toml_table(&self) -> &str {
+        "package"
+    }
+
+    fn workspace(&self) -> bool {
+        self.workspace
+    }
 }
 
 /// Represents the `package`/`project` sections of a `Cargo.toml`.
@@ -1111,12 +1173,12 @@ pub struct TomlWorkspaceField {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlPackage {
-    edition: Option<MaybeWorkspace<String>>,
-    rust_version: Option<MaybeWorkspace<String>>,
+    edition: Option<MaybeWorkspaceField<String>>,
+    rust_version: Option<MaybeWorkspaceField<String>>,
     name: InternedString,
     #[serde(deserialize_with = "version_trim_whitespace")]
-    version: MaybeWorkspace<semver::Version>,
-    authors: Option<MaybeWorkspace<Vec<String>>>,
+    version: MaybeWorkspaceField<semver::Version>,
+    authors: Option<MaybeWorkspaceField<Vec<String>>>,
     build: Option<StringOrBool>,
     metabuild: Option<StringOrVec>,
     #[serde(rename = "default-target")]
@@ -1124,9 +1186,9 @@ pub struct TomlPackage {
     #[serde(rename = "forced-target")]
     forced_target: Option<String>,
     links: Option<String>,
-    exclude: Option<MaybeWorkspace<Vec<String>>>,
-    include: Option<MaybeWorkspace<Vec<String>>>,
-    publish: Option<MaybeWorkspace<VecStringOrBool>>,
+    exclude: Option<MaybeWorkspaceField<Vec<String>>>,
+    include: Option<MaybeWorkspaceField<Vec<String>>>,
+    publish: Option<MaybeWorkspaceField<VecStringOrBool>>,
     workspace: Option<String>,
     im_a_teapot: Option<bool>,
     autobins: Option<bool>,
@@ -1136,15 +1198,15 @@ pub struct TomlPackage {
     default_run: Option<String>,
 
     // Package metadata.
-    description: Option<MaybeWorkspace<String>>,
-    homepage: Option<MaybeWorkspace<String>>,
-    documentation: Option<MaybeWorkspace<String>>,
-    readme: Option<MaybeWorkspace<StringOrBool>>,
-    keywords: Option<MaybeWorkspace<Vec<String>>>,
-    categories: Option<MaybeWorkspace<Vec<String>>>,
-    license: Option<MaybeWorkspace<String>>,
-    license_file: Option<MaybeWorkspace<String>>,
-    repository: Option<MaybeWorkspace<String>>,
+    description: Option<MaybeWorkspaceField<String>>,
+    homepage: Option<MaybeWorkspaceField<String>>,
+    documentation: Option<MaybeWorkspaceField<String>>,
+    readme: Option<MaybeWorkspaceField<StringOrBool>>,
+    keywords: Option<MaybeWorkspaceField<Vec<String>>>,
+    categories: Option<MaybeWorkspaceField<Vec<String>>>,
+    license: Option<MaybeWorkspaceField<String>>,
+    license_file: Option<MaybeWorkspaceField<String>>,
+    repository: Option<MaybeWorkspaceField<String>>,
     resolver: Option<String>,
 
     // Note that this field must come last due to the way toml serialization
@@ -1217,7 +1279,7 @@ impl InheritableFields {
         )
     }
 
-    pub fn get_dependency(&self, name: &str) -> CargoResult<TomlDependency> {
+    pub fn get_dependency(&self, name: &str, package_root: &Path) -> CargoResult<TomlDependency> {
         self.dependencies.clone().map_or(
             Err(anyhow!("`workspace.dependencies` was not defined")),
             |deps| {
@@ -1226,7 +1288,13 @@ impl InheritableFields {
                         "`dependency.{}` was not found in `workspace.dependencies`",
                         name
                     )),
-                    |dep| Ok(dep.clone()),
+                    |dep| {
+                        let mut dep = dep.clone();
+                        if let TomlDependency::Detailed(detailed) = &mut dep {
+                            detailed.resolve_path(name, self.ws_root(), package_root)?
+                        }
+                        Ok(dep)
+                    },
                 )
             },
         )
@@ -1532,24 +1600,33 @@ impl TomlManifest {
 
         fn map_deps(
             config: &Config,
-            deps: Option<&BTreeMap<String, TomlDependency>>,
+            deps: Option<&BTreeMap<String, MaybeWorkspaceDependency>>,
             filter: impl Fn(&TomlDependency) -> bool,
-        ) -> CargoResult<Option<BTreeMap<String, TomlDependency>>> {
+        ) -> CargoResult<Option<BTreeMap<String, MaybeWorkspaceDependency>>> {
             let deps = match deps {
                 Some(deps) => deps,
                 None => return Ok(None),
             };
             let deps = deps
                 .iter()
-                .filter(|(_k, v)| filter(v))
+                .filter(|(_k, v)| {
+                    if let MaybeWorkspace::Defined(def) = v {
+                        filter(def)
+                    } else {
+                        false
+                    }
+                })
                 .map(|(k, v)| Ok((k.clone(), map_dependency(config, v)?)))
                 .collect::<CargoResult<BTreeMap<_, _>>>()?;
             Ok(Some(deps))
         }
 
-        fn map_dependency(config: &Config, dep: &TomlDependency) -> CargoResult<TomlDependency> {
-            match dep {
-                TomlDependency::Detailed(d) => {
+        fn map_dependency(
+            config: &Config,
+            dep: &MaybeWorkspaceDependency,
+        ) -> CargoResult<MaybeWorkspaceDependency> {
+            let dep = match dep {
+                MaybeWorkspace::Defined(TomlDependency::Detailed(d)) => {
                     let mut d = d.clone();
                     // Path dependencies become crates.io deps.
                     d.path.take();
@@ -1562,15 +1639,16 @@ impl TomlManifest {
                     if let Some(registry) = d.registry.take() {
                         d.registry_index = Some(config.get_registry_index(&registry)?.to_string());
                     }
-                    Ok(TomlDependency::Detailed(d))
+                    Ok(d)
                 }
-                TomlDependency::Simple(s) => Ok(TomlDependency::Detailed(DetailedTomlDependency {
+                MaybeWorkspace::Defined(TomlDependency::Simple(s)) => Ok(DetailedTomlDependency {
                     version: Some(s.clone()),
                     ..Default::default()
-                })),
-                // Unreachable as we resolve everything before this
-                TomlDependency::Workspace(_) => unreachable!(),
-            }
+                }),
+                _ => unreachable!(),
+            };
+            dep.map(TomlDependency::Detailed)
+                .map(MaybeWorkspace::Defined)
         }
     }
 
@@ -1822,29 +1900,31 @@ impl TomlManifest {
 
         fn process_dependencies(
             cx: &mut Context<'_, '_>,
-            new_deps: Option<&BTreeMap<String, TomlDependency>>,
+            new_deps: Option<&BTreeMap<String, MaybeWorkspaceDependency>>,
             kind: Option<DepKind>,
             workspace_config: &WorkspaceConfig,
             inherit_cell: &LazyCell<InheritableFields>,
-        ) -> CargoResult<Option<BTreeMap<String, TomlDependency>>> {
+        ) -> CargoResult<Option<BTreeMap<String, MaybeWorkspaceDependency>>> {
             let dependencies = match new_deps {
                 Some(dependencies) => dependencies,
                 None => return Ok(None),
             };
 
-            let inherit = || {
+            let inheritable = || {
                 inherit_cell.try_borrow_with(|| {
                     get_ws(cx.config, &cx.root.join("Cargo.toml"), &workspace_config)
                 })
             };
 
-            let mut deps: BTreeMap<String, TomlDependency> = BTreeMap::new();
+            let mut deps: BTreeMap<String, MaybeWorkspaceDependency> = BTreeMap::new();
             for (n, v) in dependencies.iter() {
-                let resolved = v.clone().resolve(n, cx, || inherit())?;
+                let resolved = v
+                    .clone()
+                    .resolve_with_self(n, |dep| dep.resolve(n, inheritable, cx))?;
                 let dep = resolved.to_dependency(n, cx, kind)?;
                 validate_package_name(dep.name_in_toml().as_str(), "dependency name", "")?;
                 cx.deps.push(dep);
-                deps.insert(n.to_string(), resolved.clone());
+                deps.insert(n.to_string(), MaybeWorkspace::Defined(resolved.clone()));
             }
             Ok(Some(deps))
         }
@@ -2557,7 +2637,6 @@ impl<P: ResolveToPath + Clone> TomlDependency<P> {
             }
             .to_dependency(name, cx, kind),
             TomlDependency::Detailed(ref details) => details.to_dependency(name, cx, kind),
-            TomlDependency::Workspace(_) => unreachable!(),
         }
     }
 
@@ -2565,7 +2644,6 @@ impl<P: ResolveToPath + Clone> TomlDependency<P> {
         match self {
             TomlDependency::Detailed(d) => d.version.is_some(),
             TomlDependency::Simple(..) => true,
-            TomlDependency::Workspace(_) => unreachable!(),
         }
     }
 
@@ -2573,111 +2651,6 @@ impl<P: ResolveToPath + Clone> TomlDependency<P> {
         match self {
             TomlDependency::Detailed(d) => d.optional.unwrap_or(false),
             TomlDependency::Simple(..) => false,
-            TomlDependency::Workspace(w) => w.optional.unwrap_or(false),
-        }
-    }
-}
-
-impl TomlDependency {
-    fn resolve<'a>(
-        self,
-        label: &str,
-        cx: &mut Context<'_, '_>,
-        get_inheritable: impl FnOnce() -> CargoResult<&'a InheritableFields>,
-    ) -> CargoResult<TomlDependency> {
-        fn default_features_msg(label: &str, ws_def_feat: Option<bool>, cx: &mut Context<'_, '_>) {
-            let ws_def_feat = match ws_def_feat {
-                Some(true) => "true",
-                Some(false) => "false",
-                None => "not specified",
-            };
-            cx.warnings.push(format!(
-                "`default-features` is ignored for {label}, since `default-features` was \
-                {ws_def_feat} for `workspace.dependencies.{label}`, \
-                this could become a hard error in the future"
-            ))
-        }
-        match self {
-            TomlDependency::Detailed(d) => Ok(TomlDependency::Detailed(d)),
-            TomlDependency::Simple(s) => Ok(TomlDependency::Simple(s)),
-            TomlDependency::Workspace(TomlWorkspaceDependency {
-                workspace: true,
-                features,
-                optional,
-                default_features,
-                default_features2,
-            }) => {
-                if default_features.is_some() && default_features2.is_some() {
-                    warn_on_deprecated("default-features", label, "dependency", cx.warnings);
-                }
-                let inheritable = get_inheritable()?;
-                inheritable.get_dependency(label).context(format!(
-                    "error reading `dependencies.{}` from workspace root manifest's `workspace.dependencies.{}`",
-                    label, label
-                )).map(|dep| {
-                    match dep {
-                        TomlDependency::Simple(s) => {
-                            if let Some(false) = default_features.or(default_features2) {
-                                default_features_msg(label, None, cx);
-                            }
-                            if optional.is_some() || features.is_some() {
-                                Ok(TomlDependency::Detailed(DetailedTomlDependency {
-                                    version: Some(s),
-                                    optional,
-                                    features,
-                                    ..Default::default()
-                                }))
-                            } else {
-                                Ok(TomlDependency::Simple(s))
-                            }
-                        },
-                        TomlDependency::Detailed(d) => {
-                            let mut dep = d.clone();
-                            match (
-                                default_features.or(default_features2),
-                                d.default_features.or(d.default_features2)
-                            ) {
-                                // member: default-features = true and
-                                // workspace: default-features = false should turn on
-                                // default-features
-                                (Some(true), Some(false)) => {
-                                    dep.default_features = Some(true);
-                                }
-                                // member: default-features = false and
-                                // workspace: default-features = true should ignore member
-                                // default-features
-                                (Some(false), Some(true)) => {
-                                    default_features_msg(label, Some(true), cx);
-                                }
-                                // member: default-features = false and
-                                // workspace: dep = "1.0" should ignore member default-features
-                                (Some(false), None) => {
-                                    default_features_msg(label, None, cx);
-                                }
-                                _ => {}
-                            }
-                            dep.add_features(features);
-                            dep.update_optional(optional);
-                            dep.resolve_path(label,inheritable.ws_root(), cx.root)?;
-                            Ok(TomlDependency::Detailed(dep))
-                        },
-                        TomlDependency::Workspace(_) => {
-                            unreachable!(
-                                "We check that no workspace defines dependencies with \
-                                `{{ workspace = true }}` when we read a manifest from a string. \
-                                this should not happen but did on {}",
-                                label
-                            )
-                        },
-                    }
-                })?
-            }
-            TomlDependency::Workspace(TomlWorkspaceDependency {
-                workspace: false, ..
-            }) => Err(anyhow!(
-                "`workspace=false` is unsupported for `package.dependencies.{}`",
-                label,
-            )),
         }
     }
 }
@@ -3017,15 +2990,15 @@ impl ser::Serialize for PathValue {
 /// Corresponds to a `target` entry, but `TomlTarget` is already used.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct TomlPlatform {
-    dependencies: Option<BTreeMap<String, TomlDependency>>,
+    dependencies: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     #[serde(rename = "build-dependencies")]
-    build_dependencies: Option<BTreeMap<String, TomlDependency>>,
+    build_dependencies: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     #[serde(rename = "build_dependencies")]
-    build_dependencies2: Option<BTreeMap<String, TomlDependency>>,
+    build_dependencies2: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     #[serde(rename = "dev-dependencies")]
-    dev_dependencies: Option<BTreeMap<String, TomlDependency>>,
+    dev_dependencies: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
     #[serde(rename = "dev_dependencies")]
-    dev_dependencies2: Option<BTreeMap<String, TomlDependency>>,
+    dev_dependencies2: Option<BTreeMap<String, MaybeWorkspaceDependency>>,
 }
 
 impl TomlTarget {


### PR DESCRIPTION
**This should not be merged until after #11409**

In #11523 it was noted that you could use `{}.workspace = true` in `[patch.{}]`, but it would cause a panic. This panic was caused by an oversight on my part when implementing [workspace inheritance](https://github.com/rust-lang/rfcs/blob/master/text/2906-cargo-workspace-deduplicate.md). Before this PR any field that had the type `TomlDependency` could specify `{}.workspace = true` and `cargo` would allow it to be a `TomlWorkspaceDependency`. While it could be `TomlWorkspaceDependency` it would never be resolved since only:
 
> Dependencies in the `[dependencies]`, `[dev-dependencies]`, [`build-dependencies]`, and `[target."...".dependencies]` sections will support the ability to reference the `[workspace.dependencies]` definition of dependencies.[^1]

This PR makes it so that only those fields can pull from `[workspace.dependencies]`, while still sharing `TomlDependency` everywhere it is needed. It does this by making `MaybeWorkspace` generic over both `Defined` and `Workspace`, then moving `TomlWorkspaceDependency` out of `TomlDependency` and into a `MaybeWorkspace` that the correct fields can use.

[^1]: [rfc2906-new-dependency-directives](https://github.com/rust-lang/rfcs/blob/master/text/2906-cargo-workspace-deduplicate.md#new-dependency-directives)

Closes: #11523 