### PR TITLE
`-Zrustdoc-scrape-example` must fail with bad build script

### DIFF
--- a/src/cargo/core/compiler/rustdoc.rs
+++ b/src/cargo/core/compiler/rustdoc.rs
@@ -211,16 +211,24 @@ impl RustdocScrapeExamples {
 }
 
 impl BuildContext<'_, '_> {
-    /// Returns the set of Docscrape units that have a direct dependency on `unit`
+    /// Returns the set of [`Docscrape`] units that have a direct dependency on `unit`.
+    ///
+    /// [`RunCustomBuild`] units are excluded because we allow failures
+    /// from type checks but not build script executions.
+    /// A plain old `cargo doc` would just die if a build script execution fails,
+    /// there is no reason for `-Zrustdoc-scrape-examples` to keep going.
+    ///
+    /// [`Docscrape`]: crate::core::compiler::CompileMode::Docscrape
+    /// [`RunCustomBuild`]: crate::core::compiler::CompileMode::Docscrape
     pub fn scrape_units_have_dep_on<'a>(&'a self, unit: &'a Unit) -> Vec<&'a Unit> {
         self.scrape_units
             .iter()
             .filter(|scrape_unit| {
                 self.unit_graph[scrape_unit]
                     .iter()
-                    .any(|dep| &dep.unit == unit)
+                    .any(|dep| &dep.unit == unit && !dep.unit.mode.is_run_custom_build())
             })
-            .collect::<Vec<_>>()
+            .collect()
     }
 
     /// Returns true if this unit is needed for doing doc-scraping and is also

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -389,17 +389,11 @@ fn fail_bad_build_script() {
         .with_stderr_contains("[..]You shall not pass[..]")
         .run();
 
-    // FIXME: scrape examples should fail whenever `cargo doc` fails.
+    // scrape examples should fail whenever `cargo doc` fails.
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[SCRAPING] foo v0.0.1 ([CWD])
-[DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [..]
-",
-        )
+        .with_status(101)
+        .with_stderr_contains("[..]You shall not pass[..]")
         .run();
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

When running `cargo doc -Zrustdoc-scrape-example`, it performs
additional type checks that a plain old `cargo doc` doesn't.
That leads to some extra failure when adopting scrape-example for docs.rs. 

In de34d60 we introduced `unit_can_fail_for_docscraping` in order to
make `-Zrustdoc-scrape-example` not fail whenever `cargo doc` builds.
Build script executions were accidentally included in the list of
fallible units. A plain `cargo doc` does fail when a build script
fails. `-Zrustdoc-scrape-example` should follow that.

### How should we test and review this PR?

A test `fail_bad_build_script` is added.

You can also follow the reproducer in #11623. Both `cargo doc` and `cargo doc -Zrustdoc-scrape-examples` should fails in the same manner.

### Additional information

fixes #11623

cc @willcrichton
<!-- homu-ignore:end -->
