### PR TITLE
Replace `winapi` with `windows-sys` crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,25 +84,16 @@ rustc-workspace-hack = "1.0.0"
 [target.'cfg(windows)'.dependencies]
 fwdansi = "1.1.0"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.45"
 features = [
-  "basetsd",
-  "handleapi",
-  "jobapi",
-  "jobapi2",
-  "memoryapi",
-  "minwindef",
-  "ntdef",
-  "ntstatus",
-  "processenv",
-  "processthreadsapi",
-  "psapi",
-  "synchapi",
-  "winerror",
-  "winbase",
-  "wincon",
-  "winnt",
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+  "Win32_System_Threading",
+  "Win32_System_JobObjects",
+  "Win32_Security",
+  "Win32_System_SystemServices"
 ]
 
 [dev-dependencies]

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -29,7 +29,7 @@ toml_edit = { version = "0.15.0", features = ["serde", "easy", "perf"] }
 url = "2.2.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = "0.3"
+windows-sys = { version = "0.45.0", features = ["Win32_Storage_FileSystem"] }
 
 [features]
 deny-warnings = []

--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -305,7 +305,7 @@ pub fn windows_reserved_names_are_allowed() -> bool {
     use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
-    use winapi::um::fileapi::GetFullPathNameW;
+    use windows_sys::Win32::Storage::FileSystem::GetFullPathNameW;
 
     let test_file_name: Vec<_> = OsStr::new("aux.rs").encode_wide().collect();
 

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -25,4 +25,4 @@ core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.5.0"
-winapi = { version = "0.3.9", features = ["consoleapi", "minwindef"] }
+windows-sys = { version = "0.45.0", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Console"] }

--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -701,8 +701,9 @@ fn exclude_from_content_indexing(path: &Path) {
     {
         use std::iter::once;
         use std::os::windows::prelude::OsStrExt;
-        use winapi::um::fileapi::{GetFileAttributesW, SetFileAttributesW};
-        use winapi::um::winnt::FILE_ATTRIBUTE_NOT_CONTENT_INDEXED;
+        use windows_sys::Win32::Storage::FileSystem::{
+            GetFileAttributesW, SetFileAttributesW, FILE_ATTRIBUTE_NOT_CONTENT_INDEXED,
+        };
 
         let path: Vec<u16> = path.as_os_str().encode_wide().chain(once(0)).collect();
         unsafe {

--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -606,10 +606,10 @@ mod imp {
     use super::{ProcessBuilder, ProcessError};
     use anyhow::Result;
     use std::io;
-    use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
-    use winapi::um::consoleapi::SetConsoleCtrlHandler;
+    use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 
-    unsafe extern "system" fn ctrlc_handler(_: DWORD) -> BOOL {
+    unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
         // Do nothing; let the child process handle it.
         TRUE
     }
@@ -626,7 +626,7 @@ mod imp {
     }
 
     pub fn command_line_too_big(err: &io::Error) -> bool {
-        use winapi::shared::winerror::ERROR_FILENAME_EXCED_RANGE;
+        use windows_sys::Win32::Foundation::ERROR_FILENAME_EXCED_RANGE;
         err.raw_os_error() == Some(ERROR_FILENAME_EXCED_RANGE as i32)
     }
 }

--- a/crates/cargo-util/src/process_error.rs
+++ b/crates/cargo-util/src/process_error.rs
@@ -140,11 +140,10 @@ pub fn exit_status_to_string(status: ExitStatus) -> String {
 
     #[cfg(windows)]
     fn status_to_string(status: ExitStatus) -> String {
-        use winapi::shared::minwindef::DWORD;
-        use winapi::um::winnt::*;
+        use windows_sys::Win32::Foundation::*;
 
         let mut base = status.to_string();
-        let extra = match status.code().unwrap() as DWORD {
+        let extra = match status.code().unwrap() as i32 {
             STATUS_ACCESS_VIOLATION => "STATUS_ACCESS_VIOLATION",
             STATUS_IN_PAGE_ERROR => "STATUS_IN_PAGE_ERROR",
             STATUS_INVALID_HANDLE => "STATUS_INVALID_HANDLE",

--- a/crates/cargo-util/src/read2.rs
+++ b/crates/cargo-util/src/read2.rs
@@ -84,7 +84,7 @@ mod imp {
     use miow::iocp::{CompletionPort, CompletionStatus};
     use miow::pipe::NamedPipe;
     use miow::Overlapped;
-    use winapi::shared::winerror::ERROR_BROKEN_PIPE;
+    use windows_sys::Win32::Foundation::ERROR_BROKEN_PIPE;
 
     struct Pipe<'a> {
         dst: &'a mut Vec<u8>,

--- a/crates/credential/cargo-credential-wincred/Cargo.toml
+++ b/crates/credential/cargo-credential-wincred/Cargo.toml
@@ -8,4 +8,4 @@ description = "A Cargo credential process that stores tokens with Windows Creden
 
 [dependencies]
 cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
-winapi = { version = "0.3.9", features = ["wincred", "winerror", "impl-default"] }
+windows-sys = { version = "0.45", features = [] }

--- a/crates/credential/cargo-credential-wincred/Cargo.toml
+++ b/crates/credential/cargo-credential-wincred/Cargo.toml
@@ -8,4 +8,4 @@ description = "A Cargo credential process that stores tokens with Windows Creden
 
 [dependencies]
 cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
-windows-sys = { version = "0.45", features = [] }
+windows-sys = { version = "0.45", features = ["Win32_Foundation", "Win32_Security_Credentials"] }

--- a/crates/credential/cargo-credential-wincred/src/main.rs
+++ b/crates/credential/cargo-credential-wincred/src/main.rs
@@ -38,13 +38,13 @@ impl Credential for WindowsCredential {
 
     fn get(&self, index_url: &str) -> Result<String, Error> {
         let target_name = target_name(index_url);
-        let mut p_credential: CREDENTIALW = std::ptr::null_mut();
+        let p_credential: *mut CREDENTIALW = std::ptr::null_mut() as *mut _;
         unsafe {
             if CredReadW(
                 target_name.as_ptr(),
                 CRED_TYPE_GENERIC,
                 0,
-                &mut p_credential as *mut _,
+                p_credential as *mut _ as *mut _,
             ) != TRUE
             {
                 return Err(
@@ -52,8 +52,8 @@ impl Credential for WindowsCredential {
                 );
             }
             let bytes = std::slice::from_raw_parts(
-                p_credential.CredentialBlob,
-                p_credential.CredentialBlobSize as usize,
+                (*p_credential).CredentialBlob,
+                (*p_credential).CredentialBlobSize as usize,
             );
             String::from_utf8(bytes.to_vec()).map_err(|_| "failed to convert token to UTF8".into())
         }

--- a/crates/credential/cargo-credential-wincred/src/main.rs
+++ b/crates/credential/cargo-credential-wincred/src/main.rs
@@ -3,10 +3,17 @@
 use cargo_credential::{Credential, Error};
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
-use winapi::shared::minwindef::{DWORD, FILETIME, LPBYTE, TRUE};
-use winapi::shared::winerror;
-use winapi::um::wincred;
-use winapi::um::winnt::LPWSTR;
+
+use windows_sys::core::PWSTR;
+use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
+use windows_sys::Win32::Foundation::FILETIME;
+use windows_sys::Win32::Foundation::TRUE;
+use windows_sys::Win32::Security::Credentials::CredDeleteW;
+use windows_sys::Win32::Security::Credentials::CredReadW;
+use windows_sys::Win32::Security::Credentials::CredWriteW;
+use windows_sys::Win32::Security::Credentials::CREDENTIALW;
+use windows_sys::Win32::Security::Credentials::CRED_PERSIST_LOCAL_MACHINE;
+use windows_sys::Win32::Security::Credentials::CRED_TYPE_GENERIC;
 
 struct WindowsCredential;
 
@@ -31,13 +38,13 @@ impl Credential for WindowsCredential {
 
     fn get(&self, index_url: &str) -> Result<String, Error> {
         let target_name = target_name(index_url);
-        let mut p_credential: wincred::PCREDENTIALW = std::ptr::null_mut();
+        let mut p_credential: CREDENTIALW = std::ptr::null_mut();
         unsafe {
-            if wincred::CredReadW(
+            if CredReadW(
                 target_name.as_ptr(),
-                wincred::CRED_TYPE_GENERIC,
+                CRED_TYPE_GENERIC,
                 0,
-                &mut p_credential,
+                &mut p_credential as *mut _,
             ) != TRUE
             {
                 return Err(
@@ -45,8 +52,8 @@ impl Credential for WindowsCredential {
                 );
             }
             let bytes = std::slice::from_raw_parts(
-                (*p_credential).CredentialBlob,
-                (*p_credential).CredentialBlobSize as usize,
+                p_credential.CredentialBlob,
+                p_credential.CredentialBlobSize as usize,
             );
             String::from_utf8(bytes.to_vec()).map_err(|_| "failed to convert token to UTF8".into())
         }
@@ -59,21 +66,24 @@ impl Credential for WindowsCredential {
             Some(name) => wstr(&format!("Cargo registry token for {}", name)),
             None => wstr("Cargo registry token"),
         };
-        let mut credential = wincred::CREDENTIALW {
+        let mut credential = CREDENTIALW {
             Flags: 0,
-            Type: wincred::CRED_TYPE_GENERIC,
-            TargetName: target_name.as_ptr() as LPWSTR,
-            Comment: comment.as_ptr() as LPWSTR,
-            LastWritten: FILETIME::default(),
-            CredentialBlobSize: token.len() as DWORD,
-            CredentialBlob: token.as_ptr() as LPBYTE,
-            Persist: wincred::CRED_PERSIST_LOCAL_MACHINE,
+            Type: CRED_TYPE_GENERIC,
+            TargetName: target_name.as_ptr() as PWSTR,
+            Comment: comment.as_ptr() as PWSTR,
+            LastWritten: FILETIME {
+                dwLowDateTime: 0,
+                dwHighDateTime: 0,
+            },
+            CredentialBlobSize: token.len() as u32,
+            CredentialBlob: token.as_ptr() as *mut u8,
+            Persist: CRED_PERSIST_LOCAL_MACHINE,
             AttributeCount: 0,
             Attributes: std::ptr::null_mut(),
             TargetAlias: std::ptr::null_mut(),
             UserName: std::ptr::null_mut(),
         };
-        let result = unsafe { wincred::CredWriteW(&mut credential, 0) };
+        let result = unsafe { CredWriteW(&mut credential, 0) };
         if result != TRUE {
             let err = std::io::Error::last_os_error();
             return Err(format!("failed to store token: {}", err).into());
@@ -83,11 +93,10 @@ impl Credential for WindowsCredential {
 
     fn erase(&self, index_url: &str) -> Result<(), Error> {
         let target_name = target_name(index_url);
-        let result =
-            unsafe { wincred::CredDeleteW(target_name.as_ptr(), wincred::CRED_TYPE_GENERIC, 0) };
+        let result = unsafe { CredDeleteW(target_name.as_ptr(), CRED_TYPE_GENERIC, 0) };
         if result != TRUE {
             let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(winerror::ERROR_NOT_FOUND as i32) {
+            if err.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
                 eprintln!("not currently logged in to `{}`", index_url);
                 return Ok(());
             }

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -16,10 +16,5 @@ readme = "README.md"
 repository = "https://github.com/brson/home"
 description = "Shared definitions of home directories"
 
-[target."cfg(windows)".dependencies.winapi]
-version = "0.3"
-features = [
-    "shlobj",
-    "std",
-    "winerror",
-]
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_UI_Shell"] }

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -16,5 +16,5 @@ readme = "README.md"
 repository = "https://github.com/brson/home"
 description = "Shared definitions of home directories"
 
-[target."cfg(windows)".dependencies]
+[target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_UI_Shell"] }

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -30,7 +30,7 @@
 
 pub mod env;
 
-#[cfg(windows)]
+#[cfg(target_os(windows))]
 mod windows;
 
 use std::io;

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -30,7 +30,7 @@
 
 pub mod env;
 
-#[cfg(target_os(windows))]
+#[cfg(target_os = "windows")]
 mod windows;
 
 use std::io;

--- a/crates/home/src/windows.rs
+++ b/crates/home/src/windows.rs
@@ -4,9 +4,8 @@ use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::ptr;
 
-use winapi::shared::minwindef::MAX_PATH;
-use winapi::shared::winerror::S_OK;
-use winapi::um::shlobj::{SHGetFolderPathW, CSIDL_PROFILE};
+use windows_sys::Win32::Foundation::{MAX_PATH, S_OK};
+use windows_sys::Win32::UI::Shell::{SHGetFolderPathW, CSIDL_PROFILE};
 
 pub fn home_dir_inner() -> Option<PathBuf> {
     env::var_os("USERPROFILE")

--- a/crates/home/src/windows.rs
+++ b/crates/home/src/windows.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::ffi::OsString;
 use std::os::windows::ffi::OsStringExt;
 use std::path::PathBuf;
-use std::ptr;
 
 use windows_sys::Win32::Foundation::{MAX_PATH, S_OK};
 use windows_sys::Win32::UI::Shell::{SHGetFolderPathW, CSIDL_PROFILE};
@@ -17,14 +16,8 @@ pub fn home_dir_inner() -> Option<PathBuf> {
 #[cfg(not(target_vendor = "uwp"))]
 fn home_dir_crt() -> Option<PathBuf> {
     unsafe {
-        let mut path: Vec<u16> = Vec::with_capacity(MAX_PATH);
-        match SHGetFolderPathW(
-            ptr::null_mut(),
-            CSIDL_PROFILE,
-            ptr::null_mut(),
-            0,
-            path.as_mut_ptr(),
-        ) {
+        let mut path: Vec<u16> = Vec::with_capacity(MAX_PATH as usize);
+        match SHGetFolderPathW(0, CSIDL_PROFILE as i32, 0, 0, path.as_mut_ptr()) {
             S_OK => {
                 let len = wcslen(path.as_ptr());
                 path.set_len(len);

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -812,7 +812,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                         true
                     })
                     .flat_map(|dep| {
-                        // Each dependency can be built for multiple targets. For one, it
+                        // Each `dep`endency can be built for multiple targets. For one, it
                         // may be a library target which is built as initially configured
                         // by `fk`. If it appears as build dependency, it must be built
                         // for the host.

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -812,7 +812,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                         true
                     })
                     .flat_map(|dep| {
-                        // Each `dep`endency can be built for multiple targets. For one, it
+                        // Each dependency can be built for multiple targets. For one, it
                         // may be a library target which is built as initially configured
                         // by `fk`. If it appears as build dependency, it must be built
                         // for the host.

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -589,7 +589,7 @@ mod imp {
                 ptr::null_mut(),
                 OPEN_EXISTING,
                 0,
-                ptr::null_mut(),
+                0,
             );
             if h == INVALID_HANDLE_VALUE {
                 return TtyWidth::NoTty;

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -557,12 +557,17 @@ mod imp {
 #[cfg(windows)]
 mod imp {
     use std::{cmp, mem, ptr};
-    use winapi::um::fileapi::*;
-    use winapi::um::handleapi::*;
-    use winapi::um::processenv::*;
-    use winapi::um::winbase::*;
-    use winapi::um::wincon::*;
-    use winapi::um::winnt::*;
+
+    use windows_sys::core::PCSTR;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileA, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::Console::{
+        GetConsoleScreenBufferInfo, GetStdHandle, CONSOLE_SCREEN_BUFFER_INFO, STD_ERROR_HANDLE,
+    };
+    use windows_sys::Win32::System::SystemServices::{GENERIC_READ, GENERIC_WRITE};
 
     pub(super) use super::{default_err_erase_line as err_erase_line, TtyWidth};
 
@@ -578,7 +583,7 @@ mod imp {
             // INVALID_HANDLE_VALUE. Use an alternate method which works
             // in that case as well.
             let h = CreateFileA(
-                "CONOUT$\0".as_ptr() as *const CHAR,
+                "CONOUT$\0".as_ptr() as PCSTR,
                 GENERIC_READ | GENERIC_WRITE,
                 FILE_SHARE_READ | FILE_SHARE_WRITE,
                 ptr::null_mut(),

--- a/src/cargo/util/cpu.rs
+++ b/src/cargo/util/cpu.rs
@@ -190,8 +190,9 @@ mod imp {
 mod imp {
     use std::io;
     use std::mem;
-    use winapi::shared::minwindef::*;
-    use winapi::um::processthreadsapi::*;
+
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::System::Threading::GetSystemTimes;
 
     pub struct State {
         idle: FILETIME,

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -437,10 +437,11 @@ mod sys {
     use std::mem;
     use std::os::windows::io::AsRawHandle;
 
-    use winapi::shared::minwindef::DWORD;
-    use winapi::shared::winerror::{ERROR_INVALID_FUNCTION, ERROR_LOCK_VIOLATION};
-    use winapi::um::fileapi::{LockFileEx, UnlockFile};
-    use winapi::um::minwinbase::{LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY};
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Foundation::{ERROR_INVALID_FUNCTION, ERROR_LOCK_VIOLATION};
+    use windows_sys::Win32::Storage::FileSystem::{
+        LockFileEx, UnlockFile, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
+    };
 
     pub(super) fn lock_shared(file: &File) -> Result<()> {
         lock_file(file, 0)
@@ -470,7 +471,7 @@ mod sys {
 
     pub(super) fn unlock(file: &File) -> Result<()> {
         unsafe {
-            let ret = UnlockFile(file.as_raw_handle(), 0, 0, !0, !0);
+            let ret = UnlockFile(file.as_raw_handle() as HANDLE, 0, 0, !0, !0);
             if ret == 0 {
                 Err(Error::last_os_error())
             } else {
@@ -479,10 +480,17 @@ mod sys {
         }
     }
 
-    fn lock_file(file: &File, flags: DWORD) -> Result<()> {
+    fn lock_file(file: &File, flags: u32) -> Result<()> {
         unsafe {
             let mut overlapped = mem::zeroed();
-            let ret = LockFileEx(file.as_raw_handle(), flags, 0, !0, !0, &mut overlapped);
+            let ret = LockFileEx(
+                file.as_raw_handle() as HANDLE,
+                flags,
+                0,
+                !0,
+                !0,
+                &mut overlapped,
+            );
             if ret == 0 {
                 Err(Error::last_os_error())
             } else {

--- a/src/cargo/util/job.rs
+++ b/src/cargo/util/job.rs
@@ -44,6 +44,7 @@ mod imp {
     use std::io;
     use std::mem;
     use std::ptr;
+    use std::ptr::addr_of;
 
     use log::info;
 
@@ -96,8 +97,8 @@ mod imp {
         let r = SetInformationJobObject(
             job.inner,
             JobObjectExtendedLimitInformation,
-            &mut info as *mut _ as LPVOID,
-            mem::size_of_val(&info) as DWORD,
+            addr_of!(info) as *const _,
+            mem::size_of_val(&info) as u32,
         );
         if r == 0 {
             return None;
@@ -120,13 +121,13 @@ mod imp {
             // processes. The destructor here configures our job object to
             // **not** kill everything on close, then closes the job object.
             unsafe {
-                let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+                let info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
                 info = mem::zeroed();
                 let r = SetInformationJobObject(
                     self.job.inner,
                     JobObjectExtendedLimitInformation,
-                    &mut info as *mut _ as LPVOID,
-                    mem::size_of_val(&info) as DWORD,
+                    addr_of!(info) as *const _,
+                    mem::size_of_val(&info) as u32,
                 );
                 if r == 0 {
                     info!("failed to configure job object to defaults: {}", last_err());

--- a/src/cargo/util/job.rs
+++ b/src/cargo/util/job.rs
@@ -47,12 +47,15 @@ mod imp {
 
     use log::info;
 
-    use winapi::shared::minwindef::*;
-    use winapi::um::handleapi::*;
-    use winapi::um::jobapi2::*;
-    use winapi::um::processthreadsapi::*;
-    use winapi::um::winnt::HANDLE;
-    use winapi::um::winnt::*;
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+    use windows_sys::Win32::System::JobObjects::CreateJobObjectW;
+    use windows_sys::Win32::System::JobObjects::JobObjectExtendedLimitInformation;
+    use windows_sys::Win32::System::JobObjects::SetInformationJobObject;
+    use windows_sys::Win32::System::JobObjects::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
     pub struct Setup {
         job: Handle,
@@ -77,7 +80,7 @@ mod imp {
         // we're otherwise part of someone else's job object in this case.
 
         let job = CreateJobObjectW(ptr::null_mut(), ptr::null());
-        if job.is_null() {
+        if job == INVALID_HANDLE_VALUE {
             return None;
         }
         let job = Handle { inner: job };

--- a/src/cargo/util/job.rs
+++ b/src/cargo/util/job.rs
@@ -55,6 +55,7 @@ mod imp {
     use windows_sys::Win32::System::JobObjects::JobObjectExtendedLimitInformation;
     use windows_sys::Win32::System::JobObjects::SetInformationJobObject;
     use windows_sys::Win32::System::JobObjects::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+    use windows_sys::Win32::System::JobObjects::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
     use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
     pub struct Setup {


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

replace `winapi` with `windows-sys` crate.

It's office is maintained.

### How should we test and review this PR?

I just do the replacement of API. I think it is quiet clear.

And I found a `cfg` for `windows` may miss checked error.

### Additional information

No one.
-->
<!-- homu-ignore:end -->

### What does this PR try to resolve?

replace `winapi` with `windows-sys` crate.

It's officially maintained.

### How should we test and review this PR?

I just do the replacement of API. I think it is quite clear.

And I found a `cfg` for `windows` may miss checked error.

### Additional information

No one.
