### PR TITLE
Add semver rule for lints

### DIFF
--- a/src/doc/semver-check/src/main.rs
+++ b/src/doc/semver-check/src/main.rs
@@ -31,11 +31,15 @@ fn doit() -> Result<(), Box<dyn Error>> {
 
     loop {
         // Find a rust block.
-        let (block_start, run_program) = loop {
+        let (block_start, run_program, deny_warnings) = loop {
             match lines.next() {
                 Some((lineno, line)) => {
                     if line.trim().starts_with("```rust") && !line.contains("skip") {
-                        break (lineno + 1, line.contains("run-fail"));
+                        break (
+                            lineno + 1,
+                            line.contains("run-fail"),
+                            !line.contains("dont-deny"),
+                        );
                     }
                 }
                 None => return Ok(()),
@@ -73,7 +77,10 @@ fn doit() -> Result<(), Box<dyn Error>> {
         }
         let join = |part: &[&str]| {
             let mut result = String::new();
-            result.push_str("#![allow(unused)]\n#![deny(warnings)]\n");
+            result.push_str("#![allow(unused)]\n");
+            if deny_warnings {
+                result.push_str("#![deny(warnings)]\n");
+            }
             result.push_str(&part.join("\n"));
             if !result.ends_with('\n') {
                 result.push('\n');

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1210,10 +1210,13 @@ Mitigating strategies:
     * Understand you may need to deal with resolving new warnings whenever you update your dependencies.
     * Place `deny(warnings)` behind a [feature][Cargo features], for example `#![cfg_attr(feature = "deny-warnings", deny(warnings))]`.
       Set up your automated CI to check your crate with the feature enabled, possibly as an allowed failure with a notification.
+      Beware that features are exposed to users, so you may want to clearly document it as something that is not to be used.
+    * If using RUSTFLAGS to pass `-Dwarnings`, also add the `-A` flag to allow lints that are likely to cause issues, such as `-Adeprecated`.
 * Introduce deprecations behind a [feature][Cargo features].
   For example `#[cfg_attr(feature = "deprecated", deprecated="use bar instead")]`.
   Then, when you plan to remove an item in a future SemVer breaking change, you can communicate with your users that they should enable the `deprecated` feature *before* updating to remove the use of the deprecated items.
-
+  This allows users to choose when to respond to deprecations without needing to immediately respond to them.
+  A downside is that it can be difficult to communicate to users that they need to take these manual steps to prepare for a major update.
 
 [`unused_must_use`]: ../../rustc/lints/listing/warn-by-default.html#unused-must-use
 [deprecated-lint]: ../../rustc/lints/listing/warn-by-default.html#deprecated

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1206,12 +1206,8 @@ Additionally, updating `rustc` to a new version may introduce new lints.
 Transitive dependencies which introduce new lints should not usually cause a failure because Cargo uses [`--cap-lints`](../../rustc/lints/levels.html#capping-lints) to suppress all lints in dependencies.
 
 Mitigating strategies:
-* Options for dealing with denying warnings:
-    * Understand you may need to deal with resolving new warnings whenever you update your dependencies.
-    * Place `deny(warnings)` behind a [feature][Cargo features], for example `#![cfg_attr(feature = "deny-warnings", deny(warnings))]`.
-      Set up your automated CI to check your crate with the feature enabled, possibly as an allowed failure with a notification.
-      Beware that features are exposed to users, so you may want to clearly document it as something that is not to be used.
-    * If using RUSTFLAGS to pass `-Dwarnings`, also add the `-A` flag to allow lints that are likely to cause issues, such as `-Adeprecated`.
+* If you build with warnings denied, understand you may need to deal with resolving new warnings whenever you update your dependencies.
+  If using RUSTFLAGS to pass `-Dwarnings`, also add the `-A` flag to allow lints that are likely to cause issues, such as `-Adeprecated`.
 * Introduce deprecations behind a [feature][Cargo features].
   For example `#[cfg_attr(feature = "deprecated", deprecated="use bar instead")]`.
   Then, when you plan to remove an item in a future SemVer breaking change, you can communicate with your users that they should enable the `deprecated` feature *before* updating to remove the use of the deprecated items.


### PR DESCRIPTION
This adds a new rule to the semver compatibility list explaining the expectations around diagnostic lints.

cc #8736