### PR TITLE
Add more information to wait-for-publish

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -232,6 +232,7 @@ fn substitute_macros(input: &str) -> String {
         ("[EXECUTABLE]", "  Executable"),
         ("[SKIPPING]", "    Skipping"),
         ("[WAITING]", "     Waiting"),
+        ("[PUBLISHED]", "   Published"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -211,6 +211,7 @@ fn substitute_macros(input: &str) -> String {
         ("[DOWNLOADING]", " Downloading"),
         ("[DOWNLOADED]", "  Downloaded"),
         ("[UPLOADING]", "   Uploading"),
+        ("[UPLOADED]", "    Uploaded"),
         ("[VERIFYING]", "   Verifying"),
         ("[ARCHIVING]", "   Archiving"),
         ("[INSTALLING]", "  Installing"),

--- a/crates/cargo-test-support/src/publish.rs
+++ b/crates/cargo-test-support/src/publish.rs
@@ -189,7 +189,7 @@ pub(crate) fn create_index_line(
     json.to_string()
 }
 
-pub(crate) fn write_to_index(registry_path: &PathBuf, name: &str, line: String, local: bool) {
+pub(crate) fn write_to_index(registry_path: &Path, name: &str, line: String, local: bool) {
     let file = cargo_util::registry::make_dep_path(name, false);
 
     // Write file/line in the index.

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -13,7 +13,7 @@ use std::fmt;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::thread::{self, JoinHandle};
 use tar::{Builder, Header};
 use time::format_description::well_known::Rfc3339;
@@ -98,6 +98,8 @@ pub struct RegistryBuilder {
     configure_registry: bool,
     /// API responders.
     custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
+    /// If nonzero, the git index update to be delayed by the given number of seconds.
+    delayed_index_update: usize,
 }
 
 pub struct TestRegistry {
@@ -157,6 +159,7 @@ impl RegistryBuilder {
             configure_registry: true,
             configure_token: true,
             custom_responders: HashMap::new(),
+            delayed_index_update: 0,
         }
     }
 
@@ -168,6 +171,13 @@ impl RegistryBuilder {
         responder: R,
     ) -> Self {
         self.custom_responders.insert(url, Box::new(responder));
+        self
+    }
+
+    /// Configures the git index update to be delayed by the given number of seconds.
+    #[must_use]
+    pub fn delayed_index_update(mut self, delay: usize) -> Self {
+        self.delayed_index_update = delay;
         self
     }
 
@@ -265,6 +275,7 @@ impl RegistryBuilder {
                 token.clone(),
                 self.auth_required,
                 self.custom_responders,
+                self.delayed_index_update,
             );
             let index_url = if self.http_index {
                 server.index_url()
@@ -591,6 +602,7 @@ pub struct HttpServer {
     token: Token,
     auth_required: bool,
     custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
+    delayed_index_update: usize,
 }
 
 /// A helper struct that collects the arguments for [HttpServer::check_authorized].
@@ -613,6 +625,7 @@ impl HttpServer {
             &'static str,
             Box<dyn Send + Fn(&Request, &HttpServer) -> Response>,
         >,
+        delayed_index_update: usize,
     ) -> HttpServerHandle {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
@@ -625,6 +638,7 @@ impl HttpServer {
             token,
             auth_required,
             custom_responders: api_responders,
+            delayed_index_update,
         };
         let handle = Some(thread::spawn(move || server.start()));
         HttpServerHandle { addr, handle }
@@ -1040,49 +1054,23 @@ impl HttpServer {
                 return self.unauthorized(req);
             }
 
-            // Write the `.crate`
             let dst = self
                 .dl_path
                 .join(&new_crate.name)
                 .join(&new_crate.vers)
                 .join("download");
-            t!(fs::create_dir_all(dst.parent().unwrap()));
-            t!(fs::write(&dst, file));
 
-            let deps = new_crate
-                .deps
-                .iter()
-                .map(|dep| {
-                    let (name, package) = match &dep.explicit_name_in_toml {
-                        Some(explicit) => (explicit.to_string(), Some(dep.name.to_string())),
-                        None => (dep.name.to_string(), None),
-                    };
-                    serde_json::json!({
-                        "name": name,
-                        "req": dep.version_req,
-                        "features": dep.features,
-                        "default_features": true,
-                        "target": dep.target,
-                        "optional": dep.optional,
-                        "kind": dep.kind,
-                        "registry": dep.registry,
-                        "package": package,
-                    })
-                })
-                .collect::<Vec<_>>();
-
-            let line = create_index_line(
-                serde_json::json!(new_crate.name),
-                &new_crate.vers,
-                deps,
-                &file_cksum,
-                new_crate.features,
-                false,
-                new_crate.links,
-                None,
-            );
-
-            write_to_index(&self.registry_path, &new_crate.name, line, false);
+            if self.delayed_index_update == 0 {
+                save_new_crate(dst, new_crate, file, file_cksum, &self.registry_path);
+            } else {
+                let delayed_index_update = self.delayed_index_update;
+                let registry_path = self.registry_path.clone();
+                let file = Vec::from(file);
+                thread::spawn(move || {
+                    thread::sleep(std::time::Duration::new(delayed_index_update as u64, 0));
+                    save_new_crate(dst, new_crate, &file, file_cksum, &registry_path);
+                });
+            }
 
             self.ok(&req)
         } else {
@@ -1093,6 +1081,53 @@ impl HttpServer {
             }
         }
     }
+}
+
+fn save_new_crate(
+    dst: PathBuf,
+    new_crate: crates_io::NewCrate,
+    file: &[u8],
+    file_cksum: String,
+    registry_path: &Path,
+) {
+    // Write the `.crate`
+    t!(fs::create_dir_all(dst.parent().unwrap()));
+    t!(fs::write(&dst, file));
+
+    let deps = new_crate
+        .deps
+        .iter()
+        .map(|dep| {
+            let (name, package) = match &dep.explicit_name_in_toml {
+                Some(explicit) => (explicit.to_string(), Some(dep.name.to_string())),
+                None => (dep.name.to_string(), None),
+            };
+            serde_json::json!({
+                "name": name,
+                "req": dep.version_req,
+                "features": dep.features,
+                "default_features": true,
+                "target": dep.target,
+                "optional": dep.optional,
+                "kind": dep.kind,
+                "registry": dep.registry,
+                "package": package,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    let line = create_index_line(
+        serde_json::json!(new_crate.name),
+        &new_crate.vers,
+        deps,
+        &file_cksum,
+        new_crate.features,
+        false,
+        new_crate.links,
+        None,
+    );
+
+    write_to_index(registry_path, &new_crate.name, line, false);
 }
 
 impl Package {

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -44,6 +44,9 @@ pub trait Source {
     /// Ensure that the source is fully up-to-date for the current session on the next query.
     fn invalidate_cache(&mut self);
 
+    /// If quiet, the source should not display any progress or status messages.
+    fn set_quiet(&mut self, quiet: bool);
+
     /// Fetches the full package for each name and version specified.
     fn download(&mut self, package: PackageId) -> CargoResult<MaybePackage>;
 
@@ -163,6 +166,10 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
         (**self).invalidate_cache()
     }
 
+    fn set_quiet(&mut self, quiet: bool) {
+        (**self).set_quiet(quiet)
+    }
+
     /// Forwards to `Source::download`.
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         (**self).download(id)
@@ -231,6 +238,10 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
 
     fn invalidate_cache(&mut self) {
         (**self).invalidate_cache()
+    }
+
+    fn set_quiet(&mut self, quiet: bool) {
+        (**self).set_quiet(quiet)
     }
 
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -453,9 +453,12 @@ fn wait_for_publish(
     let now = std::time::Instant::now();
     let sleep_time = std::time::Duration::from_secs(1);
     let max = timeout.as_secs() as usize;
-    config.shell().status("Published", pkg.to_string())?;
     // Short does not include the registry name.
     let short_pkg_description = format!("{} v{}", pkg.name(), pkg.version());
+    config.shell().status(
+        "Uploaded",
+        format!("{short_pkg_description} to {source_description}"),
+    )?;
     config.shell().note(format!(
         "Waiting up to {max} seconds for `{short_pkg_description}` to be available at {source_description}.\n\
         You may press ctrl-c to skip waiting; the crate should be available shortly."
@@ -505,8 +508,8 @@ fn wait_for_publish(
     };
     if is_available {
         config.shell().status(
-            "Completed",
-            format!("{pkg} has been successfully published to {source_description}"),
+            "Published",
+            format!("{short_pkg_description} at {source_description}"),
         )?;
     }
 

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -460,7 +460,7 @@ fn wait_for_publish(
         format!("{short_pkg_description} to {source_description}"),
     )?;
     config.shell().note(format!(
-        "Waiting up to {max} seconds for `{short_pkg_description}` to be available at {source_description}.\n\
+        "Waiting for `{short_pkg_description}` to be available at {source_description}.\n\
         You may press ctrl-c to skip waiting; the crate should be available shortly."
     ))?;
     let mut progress = Progress::with_style("Waiting", ProgressStyle::Ratio, config);

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -36,6 +36,7 @@ use crate::util::config::{Config, SslVersionConfig, SslVersionConfigRange};
 use crate::util::errors::CargoResult;
 use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::{truncate_with_ellipsis, IntoUrl};
+use crate::util::{Progress, ProgressStyle};
 use crate::{drop_print, drop_println, version};
 
 /// Registry settings loaded from config files.
@@ -442,13 +443,26 @@ fn wait_for_publish(
 ) -> CargoResult<()> {
     let version_req = format!("={}", pkg.version());
     let mut source = SourceConfigMap::empty(config)?.load(registry_src, &HashSet::new())?;
-    let source_description = source.describe();
+    // Disable the source's built-in progress bars. Repeatedly showing a bunch
+    // of independent progress bars can be a little confusing. There is an
+    // overall progress bar managed here.
+    source.set_quiet(true);
+    let source_description = source.source_id().to_string();
     let query = Dependency::parse(pkg.name(), Some(&version_req), registry_src)?;
 
     let now = std::time::Instant::now();
     let sleep_time = std::time::Duration::from_secs(1);
-    let mut logged = false;
-    loop {
+    let max = timeout.as_secs() as usize;
+    config.shell().status("Published", pkg.to_string())?;
+    // Short does not include the registry name.
+    let short_pkg_description = format!("{} v{}", pkg.name(), pkg.version());
+    config.shell().note(format!(
+        "Waiting up to {max} seconds for `{short_pkg_description}` to be available at {source_description}.\n\
+        You may press ctrl-c to skip waiting; the crate should be available shortly."
+    ))?;
+    let mut progress = Progress::with_style("Waiting", ProgressStyle::Ratio, config);
+    progress.tick_now(0, max, "")?;
+    let is_available = loop {
         {
             let _lock = config.acquire_package_cache_lock()?;
             // Force re-fetching the source
@@ -470,31 +484,30 @@ fn wait_for_publish(
                 }
             };
             if !summaries.is_empty() {
-                break;
+                break true;
             }
         }
 
-        if timeout < now.elapsed() {
+        let elapsed = now.elapsed();
+        if timeout < elapsed {
             config.shell().warn(format!(
-                "timed out waiting for `{}` to be in {}",
-                pkg.name(),
-                source_description
+                "timed out waiting for `{short_pkg_description}` to be available in {source_description}",
             ))?;
-            break;
+            config.shell().note(
+                "The registry may have a backlog that is delaying making the \
+                crate available. The crate should be available soon.",
+            )?;
+            break false;
         }
 
-        if !logged {
-            config.shell().status(
-                "Waiting",
-                format!(
-                    "on `{}` to propagate to {} (ctrl-c to wait asynchronously)",
-                    pkg.name(),
-                    source_description
-                ),
-            )?;
-            logged = true;
-        }
+        progress.tick_now(elapsed.as_secs() as usize, max, "")?;
         std::thread::sleep(sleep_time);
+    };
+    if is_available {
+        config.shell().status(
+            "Completed",
+            format!("{pkg} has been successfully published to {source_description}"),
+        )?;
     }
 
     Ok(())

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -217,6 +217,10 @@ impl<'cfg> Source for DirectorySource<'cfg> {
     }
 
     fn invalidate_cache(&mut self) {
-        // Path source has no local cache.
+        // Directory source has no local cache.
+    }
+
+    fn set_quiet(&mut self, _quiet: bool) {
+        // Directory source does not display status
     }
 }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -21,6 +21,7 @@ pub struct GitSource<'cfg> {
     path_source: Option<PathSource<'cfg>>,
     ident: String,
     config: &'cfg Config,
+    quiet: bool,
 }
 
 impl<'cfg> GitSource<'cfg> {
@@ -43,6 +44,7 @@ impl<'cfg> GitSource<'cfg> {
             path_source: None,
             ident,
             config,
+            quiet: false,
         };
 
         Ok(source)
@@ -162,10 +164,12 @@ impl<'cfg> Source for GitSource<'cfg> {
                         self.remote.url()
                     );
                 }
-                self.config.shell().status(
-                    "Updating",
-                    format!("git repository `{}`", self.remote.url()),
-                )?;
+                if !self.quiet {
+                    self.config.shell().status(
+                        "Updating",
+                        format!("git repository `{}`", self.remote.url()),
+                    )?;
+                }
 
                 trace!("updating git source `{:?}`", self.remote);
 
@@ -233,6 +237,10 @@ impl<'cfg> Source for GitSource<'cfg> {
     }
 
     fn invalidate_cache(&mut self) {}
+
+    fn set_quiet(&mut self, quiet: bool) {
+        self.quiet = quiet;
+    }
 }
 
 #[cfg(test)]

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -574,4 +574,8 @@ impl<'cfg> Source for PathSource<'cfg> {
     fn invalidate_cache(&mut self) {
         // Path source has no local cache.
     }
+
+    fn set_quiet(&mut self, _quiet: bool) {
+        // Path source does not display status
+    }
 }

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -18,6 +18,7 @@ pub struct LocalRegistry<'cfg> {
     src_path: Filesystem,
     config: &'cfg Config,
     updated: bool,
+    quiet: bool,
 }
 
 impl<'cfg> LocalRegistry<'cfg> {
@@ -28,6 +29,7 @@ impl<'cfg> LocalRegistry<'cfg> {
             root: Filesystem::new(root.to_path_buf()),
             config,
             updated: false,
+            quiet: false,
         }
     }
 }
@@ -104,6 +106,10 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
         // Local registry has no cache - just reads from disk.
     }
 
+    fn set_quiet(&mut self, _quiet: bool) {
+        self.quiet = true;
+    }
+
     fn is_updated(&self) -> bool {
         self.updated
     }
@@ -124,7 +130,9 @@ impl<'cfg> RegistryData for LocalRegistry<'cfg> {
             return Ok(MaybeLock::Ready(crate_file));
         }
 
-        self.config.shell().status("Unpacking", pkg)?;
+        if !self.quiet {
+            self.config.shell().status("Unpacking", pkg)?;
+        }
 
         // We don't actually need to download anything per-se, we just need to
         // verify the checksum matches the .crate file itself.

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -474,6 +474,9 @@ pub trait RegistryData {
     /// Invalidates locally cached data.
     fn invalidate_cache(&mut self);
 
+    /// If quiet, the source should not display any progress or status messages.
+    fn set_quiet(&mut self, quiet: bool);
+
     /// Is the local cached data up-to-date?
     fn is_updated(&self) -> bool;
 
@@ -830,6 +833,10 @@ impl<'cfg> Source for RegistrySource<'cfg> {
     fn invalidate_cache(&mut self) {
         self.index.clear_summaries_cache();
         self.ops.invalidate_cache();
+    }
+
+    fn set_quiet(&mut self, quiet: bool) {
+        self.ops.set_quiet(quiet);
     }
 
     fn download(&mut self, package: PackageId) -> CargoResult<MaybePackage> {

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -67,6 +67,10 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         self.inner.invalidate_cache()
     }
 
+    fn set_quiet(&mut self, quiet: bool) {
+        self.inner.set_quiet(quiet);
+    }
+
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         let id = id.with_source_id(self.replace_with);
         let pkg = self

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -1,3 +1,5 @@
+//! Support for CLI progress bars.
+
 use std::cmp;
 use std::time::{Duration, Instant};
 
@@ -7,13 +9,49 @@ use crate::util::{CargoResult, Config};
 use cargo_util::is_ci;
 use unicode_width::UnicodeWidthChar;
 
+/// CLI progress bar.
+///
+/// The `Progress` object can be in an enabled or disabled state. When
+/// disabled, calling any of the methods to update it will not display
+/// anything. Disabling is typically done by the user with options such as
+/// `--quiet` or the `term.progress` config option.
+///
+/// There are several methods to update the progress bar and to cause it to
+/// update its display.
+///
+/// The bar will be removed from the display when the `Progress` object is
+/// dropped or [`Progress::clear`] is called.
+///
+/// The progress bar has built-in rate limiting to avoid updating the display
+/// too fast. It should usually be fine to call [`Progress::tick`] as often as
+/// needed, though be cautious if the tick rate is very high or it is
+/// expensive to compute the progress value.
 pub struct Progress<'cfg> {
     state: Option<State<'cfg>>,
 }
 
+/// Indicates the style of information for displaying the amount of progress.
+///
+/// See also [`Progress::print_now`] for displaying progress without a bar.
 pub enum ProgressStyle {
+    /// Displays progress as a percentage.
+    ///
+    /// Example: `Fetch [=====================>   ]  88.15%`
+    ///
+    /// This is good for large values like number of bytes downloaded.
     Percentage,
+    /// Displays progress as a ratio.
+    ///
+    /// Example: `Building [===>                      ] 35/222`
+    ///
+    /// This is good for smaller values where the exact number is useful to see.
     Ratio,
+    /// Does not display an exact value of how far along it is.
+    ///
+    /// Example: `Fetch [===========>                     ]`
+    ///
+    /// This is good for situations where the exact value is an approximation,
+    /// and thus there isn't anything accurate to display to the user.
     Indeterminate,
 }
 
@@ -39,6 +77,16 @@ struct Format {
 }
 
 impl<'cfg> Progress<'cfg> {
+    /// Creates a new progress bar.
+    ///
+    /// The first parameter is the text displayed to the left of the bar, such
+    /// as "Fetching".
+    ///
+    /// The progress bar is not displayed until explicitly updated with one if
+    /// its methods.
+    ///
+    /// The progress bar may be created in a disabled state if the user has
+    /// disabled progress display (such as with the `--quiet` option).
     pub fn with_style(name: &str, style: ProgressStyle, cfg: &'cfg Config) -> Progress<'cfg> {
         // report no progress when -q (for quiet) or TERM=dumb are set
         // or if running on Continuous Integration service like Travis where the
@@ -84,18 +132,33 @@ impl<'cfg> Progress<'cfg> {
         }
     }
 
+    /// Disables the progress bar, ensuring it won't be displayed.
     pub fn disable(&mut self) {
         self.state = None;
     }
 
+    /// Returns whether or not the progress bar is allowed to be displayed.
     pub fn is_enabled(&self) -> bool {
         self.state.is_some()
     }
 
+    /// Creates a new `Progress` with the [`ProgressStyle::Percentage`] style.
+    ///
+    /// See [`Progress::with_style`] for more information.
     pub fn new(name: &str, cfg: &'cfg Config) -> Progress<'cfg> {
         Self::with_style(name, ProgressStyle::Percentage, cfg)
     }
 
+    /// Updates the state of the progress bar.
+    ///
+    /// * `cur` should be how far along the progress is.
+    /// * `max` is the maximum value for the progress bar.
+    /// * `msg` is a small piece of text to display at the end of the progress
+    ///   bar. It will be truncated with `...` if it does not fit on the
+    ///   terminal.
+    ///
+    /// This may not actually update the display if `tick` is being called too
+    /// quickly.
     pub fn tick(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
         let s = match &mut self.state {
             Some(s) => s,
@@ -121,6 +184,14 @@ impl<'cfg> Progress<'cfg> {
         s.tick(cur, max, msg)
     }
 
+    /// Updates the state of the progress bar.
+    ///
+    /// This is the same as [`Progress::tick`], but ignores rate throttling
+    /// and forces the display to be updated immediately.
+    ///
+    /// This may be useful for situations where you know you aren't calling
+    /// `tick` too fast, and accurate information is more important than
+    /// limiting the console update rate.
     pub fn tick_now(&mut self, cur: usize, max: usize, msg: &str) -> CargoResult<()> {
         match self.state {
             Some(ref mut s) => s.tick(cur, max, msg),
@@ -128,6 +199,10 @@ impl<'cfg> Progress<'cfg> {
         }
     }
 
+    /// Returns whether or not updates are currently being throttled.
+    ///
+    /// This can be useful if computing the values for calling the
+    /// [`Progress::tick`] function may require some expensive work.
     pub fn update_allowed(&mut self) -> bool {
         match &mut self.state {
             Some(s) => s.throttle.allowed(),
@@ -135,6 +210,14 @@ impl<'cfg> Progress<'cfg> {
         }
     }
 
+    /// Displays progress without a bar.
+    ///
+    /// The given `msg` is the text to display after the status message.
+    ///
+    /// Example: `Downloading 61 crates, remaining bytes: 28.0 MB`
+    ///
+    /// This does not have any rate limit throttling, so be careful about
+    /// calling it too often.
     pub fn print_now(&mut self, msg: &str) -> CargoResult<()> {
         match &mut self.state {
             Some(s) => s.print("", msg),
@@ -142,6 +225,7 @@ impl<'cfg> Progress<'cfg> {
         }
     }
 
+    /// Clears the progress bar from the console.
     pub fn clear(&mut self) {
         if let Some(ref mut s) = self.state {
             s.clear();

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -328,7 +328,10 @@ fn publish_with_registry_dependency() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 [..]
-[UPDATING] `alternative` index
+[UPLOADED] foo v0.0.1 to registry `alternative`
+note: Waiting for `foo v0.0.1` to be available at registry `alternative`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] foo v0.0.1 at registry `alternative`
 ",
         )
         .run();
@@ -457,7 +460,10 @@ fn publish_to_alt_registry() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 [..]
-[UPDATING] `alternative` index
+[UPLOADED] foo v0.0.1 to registry `alternative`
+note: Waiting for `foo v0.0.1` to be available at registry `alternative`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] foo v0.0.1 at registry `alternative`
 ",
         )
         .run();
@@ -535,7 +541,10 @@ fn publish_with_crates_io_dep() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 [..]
-[UPDATING] `alternative` index
+[UPLOADED] foo v0.0.1 to registry `alternative`
+note: Waiting for `foo v0.0.1` to be available at registry `alternative`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] foo v0.0.1 at registry `alternative`
 ",
         )
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1911,7 +1911,10 @@ fn publish_artifact_dep() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] [..]
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1911,10 +1911,10 @@ fn publish_artifact_dep() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -644,7 +644,10 @@ fn publish_allowed() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] a v0.0.1 [..]
-[UPDATING] [..]
+[UPLOADED] a v0.0.1 to registry `crates-io`
+note: Waiting for `a v0.0.1` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] a v0.0.1 at registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -130,10 +130,10 @@ Only one of these values may be set, remove one or the other to proceed.
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -225,10 +225,10 @@ fn publish() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -130,7 +130,10 @@ Only one of these values may be set, remove one or the other to proceed.
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] [..]
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -222,7 +225,10 @@ fn publish() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] [..]
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -112,10 +112,10 @@ fn publish_with_target() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.0 ([CWD])
-[PUBLISHED] foo v0.0.0 ([CWD])
+[UPLOADED] foo v0.0.0 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.0 [..]
+[PUBLISHED] foo v0.0.0 at registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -112,7 +112,10 @@ fn publish_with_target() {
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.0 ([CWD])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.0 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -894,7 +894,10 @@ fn publish_no_implicit() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] [..]
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -1013,7 +1016,10 @@ fn publish() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] [..]
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -894,10 +894,10 @@ fn publish_no_implicit() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -1016,10 +1016,10 @@ fn publish() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -172,7 +172,10 @@ fn inherit_own_workspace_fields() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v1.2.3 [..]
-[UPDATING] [..]
+[UPLOADED] foo v1.2.3 to registry `crates-io`
+note: Waiting for `foo v1.2.3` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] foo v1.2.3 at registry `crates-io`
 ",
         )
         .run();
@@ -318,7 +321,10 @@ fn inherit_own_dependencies() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] bar v0.2.0 [..]
-[UPDATING] [..]
+[UPLOADED] bar v0.2.0 to registry `crates-io`
+note: Waiting for `bar v0.2.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] bar v0.2.0 at registry `crates-io`
 ",
         )
         .run();
@@ -460,7 +466,10 @@ fn inherit_own_detailed_dependencies() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] bar v0.2.0 [..]
-[UPDATING] [..]
+[UPLOADED] bar v0.2.0 to registry `crates-io`
+note: Waiting for `bar v0.2.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] bar v0.2.0 at registry `crates-io`
 ",
         )
         .run();
@@ -696,7 +705,10 @@ fn inherit_workspace_fields() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] bar v1.2.3 [..]
-[UPDATING] [..]
+[UPLOADED] bar v1.2.3 to registry `crates-io`
+note: Waiting for `bar v1.2.3` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] bar v1.2.3 at registry `crates-io`
 ",
         )
         .run();
