### PR TITLE
Re-export cargo_new::NewProjectKind as public

### DIFF
--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -11,7 +11,7 @@ pub use self::cargo_generate_lockfile::generate_lockfile;
 pub use self::cargo_generate_lockfile::update_lockfile;
 pub use self::cargo_generate_lockfile::UpdateOptions;
 pub use self::cargo_install::{install, install_list};
-pub use self::cargo_new::{init, new, NewOptions, VersionControl};
+pub use self::cargo_new::{init, new, NewOptions, NewProjectKind, VersionControl};
 pub use self::cargo_output_metadata::{output_metadata, ExportInfo, OutputMetadataOptions};
 pub use self::cargo_package::{check_yanked, package, package_one, PackageOpts};
 pub use self::cargo_pkgid::pkgid;


### PR DESCRIPTION
`NewProjectKind` needs to be exported since the module cargo_new is private. It's unreachable for use-cases interfacing with the library directly.

This is from the jonhoo stream. Apparently a maintainer is picking this up now, so feel free to close this out.