### PR TITLE
Link CoC to  www.rust-lang.org/conduct.html

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# The Rust Code of Conduct
+
+The Code of Conduct for this repository [can be found online](https://www.rust-lang.org/conduct.html).


### PR DESCRIPTION
Just noticed that Cargo is missing a CoC file while browsing its open source project metrics.

This PR effectively does what `rust-lang/rust` and others projects do.