### PR TITLE
Make cargo aware of dwp files.

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -831,12 +831,17 @@ impl Execs {
         self
     }
 
+    pub fn enable_split_debuginfo_packed(&mut self) -> &mut Self {
+        self.env("CARGO_PROFILE_DEV_SPLIT_DEBUGINFO", "packed")
+            .env("CARGO_PROFILE_TEST_SPLIT_DEBUGINFO", "packed")
+            .env("CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO", "packed")
+            .env("CARGO_PROFILE_BENCH_SPLIT_DEBUGINFO", "packed");
+        self
+    }
+
     pub fn enable_mac_dsym(&mut self) -> &mut Self {
         if cfg!(target_os = "macos") {
-            self.env("CARGO_PROFILE_DEV_SPLIT_DEBUGINFO", "packed")
-                .env("CARGO_PROFILE_TEST_SPLIT_DEBUGINFO", "packed")
-                .env("CARGO_PROFILE_RELEASE_SPLIT_DEBUGINFO", "packed")
-                .env("CARGO_PROFILE_BENCH_SPLIT_DEBUGINFO", "packed");
+            return self.enable_split_debuginfo_packed();
         }
         self
     }

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -463,11 +463,22 @@ impl TargetInfo {
                     should_replace_hyphens: true,
                 })
             } else {
+                // Because DWARF Package (dwp) files are produced after the
+                // fact by another tool, there is nothing in the binary that
+                // provides a means to locate them. By convention, debuggers
+                // take the binary filename and append ".dwp" (including to
+                // binaries that already have an extension such as shared libs)
+                // to find the dwp.
                 ret.push(FileType {
-                    suffix: format!("{}.dwp", suffix),
+                    // It is important to preserve the existing suffix for
+                    // e.g. shared libraries, where the dwp for libfoo.so is
+                    // expected to be at libfoo.so.dwp.
+                    suffix: format!("{suffix}.dwp"),
                     prefix: prefix.clone(),
                     flavor: FileFlavor::DebugInfo,
                     crate_type: Some(crate_type.clone()),
+                    // Likewise, the dwp needs to match the primary artifact's
+                    // hyphenation exactly.
                     should_replace_hyphens: crate_type != CrateType::Bin,
                 })
             }

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -462,6 +462,14 @@ impl TargetInfo {
                     // preserved.
                     should_replace_hyphens: true,
                 })
+            } else {
+                ret.push(FileType {
+                    suffix: format!("{}.dwp", suffix),
+                    prefix: prefix.clone(),
+                    flavor: FileFlavor::DebugInfo,
+                    crate_type: Some(crate_type.clone()),
+                    should_replace_hyphens: crate_type != CrateType::Bin,
+                })
             }
         }
 

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -203,6 +203,8 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                         rm_rf_glob(&split_debuginfo_obj, config, &mut progress)?;
                         let split_debuginfo_dwo = dir_glob.join(format!("{}.*.dwo", crate_name));
                         rm_rf_glob(&split_debuginfo_dwo, config, &mut progress)?;
+                        let split_debuginfo_dwp = dir_glob.join(format!("{}.*.dwp", crate_name));
+                        rm_rf_glob(&split_debuginfo_dwp, config, &mut progress)?;
 
                         // Remove the uplifted copy.
                         if let Some(uplift_dir) = uplift_dir {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5216,6 +5216,29 @@ fn uplift_pdb_of_bin_on_windows() {
     assert!(!p.target_debug_dir().join("d.pdb").exists());
 }
 
+#[cargo_test]
+#[cfg(target_os = "linux")]
+fn uplift_dwp_of_bin_on_linux() {
+    let p = project()
+        .file("src/main.rs", "fn main() { panic!(); }")
+        .file("src/bin/b.rs", "fn main() { panic!(); }")
+        .file("src/bin/foo-bar.rs", "fn main() { panic!(); }")
+        .file("examples/c.rs", "fn main() { panic!(); }")
+        .file("tests/d.rs", "fn main() { panic!(); }")
+        .build();
+
+    p.cargo("build --bins --examples --tests")
+        .enable_split_debuginfo_packed()
+        .run();
+    assert!(p.target_debug_dir().join("foo.dwp").is_file());
+    assert!(p.target_debug_dir().join("b.dwp").is_file());
+    assert!(p.target_debug_dir().join("examples/c.dwp").exists());
+    assert!(p.target_debug_dir().join("foo-bar").is_file());
+    assert!(p.target_debug_dir().join("foo-bar.dwp").is_file());
+    assert!(!p.target_debug_dir().join("c.dwp").exists());
+    assert!(!p.target_debug_dir().join("d.dwp").exists());
+}
+
 // Ensure that `cargo build` chooses the correct profile for building
 // targets based on filters (assuming `--profile` is not specified).
 #[cargo_test]


### PR DESCRIPTION
When using -Csplit-debuginfo=packed on Linux, rustc will produce a dwp file. Unlike the dwo files, whose paths are embedded into the binary, there's no information in the binary to help a debugger locate a dwp file. By convention, the dwp file for `<EXE>` is given the name `<EXE>.dwp` and placed next to `<EXE>`.

When cargo hardlinks the executable file rustc put in target/debug/deps into target/debug, it also needs to hardlink the dwp file along with it. Failing to do this prevents the debugger from finding the dwp file when the binary is executed from target/debug, as there's no way for the debugger to know to look in the deps subdirectory.

The split_debuginfo option is passed down into file_types to make this possible. For cargo clean manual handling is added to match the other split_debuginfo files. bin_link_for_target also passes in None because it won't care about the dwp file.
