### PR TITLE
Do not error for `auth-required: true` without `-Z sparse-registry`

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -334,13 +334,6 @@ impl<'cfg> HttpRegistry<'cfg> {
         }
     }
 
-    fn check_registry_auth_unstable(&self) -> CargoResult<()> {
-        if self.auth_required && !self.config.cli_unstable().registry_auth {
-            anyhow::bail!("authenticated registries require `-Z registry-auth`");
-        }
-        Ok(())
-    }
-
     /// Get the cached registry configuration, if it exists.
     fn config_cached(&mut self) -> CargoResult<Option<&RegistryConfig>> {
         if self.registry_config.is_some() {
@@ -486,7 +479,9 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
                     return Poll::Ready(Ok(LoadResponse::NotFound));
                 }
                 StatusCode::Unauthorized
-                    if !self.auth_required && path == Path::new("config.json") =>
+                    if !self.auth_required
+                        && path == Path::new("config.json")
+                        && self.config.cli_unstable().registry_auth =>
                 {
                     debug!("re-attempting request for config.json with authorization included.");
                     self.fresh.remove(path);
@@ -542,6 +537,10 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
             }
         }
 
+        if !self.config.cli_unstable().registry_auth {
+            self.auth_required = false;
+        }
+
         // Looks like we're going to have to do a network request.
         self.start_fetch()?;
 
@@ -587,7 +586,6 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
             }
         }
         if self.auth_required {
-            self.check_registry_auth_unstable()?;
             let authorization =
                 auth::auth_token(self.config, &self.source_id, self.login_url.as_ref(), None)?;
             headers.append(&format!("Authorization: {}", authorization))?;
@@ -660,8 +658,10 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
     }
 
     fn config(&mut self) -> Poll<CargoResult<Option<RegistryConfig>>> {
-        let cfg = ready!(self.config()?).clone();
-        self.check_registry_auth_unstable()?;
+        let mut cfg = ready!(self.config()?).clone();
+        if !self.config.cli_unstable().registry_auth {
+            cfg.auth_required = false;
+        }
         Poll::Ready(Ok(Some(cfg)))
     }
 

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -245,11 +245,9 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         match ready!(self.load(Path::new(""), Path::new("config.json"), None)?) {
             LoadResponse::Data { raw_data, .. } => {
                 trace!("config loaded");
-                let cfg: RegistryConfig = serde_json::from_slice(&raw_data)?;
-                if cfg.auth_required && !self.config.cli_unstable().registry_auth {
-                    return Poll::Ready(Err(anyhow::anyhow!(
-                        "authenticated registries require `-Z registry-auth`"
-                    )));
+                let mut cfg: RegistryConfig = serde_json::from_slice(&raw_data)?;
+                if !self.config.cli_unstable().registry_auth {
+                    cfg.auth_required = false;
                 }
                 Poll::Ready(Ok(Some(cfg)))
             }

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -42,12 +42,26 @@ static SUCCESS_OUTPUT: &'static str = "\
 
 #[cargo_test]
 fn requires_nightly() {
-    let _registry = RegistryBuilder::new().alternative().auth_required().build();
+    let _registry = RegistryBuilder::new()
+        .alternative()
+        .auth_required()
+        .http_api()
+        .build();
 
     let p = make_project();
     p.cargo("build")
         .with_status(101)
-        .with_stderr_contains("  authenticated registries require `-Z registry-auth`")
+        .with_stderr(
+            r#"[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+error: failed to download from `[..]/dl/bar/0.0.1/download`
+
+Caused by:
+  failed to get successful HTTP response from `[..]`, got 401
+  body:
+  Unauthorized message from server.
+"#,
+        )
         .run();
 }
 


### PR DESCRIPTION
Registries that include `auth-required: true` in their `config.json` currently hit the following error on stable:
```
authenticated registries require `-Z registry-auth`
```

This situation makes it difficult for a registry to optionally offer the `auth-required: true` feature, since it forces users on to the nightly toolchain.

This PR changes the behavior to ignore the `auth-required: true` field of `config.json` without `-Z registry-auth`.

The downside to this change is that it makes it harder to discover why a registry isn't working, since the user will get an HTTP 401 error from the server, rather than a message from Cargo suggesting adding `-Z registry-auth`.

r? @Eh2406 