### PR TITLE
Enable source_config_env test on Windows

### DIFF
--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -3,9 +3,6 @@
 use cargo_test_support::{paths, project, registry::Package};
 
 #[cargo_test]
-// I don't know why, but `Command` forces all env keys to be upper case on
-// Windows. Seems questionable, since I think Windows is case-preserving.
-#[cfg_attr(windows, ignore = "broken due to not preserving case on Windows")]
 fn source_config_env() {
     // Try to define [source] with environment variables.
     let p = project()


### PR DESCRIPTION
This enables the `advaned_env::source_config_env` test on Windows. The issue with `Command` modifying the case of environment variables was fixed by https://github.com/rust-lang/rust/pull/85270.