### PR TITLE
doc(contrib): remove rls in release process

### DIFF
--- a/src/doc/contrib/src/process/release.md
+++ b/src/doc/contrib/src/process/release.md
@@ -47,7 +47,6 @@ subup --up-branch update-cargo \
     --test="src/tools/linkchecker tidy \
         src/tools/cargo \
         src/tools/rustfmt \
-        src/tools/rls" \
     src/tools/cargo
 ```
 
@@ -61,8 +60,7 @@ subup --up-branch update-beta-cargo \
     --test="src/tools/linkchecker tidy \
         src/tools/cargo \
         src/tools/rustfmt \
-        src/tools/rls" \
-    rust-1.63.0:src/tools/cargo
+    rust-1.66.0:src/tools/cargo
 ```
 
 [@ehuss]: https://github.com/ehuss/


### PR DESCRIPTION
### What does this PR try to resolve?

Remove mentions of RLS from doc of release process. RLS is no longer required to test when bumping Cargo version in rust-lang/rust.

See:

- https://github.com/rust-lang/rust/pull/100863
- https://blog.rust-lang.org/2022/07/01/RLS-deprecation.html
