### PR TITLE
make `util::Progress` thread-safe as prerequisite of #11448

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ libgit2-sys = "=0.14.1"
 memchr = "2.1.3"
 opener = "0.5"
 os_info = "3.5.0"
+parking_lot = "0.12.1"
 pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"
 percent-encoding = "2.0"

--- a/src/cargo/core/compiler/job_queue.rs
+++ b/src/cargo/core/compiler/job_queue.rs
@@ -137,7 +137,7 @@ struct DrainState<'cfg> {
     documented: HashSet<PackageId>,
     scraped: HashSet<PackageId>,
     counts: HashMap<PackageId, usize>,
-    progress: Progress<'cfg>,
+    progress: Progress,
     next_id: u32,
     timings: Timings<'cfg>,
 

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -328,7 +328,7 @@ pub struct Downloads<'a, 'cfg> {
     /// The next ID to use for creating a token (see `Download::token`).
     next: usize,
     /// Progress bar.
-    progress: RefCell<Option<Progress<'cfg>>>,
+    progress: RefCell<Option<Progress>>,
     /// Number of downloads that have successfully finished.
     downloads_finished: usize,
     /// Total bytes for all successfully downloaded packages.

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -75,7 +75,7 @@ impl fmt::Debug for Shell {
 /// A `Write`able object, either with or without color support
 enum ShellOut {
     /// A plain write object without color support
-    Write(Box<dyn Write>),
+    Write(Box<dyn Write + Send>),
     /// Color-enabled stdio, with information on whether color should be used
     Stream {
         stdout: StandardStream,
@@ -114,7 +114,7 @@ impl Shell {
     }
 
     /// Creates a shell from a plain writable object, with no color, and max verbosity.
-    pub fn from_write(out: Box<dyn Write>) -> Shell {
+    pub fn from_write(out: Box<dyn Write + Send>) -> Shell {
         Shell {
             output: ShellOut::Write(out),
             verbosity: Verbosity::Verbose,

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -315,14 +315,14 @@ trait CleaningProgressBar {
     fn on_clean(&mut self) -> CargoResult<()>;
 }
 
-struct CleaningFolderBar<'cfg> {
-    bar: Progress<'cfg>,
+struct CleaningFolderBar {
+    bar: Progress,
     max: usize,
     cur: usize,
 }
 
-impl<'cfg> CleaningFolderBar<'cfg> {
-    fn new(cfg: &'cfg Config, max: usize) -> Self {
+impl CleaningFolderBar {
+    fn new(cfg: &Config, max: usize) -> Self {
         Self {
             bar: Progress::with_style("Cleaning", ProgressStyle::Percentage, cfg),
             max,
@@ -335,7 +335,7 @@ impl<'cfg> CleaningFolderBar<'cfg> {
     }
 }
 
-impl<'cfg> CleaningProgressBar for CleaningFolderBar<'cfg> {
+impl CleaningProgressBar for CleaningFolderBar {
     fn display_now(&mut self) -> CargoResult<()> {
         self.bar.tick_now(self.cur_progress(), self.max, "")
     }
@@ -346,16 +346,16 @@ impl<'cfg> CleaningProgressBar for CleaningFolderBar<'cfg> {
     }
 }
 
-struct CleaningPackagesBar<'cfg> {
-    bar: Progress<'cfg>,
+struct CleaningPackagesBar {
+    bar: Progress,
     max: usize,
     cur: usize,
     num_files_folders_cleaned: usize,
     package_being_cleaned: String,
 }
 
-impl<'cfg> CleaningPackagesBar<'cfg> {
-    fn new(cfg: &'cfg Config, max: usize) -> Self {
+impl CleaningPackagesBar {
+    fn new(cfg: &Config, max: usize) -> Self {
         Self {
             bar: Progress::with_style("Cleaning", ProgressStyle::Ratio, cfg),
             max,
@@ -384,7 +384,7 @@ impl<'cfg> CleaningPackagesBar<'cfg> {
     }
 }
 
-impl<'cfg> CleaningProgressBar for CleaningPackagesBar<'cfg> {
+impl CleaningProgressBar for CleaningPackagesBar {
     fn display_now(&mut self) -> CargoResult<()> {
         self.bar
             .tick_now(self.cur_progress(), self.max, &self.format_message())

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -105,7 +105,7 @@ pub struct Downloads<'cfg> {
     /// The next ID to use for creating a token (see `Download::token`).
     next: usize,
     /// Progress bar.
-    progress: RefCell<Option<Progress<'cfg>>>,
+    progress: RefCell<Option<Progress>>,
     /// Number of downloads that have successfully finished.
     downloads_finished: usize,
     /// Number of times the caller has requested blocking. This is used for


### PR DESCRIPTION
This is a pre-requisite for obtaining progress information from `gitoxde` which is integrated [via this PR](https://github.com/rust-lang/cargo/pull/11448).

Obtaining progress information works by having a thread poll `gitoxide`'s progress in regular intervals.

### Alternatives Considered

`gitoxide` hands progress information to a `Progress` trait which allows it to build hierarchies of progress information to reflect potentially concurrent state updates. It also assumes that progress updates are fast and doesn't rate-limit its own calls.

Implementing this trait for `Progress` would have to involve rate limiting, which typically uses the local time to determine if a call will cause a display update or not, which at least in the past has been prohibitively slow. By now, at least on linux, I think this has been fixed but I am not sure about Windows.

As there are uncertainties to this approach and which also comes with considerable higher complexity (and more code), I decided to instead make `util::Progress` thread-safe with the minimal amount of changes.