@@ -850,7 +862,10 @@ fn inherit_dependencies() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] bar v0.2.0 [..]
-[UPDATING] [..]
+[UPLOADED] bar v0.2.0 to registry `crates-io`
+note: Waiting for `bar v0.2.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[PUBLISHED] bar v0.2.0 at registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -114,7 +114,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `crates-io`
 ",
         )
         .run();
@@ -155,7 +158,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] `dummy-registry` index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `dummy-registry`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `dummy-registry`
 ",
         )
         .run();
@@ -195,7 +201,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] `dummy-registry` index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `dummy-registry`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `dummy-registry`
 ",
         )
         .run();
@@ -246,7 +255,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -288,7 +300,10 @@ fn simple_with_index() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -486,7 +501,10 @@ fn publish_clean() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -532,7 +550,10 @@ fn publish_in_sub_repo() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -578,7 +599,10 @@ fn publish_when_ignored() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -623,7 +647,10 @@ fn ignore_when_crate_ignored() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -809,7 +836,10 @@ fn publish_allowed_registry() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] `alternative` index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `alternative`.
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `alternative`
 ",
         )
         .run();
@@ -867,7 +897,10 @@ fn publish_implicitly_to_only_allowed_registry() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] `alternative` index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -993,7 +1026,10 @@ The registry `alternative` is not listed in the `package.publish` value in Cargo
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1041,7 +1077,10 @@ fn publish_with_select_features() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1089,7 +1128,10 @@ fn publish_with_all_features() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1191,7 +1233,10 @@ fn publish_with_patch() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1387,7 +1432,10 @@ fn publish_git_with_version() {
 [..]
 [..]
 [UPLOADING] foo v0.1.0 ([CWD])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.1.0 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -1506,7 +1554,10 @@ fn publish_dev_dep_no_version() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -1602,7 +1653,10 @@ fn credentials_ambiguous_filename() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 [..]
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.1 [..]
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -2009,7 +2063,10 @@ See [..]
 [PACKAGING] li v0.0.1 ([CWD]/li)
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] li v0.0.1 ([CWD]/li)
-[UPDATING] crates.io index
+[PUBLISHED] li v0.0.1 ([CWD]/li)
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] li v0.0.1 [..]
 ",
         )
         .run();
@@ -2108,7 +2165,10 @@ See [..]
 [PACKAGING] li v0.0.1 ([CWD]/li)
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] li v0.0.1 ([CWD]/li)
-[UPDATING] crates.io index
+[PUBLISHED] li v0.0.1 ([CWD]/li)
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] li v0.0.1 [..]
 ",
         )
         .run();
@@ -2200,7 +2260,10 @@ See [..]
 [PACKAGING] li v0.0.1 ([CWD]/li)
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] li v0.0.1 ([CWD]/li)
-[UPDATING] crates.io index
+[PUBLISHED] li v0.0.1 ([CWD]/li)
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] li v0.0.1 [..]
 ",
         )
         .run();
@@ -2387,7 +2450,10 @@ fn http_api_not_noop() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[UPDATING] [..]
+[PUBLISHED] foo v0.0.1 ([CWD])
+note: Waiting [..]
+You may press ctrl-c [..]
+[COMPLETED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -2461,8 +2527,10 @@ See [..]
 [PACKAGING] delay v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.1 ([CWD])
-[UPDATING] crates.io index
-[WAITING] on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
+[PUBLISHED] delay v0.0.1 ([CWD])
+note: Waiting up to 60 seconds for `delay v0.0.1` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] delay v0.0.1 ([CWD]) has been successfully published to registry `crates-io`
 ",
         )
         .run();
@@ -2541,8 +2609,10 @@ See [..]
 [PACKAGING] delay_with_underscore v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay_with_underscore v0.0.1 ([CWD])
-[UPDATING] crates.io index
-[WAITING] on `delay_with_underscore` to propagate to crates.io index (ctrl-c to wait asynchronously)
+[PUBLISHED] delay_with_underscore v0.0.1 ([CWD])
+note: Waiting up to 60 seconds for `delay_with_underscore v0.0.1` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] delay_with_underscore v0.0.1 ([CWD]) has been successfully published to registry `crates-io`
 ",
         )
         .run();
@@ -2631,8 +2701,10 @@ See [..]
 [PACKAGING] delay v0.0.2 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.2 ([CWD])
-[UPDATING] crates.io index
-[WAITING] on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
+[PUBLISHED] delay v0.0.2 ([CWD])
+note: Waiting up to 60 seconds for `delay v0.0.2` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] delay v0.0.2 ([CWD]) has been successfully published to registry `crates-io`
 ",
         )
         .run();
@@ -2657,7 +2729,7 @@ See [..]
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").with_status(0).run();
+    p.cargo("check").with_status(0).run();
 }
 
 #[cargo_test]
@@ -2737,9 +2809,7 @@ fn timeout_waiting_for_publish() {
         .replace_crates_io(registry.index_url())
         .masquerade_as_nightly_cargo(&["publish-timeout"])
         .with_status(0)
-        // There may be a variable number of "Updating crates.io index" at the
-        // end, which is timing-dependent.
-        .with_stderr_contains(
+        .with_stderr(
             "\
 [UPDATING] crates.io index
 [WARNING] manifest has no documentation, [..]
@@ -2747,11 +2817,13 @@ See [..]
 [PACKAGING] delay v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.1 ([CWD])
-[UPDATING] crates.io index
-[WAITING] on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
+[PUBLISHED] delay v0.0.1 ([CWD])
+note: Waiting up to 2 seconds for `delay v0.0.1` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+warning: timed out waiting for `delay v0.0.1` to be available in registry `crates-io`
+note: The registry may have a backlog that is delaying making the crate available. The crate should be available soon.
 ",
         )
-        .with_stderr_contains("warning: timed out waiting for `delay` to be in crates.io index")
         .run();
 }
 
@@ -2786,7 +2858,7 @@ fn wait_for_git_publish() {
     p.cargo("publish --no-verify")
         .replace_crates_io(registry.index_url())
         .with_status(0)
-        .with_stderr_contains(
+        .with_stderr(
             "\
 [UPDATING] crates.io index
 [WARNING] manifest has no documentation, [..]
@@ -2794,17 +2866,10 @@ See [..]
 [PACKAGING] delay v0.0.2 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.2 ([CWD])
-[UPDATING] crates.io index
-[WAITING] on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
-",
-        )
-        // The exact number of updates is timing dependent. This just checks
-        // that at least a few show up.
-        .with_stderr_contains(
-            "\
-[UPDATING] crates.io index
-[UPDATING] crates.io index
-[UPDATING] crates.io index
+[PUBLISHED] delay v0.0.2 ([CWD])
+note: Waiting up to 60 seconds for `delay v0.0.2` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] delay v0.0.2 ([CWD]) has been successfully published to registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -114,10 +114,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `crates-io`
+[PUBLISHED] foo v0.0.1 at registry `crates-io`
 ",
         )
         .run();
@@ -158,10 +158,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `dummy-registry`
 note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `dummy-registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `dummy-registry`
