### PR TITLE
util toml targets: Do not infer directory as a file

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -624,10 +624,10 @@ fn infer_from_directory(directory: &Path) -> Vec<(String, PathBuf)> {
 }
 
 fn infer_any(entry: &DirEntry) -> Option<(String, PathBuf)> {
-    if entry.path().extension().and_then(|p| p.to_str()) == Some("rs") {
-        infer_file(entry)
-    } else if entry.file_type().map(|t| t.is_dir()).ok() == Some(true) {
+    if entry.file_type().map_or(false, |t| t.is_dir()) {
         infer_subdirectory(entry)
+    } else if entry.path().extension().and_then(|p| p.to_str()) == Some("rs") {
+        infer_file(entry)
     } else {
         None
     }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5023,6 +5023,18 @@ fn inferred_benchmarks() {
 }
 
 #[cargo_test]
+fn no_infer_dirs() {
+    let p = project()
+        .file("src/lib.rs", "fn main() {}")
+        .file("examples/dir.rs/dummy", "")
+        .file("benches/dir.rs/dummy", "")
+        .file("tests/dir.rs/dummy", "")
+        .build();
+
+    p.cargo("build --examples --benches --tests").run(); // should not fail with "is a directory"
+}
+
+#[cargo_test]
 fn target_edition() {
     let p = project()
         .file(


### PR DESCRIPTION
Any directory entry that ends with `.rs` is currently inferred to be a file, causing it to be added as a target. This means that directories that end with .rs may also end up as targets.

An example where this is apparent, running in an existing project directory;
```
$ mkdir -p tests/some_dir.rs
$ cargo fmt
Error: `tests/some_dir.rs` is a directory
```
causes cargo-fmt to pass the directory to rustfmt, which in turn makes rustfmt exit with an error.
