### PR TITLE
Set CARGO_BIN_NAME environment variable also for binary examples

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -372,7 +372,7 @@ impl<'cfg> Compilation<'cfg> {
 /// Prepares a rustc_tool process with additional environment variables
 /// that are only relevant in a context that has a unit
 fn fill_rustc_tool_env(mut cmd: ProcessBuilder, unit: &Unit) -> ProcessBuilder {
-    if unit.target.is_bin() {
+    if unit.target.is_executable() {
         let name = unit
             .target
             .binary_filename()

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -232,7 +232,9 @@ corresponding environment variable is set to the empty string, `""`.
   Note that this is the minimum Rust version supported by the package, not the
   current Rust version.
 * `CARGO_CRATE_NAME` — The name of the crate that is currently being compiled. It is the name of the [Cargo target] with `-` converted to `_`, such as the name of the library, binary, example, integration test, or benchmark.
-* `CARGO_BIN_NAME` — The name of the binary that is currently being compiled (if it is a binary). This name does not include any file extension, such as `.exe`.
+* `CARGO_BIN_NAME` — The name of the binary that is currently being compiled.
+  Only set for [binaries] or binary [examples]. This name does not include any
+  file extension, such as `.exe`.
 * `OUT_DIR` — If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)
@@ -256,6 +258,8 @@ corresponding environment variable is set to the empty string, `""`.
   manage its content in any way, this is the responsibility of the test code.
 
 [Cargo target]: cargo-targets.md
+[binaries]: cargo-targets.md#binaries
+[examples]: cargo-targets.md#examples
 [integration test]: cargo-targets.md#integration-tests
 [`env` macro]: ../../std/macro.env.html
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1467,6 +1467,23 @@ fn crate_env_vars() {
             "#,
         )
         .file(
+            "examples/ex-env-vars.rs",
+            r#"
+                static PKG_NAME: &'static str = env!("CARGO_PKG_NAME");
+                static BIN_NAME: &'static str = env!("CARGO_BIN_NAME");
+                static CRATE_NAME: &'static str = env!("CARGO_CRATE_NAME");
+
+                fn main() {
+                    assert_eq!("foo", PKG_NAME);
+                    assert_eq!("ex-env-vars", BIN_NAME);
+                    assert_eq!("ex_env_vars", CRATE_NAME);
+
+                    // Verify CARGO_TARGET_TMPDIR isn't set for examples
+                    assert!(option_env!("CARGO_TARGET_TMPDIR").is_none());
+                }
+            "#,
+        )
+        .file(
             "tests/env.rs",
             r#"
                 #[test]
@@ -1502,6 +1519,9 @@ fn crate_env_vars() {
     p.process(&p.bin("foo-bar"))
         .with_stdout("0-5-1 @ alpha.1 in [CWD]")
         .run();
+
+    println!("example");
+    p.cargo("run --example ex-env-vars -v").run();
 
     println!("test");
     p.cargo("test -v").run();


### PR DESCRIPTION
### What does this PR try to resolve?

The existing CARGO_BIN_NAME environment variable is useful when building command-line programs. It lets the command know its binary name, e.g. for printing out simple usage instructions. This PR extends the CARGO_BIN_NAME environment variable to be set when building binary example targets, additional to "normal" binary targets.

Fixes #11689.

### How should we test and review this PR?

Create a new binary project with `cargo new hello-env`. Add a new file "examples/foo-bar.rs" with the following lines:

```
fn main() {
    let program = env!("CARGO_BIN_NAME");
    println!("{program}");
}
```

Building and running the example with `cargo run --example foo-bar` should print a line with the string "foo-bar".

Note that this PR extends the existing testcase for the CARGO_BIN_NAME environment variable with an example target.