+[PUBLISHED] foo v0.0.1 at registry `dummy-registry`
 ",
         )
         .run();
@@ -201,10 +201,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `dummy-registry`
 note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `dummy-registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `dummy-registry`
+[PUBLISHED] foo v0.0.1 at registry `dummy-registry`
 ",
         )
         .run();
@@ -255,10 +255,10 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -300,10 +300,10 @@ fn simple_with_index() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `[ROOT]/registry`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -501,10 +501,10 @@ fn publish_clean() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -550,10 +550,10 @@ fn publish_in_sub_repo() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -599,10 +599,10 @@ fn publish_when_ignored() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -647,10 +647,10 @@ fn ignore_when_crate_ignored() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -836,10 +836,10 @@ fn publish_allowed_registry() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `alternative`
 note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `alternative`.
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 ([CWD]) has been successfully published to registry `alternative`
+[PUBLISHED] foo v0.0.1 at registry `alternative`
 ",
         )
         .run();
@@ -897,10 +897,10 @@ fn publish_implicitly_to_only_allowed_registry() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `alternative`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1026,10 +1026,10 @@ The registry `alternative` is not listed in the `package.publish` value in Cargo
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1077,10 +1077,10 @@ fn publish_with_select_features() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1128,10 +1128,10 @@ fn publish_with_all_features() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1233,10 +1233,10 @@ fn publish_with_patch() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -1432,10 +1432,10 @@ fn publish_git_with_version() {
 [..]
 [..]
 [UPLOADING] foo v0.1.0 ([CWD])
-[PUBLISHED] foo v0.1.0 ([CWD])
+[UPLOADED] foo v0.1.0 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -1554,10 +1554,10 @@ fn publish_dev_dep_no_version() {
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.1.0 [..]
+[PUBLISHED] foo v0.1.0 [..]
 ",
         )
         .run();
@@ -1653,10 +1653,10 @@ fn credentials_ambiguous_filename() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 [..]
-[PUBLISHED] foo v0.0.1 [..]
+[UPLOADED] foo v0.0.1 [..]
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -2063,10 +2063,10 @@ See [..]
 [PACKAGING] li v0.0.1 ([CWD]/li)
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] li v0.0.1 ([CWD]/li)
-[PUBLISHED] li v0.0.1 ([CWD]/li)
+[UPLOADED] li v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] li v0.0.1 [..]
+[PUBLISHED] li v0.0.1 [..]
 ",
         )
         .run();
@@ -2165,10 +2165,10 @@ See [..]
 [PACKAGING] li v0.0.1 ([CWD]/li)
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] li v0.0.1 ([CWD]/li)
-[PUBLISHED] li v0.0.1 ([CWD]/li)
+[UPLOADED] li v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] li v0.0.1 [..]
+[PUBLISHED] li v0.0.1 [..]
 ",
         )
         .run();
@@ -2260,10 +2260,10 @@ See [..]
 [PACKAGING] li v0.0.1 ([CWD]/li)
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] li v0.0.1 ([CWD]/li)
-[PUBLISHED] li v0.0.1 ([CWD]/li)
+[UPLOADED] li v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] li v0.0.1 [..]
+[PUBLISHED] li v0.0.1 [..]
 ",
         )
         .run();
@@ -2450,10 +2450,10 @@ fn http_api_not_noop() {
 [..]
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
-[PUBLISHED] foo v0.0.1 ([CWD])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting [..]
 You may press ctrl-c [..]
-[COMPLETED] foo v0.0.1 [..]
+[PUBLISHED] foo v0.0.1 [..]
 ",
         )
         .run();
@@ -2527,10 +2527,10 @@ See [..]
 [PACKAGING] delay v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.1 ([CWD])
-[PUBLISHED] delay v0.0.1 ([CWD])
+[UPLOADED] delay v0.0.1 to registry `crates-io`
 note: Waiting up to 60 seconds for `delay v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] delay v0.0.1 ([CWD]) has been successfully published to registry `crates-io`
