### PR TITLE
ci: reflect to clap updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ toml_edit =  { version = "0.15.0", features = ["serde", "easy", "perf"] }
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
-clap = "4.0.15"
+clap = "4.1.1"
 unicode-width = "0.1.5"
 openssl = { version = '0.10.11', optional = true }
 im-rc = "15.0.0"

--- a/tests/testsuite/cargo_add/dev_build_conflict/stderr.log
+++ b/tests/testsuite/cargo_add/dev_build_conflict/stderr.log
@@ -1,7 +1,7 @@
-error: The argument '--dev' cannot be used with '--build'
+error: the argument '--dev' cannot be used with '--build'
 
 Usage: cargo add [OPTIONS] <DEP>[@<VERSION>] ...
        cargo add [OPTIONS] --path <PATH> ...
        cargo add [OPTIONS] --git <URL> ...
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/cargo_add/invalid_arg/stderr.log
+++ b/tests/testsuite/cargo_add/invalid_arg/stderr.log
@@ -1,9 +1,9 @@
-error: Found argument '--flag' which wasn't expected, or isn't valid in this context
+error: unexpected argument '--flag' found
 
-  If you tried to supply '--flag' as a value rather than a flag, use '-- --flag'
+  note: to pass '--flag' as a value, use '-- --flag'
 
 Usage: cargo add [OPTIONS] <DEP>[@<VERSION>] ...
        cargo add [OPTIONS] --path <PATH> ...
        cargo add [OPTIONS] --git <URL> ...
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/cargo_add/invalid_target_empty/stderr.log
+++ b/tests/testsuite/cargo_add/invalid_target_empty/stderr.log
@@ -1,3 +1,3 @@
-error: The argument '--target <TARGET>' requires a value but none was supplied
+error: a value is required for '--target <TARGET>' but none was supplied
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/cargo_add/no_args/stderr.log
+++ b/tests/testsuite/cargo_add/no_args/stderr.log
@@ -1,8 +1,8 @@
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <DEP_ID|--path <PATH>|--git <URI>>
 
 Usage: cargo add [OPTIONS] <DEP>[@<VERSION>] ...
        cargo add [OPTIONS] --path <PATH> ...
        cargo add [OPTIONS] --git <URL> ...
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/cargo_remove/invalid_arg/stderr.log
+++ b/tests/testsuite/cargo_remove/invalid_arg/stderr.log
@@ -1,7 +1,7 @@
-error: Found argument '--flag' which wasn't expected, or isn't valid in this context
+error: unexpected argument '--flag' found
 
-  If you tried to supply '--flag' as a value rather than a flag, use '-- --flag'
+  note: to pass '--flag' as a value, use '-- --flag'
 
 Usage: cargo[EXE] remove <DEP_ID>...
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/cargo_remove/no_arg/stderr.log
+++ b/tests/testsuite/cargo_remove/no_arg/stderr.log
@@ -1,6 +1,6 @@
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <DEP_ID>...
 
 Usage: cargo[EXE] remove <DEP_ID>...
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/init/unknown_flags/stderr.log
+++ b/tests/testsuite/init/unknown_flags/stderr.log
@@ -1,7 +1,7 @@
-error: Found argument '--flag' which wasn't expected, or isn't valid in this context
+error: unexpected argument '--flag' found
 
-  If you tried to supply '--flag' as a value rather than a flag, use '-- --flag'
+  note: to pass '--flag' as a value, use '-- --flag'
 
 Usage: cargo[EXE] init <path>
 
