### PR TITLE
fix(toml): Provide a way to show unused manifest keys for dependencies

### DIFF
--- a/src/cargo/core/dependency.rs
+++ b/src/cargo/core/dependency.rs
@@ -106,6 +106,16 @@ pub enum DepKind {
     Build,
 }
 
+impl DepKind {
+    pub fn kind_table(&self) -> &'static str {
+        match self {
+            DepKind::Normal => "dependencies",
+            DepKind::Development => "dev-dependencies",
+            DepKind::Build => "build-dependencies",
+        }
+    }
+}
+
 impl ser::Serialize for DepKind {
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -239,6 +239,15 @@ impl<'de, P: Deserialize<'de> + Clone> de::Deserialize<'de> for TomlDependency<P
     }
 }
 
+impl TomlDependency {
+    fn unused_keys(&self) -> Vec<String> {
+        match self {
+            TomlDependency::Simple(_) => vec![],
+            TomlDependency::Detailed(detailed) => detailed.other.keys().cloned().collect(),
+        }
+    }
+}
+
 pub trait ResolveToPath {
     fn resolve(&self, config: &Config) -> PathBuf;
 }
@@ -288,6 +297,10 @@ pub struct DetailedTomlDependency<P: Clone = String> {
     lib: Option<bool>,
     /// A platform name, like `x86_64-apple-darwin`
     target: Option<String>,
+    /// This is here to provide a way to see the "unused manifest keys" when deserializing
+    #[serde(skip_serializing)]
+    #[serde(flatten)]
+    other: BTreeMap<String, toml::Value>,
 }
 
 // Explicit implementation so we avoid pulling in P: Default
@@ -311,6 +324,7 @@ impl<P: Clone> Default for DetailedTomlDependency<P> {
             artifact: Default::default(),
             lib: Default::default(),
             target: Default::default(),
+            other: Default::default(),
         }
     }
 }
@@ -340,7 +354,7 @@ pub struct TomlManifest {
     replace: Option<BTreeMap<String, TomlDependency>>,
     patch: Option<BTreeMap<String, BTreeMap<String, TomlDependency>>>,
     workspace: Option<TomlWorkspace>,
-    badges: Option<MaybeWorkspaceField<BTreeMap<String, BTreeMap<String, String>>>>,
+    badges: Option<MaybeWorkspaceBtreeMap>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -901,16 +915,14 @@ impl<'de> de::Deserialize<'de> for VecStringOrBool {
     }
 }
 
