### PR TITLE
Redirect nightly apidoc to `doc.rust-lang.org/nightly/nightly-rustc/cargo`

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -21,11 +21,6 @@ jobs:
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.9/mdbook-v0.4.9-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-    - name: Update toolchain
-      run: rustup update --no-self-update stable && rustup default stable
-    - name: Build API doc
-      run: |
-          cargo doc --document-private-items --no-deps
     - name: Deploy docs
       run: |
         cd src/doc/contrib
@@ -38,8 +33,6 @@ jobs:
         git update-ref -d refs/heads/gh-pages
         rm -rf contrib
         mv ../book contrib
-        # Move rustdoc under contrib/
-        mv ../../../../target/doc contrib/apidoc
         git add contrib
         git commit -m "Deploy $GITHUB_SHA to gh-pages"
         git push --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,7 +235,7 @@
 - External subcommands can now inherit jobserver file descriptors from Cargo.
   [#10511](https://github.com/rust-lang/cargo/pull/10511)
 - Added an API documentation for private items in cargo-the-library. See
-  <https://doc.crates.io/contrib/apidoc/cargo>.
+  <https://doc.rust-lang.org/nightly/nightly-rustc/cargo>.
   [#11019](https://github.com/rust-lang/cargo/pull/11019)
 
 ### Changed

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -14,7 +14,7 @@
 //! There are two places you can find API documentation of cargo-the-library,
 //!
 //! - <https://docs.rs/cargo> and
-//! - <https://doc.crates.io/contrib/apidoc/cargo>.
+//! - <https://doc.rust-lang.org/nightly/nightly-rustc/cargo>.
 //!
 //! Each of them targets on a slightly different audience.
 //!
@@ -33,7 +33,7 @@
 //!
 //! ## For Cargo contributors
 //!
-//! The documentation on <https://doc.crates.io/contrib/apidoc/cargo> contains all items in Cargo.
+//! The documentation on <https://doc.rust-lang.org/nightly/nightly-rustc/cargo> contains all items in Cargo.
 //! Contributors of Cargo may find it useful as a reference of Cargo's implementation details.
 //! It's built with `--document-private-items` rustdoc flag,
 //! so you might expect to see some noise and strange items here.

--- a/src/doc/contrib/book.toml
+++ b/src/doc/contrib/book.toml
@@ -6,4 +6,4 @@ authors = ["Eric Huss"]
 git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/contrib/src"
 
 [output.html.redirect]
-"/apidoc/cargo/" = "https://doc.rust-lang.org/nightly/nightly-rustc/cargo/"
+"/apidoc/cargo/index.html" = "https://doc.rust-lang.org/nightly/nightly-rustc/cargo/"

--- a/src/doc/contrib/book.toml
+++ b/src/doc/contrib/book.toml
@@ -4,3 +4,6 @@ authors = ["Eric Huss"]
 
 [output.html]
 git-repository-url = "https://github.com/rust-lang/cargo/tree/master/src/doc/contrib/src"
+
+[output.html.redirect]
+"/apidoc/cargo/" = "https://doc.rust-lang.org/nightly/nightly-rustc/cargo/"


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fix for #11555. I more or less blindly followed the instructions given by @weihanglo in the description of the issue:

1. I replaced every link from `doc.crates.io/contrib/apidoc/cargo` with `doc.rust-lang.org/nightly/nightly-rustc/cargo`
2. Added redirection rule to `src/doc/contrib/book.toml` that should redirect the `/apidoc/cargo/` endpoint to `https://doc.rust-lang.org/nightly/nightly-rustc/cargo`
3. Reverted the changes made to the CI workflow in https://github.com/rust-lang/cargo/commit/ba3d2e981bf69b13f7024eee7914e719a96cc620 and https://github.com/rust-lang/cargo/commit/1c82d9c8c3f00075ea4535fcd5fb86fb8dd99ac6 (building the api docs as part of the contribution guide)
