### PR TITLE
Update semver checks for 1.68

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -702,7 +702,7 @@ impl Trait for Foo {}
 
 fn main() {
     let x = Foo;
-    x.foo(1); // Error: this function takes 0 arguments
+    x.foo(1); // Error: this method takes 0 arguments
 }
 ```
 


### PR DESCRIPTION
The diagnostic message for one of the SemVer checks needs to be updated for 1.67.
