### PR TITLE
Add experimental [cfgs] section to decribe the expected cfgs

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -325,7 +325,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
 
     let nightly_features_allowed = cx.bcx.config.nightly_features_allowed;
     let extra_check_cfg = match cx.bcx.config.cli_unstable().check_cfg {
-        Some((_, _, _, output)) => output,
+        Some((_, _, _, output, _)) => output,
         None => false,
     };
     let targets: Vec<Target> = unit.pkg.targets().to_vec();
@@ -989,7 +989,7 @@ fn prev_build_output(cx: &mut Context<'_, '_>, unit: &Unit) -> (Option<BuildOutp
             &prev_script_out_dir,
             &script_out_dir,
             match cx.bcx.config.cli_unstable().check_cfg {
-                Some((_, _, _, output)) => output,
+                Some((_, _, _, output, _)) => output,
                 None => false,
             },
             cx.bcx.config.nightly_features_allowed,

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1153,6 +1153,46 @@ fn check_cfg_args(cx: &Context<'_, '_>, unit: &Unit) -> Vec<OsString> {
             args.push(arg);
         }
 
+        if let Some(cfgs) = unit.pkg.cfgs() {
+            let mut names = OsString::from("names(");
+            let mut has_names = false;
+
+            for name in cfgs
+                .iter()
+                .filter_map(|(name, values)| values.as_ref().is_none().then_some(name))
+            {
+                if has_names {
+                    names.push(",");
+                }
+                names.push(name);
+                has_names = true;
+            }
+
+            if has_names {
+                names.push(")");
+                args.push(OsString::from("--check-cfg"));
+                args.push(names);
+            }
+
+            for (name, values) in cfgs
+                .iter()
+                .filter_map(|(name, values)| values.as_ref().map(|values| (name, values)))
+            {
+                let mut arg = OsString::from("values(");
+
+                arg.push(name);
+                for val in values {
+                    arg.push(", \"");
+                    arg.push(&val);
+                    arg.push("\"");
+                }
+                arg.push(")");
+
+                args.push(OsString::from("--check-cfg"));
+                args.push(arg);
+            }
+        }
+
         if well_known_names {
             args.push(OsString::from("--check-cfg"));
             args.push(OsString::from("names()"));

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1131,7 +1131,7 @@ fn features_args(unit: &Unit) -> Vec<OsString> {
 
 /// Generate the --check-cfg arguments for the unit
 fn check_cfg_args(cx: &Context<'_, '_>, unit: &Unit) -> Vec<OsString> {
-    if let Some((features, well_known_names, well_known_values, _output)) =
+    if let Some((features, well_known_names, well_known_values, _output, _cfgs)) =
         cx.bcx.config.cli_unstable().check_cfg
     {
         let mut args = Vec::with_capacity(unit.pkg.summary().features().len() * 2 + 4);

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -64,6 +64,7 @@ pub struct Manifest {
     default_run: Option<String>,
     metabuild: Option<Vec<String>>,
     resolve_behavior: Option<ResolveBehavior>,
+    cfgs: Option<BTreeMap<String, Option<Vec<String>>>>,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -405,6 +406,7 @@ impl Manifest {
         original: Rc<TomlManifest>,
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
+        cfgs: Option<BTreeMap<String, Option<Vec<String>>>>,
     ) -> Manifest {
         Manifest {
             summary,
@@ -430,6 +432,7 @@ impl Manifest {
             default_run,
             metabuild,
             resolve_behavior,
+            cfgs,
         }
     }
 
@@ -496,6 +499,9 @@ impl Manifest {
     }
     pub fn links(&self) -> Option<&str> {
         self.links.as_deref()
+    }
+    pub fn cfgs(&self) -> &Option<BTreeMap<String, Option<Vec<String>>>> {
+        &self.cfgs
     }
 
     pub fn workspace_config(&self) -> &WorkspaceConfig {

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -87,6 +87,7 @@ pub struct SerializedPackage {
     dependencies: Vec<Dependency>,
     targets: Vec<Target>,
     features: BTreeMap<InternedString, Vec<InternedString>>,
+    // cfgs: BTreeMap<String, Option<Vec<String>>>,
     manifest_path: PathBuf,
     metadata: Option<toml::Value>,
     publish: Option<Vec<String>>,
@@ -163,6 +164,10 @@ impl Package {
     /// Gets the package authors.
     pub fn authors(&self) -> &Vec<String> {
         &self.manifest().metadata().authors
+    }
+    /// Gets the cfgs.
+    pub fn cfgs(&self) -> &Option<BTreeMap<String, Option<Vec<String>>>> {
+        self.manifest().cfgs()
     }
 
     /// Returns `None` if the package is set to publish.

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -138,7 +138,7 @@ fn parse_links_overrides(
 ) -> CargoResult<BTreeMap<String, BuildOutput>> {
     let mut links_overrides = BTreeMap::new();
     let extra_check_cfg = match config.cli_unstable().check_cfg {
-        Some((_, _, _, output)) => output,
+        Some((_, _, _, output, _)) => output,
         None => false,
     };
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1197,6 +1197,7 @@ It's values are:
  - `names`: enables well known names checking via `--check-cfg=names()`.
  - `values`: enables well known values checking via `--check-cfg=values()`.
  - `output`: enable the use of `rustc-check-cfg` in build script.
+ - `cfgs`: enable the use of the `#[cfgs]` in the `Cargo.toml` manifest.
 
 For instance:
 
@@ -1204,10 +1205,18 @@ For instance:
 cargo check -Z unstable-options -Z check-cfg=features
 cargo check -Z unstable-options -Z check-cfg=names
 cargo check -Z unstable-options -Z check-cfg=values
-cargo check -Z unstable-options -Z check-cfg=features,names,values
+cargo check -Z unstable-options -Z check-cfg=cfgs
+cargo check -Z unstable-options -Z check-cfg=features,names,values,cfgs
 ```
 
-Or for `output`:
+Those values can also be set in the `[unstable]` section of `.cargo/config.toml`:
+
+```toml
+[unstable]
+check-cfg = ["cfgs", "features"]
+```
+
+#### Usage of `output`
 
 ```rust,no_run
 // build.rs
@@ -1216,6 +1225,23 @@ println!("cargo:rustc-check-cfg=names(foo, bar)");
 
 ```
 cargo check -Z unstable-options -Z check-cfg=output
+```
+
+#### Usage of `cfgs`
+
+In `Cargo.toml`:
+
+```toml
+[cfgs]
+"use_libc" = []                # means `--check-cfg=values('use_libc')`
+"loom" = ["yes", "no", "auto"] # means `--check-cfg=values('feature', "yes", "no", "auto")`
+
+[cfgs."unknow_values"] # means `--check-cfg=names('unknow_values')`
+values = false         # aka values are unknown (so everything is accepted)
+```
+
+```
+cargo check -Z unstable-options -Z check-cfg=cfgs
 ```
 
 ### `cargo:rustc-check-cfg=CHECK_CFG`


### PR DESCRIPTION
This PR adds new section experimental `[cfgs]` to the manifest to describe the expected cfgs and their values. This change was proposed on the Cargo zulip [thread](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/RFC.203013.3A.20Checking.20conditional.20compilation.20at.20compile.20time/near/323550538) without any objection, so I'm proposing it.

The new section is gated under cargo [`-Zcheck-cfg`](https://github.com/rust-lang/cargo/issues/10554) with `cfgs` (`-Zcheck-cfg=cfgs`).

The syntax is straight forward, a simple key/values<sup>*</sup>. <sub>With a custom `values` sub-key for the rare occasion where the values are unknown (empty list != unknown). This could be removed if not desired.</sub>

```toml
[cfgs]
"use_libc" = []                # means `--check-cfg=values('use_libc')`
"loom" = ["yes", "no", "auto"] # means `--check-cfg=values('feature', "yes", "no", "auto")`

[cfgs."unknow_values"] # means `--check-cfg=names('unknow_values')`
values = false         # aka values are unknown (so everything is accepted)
```

### What does this PR try to resolve?

This PR tries to add the missing piece of the all "Checking conditional compilation at compile time", that is, statically defining for a package it's expected cfgs. With all the other [`-Zcheck-cfg` options](https://doc.rust-lang.org/cargo/reference/unstable.html#check-cfg) it was possible to enable checking of well known values, well known names, feature cfgs and add thoses with build script; but there was no way (except `RUSTFLAGS`) to statically set the expected cfgs so that anyone compiling the project could have the unexpected cfgs warnings.

Also by adding this section we also unblock the feature, especially the well know names, which without this section (and probably and edition) would be a breaking change if enable as there would be no way of setting the expected cfgs.

### How should we test and review this PR?

This PR should be reviewed commit by commit and tested with the automated tests and examples.

### Additional information

The implementation use the already existent `check_cfg_args` function that adds the `--check-cfg` args to the `rustc`/`rustdoc` invocation, so nothing new here.

The implementation also use `#[serde(untagged)]` to be able to dezerialize (and serialize?) the `[cfgs]` and `[cfgs.*]` sections into one struct. First time using it, so if you think it's not the right tool, let me know.

#### Questions

 - Should there be any restrictions on the name (like disallowing `feature`) or on the values (like disallowing any value with `"`) ?
 - Should cargo give the possibility of expressing "unknown" values ?