### PR TITLE
Enable sparse protocol in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,6 +81,9 @@ jobs:
     - name: Configure extra test environment
       run: echo CARGO_CONTAINER_TESTS=1 >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'
+    - name: Enable sparse
+      run: echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV
+      if: "!contains(matrix.rust, 'stable')"
 
     # Deny warnings on CI to avoid warnings getting into the codebase.
     - run: cargo test --features 'deny-warnings'
@@ -140,6 +143,8 @@ jobs:
 
   build_std:
     runs-on: ubuntu-latest
+    env:
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
     - uses: actions/checkout@v3
     - run: rustup update nightly && rustup default nightly


### PR DESCRIPTION
This enables the sparse protocol in CI in order to exercise and dogfood it. This is intended test the production server in a real-world situation.
