### PR TITLE
Do not mention a non-existing default of crates.io

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -202,8 +202,7 @@ description = "A short description of my package"
 #### The `documentation` field
 
 The `documentation` field specifies a URL to a website hosting the crate's
-documentation. If no URL is specified in the manifest file, [crates.io] will
-automatically link your crate to the corresponding [docs.rs] page.
+documentation.
 
 ```toml
 [package]


### PR DESCRIPTION
I just published a new crate on crates.io, and it does not appear to link the documentation at all when no documentation field is provided.

Example: https://crates.io/crates/kine/0.1.0