### PR TITLE
[Doc]: Added links to the `Target` section of the glossary for occurences of `target triple` 

### DIFF
--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -311,7 +311,8 @@ possible value.
 
 {{#option "`--filter-platform` _triple_" }}
 This filters the `resolve` output to only include dependencies for the
-given target triple. Without this flag, the resolve includes all targets.
+given [target triple](../appendix/glossary.html#target). 
+Without this flag, the resolve includes all targets.
 
 Note that the dependencies listed in the "packages" array still includes all
 dependencies. Each package definition is intended to be an unaltered

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -137,8 +137,8 @@ The default is `normal,build,dev`.
 {{/option}}
 
 {{#option "`--target` _triple_" }}
-Filter dependencies matching the given target-triple. The default is the host
-platform. Use the value `all` to include *all* targets.
+Filter dependencies matching the given [target triple](../appendix/glossary.html#target). 
+The default is the host platform. Use the value `all` to include *all* targets.
 {{/option}}
 
 {{/options}}

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -299,8 +299,9 @@ OPTIONS
 
        --filter-platform triple
            This filters the resolve output to only include dependencies for the
-           given target triple. Without this flag, the resolve includes all
-           targets.
+           given target triple
+           <https://doc.rust-lang.org/cargo/appendix/glossary.html#target>.
+           Without this flag, the resolve includes all targets.
 
            Note that the dependencies listed in the "packages" array still
            includes all dependencies. Each package definition is intended to be

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -133,8 +133,10 @@ OPTIONS
            The default is normal,build,dev.
 
        --target triple
-           Filter dependencies matching the given target-triple. The default is
-           the host platform. Use the value all to include all targets.
+           Filter dependencies matching the given target triple
+           <https://doc.rust-lang.org/cargo/appendix/glossary.html#target>. The
+           default is the host platform. Use the value all to include all
+           targets.
 
    Tree Formatting Options
        --charset charset

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -311,8 +311,8 @@ possible value.</dd>
 
 <dt class="option-term" id="option-cargo-metadata---filter-platform"><a class="option-anchor" href="#option-cargo-metadata---filter-platform"></a><code>--filter-platform</code> <em>triple</em></dt>
 <dd class="option-desc">This filters the <code>resolve</code> output to only include dependencies for the
-given <a href="../appendix/glossary.md#target">target triple</a>. Without this flag, the resolve includes 
-all targets.</p>
+given <a href="../appendix/glossary.html#target">target triple</a>. 
+Without this flag, the resolve includes all targets.</p>
 <p>Note that the dependencies listed in the &quot;packages&quot; array still includes all
 dependencies. Each package definition is intended to be an unaltered
 reproduction of the information within <code>Cargo.toml</code>.</dd>

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -311,7 +311,8 @@ possible value.</dd>
 
 <dt class="option-term" id="option-cargo-metadata---filter-platform"><a class="option-anchor" href="#option-cargo-metadata---filter-platform"></a><code>--filter-platform</code> <em>triple</em></dt>
 <dd class="option-desc">This filters the <code>resolve</code> output to only include dependencies for the
-given target triple. Without this flag, the resolve includes all targets.</p>
+given <a href="../appendix/glossary.md#target">target triple</a>. Without this flag, the resolve includes 
+all targets.</p>
 <p>Note that the dependencies listed in the &quot;packages&quot; array still includes all
 dependencies. Each package definition is intended to be an unaltered
 reproduction of the information within <code>Cargo.toml</code>.</dd>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -137,9 +137,8 @@ kind given, then it will automatically include the other dependency kinds.</li>
 
 
 <dt class="option-term" id="option-cargo-tree---target"><a class="option-anchor" href="#option-cargo-tree---target"></a><code>--target</code> <em>triple</em></dt>
-<dd class="option-desc">Filter dependencies matching the given target-triple. The default is the host
-platform. Use the value <code>all</code> to include <em>all</em> targets.</dd>
-
+<dd class="option-desc">Filter dependencies matching the given <a href="../appendix/glossary.md#target">target triple</a>.
+The default is the host platform. Use the value <code>all</code> to include <em>all</em> targets.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -137,8 +137,9 @@ kind given, then it will automatically include the other dependency kinds.</li>
 
 
 <dt class="option-term" id="option-cargo-tree---target"><a class="option-anchor" href="#option-cargo-tree---target"></a><code>--target</code> <em>triple</em></dt>
-<dd class="option-desc">Filter dependencies matching the given <a href="../appendix/glossary.md#target">target triple</a>.
+<dd class="option-desc">Filter dependencies matching the given <a href="../appendix/glossary.html#target">target triple</a>. 
 The default is the host platform. Use the value <code>all</code> to include <em>all</em> targets.</dd>
+
 
 </dl>
 

--- a/src/doc/src/guide/build-cache.md
+++ b/src/doc/src/guide/build-cache.md
@@ -24,7 +24,7 @@ For historical reasons, the `dev` and `test` profiles are stored in the
 same name as the profile.
 
 When building for another target with `--target`, the output is placed in a
-directory with the name of the target:
+directory with the name of the [target]:
 
 Directory | Example
 ----------|--------
@@ -98,6 +98,7 @@ configuration][config]. Refer to sccache documentation for more details.
 [build scripts]: ../reference/build-scripts.md
 [config]: ../reference/config.md
 [def-workspace]:  ../appendix/glossary.md#workspace  '"workspace" (glossary entry)'
+[target]: ../appendix/glossary.md#target '"target" (glossary entry)'
 [environment variable]: ../reference/environment-variables.md
 [incremental output]: ../reference/profiles.md#incremental
 [sccache]: https://github.com/mozilla/sccache

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -321,7 +321,7 @@ all capital letters.
 
 This section documents all configuration keys. The description for keys with
 variable parts are annotated with angled brackets like `target.<triple>` where
-the [`<triple>`] part can be any [target triple] like
+the `<triple>` part can be any [target triple] like
 `target.x86_64-pc-windows-msvc`.
 
 #### `paths`
@@ -1050,7 +1050,7 @@ If none of `branch`, `tag`, or `rev` is set, defaults to the `master` branch.
 The `[target]` table is used for specifying settings for specific platform
 targets. It consists of a sub-table which is either a [platform triple][target triple] 
 or a [`cfg()` expression]. The given values will be used if the target platform
-matches either the [`<triple>`] value or the `<cfg>` expression.
+matches either the `<triple>` value or the `<cfg>` expression.
 
 ```toml
 [target.thumbv7m-none-eabi]

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -321,7 +321,7 @@ all capital letters.
 
 This section documents all configuration keys. The description for keys with
 variable parts are annotated with angled brackets like `target.<triple>` where
-the `<triple>` part can be any target triple like
+the [`<triple>`] part can be any [target triple] like
 `target.x86_64-pc-windows-msvc`.
 
 #### `paths`
@@ -418,7 +418,7 @@ Sets the executable to use for `rustdoc`.
 * Default: host platform
 * Environment: `CARGO_BUILD_TARGET`
 
-The default target platform triples to compile to.
+The default [target platform triples][target triple] to compile to.
 
 This allows passing either a string or an array of strings. Each string value
 is a target platform triple. The selected build targets will be built for each
@@ -468,7 +468,7 @@ for the host, such as build scripts or proc macros, will not receive the args.
 Without `--target`, the flags will be passed to all compiler invocations
 (including build scripts and proc macros) because dependencies are shared. If
 you have args that you do not want to pass to build scripts or proc macros and
-are building for the host, pass `--target` with the host triple.
+are building for the host, pass `--target` with the [host triple][target triple].
 
 It is not recommended to pass in flags that Cargo itself usually manages. For
 example, the flags driven by [profiles](profiles.md) are best handled by setting the
@@ -1048,9 +1048,9 @@ If none of `branch`, `tag`, or `rev` is set, defaults to the `master` branch.
 #### `[target]`
 
 The `[target]` table is used for specifying settings for specific platform
-targets. It consists of a sub-table which is either a platform triple or a
-[`cfg()` expression]. The given values will be used if the target platform
-matches either the `<triple>` value or the `<cfg>` expression.
+targets. It consists of a sub-table which is either a [platform triple][target triple] 
+or a [`cfg()` expression]. The given values will be used if the target platform
+matches either the [`<triple>`] value or the `<cfg>` expression.
 
 ```toml
 [target.thumbv7m-none-eabi]
@@ -1068,7 +1068,7 @@ to view), values set by [build scripts], and extra `--cfg` flags passed to
 `rustc` (such as those defined in `RUSTFLAGS`). Do not try to match on
 `debug_assertions` or Cargo features like `feature="foo"`.
 
-If using a target spec JSON file, the `<triple>` value is the filename stem.
+If using a target spec JSON file, the [`<triple>`] value is the filename stem.
 For example `--target foo/bar.json` would match `[target.bar]`.
 
 ##### `target.<triple>.ar`
@@ -1081,14 +1081,14 @@ This option is deprecated and unused.
 * Environment: `CARGO_TARGET_<triple>_LINKER`
 
 Specifies the linker which is passed to `rustc` (via [`-C linker`]) when the
-`<triple>` is being compiled for. By default, the linker is not overridden.
+[`<triple>`] is being compiled for. By default, the linker is not overridden.
 
 ##### `target.<triple>.runner`
 * Type: string or array of strings ([program path with args])
 * Default: none
 * Environment: `CARGO_TARGET_<triple>_RUNNER`
 
-If a runner is provided, executables for the target `<triple>` will be
+If a runner is provided, executables for the target [`<triple>`] will be
 executed by invoking the specified runner with the actual executable passed as
 an argument. This applies to [`cargo run`], [`cargo test`] and [`cargo bench`]
 commands. By default, compiled executables are executed directly.
@@ -1096,7 +1096,7 @@ commands. By default, compiled executables are executed directly.
 ##### `target.<cfg>.runner`
 
 This is similar to the [target runner](#targettriplerunner), but using
-a [`cfg()` expression]. If both a `<triple>` and `<cfg>` runner match,
+a [`cfg()` expression]. If both a [`<triple>`] and `<cfg>` runner match,
 the `<triple>` will take precedence. It is an error if more than one
 `<cfg>` runner matches the current target.
 
@@ -1105,8 +1105,8 @@ the `<triple>` will take precedence. It is an error if more than one
 * Default: none
 * Environment: `CARGO_TARGET_<triple>_RUSTFLAGS`
 
-Passes a set of custom flags to the compiler for this `<triple>`. The value
-may be an array of strings or a space-separated string.
+Passes a set of custom flags to the compiler for this [`<triple>`]. 
+The value may be an array of strings or a space-separated string.
 
 See [`build.rustflags`](#buildrustflags) for more details on the different
 ways to specific extra flags.
@@ -1114,7 +1114,7 @@ ways to specific extra flags.
 ##### `target.<cfg>.rustflags`
 
 This is similar to the [target rustflags](#targettriplerustflags), but
-using a [`cfg()` expression]. If several `<cfg>` and `<triple>` entries
+using a [`cfg()` expression]. If several `<cfg>` and [`<triple>`] entries
 match the current target, the flags are joined together.
 
 ##### `target.<triple>.<links>`
@@ -1214,3 +1214,5 @@ Sets the width for progress bar.
 [revision]: https://git-scm.com/docs/gitrevisions
 [registries]: registries.md
 [crates.io]: https://crates.io/
+[target triple]: ../appendix/glossary.md#target '"target" (glossary)'
+[`<triple>`]: ../appendix/glossary.md#target '"target" (glossary)'

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -459,17 +459,19 @@ CLI paths are relative to the current working directory.
 * Tracking Issue: [#9453](https://github.com/rust-lang/cargo/issues/9453)
 
 Historically, Cargo's behavior for whether the `linker` and `rustflags`
-configuration options from environment variables and `[target]` are
-respected for build scripts, plugins, and other artifacts that are
-_always_ built for the host platform has been somewhat inconsistent.
+configuration options from environment variables and 
+[`[target]`](config.md#target) are respected for build scripts, plugins, 
+and other artifacts that are _always_ built for the host platform has 
+been somewhat inconsistent.
 When `--target` is _not_ passed, Cargo respects the same `linker` and
 `rustflags` for build scripts as for all other compile artifacts. When
 `--target` _is_ passed, however, Cargo respects `linker` from
-`[target.<host triple>]`, and does not pick up any `rustflags`
-configuration. This dual behavior is confusing, but also makes it
-difficult to correctly configure builds where the host triple and the
-target triple happen to be the same, but artifacts intended to run on
-the build host should still be configured differently.
+[`[target.<host triple>]`](config.md#targettriplelinker), and does not 
+pick up any `rustflags` configuration. 
+This dual behavior is confusing, but also makes it difficult to correctly 
+configure builds where the host triple and the [target triple] happen to 
+be the same, but artifacts intended to run on the build host should still 
+be configured differently.
 
 `-Ztarget-applies-to-host` enables the top-level
 `target-applies-to-host` setting in Cargo configuration files which
@@ -1432,7 +1434,7 @@ information.
 
 The `-Z multitarget` option has been stabilized in the 1.64 release.
 See [`build.target`](config.md#buildtarget) for more information about
-setting the default target platform triples.
+setting the default [target platform triples][target triple].
 
 ### crate-type
 
@@ -1459,3 +1461,5 @@ terminal where Cargo can automatically detect the width.
 
 Sparse registry support has been stabilized in the 1.68 release.
 See [Registry Protocols](registries.md#registry-protocols) for more information.
+
+[target triple]: ../appendix/glossary.md#target '"target" (glossary)'

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -308,7 +308,8 @@ possible value.
 \fB\-\-filter\-platform\fR \fItriple\fR
 .RS 4
 This filters the \fBresolve\fR output to only include dependencies for the
-given target triple. Without this flag, the resolve includes all targets.
+given \fItarget triple\fR <https://doc.rust\-lang.org/cargo/appendix/glossary.html#target>\&. 
+Without this flag, the resolve includes all targets.
 .sp
 Note that the dependencies listed in the "packages" array still includes all
 dependencies. Each package definition is intended to be an unaltered

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -167,8 +167,8 @@ The default is \fBnormal,build,dev\fR\&.
 .sp
 \fB\-\-target\fR \fItriple\fR
 .RS 4
-Filter dependencies matching the given target\-triple. The default is the host
-platform. Use the value \fBall\fR to include \fIall\fR targets.
+Filter dependencies matching the given \fItarget triple\fR <https://doc.rust\-lang.org/cargo/appendix/glossary.html#target>\&. 
+The default is the host platform. Use the value \fBall\fR to include \fIall\fR targets.
 .RE
 .SS "Tree Formatting Options"
 .sp


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fix for #11398. #11398 raises the concern that it isn't always abundantly clear in the cargo book, what a `target triple` (i.e. `x86_64-unknown-linux-gnu`) is. This is unfortunate, as it is well described in the [glossary](https://doc.rust-lang.org/cargo/appendix/glossary.html#target) of the cargo book (including the command on how to get all targets supported by `rustc`). To mitigate this problem I added links to the glossary entry for target triples to the sections where triples are referenced, but not enough information is given on what they are and how they look like.