### PR TITLE
Show progress of crates.io index update even `net.git-fetch-with-cli` option enabled

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -961,7 +961,7 @@ fn fetch_with_cli(
     config
         .shell()
         .verbose(|s| s.status("Running", &cmd.to_string()))?;
-    cmd.exec_with_output()?;
+    cmd.exec()?;
     Ok(())
 }
 

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1,7 +1,7 @@
 //! Utilities for handling git repositories, mainly around
 //! authentication/cloning.
 
-use crate::core::GitReference;
+use crate::core::{GitReference, Verbosity};
 use crate::util::errors::CargoResult;
 use crate::util::{human_readable_bytes, network, Config, IntoUrl, MetricsCounter, Progress};
 use anyhow::{anyhow, Context as _};
@@ -932,6 +932,15 @@ fn fetch_with_cli(
     cmd.arg("fetch");
     if tags {
         cmd.arg("--tags");
+    }
+    match config.shell().verbosity() {
+        Verbosity::Normal => {}
+        Verbosity::Verbose => {
+            cmd.arg("--verbose");
+        }
+        Verbosity::Quiet => {
+            cmd.arg("--quiet");
+        }
     }
     cmd.arg("--force") // handle force pushes
         .arg("--update-head-ok") // see discussion in #2078

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2749,6 +2749,8 @@ fn use_the_cli() {
     let stderr = "\
 [UPDATING] git repository `[..]`
 [RUNNING] `git fetch [..]`
+From [..]
+ * [new ref]                    -> origin/HEAD
 [COMPILING] dep1 [..]
 [RUNNING] `rustc [..]`
 [COMPILING] foo [..]


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes #11574 .

### How should we test and review this PR?

Please run `cargo` with `net.git-fetch-with-cli` option enabled.
It should show `git fetch`'s progress output like below.
```
❯ CARGO_NET_GIT_FETCH_WITH_CLI=true ./target/debug/cargo b
    Updating crates.io index
remote: Enumerating objects: 139821, done.
remote: Counting objects: 100% (2226/2226), done.
remote: Compressing objects: 100% (769/769), done.
receiving objects:   0% (1/139821)
```
