### PR TITLE
Add `CARGO_PKG_README`

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -343,6 +343,10 @@ impl<'cfg> Compilation<'cfg> {
                 "CARGO_PKG_RUST_VERSION",
                 &pkg.rust_version().unwrap_or(&String::new()),
             )
+            .env(
+                "CARGO_PKG_README",
+                metadata.readme.as_ref().unwrap_or(&String::new()),
+            )
             .cwd(pkg.root());
 
         // Apply any environment variables from the config

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -231,7 +231,7 @@ corresponding environment variable is set to the empty string, `""`.
 * `CARGO_PKG_RUST_VERSION` --- The Rust version from the manifest of your package.
   Note that this is the minimum Rust version supported by the package, not the
   current Rust version.
-* `CARGO_PKG_README` — Path to the README file of your package.
+* `CARGO_PKG_README` --- Path to the README file of your package.
 * `CARGO_CRATE_NAME` --- The name of the crate that is currently being compiled. It is the name of the [Cargo target] with `-` converted to `_`, such as the name of the library, binary, example, integration test, or benchmark.
 * `CARGO_BIN_NAME` --- The name of the binary that is currently being compiled.
   Only set for [binaries] or binary [examples]. This name does not include any

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -231,12 +231,12 @@ corresponding environment variable is set to the empty string, `""`.
 * `CARGO_PKG_RUST_VERSION` --- The Rust version from the manifest of your package.
   Note that this is the minimum Rust version supported by the package, not the
   current Rust version.
-* `CARGO_PKG_README` — The location of README of your package.
+* `CARGO_PKG_README` — Path to the README file of your package.
 * `CARGO_CRATE_NAME` --- The name of the crate that is currently being compiled. It is the name of the [Cargo target] with `-` converted to `_`, such as the name of the library, binary, example, integration test, or benchmark.
 * `CARGO_BIN_NAME` --- The name of the binary that is currently being compiled.
   Only set for [binaries] or binary [examples]. This name does not include any
   file extension, such as `.exe`.
-* `OUT_DIR` — If the package has a build script, this is set to the folder where the build
+* `OUT_DIR` --- If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)
 * `CARGO_BIN_EXE_<name>` --- The absolute path to a binary target's executable.

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -231,11 +231,12 @@ corresponding environment variable is set to the empty string, `""`.
 * `CARGO_PKG_RUST_VERSION` --- The Rust version from the manifest of your package.
   Note that this is the minimum Rust version supported by the package, not the
   current Rust version.
+* `CARGO_PKG_README` — The location of README of your package.
 * `CARGO_CRATE_NAME` --- The name of the crate that is currently being compiled. It is the name of the [Cargo target] with `-` converted to `_`, such as the name of the library, binary, example, integration test, or benchmark.
 * `CARGO_BIN_NAME` --- The name of the binary that is currently being compiled.
   Only set for [binaries] or binary [examples]. This name does not include any
   file extension, such as `.exe`.
-* `OUT_DIR` --- If the package has a build script, this is set to the folder where the build
+* `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)
 * `CARGO_BIN_EXE_<name>` --- The absolute path to a binary target's executable.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1370,6 +1370,7 @@ fn crate_env_vars() {
             license = "MIT OR Apache-2.0"
             license-file = "license.txt"
             rust-version = "1.61.0"
+            readme = "../../README.md"
 
             [[bin]]
             name = "foo-bar"
@@ -1395,6 +1396,7 @@ fn crate_env_vars() {
                 static LICENSE_FILE: &'static str = env!("CARGO_PKG_LICENSE_FILE");
                 static DESCRIPTION: &'static str = env!("CARGO_PKG_DESCRIPTION");
                 static RUST_VERSION: &'static str = env!("CARGO_PKG_RUST_VERSION");
+                static README: &'static str = env!("CARGO_PKG_README");
                 static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
                 static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
 
@@ -1414,6 +1416,7 @@ fn crate_env_vars() {
                      assert_eq!("license.txt", LICENSE_FILE);
                      assert_eq!("This is foo", DESCRIPTION);
                      assert_eq!("1.61.0", RUST_VERSION);
+                     assert_eq!("../../README.md", README);
                     let s = format!("{}.{}.{}-{}", VERSION_MAJOR,
                                     VERSION_MINOR, VERSION_PATCH, VERSION_PRE);
                     assert_eq!(s, VERSION);


### PR DESCRIPTION
Fixes #11597

This environment variable shows the path to the README file of your package. From #11597:

> Cargo may rewrite the package’s `Cargo.toml` and move the README file around, relative to the manifest. I would like to `include_str!()` this README in my `lib.rs`, but am unable to do so right now, because if I specify `include_str!("../../README")` it works for development, but I can’t package my crate. Conversely if I specify `include_str!("../README")` it works when packaged, but not during development.

