### PR TITLE
Deny warnings in CI, not locally

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,8 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: 1
       CARGO_INCREMENTAL: 0
       CARGO_PUBLIC_NETWORK_TESTS: 1
+      # Deny warnings on CI to avoid warnings getting into the codebase.
+      RUSTFLAGS: -D warnings
     strategy:
       matrix:
         include:
@@ -85,8 +87,7 @@ jobs:
       run: echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV
       if: "!contains(matrix.rust, 'stable')"
 
-    # Deny warnings on CI to avoid warnings getting into the codebase.
-    - run: cargo test --features 'deny-warnings'
+    - run: cargo test
     # The testsuite generates a huge amount of data, and fetch-smoke-test was
     # running out of disk space.
     - name: Clear test output
@@ -100,8 +101,8 @@ jobs:
       run: |
         # This only tests `cargo fix` because fix-proxy-mode is one of the most
         # complicated subprocess management in Cargo.
-        cargo test --test testsuite --features 'deny-warnings' -- fix::
-    - run: cargo test --features 'deny-warnings' --manifest-path crates/cargo-test-support/Cargo.toml
+        cargo test --test testsuite -- fix::
+    - run: cargo test --manifest-path crates/cargo-test-support/Cargo.toml
       env:
         CARGO_TARGET_DIR: target
     - run: cargo test -p cargo-platform

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ test = false
 doc = false
 
 [features]
-deny-warnings = []
 vendored-openssl = ["openssl/vendored"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
 pretty-env-logger = ["pretty_env_logger"]

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -30,6 +30,3 @@ url = "2.2.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Storage_FileSystem"] }
-
-[features]
-deny-warnings = []

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -3,7 +3,6 @@
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
 
 #![allow(clippy::all)]
-#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 
 use std::env;
 use std::ffi::OsStr;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,7 +1,7 @@
 // For various reasons, some idioms are still allow'ed, but we would like to
 // test and enforce them.
 #![warn(rust_2018_idioms)]
-#![cfg_attr(test, deny(warnings))]
+#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -1,7 +1,6 @@
 // For various reasons, some idioms are still allow'ed, but we would like to
 // test and enforce them.
 #![warn(rust_2018_idioms)]
-#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,7 +1,6 @@
 // See src/cargo/lib.rs for notes on these lint settings.
 #![warn(rust_2018_idioms)]
 #![allow(clippy::all)]
-#![cfg_attr(feature = "deny-warnings", deny(warnings))]
 
 #[macro_use]
 extern crate cargo_test_macro;


### PR DESCRIPTION
### What does this PR try to resolve?

The problem with #![deny(warnings)] is it makes iteration more difficult as you might have intermediate states with warnings. Its slightly better that we defer this to cargo test --lib but that still means you can't run a subset of tests against your experiment until you've cleaned up all of your warnings. This can lead to users [working around the problem which could accidentally slip in](https://github.com/rust-lang/cargo/commit/d92d04840c1fb518faf8f964054b48f64e4920db).

### How should we test and review this PR?

The first round for this PR includes a warning in the `cargo` crate to ensure it breaks CI.  It will then be reverted.

### Additional information

See also https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/.60.23!.5Bcfg_attr.28test.2C.20deny.28warnings.29.29.5D.60