### PR TITLE
docs(contrib): Remove out-of-date process step

### DIFF
--- a/src/doc/contrib/src/process/unstable.md
+++ b/src/doc/contrib/src/process/unstable.md
@@ -24,11 +24,7 @@ been passed.
 Every unstable feature should have a section added to the [unstable chapter]
 describing how to use the feature.
 
-`-Z` CLI flags should be documented in the built-in help in the [`cli`
-module].
-
 [unstable chapter]: https://github.com/rust-lang/cargo/blob/master/src/doc/src/reference/unstable.md
-[`cli` module]: https://github.com/rust-lang/cargo/blob/master/src/bin/cargo/cli.rs
 
 ## Tracking issues
 


### PR DESCRIPTION
The `-Z` flag seems to now be documented as part of defining the feature in `features.rs`, so (1) the destination is wrong and (2) this will be done naturally as part of creating the feature.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
