### PR TITLE
Add clippy lints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,16 @@ jobs:
           cargo fmt --all --manifest-path $manifest --check
         done
 
+  # Ensure there are no clippy warnings
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update stable && rustup default stable
+      - run: rustup component add clippy
+      # Only check cargo lib for now
+      - run: cargo clippy -p cargo --lib -- -D warnings
+
   test:
     runs-on: ${{ matrix.os }}
     env:

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -4,6 +4,7 @@
 // Due to some of the default clippy lints being somewhat subjective and not
 // necessarily an improvement, we prefer to not use them at this time.
 #![allow(clippy::all)]
+#![warn(clippy::self_named_module_files)]
 #![allow(rustdoc::private_intra_doc_links)]
 
 //! # Cargo as a library


### PR DESCRIPTION
It was discussed in a recent cargo team meeting that it would be okay to allow specific `clippy` lints to be `warn`/`deny` within cargo.

This PR adds a CI job that denies `clippy` warnings for cargo's `lib`. As well as sets [`clippy::self_named_module_files`](https://rust-lang.github.io/rust-clippy/master/index.html#self_named_module_files) to be a warning. 

[`clippy::self_named_module_files`](https://rust-lang.github.io/rust-clippy/master/index.html#self_named_module_files): "Checks that module layout uses only `mod.rs` files". This allows cargo's structure to be consistent and enforced across the board.