### PR TITLE
chore: Make dependencies alphabetical order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,16 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
+anyhow = "1.0.47"
 base64 = "0.13.1"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.3" }
+clap = "4.1.3"
 crates-io = { path = "crates/crates-io", version = "0.35.1" }
 curl = { version = "0.4.44", features = ["http2"] }
 curl-sys = "0.4.59"
 env_logger = "0.10.0"
-pretty_env_logger = { version = "0.4", optional = true }
-anyhow = "1.0.47"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 git2 = "0.16.0"
@@ -36,29 +36,33 @@ hmac = "0.12.1"
 home = "0.5"
 http-auth = { version = "0.1.6", default-features = false }
 humantime = "2.0.0"
-indexmap = "1"
 ignore = "0.4.7"
+im-rc = "15.0.0"
+indexmap = "1"
 is-terminal = "0.4.0"
-lazy_static = "1.2.0"
+itertools = "0.10.0"
 jobserver = "0.1.24"
+lazy_static = "1.2.0"
 lazycell = "1.2.0"
 libc = "0.2"
-log = "0.4.6"
 # Temporarily pin libgit2-sys due to some issues with SSH not working on
 # Windows.
 libgit2-sys = "=0.14.1"
+log = "0.4.6"
 memchr = "2.1.3"
 opener = "0.5"
+openssl = { version = '0.10.11', optional = true }
 os_info = "3.5.0"
 pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"
 percent-encoding = "2.0"
+pretty_env_logger = { version = "0.4", optional = true }
 rustfix = "0.6.0"
 semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
+serde-value = "0.7.0"
 serde_ignored = "0.1.0"
 serde_json = { version = "1.0.30", features = ["raw_value"] }
-serde-value = "0.7.0"
 sha1 = "0.10.5"
 shell-escape = "0.1.4"
 strip-ansi-escapes = "0.1.0"
@@ -66,16 +70,12 @@ tar = { version = "0.4.38", default-features = false }
 tempfile = "3.0"
 termcolor = "1.1"
 time = { version = "0.3", features = ["parsing", "formatting"]}
-toml_edit = "0.19.0"
 toml = "0.7.0"
+toml_edit = "0.19.0"
+unicode-width = "0.1.5"
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
-clap = "4.1.3"
-unicode-width = "0.1.5"
-openssl = { version = '0.10.11', optional = true }
-im-rc = "15.0.0"
-itertools = "0.10.0"
 
 # A noop dependency that changes in the Rust repository, it's a bit of a hack.
 # See the `src/tools/rustc-workspace-hack/README.md` file in `rust-lang/rust`

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -12,19 +12,19 @@ anyhow = "1.0.34"
 cargo-test-macro = { path = "../cargo-test-macro" }
 cargo-util = { path = "../cargo-util" }
 crates-io = { path = "../crates-io" }
-snapbox = { version = "0.4.0", features = ["diff", "path"] }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
-pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
-time = { version = "0.3", features = ["parsing", "formatting"]}
 git2 = "0.16.0"
 glob = "0.3"
 itertools = "0.10.0"
 lazy_static = "1.0"
+pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
 serde_json = "1.0"
+snapbox = { version = "0.4.0", features = ["diff", "path"] }
 tar = { version = "0.4.38", default-features = false }
 termcolor = "1.1.2"
+time = { version = "0.3", features = ["parsing", "formatting"]}
 toml = "0.7.0"
 url = "2.2.2"
 

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -13,8 +13,8 @@ name = "crates_io"
 path = "lib.rs"
 
 [dependencies]
-curl = "0.4"
 anyhow = "1.0.34"
+curl = "0.4"
 percent-encoding = "2.0"
 serde = { version = "1.0", features = ['derive'] }
 serde_json = "1.0"

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 cargo = { path = "../.." }
 cargo-util = { path = "../cargo-util" }
-proptest = "0.9.1"
-lazy_static = "1.3.0"
-varisat = "0.2.1"
 is-terminal = "0.4.0"
+lazy_static = "1.3.0"
+proptest = "0.9.1"
+varisat = "0.2.1"


### PR DESCRIPTION
`[dependencies]` in some `Cargo.toml` were out of alphabetical order. This made it slightly more time-consuming to find if a dependency was in a `Cargo.toml`. 

This PR makes it so that they are in alphabetical order.

Note: `rustc-workspace-hack` was left alone at the bottom as it is a special dependency.