+[PUBLISHED] delay v0.0.1 at registry `crates-io`
 ",
         )
         .run();
@@ -2609,10 +2609,10 @@ See [..]
 [PACKAGING] delay_with_underscore v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay_with_underscore v0.0.1 ([CWD])
-[PUBLISHED] delay_with_underscore v0.0.1 ([CWD])
+[UPLOADED] delay_with_underscore v0.0.1 to registry `crates-io`
 note: Waiting up to 60 seconds for `delay_with_underscore v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] delay_with_underscore v0.0.1 ([CWD]) has been successfully published to registry `crates-io`
+[PUBLISHED] delay_with_underscore v0.0.1 at registry `crates-io`
 ",
         )
         .run();
@@ -2701,10 +2701,10 @@ See [..]
 [PACKAGING] delay v0.0.2 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.2 ([CWD])
-[PUBLISHED] delay v0.0.2 ([CWD])
+[UPLOADED] delay v0.0.2 to registry `crates-io`
 note: Waiting up to 60 seconds for `delay v0.0.2` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] delay v0.0.2 ([CWD]) has been successfully published to registry `crates-io`
+[PUBLISHED] delay v0.0.2 at registry `crates-io`
 ",
         )
         .run();
@@ -2817,7 +2817,7 @@ See [..]
 [PACKAGING] delay v0.0.1 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.1 ([CWD])
-[PUBLISHED] delay v0.0.1 ([CWD])
+[UPLOADED] delay v0.0.1 to registry `crates-io`
 note: Waiting up to 2 seconds for `delay v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 warning: timed out waiting for `delay v0.0.1` to be available in registry `crates-io`