-fn version_trim_whitespace<'de, D>(
-    deserializer: D,
-) -> Result<MaybeWorkspaceField<semver::Version>, D::Error>
+fn version_trim_whitespace<'de, D>(deserializer: D) -> Result<MaybeWorkspaceSemverVersion, D::Error>
 where
     D: de::Deserializer<'de>,
 {
     struct Visitor;
 
     impl<'de> de::Visitor<'de> for Visitor {
-        type Value = MaybeWorkspaceField<semver::Version>;
+        type Value = MaybeWorkspaceSemverVersion;
 
         fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("SemVer version")
@@ -963,29 +975,6 @@ pub enum MaybeWorkspace<T, W: WorkspaceInherit> {
     Workspace(W),
 }
 
-impl<'de, T: Deserialize<'de>, W: WorkspaceInherit + de::Deserialize<'de>> de::Deserialize<'de>
-    for MaybeWorkspace<T, W>
-{
-    fn deserialize<D>(deserializer: D) -> Result<MaybeWorkspace<T, W>, D::Error>
-    where
-        D: de::Deserializer<'de>,
-    {
-        let value = serde_value::Value::deserialize(deserializer)?;
-
-        if let Ok(w) = W::deserialize(serde_value::ValueDeserializer::<D::Error>::new(
-            value.clone(),
-        )) {
-            return if w.workspace() {
-                Ok(MaybeWorkspace::Workspace(w))
-            } else {
-                Err(de::Error::custom("`workspace` cannot be false"))
-            };
-        }
-        T::deserialize(serde_value::ValueDeserializer::<D::Error>::new(value))
-            .map(MaybeWorkspace::Defined)
-    }
-}
-
 impl<T, W: WorkspaceInherit> MaybeWorkspace<T, W> {
     fn resolve<'a>(
         self,
@@ -1029,6 +1018,37 @@ impl<T, W: WorkspaceInherit> MaybeWorkspace<T, W> {
 
 type MaybeWorkspaceDependency = MaybeWorkspace<TomlDependency, TomlWorkspaceDependency>;
 
+impl<'de> de::Deserialize<'de> for MaybeWorkspaceDependency {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let value = serde_value::Value::deserialize(deserializer)?;
+
+        if let Ok(w) = TomlWorkspaceDependency::deserialize(serde_value::ValueDeserializer::<
+            D::Error,
+        >::new(value.clone()))
+        {
+            return if w.workspace() {
+                Ok(MaybeWorkspace::Workspace(w))
+            } else {
+                Err(de::Error::custom("`workspace` cannot be false"))
+            };
+        }
+        TomlDependency::deserialize(serde_value::ValueDeserializer::<D::Error>::new(value))
+            .map(MaybeWorkspace::Defined)
+    }
+}
+
+impl MaybeWorkspaceDependency {
+    fn unused_keys(&self) -> Vec<String> {
+        match self {
+            MaybeWorkspaceDependency::Defined(d) => d.unused_keys(),
+            MaybeWorkspaceDependency::Workspace(w) => w.other.keys().cloned().collect(),
+        }
+    }
+}
+
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlWorkspaceDependency {
@@ -1038,6 +1058,10 @@ pub struct TomlWorkspaceDependency {
     #[serde(rename = "default_features")]
     default_features2: Option<bool>,
     optional: Option<bool>,
+    /// This is here to provide a way to see the "unused manifest keys" when deserializing
+    #[serde(skip_serializing)]
+    #[serde(flatten)]
+    other: BTreeMap<String, toml::Value>,
 }
 
 impl WorkspaceInherit for TomlWorkspaceDependency {
@@ -1123,11 +1147,204 @@ impl TomlWorkspaceDependency {
     }
 }
 
-type MaybeWorkspaceField<T> = MaybeWorkspace<T, TomlWorkspaceField>;
+//. This already has a `Deserialize` impl from version_trim_whitespace
+type MaybeWorkspaceSemverVersion = MaybeWorkspace<semver::Version, TomlWorkspaceField>;
+
+type MaybeWorkspaceString = MaybeWorkspace<String, TomlWorkspaceField>;
+impl<'de> de::Deserialize<'de> for MaybeWorkspaceString {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = MaybeWorkspaceString;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+                f.write_str("a string or workspace")
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(MaybeWorkspaceString::Defined(value))
+            }
+
+            fn visit_map<V>(self, map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mvd = de::value::MapAccessDeserializer::new(map);
+                TomlWorkspaceField::deserialize(mvd).map(MaybeWorkspace::Workspace)
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}
+
+type MaybeWorkspaceVecString = MaybeWorkspace<Vec<String>, TomlWorkspaceField>;
+impl<'de> de::Deserialize<'de> for MaybeWorkspaceVecString {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = MaybeWorkspaceVecString;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                f.write_str("a vector of strings or workspace")
+            }
+            fn visit_seq<A>(self, v: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let seq = de::value::SeqAccessDeserializer::new(v);
+                Vec::deserialize(seq).map(MaybeWorkspace::Defined)
+            }
+
+            fn visit_map<V>(self, map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mvd = de::value::MapAccessDeserializer::new(map);
+                TomlWorkspaceField::deserialize(mvd).map(MaybeWorkspace::Workspace)
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}
+
+type MaybeWorkspaceStringOrBool = MaybeWorkspace<StringOrBool, TomlWorkspaceField>;
+impl<'de> de::Deserialize<'de> for MaybeWorkspaceStringOrBool {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = MaybeWorkspaceStringOrBool;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                f.write_str("a string, a bool, or workspace")
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let b = de::value::BoolDeserializer::new(v);
+                StringOrBool::deserialize(b).map(MaybeWorkspace::Defined)
+            }
+
+            fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let string = de::value::StringDeserializer::new(v);
+                StringOrBool::deserialize(string).map(MaybeWorkspace::Defined)
+            }
+
+            fn visit_map<V>(self, map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mvd = de::value::MapAccessDeserializer::new(map);
+                TomlWorkspaceField::deserialize(mvd).map(MaybeWorkspace::Workspace)
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}
+
+type MaybeWorkspaceVecStringOrBool = MaybeWorkspace<VecStringOrBool, TomlWorkspaceField>;
+impl<'de> de::Deserialize<'de> for MaybeWorkspaceVecStringOrBool {
+    fn deserialize<D>(d: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = MaybeWorkspaceVecStringOrBool;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+                f.write_str("a boolean, a vector of strings, or workspace")
+            }
+
+            fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let b = de::value::BoolDeserializer::new(v);
+                VecStringOrBool::deserialize(b).map(MaybeWorkspace::Defined)
+            }
+
+            fn visit_seq<A>(self, v: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let seq = de::value::SeqAccessDeserializer::new(v);
+                VecStringOrBool::deserialize(seq).map(MaybeWorkspace::Defined)
+            }
+
+            fn visit_map<V>(self, map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mvd = de::value::MapAccessDeserializer::new(map);
+                TomlWorkspaceField::deserialize(mvd).map(MaybeWorkspace::Workspace)
+            }
+        }
+
+        d.deserialize_any(Visitor)
+    }
+}
+
+type MaybeWorkspaceBtreeMap =
+    MaybeWorkspace<BTreeMap<String, BTreeMap<String, String>>, TomlWorkspaceField>;
+
+impl<'de> de::Deserialize<'de> for MaybeWorkspaceBtreeMap {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let value = serde_value::Value::deserialize(deserializer)?;
+
+        if let Ok(w) = TomlWorkspaceField::deserialize(
+            serde_value::ValueDeserializer::<D::Error>::new(value.clone()),
+        ) {
+            return if w.workspace() {
+                Ok(MaybeWorkspace::Workspace(w))
+            } else {
+                Err(de::Error::custom("`workspace` cannot be false"))
+            };
+        }
+        BTreeMap::deserialize(serde_value::ValueDeserializer::<D::Error>::new(value))
+            .map(MaybeWorkspace::Defined)
+    }
+}
 
 #[derive(Deserialize, Serialize, Clone, Debug)]
 pub struct TomlWorkspaceField {
+    #[serde(deserialize_with = "bool_no_false")]
     workspace: bool,
+}
+
+fn bool_no_false<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {
+    let b: bool = Deserialize::deserialize(deserializer)?;
+    if b {
+        Ok(b)
+    } else {
+        Err(de::Error::custom("`workspace` cannot be false"))
+    }
 }
 
 impl WorkspaceInherit for TomlWorkspaceField {
@@ -1149,12 +1366,12 @@ impl WorkspaceInherit for TomlWorkspaceField {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlPackage {
-    edition: Option<MaybeWorkspaceField<String>>,
-    rust_version: Option<MaybeWorkspaceField<String>>,
+    edition: Option<MaybeWorkspaceString>,
+    rust_version: Option<MaybeWorkspaceString>,
     name: InternedString,
     #[serde(deserialize_with = "version_trim_whitespace")]
-    version: MaybeWorkspaceField<semver::Version>,
-    authors: Option<MaybeWorkspaceField<Vec<String>>>,
+    version: MaybeWorkspaceSemverVersion,
+    authors: Option<MaybeWorkspaceVecString>,
     build: Option<StringOrBool>,
     metabuild: Option<StringOrVec>,
     #[serde(rename = "default-target")]
@@ -1162,9 +1379,9 @@ pub struct TomlPackage {
     #[serde(rename = "forced-target")]
     forced_target: Option<String>,
     links: Option<String>,
-    exclude: Option<MaybeWorkspaceField<Vec<String>>>,
-    include: Option<MaybeWorkspaceField<Vec<String>>>,
-    publish: Option<MaybeWorkspaceField<VecStringOrBool>>,
+    exclude: Option<MaybeWorkspaceVecString>,
+    include: Option<MaybeWorkspaceVecString>,
+    publish: Option<MaybeWorkspaceVecStringOrBool>,
     workspace: Option<String>,
     im_a_teapot: Option<bool>,
     autobins: Option<bool>,
@@ -1174,15 +1391,15 @@ pub struct TomlPackage {
     default_run: Option<String>,
 
     // Package metadata.
-    description: Option<MaybeWorkspaceField<String>>,
-    homepage: Option<MaybeWorkspaceField<String>>,
-    documentation: Option<MaybeWorkspaceField<String>>,
-    readme: Option<MaybeWorkspaceField<StringOrBool>>,
-    keywords: Option<MaybeWorkspaceField<Vec<String>>>,
-    categories: Option<MaybeWorkspaceField<Vec<String>>>,
-    license: Option<MaybeWorkspaceField<String>>,
-    license_file: Option<MaybeWorkspaceField<String>>,
-    repository: Option<MaybeWorkspaceField<String>>,
+    description: Option<MaybeWorkspaceString>,
+    homepage: Option<MaybeWorkspaceString>,
+    documentation: Option<MaybeWorkspaceString>,
+    readme: Option<MaybeWorkspaceStringOrBool>,
+    keywords: Option<MaybeWorkspaceVecString>,
+    categories: Option<MaybeWorkspaceVecString>,
+    license: Option<MaybeWorkspaceString>,
+    license_file: Option<MaybeWorkspaceString>,
+    repository: Option<MaybeWorkspaceString>,
     resolver: Option<String>,
 
     // Note that this field must come last due to the way toml serialization
@@ -1700,6 +1917,16 @@ impl TomlManifest {
                 let mut inheritable = toml_config.package.clone().unwrap_or_default();
                 inheritable.update_ws_path(package_root.to_path_buf());
                 inheritable.update_deps(toml_config.dependencies.clone());
+                if let Some(ws_deps) = &inheritable.dependencies {
+                    for (name, dep) in ws_deps {
+                        unused_dep_keys(
+                            name,
+                            "workspace.dependencies",
+                            dep.unused_keys(),
+                            &mut warnings,
+                        );
+                    }
+                }
                 let ws_root_config = WorkspaceRootConfig::new(
                     package_root,
                     &toml_config.members,
@@ -1898,7 +2125,18 @@ impl TomlManifest {
                     .clone()
                     .resolve_with_self(n, |dep| dep.resolve(n, inheritable, cx))?;
                 let dep = resolved.to_dependency(n, cx, kind)?;
-                validate_package_name(dep.name_in_toml().as_str(), "dependency name", "")?;
+                let name_in_toml = dep.name_in_toml().as_str();
+                validate_package_name(name_in_toml, "dependency name", "")?;
+                let kind_name = match kind {
+                    Some(k) => k.kind_table(),
+                    None => "dependencies",
+                };
+                let table_in_toml = if let Some(platform) = &cx.platform {
+                    format!("target.{}.{kind_name}", platform.to_string())
+                } else {
+                    kind_name.to_string()
+                };
+                unused_dep_keys(name_in_toml, &table_in_toml, v.unused_keys(), cx.warnings);
                 cx.deps.push(dep);
                 deps.insert(n.to_string(), MaybeWorkspace::Defined(resolved.clone()));
             }
@@ -2426,6 +2664,12 @@ impl TomlManifest {
                     spec
                 )
             })?;
+            unused_dep_keys(
+                dep.name_in_toml().as_str(),
+                "replace",
+                replacement.unused_keys(),
+                &mut cx.warnings,
+            );
             dep.set_version_req(VersionReq::exact(version))
                 .lock_version(version);
             replace.push((spec, dep));
@@ -2435,21 +2679,32 @@ impl TomlManifest {
 
     fn patch(&self, cx: &mut Context<'_, '_>) -> CargoResult<HashMap<Url, Vec<Dependency>>> {
         let mut patch = HashMap::new();
-        for (url, deps) in self.patch.iter().flatten() {
-            let url = match &url[..] {
+        for (toml_url, deps) in self.patch.iter().flatten() {
+            let url = match &toml_url[..] {
                 CRATES_IO_REGISTRY => CRATES_IO_INDEX.parse().unwrap(),
                 _ => cx
                     .config
-                    .get_registry_index(url)
-                    .or_else(|_| url.into_url())
+                    .get_registry_index(toml_url)
+                    .or_else(|_| toml_url.into_url())
                     .with_context(|| {
-                        format!("[patch] entry `{}` should be a URL or registry name", url)
+                        format!(
+                            "[patch] entry `{}` should be a URL or registry name",
+                            toml_url
+                        )
                     })?,
             };
             patch.insert(
                 url,
                 deps.iter()
-                    .map(|(name, dep)| dep.to_dependency(name, cx, None))
+                    .map(|(name, dep)| {
+                        unused_dep_keys(
+                            name,
+                            &format!("patch.{toml_url}",),
+                            dep.unused_keys(),
+                            &mut cx.warnings,
+                        );
+                        dep.to_dependency(name, cx, None)
+                    })
                     .collect::<CargoResult<Vec<_>>>()?,
             );
         }
@@ -2486,6 +2741,18 @@ impl TomlManifest {
 
     pub fn features(&self) -> Option<&BTreeMap<InternedString, Vec<InternedString>>> {
         self.features.as_ref()
+    }
+}
+
+fn unused_dep_keys(
+    dep_name: &str,
+    kind: &str,
+    unused_keys: Vec<String>,
+    warnings: &mut Vec<String>,
+) {
+    for unused in unused_keys {
+        let key = format!("unused manifest key: {kind}.{dep_name}.{unused}");
+        warnings.push(key);
     }
 }
 

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -59,17 +59,9 @@ impl DepTable {
     /// Keys to the table.
     pub fn to_table(&self) -> Vec<&str> {
         if let Some(target) = &self.target {
-            vec!["target", target, self.kind_table()]
+            vec!["target", target, self.kind.kind_table()]
         } else {
-            vec![self.kind_table()]
-        }
-    }
-
-    fn kind_table(&self) -> &str {
-        match self.kind {
-            DepKind::Normal => "dependencies",
-            DepKind::Development => "dev-dependencies",
-            DepKind::Build => "build-dependencies",
+            vec![self.kind.kind_table()]
         }
     }
 }
@@ -164,7 +156,7 @@ impl Manifest {
         let mut sections = Vec::new();
 
         for table in DepTable::KINDS {
-            let dependency_type = table.kind_table();
+            let dependency_type = table.kind.kind_table();
             // Dependencies can be in the three standard sections...
             if self
                 .data

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1797,7 +1797,7 @@ fn cargo_metadata_with_invalid_authors_field() {
             r#"[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: string "", expected a sequence
+  invalid type: string "", expected a vector of strings or workspace
   in `package.authors`"#,
         )
         .run();
@@ -1847,7 +1847,7 @@ fn cargo_metadata_with_invalid_publish_field() {
             r#"[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: string "foo", expected a boolean or vector of strings
+  invalid type: string "foo", expected a boolean, a vector of strings, or workspace
   in `package.publish`"#,
         )
         .run();


### PR DESCRIPTION
Dependencies have not been able to show unused manifest keys for some time, this problem partially resulted in #11329. 

This problem is caused by having an `enum` when deserializing.  To get around this you can use:
```rust
#[serde(flatten)]
other: BTreeMap<String, toml::Value>,
```
This collects any unused keys into `other` that can later be used to show warnings. This idea was suggested in a thread I cannot find but is mentioned in [serde#941](https://github.com/serde-rs/serde/issues/941).