### PR TITLE
Reduce target info rustc query calls

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -219,13 +219,8 @@ impl TargetInfo {
                 map.insert(crate_type.clone(), out);
             }
 
-            let line = match lines.next() {
-                Some(line) => line,
-                None => anyhow::bail!(
-                    "output of --print=sysroot missing when learning about \
-                 target-specific information from rustc\n{}",
-                    output_err_info(&process, &output, &error)
-                ),
+            let Some(line) = lines.next() else {
+                return error_missing_print_output("sysroot", &process, &output, &error);
             };
             let sysroot = PathBuf::from(line);
             let sysroot_host_libdir = if cfg!(windows) {
@@ -601,12 +596,8 @@ fn parse_crate_type(
     };
     let mut parts = line.trim().split("___");
     let prefix = parts.next().unwrap();
-    let suffix = match parts.next() {
-        Some(part) => part,
-        None => anyhow::bail!(
-            "output of --print=file-names has changed in the compiler, cannot parse\n{}",
-            output_err_info(cmd, output, error)
-        ),
+    let Some(suffix) = parts.next() else {
+        return error_missing_print_output("file-names", cmd, output, error);
     };
 
     Ok(Some((prefix.to_string(), suffix.to_string())))

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -168,22 +168,11 @@ impl TargetInfo {
         loop {
             let extra_fingerprint = kind.fingerprint_hash();
 
-            // Query rustc for supported -Csplit-debuginfo values
-            let support_split_debuginfo = rustc
-                .cached_output(
-                    rustc.workspace_process().arg("--print=split-debuginfo"),
-                    extra_fingerprint,
-                )
-                .unwrap_or_default()
-                .0
-                .lines()
-                .map(String::from)
-                .collect();
-
             // Query rustc for several kinds of info from each line of output:
             // 0) file-names (to determine output file prefix/suffix for given crate type)
             // 1) sysroot
-            // 2) cfg
+            // 2) split-debuginfo
+            // 3) cfg
             //
             // Search `--print` to see what we query so far.
             let mut process = rustc.workspace_process();
@@ -213,6 +202,8 @@ impl TargetInfo {
             }
 
             process.arg("--print=sysroot");
+            process.arg("--print=split-debuginfo");
+            process.arg("--print=crate-name"); // `___` as a delimiter.
             process.arg("--print=cfg");
 
             let (output, error) = rustc
@@ -250,6 +241,26 @@ impl TargetInfo {
                 CompileKind::Target(target) => target.short_name(),
             });
             sysroot_target_libdir.push("lib");
+
+            let support_split_debuginfo = {
+                // HACK: abuse `--print=crate-name` to use `___` as a delimiter.
+                let mut res = Vec::new();
+                loop {
+                    match lines.next() {
+                        Some(line) if line == "___" => break,
+                        Some(line) => res.push(line.into()),
+                        None => {
+                            return error_missing_print_output(
+                                "split-debuginfo",
+                                &process,
+                                &output,
+                                &error,
+                            )
+                        }
+                    }
+                }
+                res
+            };
 
             let cfg = lines
                 .map(|line| Ok(Cfg::from_str(line)?))
@@ -599,6 +610,20 @@ fn parse_crate_type(
     };
 
     Ok(Some((prefix.to_string(), suffix.to_string())))
+}
+
+/// Helper for creating an error message for missing output from a certain `--print` request.
+fn error_missing_print_output<T>(
+    request: &str,
+    cmd: &ProcessBuilder,
+    stdout: &str,
+    stderr: &str,
+) -> CargoResult<T> {
+    let err_info = output_err_info(cmd, stdout, stderr);
+    anyhow::bail!(
+        "output of --print={request} missing when learning about \
+     target-specific information from rustc\n{err_info}",
+    )
 }
 
 /// Helper for creating an error message when parsing rustc output fails.

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -356,6 +356,22 @@ fn bad_cfg_discovery() {
                     return;
                 }
                 println!("{}", sysroot);
+
+                if mode == "no-split-debuginfo" {
+                    return;
+                }
+                loop {
+                    let line = lines.next().unwrap();
+                    if line == "___" {
+                        println!("\n{line}");
+                        break;
+                    } else {
+                        // As the number split-debuginfo options varies,
+                        // concat them into one line.
+                        print!("{line},");
+                    }
+                };
+
                 if mode != "bad-cfg" {
                     panic!("unexpected");
                 }
@@ -418,6 +434,28 @@ command was: `[..]compiler[..]--crate-type [..]`
 
     p.cargo("build")
         .env("RUSTC", &funky_rustc)
+        .env("FUNKY_MODE", "no-split-debuginfo")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] output of --print=split-debuginfo missing when learning about target-specific information from rustc
+command was: `[..]compiler[..]--crate-type [..]`
+
+--- stdout
+[..]___[..]
+[..]___[..]
+[..]___[..]
+[..]___[..]
+[..]___[..]
+[..]___[..]
+[..]
+
+",
+        )
+        .run();
+
+    p.cargo("build")
+        .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "bad-cfg")
         .with_status(101)
         .with_stderr(
@@ -430,6 +468,8 @@ command was: `[..]compiler[..]--crate-type [..]`
 [..]___[..]
 [..]___[..]
 [..]
+[..],[..]
+___
 123
 
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

A follow-up of #11347

Merge rustc calls into one. We don't need a separate `rustc --print=split-debuginfo` anymore.

This is kinda a hack as we abuse `--print=crate-name` where the crate name is `___` and used as a delimiter.

### How should we test and review this PR?

A test is added, following what has been done for other parsing logic.

One question is this <https://github.com/rust-lang/cargo/pull/11347#discussion_r1016456436>. Shall we inform users that their `split-debuginfo` option is ignored?. It may be too excessive to have a warning for every rustc invocation. It's also less worthy of having a place to track whether the warning has been emitted.

### Additional information

Given that it has already affected a portion of Rust users on Windows (https://github.com/rust-lang/rust/issues/100657, https://github.com/rust-lang/rust/issues/103976), should we do a beta backport for this and #11347?

<!-- homu-ignore:end -->