@@ -2866,10 +2866,10 @@ See [..]
 [PACKAGING] delay v0.0.2 ([CWD])
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.2 ([CWD])
-[PUBLISHED] delay v0.0.2 ([CWD])
+[UPLOADED] delay v0.0.2 to registry `crates-io`
 note: Waiting up to 60 seconds for `delay v0.0.2` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] delay v0.0.2 ([CWD]) has been successfully published to registry `crates-io`
+[PUBLISHED] delay v0.0.2 at registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -115,7 +115,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `crates-io`.
+note: Waiting for `foo v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 ",
@@ -159,7 +159,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
 [UPLOADED] foo v0.0.1 to registry `dummy-registry`
-note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `dummy-registry`.
+note: Waiting for `foo v0.0.1` to be available at registry `dummy-registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `dummy-registry`
 ",
@@ -202,7 +202,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
 [UPLOADED] foo v0.0.1 to registry `dummy-registry`
-note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `dummy-registry`.
+note: Waiting for `foo v0.0.1` to be available at registry `dummy-registry`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `dummy-registry`
 ",
@@ -837,7 +837,7 @@ fn publish_allowed_registry() {
 [..]
 [UPLOADING] foo v0.0.1 ([CWD])
 [UPLOADED] foo v0.0.1 to registry `alternative`
-note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `alternative`.
+note: Waiting for `foo v0.0.1` to be available at registry `alternative`.
 You may press ctrl-c [..]
 [PUBLISHED] foo v0.0.1 at registry `alternative`
 ",
@@ -2528,7 +2528,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.1 ([CWD])
 [UPLOADED] delay v0.0.1 to registry `crates-io`
-note: Waiting up to 60 seconds for `delay v0.0.1` to be available at registry `crates-io`.
+note: Waiting for `delay v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay v0.0.1 at registry `crates-io`
 ",
@@ -2610,7 +2610,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay_with_underscore v0.0.1 ([CWD])
 [UPLOADED] delay_with_underscore v0.0.1 to registry `crates-io`
-note: Waiting up to 60 seconds for `delay_with_underscore v0.0.1` to be available at registry `crates-io`.
+note: Waiting for `delay_with_underscore v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay_with_underscore v0.0.1 at registry `crates-io`
 ",
@@ -2702,7 +2702,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.2 ([CWD])
 [UPLOADED] delay v0.0.2 to registry `crates-io`
-note: Waiting up to 60 seconds for `delay v0.0.2` to be available at registry `crates-io`.
+note: Waiting for `delay v0.0.2` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay v0.0.2 at registry `crates-io`
 ",
@@ -2818,7 +2818,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.1 ([CWD])
 [UPLOADED] delay v0.0.1 to registry `crates-io`
-note: Waiting up to 2 seconds for `delay v0.0.1` to be available at registry `crates-io`.
+note: Waiting for `delay v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 warning: timed out waiting for `delay v0.0.1` to be available in registry `crates-io`
 note: The registry may have a backlog that is delaying making the crate available. The crate should be available soon.
@@ -2867,7 +2867,7 @@ See [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] delay v0.0.2 ([CWD])
 [UPLOADED] delay v0.0.2 to registry `crates-io`
-note: Waiting up to 60 seconds for `delay v0.0.2` to be available at registry `crates-io`.
+note: Waiting for `delay v0.0.2` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] delay v0.0.2 at registry `crates-io`
 ",

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -220,10 +220,10 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] dev [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 ([..])
-[PUBLISHED] foo v0.0.1 ([..])
+[UPLOADED] foo v0.0.1 to registry `crates-io`
 note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] foo v0.0.1 ([..]) has been successfully published to registry `crates-io`
+[PUBLISHED] foo v0.0.1 at registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -220,7 +220,10 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [FINISHED] dev [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 ([..])
-[UPDATING] crates.io index
+[PUBLISHED] foo v0.0.1 ([..])
+note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] foo v0.0.1 ([..]) has been successfully published to registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -221,7 +221,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 ([..])
 [UPLOADED] foo v0.0.1 to registry `crates-io`
-note: Waiting up to 60 seconds for `foo v0.0.1` to be available at registry `crates-io`.
+note: Waiting for `foo v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
 ",

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -561,7 +561,10 @@ fn publish() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[UPDATING] [..]
+[PUBLISHED] foo v0.1.0 [..]
+note: Waiting up to 60 seconds for `foo v0.1.0` to be available at registry `crates-io`.
+You may press ctrl-c to skip waiting; the crate should be available shortly.
+[COMPLETED] foo v0.1.0 ([ROOT]/foo) has been successfully published to registry `crates-io`
 ",
         )
         .run();

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -562,7 +562,7 @@ fn publish() {
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
 [UPLOADED] foo v0.1.0 to registry `crates-io`
-note: Waiting up to 60 seconds for `foo v0.1.0` to be available at registry `crates-io`.
+note: Waiting for `foo v0.1.0` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
 ",

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -561,10 +561,10 @@ fn publish() {
 [FINISHED] [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.1.0 [..]
-[PUBLISHED] foo v0.1.0 [..]
+[UPLOADED] foo v0.1.0 to registry `crates-io`
 note: Waiting up to 60 seconds for `foo v0.1.0` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
-[COMPLETED] foo v0.1.0 ([ROOT]/foo) has been successfully published to registry `crates-io`
+[PUBLISHED] foo v0.1.0 at registry `crates-io`
 ",
         )
         .run();


### PR DESCRIPTION
This reworks the console output when waiting for a publish to be available:

* Shows a "Published" status to try to make it clear that the publish is complete, and that Cargo is moving to a separate phase.
* Removes the repeated status bars and updating messages, and uses a single progress bar to track the publish.
* Provides more of a description of why Cargo is waiting to try to make it clearer what is happening.
* Provides more information when a timeout happens to try to explain what might be happening.
* Shows a "Completed" message at the end to let the user know that everything is complete.

Comparing the output:

Before (with git):

```
    Updating crates.io index
   Packaging delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
    Packaged 3 files, 761.0B (569.0B compressed)
   Uploading delay v0.4.27 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
    Updating crates.io index
     Waiting on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
    Updating crates.io index
```

Before (with sparse):

```
    Updating crates.io index
   Packaging delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
    Packaged 3 files, 761.0B (569.0B compressed)
   Uploading delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
    Updating crates.io index
     Waiting on `delay` to propagate to crates.io index (ctrl-c to wait asynchronously)
       Fetch [=============================>   ] 36 complete; 1 pending
```

New (git or sparse):

```
    Updating crates.io index
   Packaging delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
    Packaged 3 files, 761.0B (569.0B compressed)
   Uploading delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
    Uploaded delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo)
note: Waiting for `delay@0.0.2` to be available at registry `crates-io`.
You may press ctrl-c to skip waiting; the crate should be available shortly.
     Waiting [===>                       ] 11/60
   Published delay v0.0.2 (/Users/eric/Proj/rust/cargo/target/tmp/cit/t0/foo) has been successfully published to registry `crates-io`
```

(Note: In the last two cases the progress bar disappears when it is done, I have just included it here to illustrate.)

Fixes #11304