### PR TITLE
Warn on commits to non-default branches.

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -32,6 +32,7 @@ new_pr = true
 
 [assign]
 contributing_url = "https://rust-lang.github.io/cargo/contrib/"
+warn_non_default_branch = true
 
 [assign.owners]
 "*" = ["@ehuss", "@epage", "@weihanglo"]


### PR DESCRIPTION
This will make triagebot post a warning when a PR is opened against a non-master branch.
