### PR TITLE
Run CI for macOS on nightly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,10 @@ jobs:
           os: macos-latest
           rust: stable
           other: x86_64-apple-ios
+        - name: macOS x86_64 nightly
+          os: macos-latest
+          rust: nightly
+          other: x86_64-apple-ios
         - name: Windows x86_64 MSVC stable
           os: windows-latest
           rust: stable-msvc


### PR DESCRIPTION
This adds coverage for macOS on nightly. Since Cargo is very platform-dependent, I think it would be good to have full coverage on most tier-1 platforms. This includes a small fix for a test that recently started failing on nightly.
