### PR TITLE
Temporarily pin libgit2-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,9 @@ jobserver = "0.1.24"
 lazycell = "1.2.0"
 libc = "0.2"
 log = "0.4.6"
-libgit2-sys = "0.14.1"
+# Temporarily pin libgit2-sys due to some issues with SSH not working on
+# Windows.
+libgit2-sys = "=0.14.1"
 memchr = "2.1.3"
 opener = "0.5"
 os_info = "3.5.0"


### PR DESCRIPTION
There are some issues with the most recent libgit2-sys 0.14.2 not working on Windows (https://github.com/libgit2/libgit2/issues/6453 and https://github.com/libgit2/libgit2/issues/6454). Until we figure out what to do with it, this pins the release to the previous version.
