### PR TITLE
Verify source before recompile

### DIFF
--- a/src/cargo/core/compiler/fingerprint.rs
+++ b/src/cargo/core/compiler/fingerprint.rs
@@ -391,9 +391,9 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
     let compare = compare_old_fingerprint(&loc, &*fingerprint, mtime_on_use);
     log_compare(unit, &compare);
 
-    // If our comparison failed (e.g., we're going to trigger a rebuild of this
-    // crate), then we also ensure the source of the crate passes all
-    // verification checks before we build it.
+    // If our comparison failed or reported dirty (e.g., we're going to trigger
+    // a rebuild of this crate), then we also ensure the source of the crate
+    // passes all verification checks before we build it.
     //
     // The `Source::verify` method is intended to allow sources to execute
     // pre-build checks to ensure that the relevant source code is all
@@ -401,7 +401,11 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
     // directory sources which will use this hook to perform an integrity check
     // on all files in the source to ensure they haven't changed. If they have
     // changed then an error is issued.
-    if compare.is_err() {
+    if compare
+        .as_ref()
+        .map(|dirty| dirty.is_some())
+        .unwrap_or(true)
+    {
         let source_id = unit.pkg.package_id().source_id();
         let sources = bcx.packages.sources();
         let source = sources

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2744,3 +2744,66 @@ fn changing_linker() {
         )
         .run();
 }
+
+#[cargo_test]
+fn verify_source_before_recompile() {
+    Package::new("bar", "0.1.0")
+        .file("src/lib.rs", "")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = "0.1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("vendor --respect-source-config").run();
+    p.change_file(
+        ".cargo/config.toml",
+        r#"
+            [source.crates-io]
+            replace-with = 'vendor'
+
+            [source.vendor]
+            directory = 'vendor'
+        "#,
+    );
+    // Sanity check: vendoring works correctly.
+    p.cargo("check --verbose")
+        .with_stderr_contains("[RUNNING] `rustc --crate-name bar [CWD]/vendor/bar/src/lib.rs[..]")
+        .run();
+    // Now modify vendored crate.
+    p.change_file(
+        "vendor/bar/src/lib.rs",
+        r#"compile_error!("You shall not pass!");"#,
+    );
+    // Should ignore modifed sources without any recompile.
+    p.cargo("check --verbose")
+        .with_stderr(
+            "\
+[FRESH] bar v0.1.0
+[FRESH] foo v0.1.0 ([CWD])
+[FINISHED] dev [..]
+",
+        )
+        .run();
+
+    // Add a `RUSTFLAGS` to trigger a recompile.
+    //
+    // Cargo should refuse to build because of checksum verfication failure.
+    // Cargo shouldn't recompile dependency `bar`.
+    // TODO: fix this wrong behaviour
+    p.cargo("check --verbose")
+        .env("RUSTFLAGS", "-W warnings")
+        .with_status(101)
+        .with_stderr_contains("[..]error: You shall not pass![..]")
+        .run();
+}

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2800,10 +2800,17 @@ fn verify_source_before_recompile() {
     //
     // Cargo should refuse to build because of checksum verfication failure.
     // Cargo shouldn't recompile dependency `bar`.
-    // TODO: fix this wrong behaviour
     p.cargo("check --verbose")
         .env("RUSTFLAGS", "-W warnings")
         .with_status(101)
-        .with_stderr_contains("[..]error: You shall not pass![..]")
+        .with_stderr(
+            "\
+error: the listed checksum of `[CWD]/vendor/bar/src/lib.rs` has changed:
+expected: [..]
+actual:   [..]
+
+directory sources are not [..]
+",
+        )
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This fixes a regression introduced by #11407,
which Cargo should always verify a source before it recompiles.

Before #11407, we only cared about whether the compare `Err`ed.  #11407 changed some cases of the compare from being reported as an `Err` to an `Ok` with dirty information but the check on the compare `Err`or wasn't updated.  This is easy to miss in implementation and review as it was outside of the lines changed (github won't even let reviewers comment on the relevant line).

### How should we test and review this PR?

You could checkout to branch rust-1.67.0 and run the new test case.
Cargo before #11407 refuses to build when checksum verification failed,
which is the correct behavior. You'll see this error with rust-1.67.0:

```
error: the listed checksum of `/projects/bar/src/lib.rs` has changed:
expected: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
actual:   66e843918c1d4ea8231af814f9f958958808249d4407de01114acb730ecd9bdf

directory sources are not intended to be edited, if modifications are required then it is recommended that `[patch]` is used with a forked copy of the source
```

### Additional information

Worth a <https://github.com/rust-lang/cargo/labels/beta-nominated> ?

<!-- homu-ignore:end -->
