### PR TITLE
Fix unused attribute on Windows.

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -89,6 +89,9 @@ pub fn cargo_test(attr: TokenStream, item: TokenStream) -> TokenStream {
             s if s.starts_with("reason=") => {
                 explicit_reason = Some(s[7..].parse().unwrap());
             }
+            s if s.starts_with("ignore_windows=") => {
+                set_ignore!(cfg!(windows), "{}", &s[16..s.len() - 1]);
+            }
             _ => panic!("unknown rule {:?}", rule),
         }
     }

--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -104,7 +104,7 @@ The options it supports are:
   These should work on Linux, macOS, and Windows where possible.
   Unfortunately these tests are not run in CI for macOS or Windows (no Docker on macOS, and Windows does not support Linux images).
   See [`crates/cargo-test-support/src/containers.rs`](https://github.com/rust-lang/cargo/blob/master/crates/cargo-test-support/src/containers.rs) for more on writing these tests.
-
+* `ignore_windows="reason"` — Indicates that the test should be ignored on windows for the given reason.
 
 #### Testing Nightly Features
 

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -385,11 +385,10 @@ Caused by:
         .run();
 }
 
-#[cargo_test(public_network_test)]
 // For unknown reasons, this test occasionally fails on Windows with a
 // LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE error:
 //     failed to start SSH session: Unable to exchange encryption keys; class=Ssh (23)
-#[cfg_attr(windows, ignore = "test is flaky on windows")]
+#[cargo_test(public_network_test, ignore_windows = "test is flaky on windows")]
 fn invalid_github_key() {
     // A key for github.com in known_hosts should override the built-in key.
     // This uses a bogus key which should result in an error.
@@ -420,11 +419,10 @@ fn invalid_github_key() {
         .run();
 }
 
-#[cargo_test(public_network_test)]
 // For unknown reasons, this test occasionally fails on Windows with a
 // LIBSSH2_ERROR_KEY_EXCHANGE_FAILURE error:
 //     failed to start SSH session: Unable to exchange encryption keys; class=Ssh (23)
-#[cfg_attr(windows, ignore = "test is flaky on windows")]
+#[cargo_test(public_network_test, ignore_windows = "test is flaky on windows")]
 fn bundled_github_works() {
     // The bundled key for github.com works.
     //


### PR DESCRIPTION
The change introduced in #11610 is causing unused_attribute warnings on Windows because there are two `ignore` attributes when CARGO_PUBLIC_NETWORK_TESTS is not set. The solution here is to make `cargo_test` support a hard-coded option for an additional reason to ignore a test.

Ideally I think this would use something like a `cfg()` expression, but those can't really be evaluated within the proc-macro (without pulling in `cargo_platform`). Could also just `allow(unused_attributes)`, but that felt a little icky.