-For more information try '--help'
+For more information, try '--help'.

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1446,7 +1446,7 @@ fn not_both_vers_and_version() {
         .with_status(1)
         .with_stderr_contains(
             "\
-error: The argument '--version <VERSION>' was provided more than once, but cannot be used multiple times
+[ERROR] the argument '--version <VERSION>' cannot be used multiple times
 ",
         )
         .run();
@@ -1648,9 +1648,7 @@ fn install_empty_argument() {
     cargo_process("install")
         .arg("")
         .with_status(1)
-        .with_stderr_contains(
-            "[ERROR] The argument '[crate]...' requires a value but none was supplied",
-        )
+        .with_stderr_contains("[ERROR] a value is required for '[crate]...' but none was supplied")
         .run();
 }
 

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -133,26 +133,26 @@ fn bad_asymmetric_token_args() {
     // These cases are kept brief as the implementation is covered by clap, so this is only smoke testing that we have clap configured correctly.
     cargo_process("login --key-subject=foo tok")
         .with_stderr_contains(
-            "[ERROR] The argument '--key-subject <SUBJECT>' cannot be used with '[token]'",
+            "error: the argument '--key-subject <SUBJECT>' cannot be used with '[token]'",
         )
         .with_status(1)
         .run();
 
     cargo_process("login --generate-keypair tok")
         .with_stderr_contains(
-            "[ERROR] The argument '--generate-keypair' cannot be used with '[token]'",
+            "error: the argument '--generate-keypair' cannot be used with '[token]'",
         )
         .with_status(1)
         .run();
 
     cargo_process("login --secret-key tok")
-        .with_stderr_contains("[ERROR] The argument '--secret-key' cannot be used with '[token]'")
+        .with_stderr_contains("error: the argument '--secret-key' cannot be used with '[token]'")
         .with_status(1)
         .run();
 
     cargo_process("login --generate-keypair --secret-key")
         .with_stderr_contains(
-            "[ERROR] The argument '--generate-keypair' cannot be used with '--secret-key'",
+            "error: the argument '--generate-keypair' cannot be used with '--secret-key'",
         )
         .with_status(1)
         .run();

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1910,7 +1910,7 @@ fn cargo_metadata_bad_version() {
         .with_status(1)
         .with_stderr_contains(
             "\
-error: '2' isn't a valid value for '--format-version <VERSION>'
+error: invalid value '2' for '--format-version <VERSION>'
   [possible values: 1]
 ",
         )

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -106,7 +106,7 @@ fn no_argument() {
         .with_status(1)
         .with_stderr_contains(
             "\
-error: The following required arguments were not provided:
+error: the following required arguments were not provided:
   <path>
 ",
         )
@@ -321,9 +321,7 @@ fn subpackage_git_with_vcs_arg() {
 fn unknown_flags() {
     cargo_process("new foo --flag")
         .with_status(1)
-        .with_stderr_contains(
-            "error: Found argument '--flag' which wasn't expected, or isn't valid in this context",
-        )
+        .with_stderr_contains("error: unexpected argument '--flag' found")
         .run();
 }
 
@@ -380,7 +378,7 @@ fn new_default_edition() {
 #[cargo_test]
 fn new_with_bad_edition() {
     cargo_process("new --edition something_else foo")
-        .with_stderr_contains("error: 'something_else' isn't a valid value[..]")
+        .with_stderr_contains("error: invalid value 'something_else' for '--edition <YEAR>'")
         .with_status(1)
         .run();
 }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -589,7 +589,10 @@ fn run_bins() {
     p.cargo("run --bins")
         .with_status(1)
         .with_stderr_contains(
-            "error: Found argument '--bins' which wasn't expected, or isn't valid in this context",
+            "\
+error: unexpected argument '--bins' found
+
+  note: argument '--bin' exists",
         )
         .run();
 }
@@ -1321,7 +1324,7 @@ fn run_multiple_packages() {
         .arg("d2")
         .with_status(1)
         .with_stderr_contains(
-            "error: The argument '--package [<SPEC>]' was provided more than once, but cannot be used multiple times",
+            "error: the argument '--package [<SPEC>]' cannot be used multiple times",
         )
         .run();
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -551,7 +551,7 @@ fn fail_with_multiple_packages() {
         .with_status(1)
         .with_stderr_contains(
             "\
-error: The argument '--package [<SPEC>]' was provided more than once, but cannot be used multiple times
+error: the argument '--package [<SPEC>]' cannot be used multiple times
 ",
         )
         .run();

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -436,11 +436,11 @@ fn test_sync_argument() {
 
     p.cargo("vendor --respect-source-config --manifest-path foo/Cargo.toml -s bar/Cargo.toml baz/Cargo.toml test_vendor")
         .with_stderr("\
-error: Found argument 'test_vendor' which wasn't expected, or isn't valid in this context
+error: unexpected argument 'test_vendor' found
 
 Usage: cargo[EXE] vendor [OPTIONS] [path]
 
-For more information try '--help'",
+For more information, try '--help'.",
         )
         .with_status(1)
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

CI is failing due to clap updating its error messages.

### Additional information

The update of `snapbox` tests is lovely. Just use `SNAPSHOTS=overwrite` and you're all set.

I wish other tests can do that as well.
<!-- homu-ignore:end -->
