### PR TITLE
Switch some tests from `build` to `check`

### DIFF
--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -28,14 +28,14 @@ fn depend_on_alt_registry() {
 
     Package::new("bar", "0.0.1").alternative(true).publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `alternative` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -44,11 +44,11 @@ fn depend_on_alt_registry() {
     p.cargo("clean").run();
 
     // Don't download a second time
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -81,16 +81,16 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .alternative(true)
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `alternative` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
-[COMPILING] baz v0.0.1 (registry `alternative`)
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.0.1 (registry `alternative`)
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -123,16 +123,16 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .alternative(true)
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `alternative` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
-[COMPILING] baz v0.0.1 (registry `alternative`)
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.0.1 (registry `alternative`)
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -165,7 +165,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
         .alternative(true)
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_unordered(
             "\
 [UPDATING] `alternative` index
@@ -173,9 +173,9 @@ fn depend_on_alt_registry_depends_on_crates_io() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
-[COMPILING] baz v0.0.1
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.0.1
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -205,11 +205,11 @@ fn registry_and_path_dep_works() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -237,7 +237,7 @@ fn registry_incompatible_with_git() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(
             "  dependency (bar) specification is ambiguous. \
@@ -377,7 +377,7 @@ fn alt_registry_and_crates_io_deps() {
         .alternative(true)
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_unordered(
             "\
 [UPDATING] `alternative` index
@@ -385,9 +385,9 @@ fn alt_registry_and_crates_io_deps() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] crates_io_dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] alt_reg_dep v0.1.0 (registry `alternative`)
-[COMPILING] alt_reg_dep v0.1.0 (registry `alternative`)
-[COMPILING] crates_io_dep v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] alt_reg_dep v0.1.0 (registry `alternative`)
+[CHECKING] crates_io_dep v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -580,12 +580,12 @@ fn patch_alt_reg() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -662,14 +662,14 @@ fn no_api() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `alternative` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1 (registry `alternative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1050,7 +1050,7 @@ fn unknown_registry() {
     config.insert(start + start_index, '#');
     fs::write(&cfg_path, config).unwrap();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Important parts:
     // foo -> bar registry = null
@@ -1212,14 +1212,14 @@ fn registries_index_relative_url() {
 
     Package::new("bar", "0.0.1").alternative(true).publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `relative` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `relative`)
-[COMPILING] bar v0.0.1 (registry `relative`)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1 (registry `relative`)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1259,7 +1259,7 @@ fn registries_index_relative_path_not_allowed() {
 
     Package::new("bar", "0.0.1").alternative(true).publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(&format!(
             "\
 error: failed to parse manifest at `{root}/foo/Cargo.toml`

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -15,7 +15,7 @@ fn bad1() {
             "#,
         )
         .build();
-    p.cargo("build -v --target=nonexistent-target")
+    p.cargo("check -v --target=nonexistent-target")
         .with_status(101)
         .with_stderr(
             "\
@@ -161,7 +161,7 @@ fn invalid_global_config() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -191,7 +191,7 @@ fn bad_cargo_lock() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -246,7 +246,7 @@ fn duplicate_packages_in_cargo_lock() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -295,7 +295,7 @@ fn bad_source_in_cargo_lock() {
         )
         .build();
 
-    p.cargo("build --verbose")
+    p.cargo("check --verbose")
         .with_status(101)
         .with_stderr(
             "\
@@ -326,7 +326,7 @@ fn bad_dependency_in_lockfile() {
         )
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -347,7 +347,7 @@ fn bad_git_dependency() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -416,7 +416,7 @@ fn malformed_override() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -461,7 +461,7 @@ fn duplicate_binary_names() {
         .file("b.rs", r#"fn main() -> () {}"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -498,7 +498,7 @@ fn duplicate_example_names() {
         .file("examples/ex2.rs", r#"fn main () -> () {}"#)
         .build();
 
-    p.cargo("build --example ex")
+    p.cargo("check --example ex")
         .with_status(101)
         .with_stderr(
             "\
@@ -573,7 +573,7 @@ fn duplicate_deps() {
         .file("src/main.rs", r#"fn main () {}"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -612,7 +612,7 @@ fn duplicate_deps_diff_sources() {
         .file("src/main.rs", r#"fn main () {}"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -644,11 +644,11 @@ fn unused_keys() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 warning: unused manifest key: target.foo.bar
-[COMPILING] foo v0.1.0 ([CWD])
+[CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -668,11 +668,11 @@ warning: unused manifest key: target.foo.bar
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 warning: unused manifest key: package.bulid
-[COMPILING] foo [..]
+[CHECKING] foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -695,11 +695,11 @@ warning: unused manifest key: package.bulid
         )
         .file("src/lib.rs", "pub fn foo() {}")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 warning: unused manifest key: lib.build
-[COMPILING] foo [..]
+[CHECKING] foo [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -720,11 +720,11 @@ fn unused_keys_in_virtual_manifest() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
         .file("bar/src/lib.rs", "")
         .build();
-    p.cargo("build --workspace")
+    p.cargo("check --workspace")
         .with_stderr(
             "\
 [WARNING] [..]/foo/Cargo.toml: unused manifest key: workspace.bulid
-[COMPILING] bar [..]
+[CHECKING] bar [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -751,7 +751,7 @@ fn empty_dependencies() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains(
             "\
 warning: dependency (bar) specified without providing a local path, Git repository, or version \
@@ -768,7 +768,7 @@ fn invalid_toml_historically_allowed_fails() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -812,7 +812,7 @@ fn ambiguous_git_reference() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -843,7 +843,7 @@ fn fragment_in_git_url() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -862,7 +862,7 @@ fn bad_source_config1() {
         .file(".cargo/config", "[source.foo]")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr("error: no source location specified for `source.foo`, need [..]")
         .run();
@@ -894,7 +894,7 @@ fn bad_source_config2() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -940,7 +940,7 @@ fn bad_source_config3() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -988,7 +988,7 @@ fn bad_source_config4() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1037,7 +1037,7 @@ fn bad_source_config5() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1069,7 +1069,7 @@ fn both_git_and_path_specified() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("build -v")
+    foo.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -1108,7 +1108,7 @@ fn bad_source_config6() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1146,7 +1146,7 @@ error: failed to parse manifest at `[..]`
 Caused by:
   key `branch` is ignored for dependency (bar).
 ";
-    foo.cargo("build -v")
+    foo.cargo("check -v")
         .with_status(101)
         .with_stderr(err_msg)
         .run();
@@ -1163,7 +1163,7 @@ Caused by:
             bar = { path = "bar", branch = "spam" }
         "#,
     );
-    foo.cargo("build")
+    foo.cargo("check")
         .with_status(101)
         .with_stderr(err_msg)
         .run();
@@ -1197,7 +1197,7 @@ fn bad_source_config7() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr("error: more than one source location specified for `source.foo`")
         .run();
@@ -1228,7 +1228,7 @@ fn bad_source_config8() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "[ERROR] source definition `source.foo` specifies `branch`, \
@@ -1255,7 +1255,7 @@ fn bad_dependency() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1287,7 +1287,7 @@ fn bad_debuginfo() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1317,7 +1317,7 @@ fn bad_opt_level() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -63,7 +63,7 @@ fn bench_dir_to_nonexistent_cargo_toml() {
 
 #[cargo_test]
 fn build_dir_containing_cargo_toml() {
-    assert_not_a_cargo_toml("build", "foo");
+    assert_not_a_cargo_toml("check", "foo");
 }
 
 #[cargo_test]
@@ -78,7 +78,7 @@ fn build_dir_plus_path() {
 
 #[cargo_test]
 fn build_dir_to_nonexistent_cargo_toml() {
-    assert_cargo_toml_doesnt_exist("build", "foo/bar/baz/Cargo.toml");
+    assert_cargo_toml_doesnt_exist("check", "foo/bar/baz/Cargo.toml");
 }
 
 #[cargo_test]

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -18,7 +18,7 @@ fn rerun_if_env_changes() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
@@ -26,7 +26,7 @@ fn rerun_if_env_changes() {
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .env("FOO", "bar")
         .with_stderr(
             "\
@@ -35,7 +35,7 @@ fn rerun_if_env_changes() {
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .env("FOO", "baz")
         .with_stderr(
             "\
@@ -44,11 +44,11 @@ fn rerun_if_env_changes() {
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .env("FOO", "baz")
         .with_stderr("[FINISHED] [..]")
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
@@ -74,7 +74,7 @@ fn rerun_if_env_or_file_changes() {
         .file("foo", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
@@ -82,7 +82,7 @@ fn rerun_if_env_or_file_changes() {
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .env("FOO", "bar")
         .with_stderr(
             "\
@@ -91,13 +91,13 @@ fn rerun_if_env_or_file_changes() {
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .env("FOO", "bar")
         .with_stderr("[FINISHED] [..]")
         .run();
     sleep_ms(1000);
     p.change_file("foo", "");
-    p.cargo("build")
+    p.cargo("check")
         .env("FOO", "bar")
         .with_stderr(
             "\
@@ -121,7 +121,7 @@ fn rustc_bootstrap() {
         .file("build.rs", build_rs)
         .build();
     // RUSTC_BOOTSTRAP unset on stable should error
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .with_stderr_contains(
             "help: [..] set the environment variable `RUSTC_BOOTSTRAP=has_dashes` [..]",
@@ -129,7 +129,7 @@ fn rustc_bootstrap() {
         .with_status(101)
         .run();
     // nightly should warn whether or not RUSTC_BOOTSTRAP is set
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["RUSTC_BOOTSTRAP"])
         // NOTE: uses RUSTC_BOOTSTRAP so it will be propagated to rustc
         // (this matters when tests are being run with a beta or stable cargo)
@@ -137,12 +137,12 @@ fn rustc_bootstrap() {
         .with_stderr_contains("warning: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .run();
     // RUSTC_BOOTSTRAP set to the name of the library should warn
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC_BOOTSTRAP", "has_dashes")
         .with_stderr_contains("warning: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .run();
     // RUSTC_BOOTSTRAP set to some random value should error
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC_BOOTSTRAP", "bar")
         .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .with_stderr_contains(
@@ -158,7 +158,7 @@ fn rustc_bootstrap() {
         .file("build.rs", build_rs)
         .build();
     // nightly should warn when there's no library whether or not RUSTC_BOOTSTRAP is set
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["RUSTC_BOOTSTRAP"])
         // NOTE: uses RUSTC_BOOTSTRAP so it will be propagated to rustc
         // (this matters when tests are being run with a beta or stable cargo)
@@ -166,7 +166,7 @@ fn rustc_bootstrap() {
         .with_stderr_contains("warning: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .run();
     // RUSTC_BOOTSTRAP conditionally set when there's no library should error (regardless of the value)
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC_BOOTSTRAP", "foo")
         .with_stderr_contains("error: Cannot set `RUSTC_BOOTSTRAP=1` [..]")
         .with_stderr_contains("help: [..] set the environment variable `RUSTC_BOOTSTRAP=1` [..]")
@@ -202,7 +202,7 @@ fn build_script_sees_cfg_target_feature() {
             .file("build.rs", build_rs)
             .build();
 
-        p.cargo("build -vv")
+        p.cargo("check -vv")
             .with_stderr_contains("[foo 0.0.1] CARGO_CFG_TARGET_FEATURE=[..]sse4.2[..]")
             .with_stderr_contains("[..]-Ctarget-feature=[..]+sse4.2[..]")
             .run();
@@ -233,7 +233,7 @@ fn cfg_paradox() {
         .file("build.rs", build_rs)
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .with_stderr_contains("[WARNING] non-trivial mutual dependency between target-specific configuration and RUSTFLAGS")
         .with_stderr_contains("[foo 0.0.1] cfg!(bertrand)=true")
         .with_stderr_contains("[..]--cfg=bertrand[..]")

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -297,7 +297,7 @@ fn doesnt_create_extra_files() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     assert_eq!(
         p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
@@ -311,7 +311,7 @@ fn doesnt_create_extra_files() {
         sleep_ms(1000);
     }
     p.change_file("src/lib.rs", "fn unused() {}");
-    p.cargo("build").run();
+    p.cargo("check").run();
     assert_eq!(
         p.glob("target/debug/.fingerprint/foo-*/output-*").count(),
         1
@@ -475,14 +475,14 @@ fn wacky_hashless_fingerprint() {
         .file("src/bin/a.rs", "fn main() { let unused = 1; }")
         .file("src/bin/b.rs", "fn main() {}")
         .build();
-    p.cargo("build --bin b")
+    p.cargo("check --bin b")
         .with_stderr_does_not_contain("[..]unused[..]")
         .run();
-    p.cargo("build --bin a")
+    p.cargo("check --bin a")
         .with_stderr_contains("[..]unused[..]")
         .run();
     // This should not pick up the cache from `a`.
-    p.cargo("build --bin b")
+    p.cargo("check --bin b")
         .with_stderr_does_not_contain("[..]unused[..]")
         .run();
 }

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -51,7 +51,7 @@ fn env_invalid() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]could not load config key `env.ENV_TEST_BOOL`")
         .run();
@@ -77,7 +77,7 @@ fn env_no_cargo_home() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]setting the `CARGO_HOME` environment variable is not supported in the `[env]` configuration table")
         .run();

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -18,7 +18,7 @@ fn feature_required() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
@@ -42,7 +42,7 @@ Caused by:
         .run();
 
     // Same, but stable.
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -97,7 +97,7 @@ fn feature_required_dependency() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
@@ -126,7 +126,7 @@ Caused by:
         .run();
 
     // Same, but stable.
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -173,7 +173,7 @@ fn unknown_feature() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -202,13 +202,13 @@ fn stable_feature_warns() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 warning: the cargo feature `test-dummy-stable` has been stabilized in the 1.0 \
 release and is no longer necessary to be listed in the manifest
   See https://doc.rust-lang.org/[..]cargo/ for more information about using this feature.
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )
@@ -233,17 +233,17 @@ fn allow_features() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("-Zallow-features=test-dummy-unstable build")
+    p.cargo("-Zallow-features=test-dummy-unstable check")
         .masquerade_as_nightly_cargo(&["allow-features", "test-dummy-unstable"])
         .with_stderr(
             "\
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )
         .run();
 
-    p.cargo("-Zallow-features=test-dummy-unstable,print-im-a-teapot -Zprint-im-a-teapot build")
+    p.cargo("-Zallow-features=test-dummy-unstable,print-im-a-teapot -Zprint-im-a-teapot check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",
             "test-dummy-unstable",
@@ -252,7 +252,7 @@ fn allow_features() {
         .with_stdout("im-a-teapot = true")
         .run();
 
-    p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot build")
+    p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",
             "test-dummy-unstable",
@@ -266,7 +266,7 @@ error: the feature `print-im-a-teapot` is not in the list of allowed features: [
         )
         .run();
 
-    p.cargo("-Zallow-features= build")
+    p.cargo("-Zallow-features= check")
         .masquerade_as_nightly_cargo(&["allow-features", "test-dummy-unstable"])
         .with_status(101)
         .with_stderr(
@@ -300,17 +300,17 @@ fn allow_features_to_rustc() {
         )
         .build();
 
-    p.cargo("-Zallow-features= build")
+    p.cargo("-Zallow-features= check")
         .masquerade_as_nightly_cargo(&["allow-features"])
         .with_status(101)
         .with_stderr_contains("[..]E0725[..]")
         .run();
 
-    p.cargo("-Zallow-features=test_2018_feature build")
+    p.cargo("-Zallow-features=test_2018_feature check")
         .masquerade_as_nightly_cargo(&["allow-features"])
         .with_stderr(
             "\
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )
@@ -342,7 +342,7 @@ fn allow_features_in_cfg() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",
             "test-dummy-unstable",
@@ -350,13 +350,13 @@ fn allow_features_in_cfg() {
         ])
         .with_stderr(
             "\
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )
         .run();
 
-    p.cargo("-Zprint-im-a-teapot build")
+    p.cargo("-Zprint-im-a-teapot check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",
             "test-dummy-unstable",
@@ -366,7 +366,7 @@ fn allow_features_in_cfg() {
         .with_stderr("[FINISHED] [..]")
         .run();
 
-    p.cargo("-Zunstable-options build")
+    p.cargo("-Zunstable-options check")
         .masquerade_as_nightly_cargo(&["allow-features", "test-dummy-unstable", "print-im-a-teapot"])
         .with_status(101)
         .with_stderr(
@@ -377,7 +377,7 @@ error: the feature `unstable-options` is not in the list of allowed features: [p
         .run();
 
     // -Zallow-features overrides .cargo/config
-    p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot build")
+    p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",
             "test-dummy-unstable",
@@ -391,7 +391,7 @@ error: the feature `print-im-a-teapot` is not in the list of allowed features: [
         )
         .run();
 
-    p.cargo("-Zallow-features= build")
+    p.cargo("-Zallow-features= check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",
             "test-dummy-unstable",
@@ -426,17 +426,17 @@ fn nightly_feature_requires_nightly() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -483,18 +483,18 @@ fn nightly_feature_requires_nightly_in_dep() {
         )
         .file("a/src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
-[COMPILING] a [..]
-[COMPILING] b [..]
+[CHECKING] a [..]
+[CHECKING] b [..]
 [FINISHED] [..]
 ",
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -537,17 +537,17 @@ fn cant_publish() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -581,7 +581,7 @@ fn z_flags_rejected() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build -Zprint-im-a-teapot")
+    p.cargo("check -Zprint-im-a-teapot")
         .with_status(101)
         .with_stderr(
             "error: the `-Z` flag is only accepted on the nightly \
@@ -590,18 +590,18 @@ fn z_flags_rejected() {
         )
         .run();
 
-    p.cargo("build -Zarg")
+    p.cargo("check -Zarg")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_status(101)
         .with_stderr("error: unknown `-Z` flag specified: arg")
         .run();
 
-    p.cargo("build -Zprint-im-a-teapot")
+    p.cargo("check -Zprint-im-a-teapot")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stdout("im-a-teapot = true\n")
         .with_stderr(
             "\
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -25,7 +25,7 @@ fn cfg_easy() {
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -51,10 +51,10 @@ fn dont_include() {
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] a v0.0.1 ([..])
+[CHECKING] a v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -88,16 +88,16 @@ fn works_through_the_registry() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..] index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [DOWNLOADED] [..]
-[COMPILING] baz v0.1.0
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] baz v0.1.0
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -136,14 +136,14 @@ fn ignore_version_from_other_platform() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..] index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -168,7 +168,7 @@ fn bad_target_spec() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -199,7 +199,7 @@ fn bad_target_spec2() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -245,7 +245,7 @@ fn multiple_match_ok() {
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -267,7 +267,7 @@ fn any_ok() {
         .file("b/Cargo.toml", &basic_manifest("b", "0.0.1"))
         .file("b/src/lib.rs", "")
         .build();
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 // https://github.com/rust-lang/cargo/issues/5313
@@ -300,7 +300,7 @@ fn cfg_looks_at_rustflags_for_target() {
         .file("b/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("build --target x86_64-unknown-linux-gnu")
+    p.cargo("check --target x86_64-unknown-linux-gnu")
         .env("RUSTFLAGS", "--cfg with_b")
         .run();
 }
@@ -385,7 +385,7 @@ fn bad_cfg_discovery() {
 
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "bad-version")
         .with_status(101)
@@ -398,7 +398,7 @@ foo
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "no-crate-types")
         .with_status(101)
@@ -411,7 +411,7 @@ command was: `[..]compiler[..] --crate-name ___ [..]`
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "no-sysroot")
         .with_status(101)
@@ -432,7 +432,7 @@ command was: `[..]compiler[..]--crate-type [..]`
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "no-split-debuginfo")
         .with_status(101)
@@ -454,7 +454,7 @@ command was: `[..]compiler[..]--crate-type [..]`
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTC", &funky_rustc)
         .env("FUNKY_MODE", "bad-cfg")
         .with_status(101)

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -47,7 +47,7 @@ fn features() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=features")
+    p.cargo("check -v -Zcheck-cfg=features")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
@@ -76,7 +76,7 @@ fn features_with_deps() {
         .file("bar/src/lib.rs", "#[allow(dead_code)] fn bar() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=features")
+    p.cargo("check -v -Zcheck-cfg=features")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature"))
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
@@ -107,7 +107,7 @@ fn features_with_opt_deps() {
         .file("bar/src/lib.rs", "#[allow(dead_code)] fn bar() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=features")
+    p.cargo("check -v -Zcheck-cfg=features")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature"))
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "bar" "default" "f_a" "f_b"))
@@ -137,7 +137,7 @@ fn features_with_namespaced_features() {
         .file("bar/src/lib.rs", "#[allow(dead_code)] fn bar() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=features")
+    p.cargo("check -v -Zcheck-cfg=features")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values" of "feature" with "f_a" "f_b"))
         .run();
@@ -150,7 +150,7 @@ fn well_known_names() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=names")
+    p.cargo("check -v -Zcheck-cfg=names")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .run();
@@ -163,7 +163,7 @@ fn well_known_values() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=values")
+    p.cargo("check -v -Zcheck-cfg=values")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "values"))
         .run();
@@ -187,7 +187,7 @@ fn cli_all_options() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=features,names,values")
+    p.cargo("check -v -Zcheck-cfg=features,names,values")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .with_stderr_contains(x!("rustc" => "values"))
@@ -394,7 +394,7 @@ fn build_script_feedback() {
         )
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=output")
+    p.cargo("check -v -Zcheck-cfg=output")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names" of "foo"))
         .run();
@@ -465,7 +465,7 @@ fn build_script_override() {
         )
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=output")
+    p.cargo("check -v -Zcheck-cfg=output")
         .with_stderr_contains(x!("rustc" => "names" of "foo"))
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .run();
@@ -551,7 +551,7 @@ fn config_valid() {
         )
         .build();
 
-    p.cargo("build -v -Zcheck-cfg=features,names,values")
+    p.cargo("check -v -Zcheck-cfg=features,names,values")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "names"))
         .with_stderr_contains(x!("rustc" => "values"))
@@ -580,7 +580,7 @@ fn config_invalid() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains("error: unstable check-cfg only takes `features`, `names`, `values` or `output` as valid inputs")
         .with_status(101)

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -131,7 +131,7 @@ fn read_env_vars_for_config() {
         )
         .build();
 
-    p.cargo("build").env("CARGO_BUILD_JOBS", "100").run();
+    p.cargo("check").env("CARGO_BUILD_JOBS", "100").run();
 }
 
 pub fn write_config(config: &str) {
@@ -1471,7 +1471,7 @@ target-dir = ''
 fn cargo_target_empty_env() {
     let project = project().build();
 
-    project.cargo("build")
+    project.cargo("check")
         .env("CARGO_TARGET_DIR", "")
         .with_stderr("error: the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable")
         .with_status(101)

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -61,21 +61,21 @@ fn works_with_cli() {
         ",
     );
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 [..]
+[CHECKING] foo v0.0.1 [..]
 [RUNNING] `rustc [..]-W unused`
 [FINISHED] [..]
 ",
         )
         .run();
-    p.cargo("build -v -Z config-include")
+    p.cargo("check -v -Z config-include")
         .masquerade_as_nightly_cargo(&["config-include"])
         .with_stderr(
             "\
 [DIRTY] foo v0.0.1 ([..]): the rustflags changed
-[COMPILING] foo v0.0.1 [..]
+[CHECKING] foo v0.0.1 [..]
 [RUNNING] `rustc [..]-W unsafe-code -W unused`
 [FINISHED] [..]
 ",

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -34,7 +34,7 @@ fn deleting_database_files() {
         .file("src/lib.rs", "")
         .build();
 
-    project.cargo("build").run();
+    project.cargo("check").run();
 
     let mut files = Vec::new();
     find_files(&paths::home().join(".cargo/git/db"), &mut files);
@@ -47,7 +47,7 @@ fn deleting_database_files() {
         }
         println!("deleting {}", file.display());
         cargopaths::remove_file(&file).unwrap();
-        project.cargo("build -v").env("CARGO_LOG", log).run();
+        project.cargo("check -v").env("CARGO_LOG", log).run();
 
         if !file.exists() {
             continue;
@@ -60,7 +60,7 @@ fn deleting_database_files() {
             .unwrap()
             .set_len(2)
             .unwrap();
-        project.cargo("build -v").env("CARGO_LOG", log).run();
+        project.cargo("check -v").env("CARGO_LOG", log).run();
     }
 }
 
@@ -92,7 +92,7 @@ fn deleting_checkout_files() {
         .file("src/lib.rs", "")
         .build();
 
-    project.cargo("build").run();
+    project.cargo("check").run();
 
     let dir = paths::home()
         .join(".cargo/git/checkouts")
@@ -123,7 +123,7 @@ fn deleting_checkout_files() {
         }
         println!("deleting {}", file.display());
         cargopaths::remove_file(&file).unwrap();
-        project.cargo("build -v").env("CARGO_LOG", log).run();
+        project.cargo("check -v").env("CARGO_LOG", log).run();
 
         if !file.exists() {
             continue;
@@ -136,7 +136,7 @@ fn deleting_checkout_files() {
             .unwrap()
             .set_len(2)
             .unwrap();
-        project.cargo("build -v").env("CARGO_LOG", log).run();
+        project.cargo("check -v").env("CARGO_LOG", log).run();
     }
 }
 

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -43,7 +43,7 @@ fn ctrl_c_kills_everyone() {
         )
         .build();
 
-    let mut cargo = p.cargo("build").build_command();
+    let mut cargo = p.cargo("check").build_command();
     cargo
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -505,7 +505,7 @@ fn reg_dep_source_not_tracked() {
         .file("src/lib.rs", "pub fn f() { regdep::f(); }")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     assert_deps(
         &p,
@@ -551,7 +551,7 @@ fn canonical_path() {
     real.mkdir_p();
     p.symlink(real, "target");
 
-    p.cargo("build -Z binary-dep-depinfo")
+    p.cargo("check -Z binary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
         .run();
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -103,11 +103,11 @@ fn simple() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -272,7 +272,7 @@ fn not_there() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -319,11 +319,11 @@ fn multiple() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -355,14 +355,14 @@ fn crates_io_then_directory() {
         .file("src/lib.rs", "pub fn bar() -> u32 { 0 }")
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -376,11 +376,11 @@ fn crates_io_then_directory() {
     v.cksum.package = Some(cksum);
     v.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.1.0 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -407,7 +407,7 @@ fn crates_io_then_bad_checksum() {
 
     Package::new("bar", "0.1.0").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     setup();
 
     VendorPackage::new("bar")
@@ -415,7 +415,7 @@ fn crates_io_then_bad_checksum() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -464,7 +464,7 @@ fn bad_file_checksum() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -509,7 +509,7 @@ fn only_dot_files_ok() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -542,7 +542,7 @@ fn random_files_ok() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -577,7 +577,7 @@ fn git_lock_file_doesnt_change() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let lock1 = p.read_lockfile();
 
@@ -598,11 +598,11 @@ fn git_lock_file_doesnt_change() {
         )
     ));
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] [..]
-[COMPILING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
 [FINISHED] [..]
 ",
         )
@@ -650,7 +650,7 @@ fn git_override_requires_lockfile() {
         "#
     ));
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -719,12 +719,12 @@ fn workspace_different_locations() {
         )
         .build();
 
-    p.cargo("build").cwd("foo").run();
-    p.cargo("build")
+    p.cargo("check").cwd("foo").run();
+    p.cargo("check")
         .cwd("bar")
         .with_stderr(
             "\
-[COMPILING] bar [..]
+[CHECKING] bar [..]
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -910,7 +910,7 @@ fn no_document_build_deps() {
 fn doc_release() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build --release").run();
+    p.cargo("check --release").run();
     p.cargo("doc --release -v")
         .with_stderr(
             "\
@@ -1550,7 +1550,7 @@ fn issue_5345() {
     Package::new("bar", "0.1.0").publish();
     Package::new("bar", "0.2.0").publish();
 
-    foo.cargo("build").run();
+    foo.cargo("check").run();
     foo.cargo("doc").run();
 }
 

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -31,7 +31,7 @@ fn edition_works_for_build_script() {
         .file("a/src/lib.rs", "pub fn foo() {}")
         .build();
 
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -22,7 +22,7 @@ fn invalid1() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -104,7 +104,7 @@ fn invalid3() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -139,7 +139,7 @@ fn invalid4() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -156,7 +156,7 @@ failed to select a version for `bar` which could resolve this conflict",
 
     p.change_file("Cargo.toml", &basic_manifest("foo", "0.0.1"));
 
-    p.cargo("build --features test")
+    p.cargo("check --features test")
         .with_status(101)
         .with_stderr("error: Package `foo v0.0.1 ([..])` does not have the feature `test`")
         .run();
@@ -181,7 +181,7 @@ fn invalid5() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -212,7 +212,7 @@ fn invalid6() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build --features foo")
+    p.cargo("check --features foo")
         .with_status(101)
         .with_stderr(
             "\
@@ -244,7 +244,7 @@ fn invalid7() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build --features foo")
+    p.cargo("check --features foo")
         .with_status(101)
         .with_stderr(
             "\
@@ -278,7 +278,7 @@ fn invalid8() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build --features foo")
+    p.cargo("check --features foo")
         .with_status(101)
         .with_stderr(
             "\
@@ -312,7 +312,7 @@ fn invalid9() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build --features bar")
+    p.cargo("check --features bar")
         .with_stderr(
             "\
 error: Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with that name, but only optional dependencies can be used as features.
@@ -354,7 +354,7 @@ fn invalid10() {
         .file("bar/baz/src/lib.rs", "")
         .build();
 
-    p.cargo("build").with_stderr("\
+    p.cargo("check").with_stderr("\
 error: failed to select a version for `bar`.
     ... required by package `foo v0.0.1 ([..])`
 versions that meet the requirements `*` are: 0.0.1
@@ -426,7 +426,7 @@ fn no_transitive_dep_feature_requirement() {
             "#,
         )
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -571,7 +571,7 @@ fn cyclic_feature() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr("[ERROR] cyclic feature dependency: feature `default` depends on itself")
         .run();
@@ -596,7 +596,7 @@ fn cyclic_feature2() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -645,12 +645,12 @@ fn groups_on_groups_on_groups() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -693,13 +693,13 @@ fn many_cli_features() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build --features")
+    p.cargo("check --features")
         .arg("bar baz")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -777,12 +777,12 @@ fn union_features() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] d2 v0.0.1 ([CWD]/d2)
-[COMPILING] d1 v0.0.1 ([CWD]/d1)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] d2 v0.0.1 ([CWD]/d2)
+[CHECKING] d1 v0.0.1 ([CWD]/d1)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -823,18 +823,18 @@ fn many_features_no_rebuilds() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] a v0.1.0 ([CWD]/a)
-[COMPILING] b v0.1.0 ([CWD])
+[CHECKING] a v0.1.0 ([CWD]/a)
+[CHECKING] b v0.1.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
     p.root().move_into_the_past();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr(
             "\
 [FRESH] a v0.1.0 ([..]/a)
@@ -850,7 +850,7 @@ fn many_features_no_rebuilds() {
 fn empty_features() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 
-    p.cargo("build --features").arg("").run();
+    p.cargo("check --features").arg("").run();
 }
 
 // Tests that all cmd lines work with `--features ""`
@@ -891,7 +891,7 @@ fn transitive_features() {
         )
         .build();
 
-    p.cargo("build --features foo").run();
+    p.cargo("check --features foo").run();
 }
 
 #[cargo_test]
@@ -1015,9 +1015,9 @@ fn no_rebuild_when_frobbing_default_feature() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build").with_stdout("").run();
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").run();
+    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -1066,9 +1066,9 @@ fn unions_work_with_no_default_features() {
         .file("a/src/lib.rs", r#"#[cfg(feature = "f1")] pub fn a() {}"#)
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build").with_stdout("").run();
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").run();
+    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -1093,10 +1093,10 @@ fn optional_and_dev_dep() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] test v0.1.0 ([..])
+[CHECKING] test v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1140,7 +1140,7 @@ fn activating_feature_activates_dep() {
         .file("foo/src/lib.rs", r#"#[cfg(feature = "a")] pub fn bar() {}"#)
         .build();
 
-    p.cargo("build --features a -v").run();
+    p.cargo("check --features a -v").run();
 }
 
 #[cargo_test]
@@ -1205,23 +1205,23 @@ fn dep_feature_in_cmd_line() {
 
     // The foo project requires that feature "some-feat" in "bar" is enabled.
     // Building without any features enabled should fail:
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]unresolved import `bar::test`")
         .run();
 
     // We should be able to enable the feature "derived-feat", which enables "some-feat",
     // on the command line. The feature is enabled, thus building should be successful:
-    p.cargo("build --features derived/derived-feat").run();
+    p.cargo("check --features derived/derived-feat").run();
 
     // Trying to enable features of transitive dependencies is an error
-    p.cargo("build --features bar/some-feat")
+    p.cargo("check --features bar/some-feat")
         .with_status(101)
         .with_stderr("error: package `foo v0.0.1 ([..])` does not have a dependency named `bar`")
         .run();
 
     // Hierarchical feature specification should still be disallowed
-    p.cargo("build --features derived/bar/some-feat")
+    p.cargo("check --features derived/bar/some-feat")
         .with_status(101)
         .with_stderr("[ERROR] multiple slashes in feature `derived/bar/some-feat` is not allowed")
         .run();
@@ -1269,7 +1269,7 @@ fn all_features_flag_enables_all_features() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build --all-features").run();
+    p.cargo("check --all-features").run();
 }
 
 #[cargo_test]
@@ -1308,12 +1308,12 @@ fn many_cli_features_comma_delimited() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build --features bar,baz")
+    p.cargo("check --features bar,baz")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1372,15 +1372,15 @@ fn many_cli_features_comma_and_space_delimited() {
         .file("bap/src/lib.rs", "pub fn bap() {}")
         .build();
 
-    p.cargo("build --features")
+    p.cargo("check --features")
         .arg("bar,baz bam bap")
         .with_stderr(
             "\
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] ba[..] v0.0.1 ([CWD]/ba[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1413,7 +1413,7 @@ fn only_dep_is_optional() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1449,7 +1449,7 @@ fn all_features_all_crates() {
         .file("bar/src/main.rs", "#[cfg(feature = \"foo\")] fn main() {}")
         .build();
 
-    p.cargo("build --all-features --workspace").run();
+    p.cargo("check --all-features --workspace").run();
 }
 
 #[cargo_test]
@@ -1508,7 +1508,7 @@ fn feature_off_dylib() {
         .build();
 
     // Build the dylib with `f1` feature.
-    p.cargo("build --features f1").run();
+    p.cargo("check --features f1").run();
     // Check that building without `f1` uses a dylib without `f1`.
     p.cargo("run -p bar").run();
 }
@@ -1537,11 +1537,11 @@ fn warn_if_default_features() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             r#"
 [WARNING] `default-features = [".."]` was found in [features]. Did you mean to use `default = [".."]`?
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
             "#.trim(),
         ).run();
@@ -1585,7 +1585,7 @@ fn no_feature_for_non_optional_dep() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build --features bar/a").run();
+    p.cargo("check --features bar/a").run();
 }
 
 #[cargo_test]
@@ -1613,7 +1613,7 @@ fn features_option_given_twice() {
         )
         .build();
 
-    p.cargo("build --features a --features b").run();
+    p.cargo("check --features a --features b").run();
 }
 
 #[cargo_test]
@@ -1642,7 +1642,7 @@ fn multi_multi_features() {
         )
         .build();
 
-    p.cargo("build --features a --features").arg("b c").run();
+    p.cargo("check --features a --features").arg("b c").run();
 }
 
 #[cargo_test]
@@ -1921,7 +1921,7 @@ fn nonexistent_required_features() {
         .file("examples/ololo.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --examples")
+    p.cargo("check --examples")
         .with_stderr_contains(
             "\
 [WARNING] invalid feature `not_present` in required-features of target `ololo`: \
@@ -2075,7 +2075,7 @@ fn default_features_conflicting_warning() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains(
 "[WARNING] conflicting between `default-features` and `default_features` in the `a` dependency.\n
         `default_features` is ignored and not recommended for use in the future"

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1273,7 +1273,7 @@ fn resolver_bad_setting() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1357,7 +1357,7 @@ fn resolver_not_both() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -62,7 +62,7 @@ fn namespaced_invalid_feature() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -93,7 +93,7 @@ fn namespaced_invalid_dependency() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -127,7 +127,7 @@ fn namespaced_non_optional_dependency() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
 
         .with_status(101)
         .with_stderr(
@@ -209,7 +209,7 @@ fn namespaced_shadowed_dep() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -269,7 +269,7 @@ fn namespaced_implicit_non_optional() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").with_status(101).with_stderr(
+    p.cargo("check").with_status(101).with_stderr(
         "\
 [ERROR] failed to parse manifest at `[..]`
 
@@ -701,7 +701,7 @@ fn optional_explicit_without_crate() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -658,7 +658,7 @@ fn fixes_missing_ampersand() {
         .with_stderr_contains("[FIXED] tests/a.rs (1 fix)")
         .with_stderr_contains("[FINISHED] [..]")
         .run();
-    p.cargo("build").run();
+    p.cargo("check").run();
     p.cargo("test").run();
 }
 
@@ -688,9 +688,9 @@ fn fix_features() {
         .build();
 
     p.cargo("fix --allow-no-vcs").run();
-    p.cargo("build").run();
+    p.cargo("check").run();
     p.cargo("fix --features bar --allow-no-vcs").run();
-    p.cargo("build --features bar").run();
+    p.cargo("check --features bar").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -43,7 +43,7 @@ fn output_on_stable() {
 fn no_gate_future_incompat_report() {
     let p = simple_project();
 
-    p.cargo("build --future-incompat-report")
+    p.cargo("check --future-incompat-report")
         .with_status(0)
         .run();
 
@@ -64,17 +64,17 @@ fn test_zero_future_incompat() {
         .build();
 
     // No note if --future-incompat-report is not specified.
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.0 [..]
+[CHECKING] foo v0.0.0 [..]
 [FINISHED] [..]
 ",
         )
         .run();
 
-    p.cargo("build --future-incompat-report")
+    p.cargo("check --future-incompat-report")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .with_stderr(
             "\
@@ -201,7 +201,7 @@ fn test_multi_crate() {
 
     // Test that passing the correct id via '--id' doesn't generate a warning message
     let output = p
-        .cargo("build")
+        .cargo("check")
         .env("RUSTFLAGS", "-Zfuture-incompat-test")
         .exec_with_output()
         .unwrap();

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -132,7 +132,7 @@ fn http_auth_offered() {
 
     // This is a "contains" check because the last error differs by platform,
     // may span multiple lines, and isn't relevant to this test.
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(&format!(
             "\
@@ -203,7 +203,7 @@ fn https_something_happens() {
         )
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains(&format!(
             "[UPDATING] git repository `https://{addr}/foo/bar`",
@@ -258,7 +258,7 @@ fn ssh_something_happens() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains(&format!(
             "[UPDATING] git repository `ssh://{addr}/foo/bar`",
@@ -292,7 +292,7 @@ fn net_err_suggests_fetch_with_cli() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -329,7 +329,7 @@ Caused by:
             ",
     );
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains("[..]Unable to update[..]")
         .with_stderr_does_not_contain("[..]try enabling `git-fetch-with-cli`[..]")
@@ -363,7 +363,7 @@ fn instead_of_url_printed() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(&format!(
             "\

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -36,7 +36,7 @@ fn run_test(path_env: Option<&OsStr>) {
         .build();
     Package::new("bar", "0.1.0").publish();
 
-    foo.cargo("build").run();
+    foo.cargo("check").run();
 
     let index = find_index();
     let path = paths::home().join("tmp");

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -50,11 +50,11 @@ fn permit_additional_workspace_fields() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         // Should not warn about unused fields.
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] bar v0.1.0 ([CWD]/bar)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -92,7 +92,7 @@ fn deny_optional_dependencies() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -277,15 +277,15 @@ fn inherit_own_dependencies() {
     Package::new("dep-build", "0.8.2").publish();
     Package::new("dep-dev", "0.5.2").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep-build v0.8.2 ([..])
 [DOWNLOADED] dep v0.1.2 ([..])
-[COMPILING] dep v0.1.2
-[COMPILING] bar v0.2.0 ([CWD])
+[CHECKING] dep v0.1.2
+[CHECKING] bar v0.2.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -414,14 +414,14 @@ fn inherit_own_detailed_dependencies() {
         .feature("testing", &vec![])
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 ([..])
-[COMPILING] dep v0.1.2
-[COMPILING] bar v0.2.0 ([CWD])
+[CHECKING] dep v0.1.2
+[CHECKING] bar v0.2.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -519,7 +519,7 @@ fn inherit_from_own_undefined_field() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -568,7 +568,7 @@ fn inherited_dependencies_union_features() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -576,10 +576,10 @@ fn inherited_dependencies_union_features() {
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
 [DOWNLOADED] dancy_dep v0.6.8 ([..])
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] dep v0.1.0
-[COMPILING] bar v0.2.0 ([CWD])
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] dep v0.1.0
+[CHECKING] bar v0.2.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -782,15 +782,15 @@ fn inherit_dependencies() {
     Package::new("dep-build", "0.8.2").publish();
     Package::new("dep-dev", "0.5.2").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep-build v0.8.2 ([..])
 [DOWNLOADED] dep v0.1.2 ([..])
-[COMPILING] dep v0.1.2
-[COMPILING] bar v0.2.0 ([CWD]/bar)
+[CHECKING] dep v0.1.2
+[CHECKING] bar v0.2.0 ([CWD]/bar)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -922,14 +922,14 @@ fn inherit_target_dependencies() {
 
     Package::new("dep", "0.1.2").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 ([..])
-[COMPILING] dep v0.1.2
-[COMPILING] bar v0.2.0 ([CWD]/bar)
+[CHECKING] dep v0.1.2
+[CHECKING] bar v0.2.0 ([CWD]/bar)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -968,11 +968,11 @@ fn inherit_dependency_override_optional() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[COMPILING] bar v0.2.0 ([CWD]/bar)
+[CHECKING] bar v0.2.0 ([CWD]/bar)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1010,16 +1010,16 @@ fn inherit_dependency_features() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
-[COMPILING] fancy_dep v0.2.4
-[COMPILING] dep v0.1.0
-[COMPILING] bar v0.2.0 ([CWD])
+[CHECKING] fancy_dep v0.2.4
+[CHECKING] dep v0.1.0
+[CHECKING] bar v0.2.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1081,12 +1081,12 @@ fn inherit_detailed_dependencies() {
 
     let git_root = git_project.root();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`\n\
-[COMPILING] detailed v0.5.0 ({}?branch=branchy#[..])\n\
-[COMPILING] bar v0.2.0 ([CWD]/bar)\n\
+[CHECKING] detailed v0.5.0 ({}?branch=branchy#[..])\n\
+[CHECKING] bar v0.2.0 ([CWD]/bar)\n\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
@@ -1123,11 +1123,11 @@ fn inherit_path_dependencies() {
         .file("dep/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] dep v0.9.0 ([CWD]/dep)
-[COMPILING] bar v0.2.0 ([CWD]/bar)
+[CHECKING] dep v0.9.0 ([CWD]/dep)
+[CHECKING] bar v0.2.0 ([CWD]/bar)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1166,7 +1166,7 @@ fn error_workspace_false() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1209,7 +1209,7 @@ fn error_workspace_dependency_looked_for_workspace_itself() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1252,7 +1252,7 @@ fn error_malformed_workspace_root() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1296,7 +1296,7 @@ fn error_no_root_workspace() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -1341,7 +1341,7 @@ fn error_inherit_unspecified_dependency() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr(

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -55,7 +55,7 @@ fn jobserver_exists() {
     // Explicitly use `-j2` to ensure that there's eventually going to be a
     // token to read from `validate` above, since running the build script
     // itself consumes a token.
-    p.cargo("build -j2").run();
+    p.cargo("check -j2").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -88,7 +88,7 @@ fn not_found() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -167,12 +167,12 @@ fn multiple_versions() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UNPACKING] bar v0.1.0 ([..])
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -227,14 +227,14 @@ fn multiple_names() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UNPACKING] [..]
 [UNPACKING] [..]
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -281,14 +281,14 @@ fn interdependent() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UNPACKING] [..]
 [UNPACKING] [..]
-[COMPILING] bar v0.0.1
-[COMPILING] baz v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] baz v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -349,14 +349,14 @@ fn path_dep_rewritten() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UNPACKING] [..]
 [UNPACKING] [..]
-[COMPILING] bar v0.0.1
-[COMPILING] baz v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] baz v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
         )
@@ -393,7 +393,7 @@ fn invalid_dir_bad() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -443,7 +443,7 @@ fn different_directory_replacing_the_registry_is_bad() {
 
     // Generate a lock file against the crates.io registry
     Package::new("bar", "0.0.1").publish();
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Switch back to our directory source, and now that we're replacing
     // crates.io make sure that this fails because we're replacing with a
@@ -455,7 +455,7 @@ fn different_directory_replacing_the_registry_is_bad() {
         .local(true)
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -111,7 +111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
         .file("Cargo.lock", &old_lockfile)
         .build();
 
-    p.cargo("build --locked").run();
+    p.cargo("check --locked").run();
 
     let lock = p.read_lockfile();
     assert_match_exact(&old_lockfile, &lock);
@@ -158,7 +158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let lock = p.read_lockfile();
     assert_match_exact(
@@ -223,7 +223,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -398,7 +398,7 @@ fn current_lockfile_format() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let actual = p.read_lockfile();
 
@@ -460,7 +460,7 @@ dependencies = [
 
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let lock = p.read_lockfile();
     assert_match_exact(
@@ -505,7 +505,7 @@ fn locked_correct_error() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build --locked")
+    p.cargo("check --locked")
         .with_status(101)
         .with_stderr(
             "\
@@ -762,7 +762,7 @@ dependencies = [
         .file("Cargo.lock", &lockfile)
         .build();
 
-    p.cargo("build --locked").run();
+    p.cargo("check --locked").run();
 }
 
 #[cargo_test]
@@ -832,7 +832,7 @@ source = "git+{url}#{sha}"
         .file("Cargo.lock", &lockfile)
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     assert_eq!(p.read_file("Cargo.lock"), lockfile);
 }
@@ -874,7 +874,7 @@ dependencies = [
 ]"#,
         )
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -29,17 +29,17 @@ fn double_json_works() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --message-format json,json-render-diagnostics")
+    p.cargo("check --message-format json,json-render-diagnostics")
         .run();
-    p.cargo("build --message-format json,json-diagnostic-short")
+    p.cargo("check --message-format json,json-diagnostic-short")
         .run();
-    p.cargo("build --message-format json,json-diagnostic-rendered-ansi")
+    p.cargo("check --message-format json,json-diagnostic-rendered-ansi")
         .run();
-    p.cargo("build --message-format json --message-format json-diagnostic-rendered-ansi")
+    p.cargo("check --message-format json --message-format json-diagnostic-rendered-ansi")
         .run();
-    p.cargo("build --message-format json-diagnostic-rendered-ansi")
+    p.cargo("check --message-format json-diagnostic-rendered-ansi")
         .run();
-    p.cargo("build --message-format json-diagnostic-short,json-diagnostic-rendered-ansi")
+    p.cargo("check --message-format json-diagnostic-short,json-diagnostic-rendered-ansi")
         .run();
 }
 
@@ -62,7 +62,7 @@ fn cargo_renders() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build --message-format json-render-diagnostics")
+    p.cargo("check --message-format json-render-diagnostics")
         .with_status(101)
         .with_stdout(
             "{\"reason\":\"compiler-artifact\",[..]\n\
@@ -70,8 +70,8 @@ fn cargo_renders() {
         )
         .with_stderr_contains(
             "\
-[COMPILING] bar [..]
-[COMPILING] foo [..]
+[CHECKING] bar [..]
+[CHECKING] foo [..]
 error[..]`main`[..]
 ",
         )
@@ -85,11 +85,11 @@ fn cargo_renders_short() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build --message-format json-render-diagnostics,json-diagnostic-short")
+    p.cargo("check --message-format json-render-diagnostics,json-diagnostic-short")
         .with_status(101)
         .with_stderr_contains(
             "\
-[COMPILING] foo [..]
+[CHECKING] foo [..]
 error[..]`main`[..]
 ",
         )
@@ -104,7 +104,7 @@ fn cargo_renders_ansi() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build --message-format json-diagnostic-rendered-ansi")
+    p.cargo("check --message-format json-diagnostic-rendered-ansi")
         .with_status(101)
         .with_stdout_contains("[..]\\u001b[38;5;9merror[..]")
         .run();

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -22,7 +22,7 @@ fn metabuild_gated() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_stderr(
@@ -83,7 +83,7 @@ fn basic_project() -> Project {
 #[cargo_test]
 fn metabuild_basic() {
     let p = basic_project();
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .with_stdout_contains("[foo 0.0.1] Hello mb-other")
@@ -115,7 +115,7 @@ fn metabuild_error_both() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_stderr_contains(
@@ -145,7 +145,7 @@ fn metabuild_missing_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_stderr_contains(
@@ -182,12 +182,12 @@ fn metabuild_optional_dep() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_does_not_contain("[foo 0.0.1] Hello mb")
         .run();
 
-    p.cargo("build -vv --features mb")
+    p.cargo("check -vv --features mb")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
@@ -227,7 +227,7 @@ fn metabuild_lib_name() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
@@ -266,12 +266,12 @@ fn metabuild_fresh() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_does_not_contain("[foo 0.0.1] Hello mb")
         .with_stderr(
@@ -315,7 +315,7 @@ fn metabuild_links() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[foo 0.0.1] Hello mb")
         .run();
@@ -356,7 +356,7 @@ fn metabuild_override() {
         )
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .run();
 }
@@ -420,7 +420,7 @@ fn metabuild_workspace() {
         )
         .build();
 
-    p.cargo("build -vv --workspace")
+    p.cargo("check -vv --workspace")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
         .with_stdout_contains("[member1 0.0.1] Hello mb2 [..]member1")
@@ -621,7 +621,7 @@ fn metabuild_two_versions() {
         )
         .build();
 
-    p.cargo("build -vv --workspace")
+    p.cargo("check -vv --workspace")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[member1 0.0.1] Hello mb1 [..]member1")
         .with_stdout_contains("[member2 0.0.1] Hello mb2 [..]member2")
@@ -674,7 +674,7 @@ fn metabuild_external_dependency() {
         .file("src/lib.rs", "extern crate dep;")
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_stdout_contains("[dep 1.0.0] Hello mb")
         .run();
@@ -685,7 +685,7 @@ fn metabuild_external_dependency() {
 #[cargo_test]
 fn metabuild_json_artifact() {
     let p = basic_project();
-    p.cargo("build --message-format=json")
+    p.cargo("check --message-format=json")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_json_contains_unordered(
             r#"
@@ -733,7 +733,7 @@ fn metabuild_failed_build_json() {
     let p = basic_project();
     // Modify the metabuild dep so that it fails to compile.
     p.change_file("mb/src/lib.rs", "");
-    p.cargo("build --message-format=json")
+    p.cargo("check --message-format=json")
         .masquerade_as_nightly_cargo(&["metabuild"])
         .with_status(101)
         .with_json_contains_unordered(

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -29,7 +29,7 @@ fn net_retry_loads_from_config() {
         )
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains(
             "[WARNING] spurious network error \
@@ -63,7 +63,7 @@ fn net_retry_git_outputs_warning() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build -v -j 1")
+    p.cargo("check -v -j 1")
         .with_status(101)
         .with_stderr_contains(
             "[WARNING] spurious network error \

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -24,13 +24,13 @@ fn offline_unused_target_dep() {
         .file("src/lib.rs", "")
         .build();
     // Do a build that downloads only what is necessary.
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains("[DOWNLOADED] used_dep [..]")
         .with_stderr_does_not_contain("[DOWNLOADED] unused_dep [..]")
         .run();
     p.cargo("clean").run();
     // Build offline, make sure it works.
-    p.cargo("build --offline").run();
+    p.cargo("check --offline").run();
 }
 
 #[cargo_test]
@@ -50,13 +50,13 @@ fn offline_missing_optional() {
         .file("src/lib.rs", "")
         .build();
     // Do a build that downloads only what is necessary.
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_does_not_contain("[DOWNLOADED] opt_dep [..]")
         .run();
     p.cargo("clean").run();
     // Build offline, make sure it works.
-    p.cargo("build --offline").run();
-    p.cargo("build --offline --features=opt_dep")
+    p.cargo("check --offline").run();
+    p.cargo("check --offline --features=opt_dep")
         .with_stderr(
             "\
 [ERROR] failed to download `opt_dep v1.0.0`
@@ -89,7 +89,7 @@ fn cargo_compile_path_with_offline() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build --offline").run();
+    p.cargo("check --offline").run();
 }
 
 #[cargo_test]
@@ -114,7 +114,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let p2 = project()
         .at("bar")
@@ -132,11 +132,11 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
         .file("src/lib.rs", "")
         .build();
 
-    p2.cargo("build --offline")
+    p2.cargo("check --offline")
         .with_stderr(
             "\
-[COMPILING] present_dep v1.2.3
-[COMPILING] bar v0.1.0 ([..])
+[CHECKING] present_dep v1.2.3
+[CHECKING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
@@ -171,14 +171,14 @@ surprising resolution failures, if this error is too confusing you may wish to \
 retry without the offline flag.
 ";
 
-    p.cargo("build --offline")
+    p.cargo("check --offline")
         .with_status(101)
         .with_stderr(msg)
         .run();
 
     // While we're here, also check the config works.
     p.change_file(".cargo/config", "net.offline = true");
-    p.cargo("build").with_status(101).with_stderr(msg).run();
+    p.cargo("check").with_status(101).with_stderr(msg).run();
 }
 
 #[cargo_test]
@@ -269,7 +269,7 @@ fn cargo_compile_forbird_git_httpsrepo_offline() {
         .file("src/main.rs", "")
         .build();
 
-    p.cargo("build --offline").with_status(101).with_stderr("\
+    p.cargo("check --offline").with_status(101).with_stderr("\
 [ERROR] failed to get `dep1` as a dependency of package `foo v0.5.0 [..]`
 
 Caused by:
@@ -310,7 +310,7 @@ fn compile_offline_while_transitive_dep_not_cached() {
         .build();
 
     // simulate download bar, but fail to download baz
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]failed to verify the checksum of `baz[..]")
         .run();
@@ -318,7 +318,7 @@ fn compile_offline_while_transitive_dep_not_cached() {
     // Restore the file contents.
     fs::write(&baz_path, &baz_content).unwrap();
 
-    p.cargo("build --offline")
+    p.cargo("check --offline")
         .with_status(101)
         .with_stderr(
             "\
@@ -530,7 +530,7 @@ fn offline_resolve_optional_fail() {
         "#,
     );
 
-    p.cargo("build --offline")
+    p.cargo("check --offline")
         .with_status(101)
         .with_stderr(
             "\
@@ -691,7 +691,7 @@ retry without the offline flag.
 #[cargo_test]
 fn offline_and_frozen_and_no_lock() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("build --frozen --offline")
+    p.cargo("check --frozen --offline")
         .with_status(101)
         .with_stderr("\
 error: the lock file [ROOT]/foo/Cargo.lock needs to be updated but --frozen was passed to prevent this
@@ -704,7 +704,7 @@ remove the --frozen flag and use --offline instead.
 #[cargo_test]
 fn offline_and_locked_and_no_frozen() {
     let p = project().file("src/lib.rs", "").build();
-    p.cargo("build --locked --offline")
+    p.cargo("check --locked --offline")
         .with_status(101)
         .with_stderr("\
 error: the lock file [ROOT]/foo/Cargo.lock needs to be updated but --locked was passed to prevent this

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1301,10 +1301,10 @@ fn test_edition() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr_contains(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]--edition=2018 [..]
 ",
         )
@@ -1349,7 +1349,7 @@ fn test_edition_malformed() {
         .file("src/lib.rs", r#" "#)
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -1381,7 +1381,7 @@ fn test_edition_from_the_future() {
         .file("src/main.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -466,28 +466,28 @@ fn non_member() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -p dep --features f1")
+    p.cargo("check -p dep --features f1")
         .with_status(101)
         .with_stderr("[ERROR] cannot specify features for packages outside of workspace")
         .run();
 
-    p.cargo("build -p dep --all-features")
+    p.cargo("check -p dep --all-features")
         .with_status(101)
         .with_stderr("[ERROR] cannot specify features for packages outside of workspace")
         .run();
 
-    p.cargo("build -p dep --no-default-features")
+    p.cargo("check -p dep --no-default-features")
         .with_status(101)
         .with_stderr("[ERROR] cannot specify features for packages outside of workspace")
         .run();
 
-    p.cargo("build -p dep")
+    p.cargo("check -p dep")
         .with_stderr(
             "\
 [UPDATING] [..]
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
-[COMPILING] dep [..]
+[CHECKING] dep [..]
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -49,21 +49,21 @@ fn replace() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 ([..])
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] baz v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] baz v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -95,12 +95,12 @@ fn from_config() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.1 ([..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.1 ([..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -136,12 +136,12 @@ fn from_config_relative() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.1 ([..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.1 ([..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -180,12 +180,12 @@ fn from_config_precedence() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.1 ([..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.1 ([..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -220,17 +220,17 @@ fn nonexistent() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -267,17 +267,17 @@ fn patch_git() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -314,18 +314,18 @@ fn patch_to_git() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 (file://[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -353,7 +353,7 @@ fn unused() {
         .file("bar/src/lib.rs", "not rust code")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
@@ -364,13 +364,13 @@ what is [..]
 version. [..]
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] Patch `bar v0.2.0 ([CWD]/bar)` was not used in the crate graph.
@@ -425,7 +425,7 @@ fn unused_with_mismatch_source_being_patched() {
         .file("baz/src/lib.rs", "not rust code")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
@@ -440,8 +440,8 @@ what is [..]
 version. [..]
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -473,17 +473,17 @@ fn prefer_patch_version() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.1 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.1 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [FINISHED] [..]
@@ -526,7 +526,7 @@ fn unused_from_config() {
         .file("bar/src/lib.rs", "not rust code")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
@@ -537,13 +537,13 @@ what is [..]
 version. [..]
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] Patch `bar v0.2.0 ([CWD]/bar)` was not used in the crate graph.
@@ -598,7 +598,7 @@ fn unused_git() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
@@ -610,13 +610,13 @@ what is [..]
 version. [..]
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] Patch `bar v0.2.0 ([..])` was not used in the crate graph.
@@ -652,19 +652,19 @@ fn add_patch() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     p.change_file(
         "Cargo.toml",
@@ -682,16 +682,16 @@ fn add_patch() {
         "#,
     );
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -716,19 +716,19 @@ fn add_patch_from_config() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     p.change_file(
         ".cargo/config.toml",
@@ -738,16 +738,16 @@ fn add_patch_from_config() {
         "#,
     );
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -772,19 +772,19 @@ fn add_ignored_patch() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
-[COMPILING] bar v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     p.change_file(
         "Cargo.toml",
@@ -802,7 +802,7 @@ fn add_ignored_patch() {
         "#,
     );
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] Patch `bar v0.1.1 ([CWD]/bar)` was not used in the crate graph.
@@ -813,7 +813,7 @@ version. [..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] Patch `bar v0.1.1 ([CWD]/bar)` was not used in the crate graph.
@@ -826,11 +826,11 @@ version. [..]
         .run();
 
     p.cargo("update").run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.1 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.1 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [..]
 ",
         )
@@ -862,19 +862,19 @@ fn add_patch_with_features() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] patch for `bar` uses the features mechanism. \
 default-features and features will not take effect because the patch dependency does not support this mechanism
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] patch for `bar` uses the features mechanism. \
@@ -910,19 +910,19 @@ fn add_patch_with_setting_default_features() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] patch for `bar` uses the features mechanism. \
 default-features and features will not take effect because the patch dependency does not support this mechanism
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.0 ([CWD]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([CWD]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] patch for `bar` uses the features mechanism. \
@@ -967,11 +967,11 @@ fn no_warn_ws_patch() {
         .file("c/src/lib.rs", "")
         .build();
 
-    p.cargo("build -p a")
+    p.cargo("check -p a")
         .with_stderr(
             "\
 [UPDATING] [..]
-[COMPILING] a [..]
+[CHECKING] a [..]
 [FINISHED] [..]",
         )
         .run();
@@ -1002,12 +1002,12 @@ fn new_minor() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.1 [..]
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.1 [..]
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1052,13 +1052,13 @@ fn transitive_new_minor() {
         .file("baz/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] baz v0.1.1 [..]
-[COMPILING] bar v0.1.0 [..]
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.1.1 [..]
+[CHECKING] bar v0.1.0 [..]
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1090,12 +1090,12 @@ fn new_major() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.2.0 [..]
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.2.0 [..]
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1103,7 +1103,7 @@ fn new_major() {
 
     Package::new("bar", "0.2.0").publish();
     p.cargo("update").run();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
 
@@ -1119,14 +1119,14 @@ fn new_major() {
             bar = "0.2.0"
         "#,
     );
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.2.0 [..]
-[COMPILING] bar v0.2.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.2.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1171,13 +1171,13 @@ fn transitive_new_major() {
         .file("baz/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] baz v0.2.0 [..]
-[COMPILING] bar v0.1.0 [..]
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.2.0 [..]
+[CHECKING] bar v0.1.0 [..]
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1227,14 +1227,14 @@ fn shared_by_transitive() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
-[COMPILING] baz v0.1.2 [..]
-[COMPILING] bar v0.1.0 [..]
-[COMPILING] foo v0.1.0 ([CWD])
+[CHECKING] baz v0.1.2 [..]
+[CHECKING] bar v0.1.0 [..]
+[CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -1271,7 +1271,7 @@ fn remove_patch() {
         .build();
 
     // Generate a lock file where `foo` is unused
-    p.cargo("build").run();
+    p.cargo("check").run();
     let lock_file1 = p.read_lockfile();
 
     // Remove `foo` and generate a new lock file form the old one
@@ -1290,12 +1290,12 @@ fn remove_patch() {
             bar = { path = 'bar' }
         "#,
     );
-    p.cargo("build").run();
+    p.cargo("check").run();
     let lock_file2 = p.read_lockfile();
 
     // Remove the lock file and build from scratch
     fs::remove_file(p.root().join("Cargo.lock")).unwrap();
-    p.cargo("build").run();
+    p.cargo("check").run();
     let lock_file3 = p.read_lockfile();
 
     assert!(lock_file1.contains("foo"));
@@ -1325,7 +1325,7 @@ fn non_crates_io() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1363,7 +1363,7 @@ fn replace_with_crates_io() {
         .file("bar/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1410,8 +1410,8 @@ fn patch_in_virtual() {
         .file("foo/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -1461,10 +1461,10 @@ fn patch_depends_on_another_patch() {
         .file("baz/src/lib.rs", r#""#)
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Nothing should be rebuilt, no registry should be updated.
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -1510,7 +1510,7 @@ fn replace_prerelease() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1559,13 +1559,13 @@ fn patch_older() {
         .file("baz/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..]
-[COMPILING] baz v1.0.1 [..]
-[COMPILING] bar v0.5.0 [..]
-[COMPILING] foo v0.1.0 [..]
+[CHECKING] baz v1.0.1 [..]
+[CHECKING] bar v0.5.0 [..]
+[CHECKING] foo v0.1.0 [..]
 [FINISHED] [..]
 ",
         )
@@ -1670,7 +1670,7 @@ fn multipatch() {
         .file("a2/src/lib.rs", "pub fn f2() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1711,7 +1711,7 @@ fn patch_same_version() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1763,8 +1763,8 @@ fn two_semver_compatible() {
     // assert the build succeeds and doesn't panic anywhere, and then afterwards
     // assert that the build succeeds again without updating anything or
     // building anything else.
-    p.cargo("build").run();
-    p.cargo("build")
+    p.cargo("check").run();
+    p.cargo("check")
         .with_stderr(
             "\
 warning: Patch `bar v0.1.1 [..]` was not used in the crate graph.
@@ -1817,8 +1817,8 @@ fn multipatch_select_big() {
     // assert the build succeeds, which is only possible if 0.2.0 is selected
     // since 0.1.0 is missing the function we need. Afterwards assert that the
     // build succeeds again without updating anything or building anything else.
-    p.cargo("build").run();
-    p.cargo("build")
+    p.cargo("check").run();
+    p.cargo("check")
         .with_stderr(
             "\
 warning: Patch `bar v0.1.0 [..]` was not used in the crate graph.
@@ -1887,12 +1887,12 @@ fn canonicalize_a_bunch() {
         .build();
 
     // Once to make sure it actually works
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Then a few more times for good measure to ensure no weird warnings about
     // `[patch]` are printed.
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -1928,7 +1928,7 @@ fn update_unused_new_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains("[WARNING] Patch `bar v0.1.4 [..] was not used in the crate graph.")
         .run();
     // unused patch should be in the lock file
@@ -1948,18 +1948,18 @@ fn update_unused_new_version() {
     fs::copy(p.root().join("Cargo.lock"), p.root().join("Cargo.lock.bak")).unwrap();
 
     // Try to build again, this should automatically update Cargo.lock.
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.6 ([..]/bar)
-[COMPILING] foo v0.0.1 ([..]/foo)
+[CHECKING] bar v0.1.6 ([..]/bar)
+[CHECKING] foo v0.0.1 ([..]/foo)
 [FINISHED] [..]
 ",
         )
         .run();
     // This should not update any registry.
-    p.cargo("build").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
     assert!(!p.read_lockfile().contains("unused"));
 
     // Restore the lock file, and see if `update` will work, too.

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -139,7 +139,7 @@ fn cargo_compile_with_root_dev_deps() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]can't find crate for `bar`")
         .run();
@@ -275,10 +275,10 @@ fn no_rebuild_dependency() {
         .file("bar/src/bar.rs", "pub fn bar() {}")
         .build();
     // First time around we should compile both foo and bar
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
-             [COMPILING] foo v0.5.0 ([CWD])\n\
+            "[CHECKING] bar v0.5.0 ([CWD]/bar)\n\
+             [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
@@ -293,9 +293,9 @@ fn no_rebuild_dependency() {
         "#,
     );
     // Don't compile bar, but do recompile foo.
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] foo v0.5.0 ([..])\n\
+            "[CHECKING] foo v0.5.0 ([..])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
@@ -341,16 +341,16 @@ fn deep_dependencies_trigger_rebuild() {
         .file("baz/Cargo.toml", &basic_lib_manifest("baz"))
         .file("baz/src/baz.rs", "pub fn baz() {}")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 ([CWD]/baz)\n\
-             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
-             [COMPILING] foo v0.5.0 ([CWD])\n\
+            "[CHECKING] baz v0.5.0 ([CWD]/baz)\n\
+             [CHECKING] bar v0.5.0 ([CWD]/bar)\n\
+             [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 
     // Make sure an update to baz triggers a rebuild of bar
     //
@@ -359,11 +359,11 @@ fn deep_dependencies_trigger_rebuild() {
     sleep_ms(1000);
     p.change_file("baz/src/baz.rs", r#"pub fn baz() { println!("hello!"); }"#);
     sleep_ms(1000);
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] baz v0.5.0 ([CWD]/baz)\n\
-             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
-             [COMPILING] foo v0.5.0 ([CWD])\n\
+            "[CHECKING] baz v0.5.0 ([CWD]/baz)\n\
+             [CHECKING] bar v0.5.0 ([CWD]/bar)\n\
+             [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
@@ -379,10 +379,10 @@ fn deep_dependencies_trigger_rebuild() {
         "#,
     );
     sleep_ms(1000);
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
-             [COMPILING] foo v0.5.0 ([CWD])\n\
+            "[CHECKING] bar v0.5.0 ([CWD]/bar)\n\
+             [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
@@ -464,10 +464,10 @@ fn nested_deps_recompile() {
         .file("src/bar/src/bar.rs", "pub fn gimme() -> i32 { 92 }")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] bar v0.5.0 ([CWD]/src/bar)\n\
-             [COMPILING] foo v0.5.0 ([CWD])\n\
+            "[CHECKING] bar v0.5.0 ([CWD]/src/bar)\n\
+             [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
@@ -477,9 +477,9 @@ fn nested_deps_recompile() {
     p.change_file("src/main.rs", r#"fn main() {}"#);
 
     // This shouldn't recompile `bar`
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[COMPILING] foo v0.5.0 ([CWD])\n\
+            "[CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] dev [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
@@ -507,7 +507,7 @@ fn error_message_for_missing_manifest() {
         .file("src/bar/not-a-manifest", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -559,7 +559,7 @@ fn override_relative() {
         )
         .file("src/lib.rs", "")
         .build();
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -595,7 +595,7 @@ fn override_self() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -648,7 +648,7 @@ fn override_path_dep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -808,11 +808,11 @@ fn custom_target_no_rebuild() {
         )
         .file("b/src/lib.rs", "")
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] a v0.5.0 ([..])
-[COMPILING] foo v0.5.0 ([..])
+[CHECKING] a v0.5.0 ([..])
+[CHECKING] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -822,11 +822,11 @@ fn custom_target_no_rebuild() {
         p.root().join("target"),
         p.root().join("target_moved")
     ));
-    p.cargo("build --manifest-path=b/Cargo.toml")
+    p.cargo("check --manifest-path=b/Cargo.toml")
         .env("CARGO_TARGET_DIR", "target_moved")
         .with_stderr(
             "\
-[COMPILING] b v0.5.0 ([..])
+[CHECKING] b v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -866,14 +866,14 @@ fn override_and_depend() {
         .file("b/src/lib.rs", "")
         .file("b/.cargo/config", r#"paths = ["../a"]"#)
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .cwd("b")
         .with_stderr(
             "\
 [WARNING] skipping duplicate package `a2` found at `[..]`
-[COMPILING] a2 v0.5.0 ([..])
-[COMPILING] a1 v0.5.0 ([..])
-[COMPILING] b v0.5.0 ([..])
+[CHECKING] a2 v0.5.0 ([..])
+[CHECKING] a1 v0.5.0 ([..])
+[CHECKING] b v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -890,7 +890,7 @@ fn missing_path_dependency() {
             r#"paths = ["../whoa-this-does-not-exist"]"#,
         )
         .build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -943,7 +943,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
         .build();
 
     // Generate a lock file
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Change the dependency on `bar` to an invalid path
     p.change_file(
@@ -961,7 +961,7 @@ fn invalid_path_dep_in_workspace_with_lockfile() {
 
     // Make sure we get a nice error. In the past this actually stack
     // overflowed!
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -51,7 +51,7 @@ fn broken_path_override_warns() {
         .file(".cargo/config", r#"paths = ["a2"]"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -72,9 +72,9 @@ https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
 
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
 [FINISHED] [..]
 ",
         )
@@ -118,7 +118,7 @@ fn override_to_path_dep() {
         .file(".cargo/config", r#"paths = ["bar"]"#)
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -168,11 +168,11 @@ fn paths_ok_with_optional() {
         .file(".cargo/config", r#"paths = ["bar2"]"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.1.0 ([..]bar2)
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] bar v0.1.0 ([..]bar2)
+[CHECKING] foo v0.0.1 ([..])
 [FINISHED] [..]
 ",
         )
@@ -215,7 +215,7 @@ fn paths_add_optional_bad() {
         .file(".cargo/config", r#"paths = ["bar2"]"#)
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains(
             "\
 warning: path override for crate `bar` has altered the original list of

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -58,7 +58,7 @@ fn probe_cfg_before_crate_type_discovery() {
         )
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -117,8 +117,8 @@ fn noop() {
         )
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build").run();
+    p.cargo("check").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -242,7 +242,7 @@ fn plugin_and_proc_macro() {
         .build();
 
     let msg = "  `lib.plugin` and `lib.proc-macro` cannot both be `true`";
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(msg)
         .run();
@@ -375,7 +375,7 @@ fn proc_macro_crate_type_warning() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("build")
+    foo.cargo("check")
         .with_stderr_contains(
             "[WARNING] library `foo` should only specify `proc-macro = true` instead of setting `crate-type`")
         .run();
@@ -398,7 +398,7 @@ fn proc_macro_conflicting_warning() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("build")
+    foo.cargo("check")
         .with_stderr_contains(
 "[WARNING] conflicting between `proc-macro` and `proc_macro` in the `foo` library target.\n
         `proc_macro` is ignored and not recommended for use in the future",
@@ -423,7 +423,7 @@ fn proc_macro_crate_type_warning_plugin() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("build")
+    foo.cargo("check")
         .with_stderr_contains(
             "[WARNING] proc-macro library `foo` should not specify `plugin = true`")
         .with_stderr_contains(
@@ -447,7 +447,7 @@ fn proc_macro_crate_type_multiple() {
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("build")
+    foo.cargo("check")
         .with_stderr(
             "\
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -29,11 +29,11 @@ fn profile_override_basic() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr(
-            "[COMPILING] bar [..]
+            "[CHECKING] bar [..]
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=3 [..]`
-[COMPILING] foo [..]
+[CHECKING] foo [..]
 [RUNNING] `rustc --crate-name foo [..] -C opt-level=1 [..]`
 [FINISHED] dev [optimized + debuginfo] target(s) in [..]",
         )
@@ -125,7 +125,7 @@ fn profile_override_bad_settings() {
             .file("bar/src/lib.rs", "")
             .build();
 
-        p.cargo("build")
+        p.cargo("check")
             .with_status(101)
             .with_stderr_contains(format!("Caused by:\n  {}", expected))
             .run();
@@ -257,7 +257,7 @@ fn profile_override_spec_multiple() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -323,7 +323,7 @@ fn profile_override_spec() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_stderr_contains("[RUNNING] `rustc [..]dep1/src/lib.rs [..] -C codegen-units=1 [..]")
         .with_stderr_contains("[RUNNING] `rustc [..]dep2/src/lib.rs [..] -C codegen-units=2 [..]")
         .run();
@@ -378,7 +378,7 @@ fn override_proc_macro() {
         )
         .build();
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         // Shared built for the proc-macro.
         .with_stderr_contains("[RUNNING] `rustc [..]--crate-name shared [..]-C codegen-units=4[..]")
         // Shared built for the library.
@@ -414,10 +414,10 @@ fn no_warning_ws() {
         .file("b/src/lib.rs", "")
         .build();
 
-    p.cargo("build -p b")
+    p.cargo("check -p b")
         .with_stderr(
             "\
-[COMPILING] b [..]
+[CHECKING] b [..]
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -16,7 +16,7 @@ fn bad_progress_config_unknown_when() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -43,7 +43,7 @@ fn bad_progress_config_missing_width() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -66,7 +66,7 @@ fn bad_progress_config_missing_when() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -110,7 +110,7 @@ fn always_shows_progress() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains("[DOWNLOADING] [..] crates [..]")
         .with_stderr_contains("[..][DOWNLOADED] 3 crates ([..]) in [..]")
         .with_stderr_contains("[BUILDING] [..] [..]/4: [..]")
@@ -151,7 +151,7 @@ fn never_progress() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_does_not_contain("[DOWNLOADING] [..] crates [..]")
         .with_stderr_does_not_contain("[..][DOWNLOADED] 3 crates ([..]) in [..]")
         .with_stderr_does_not_contain("[BUILDING] [..] [..]/4: [..]")

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -32,7 +32,7 @@ fn exported_priv_warning() {
         )
         .build();
 
-    p.cargo("build --message-format=short")
+    p.cargo("check --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr_contains(
             "\
@@ -71,15 +71,15 @@ fn exported_pub_dep() {
         )
         .build();
 
-    p.cargo("build --message-format=short")
+    p.cargo("check --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 ([..])
-[COMPILING] pub_dep v0.1.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] pub_dep v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -98,7 +98,7 @@ pub fn requires_nightly_cargo() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build --message-format=short")
+    p.cargo("check --message-format=short")
         .with_status(101)
         .with_stderr(
             "\
@@ -134,7 +134,7 @@ fn requires_feature() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build --message-format=short")
+    p.cargo("check --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_status(101)
         .with_stderr(
@@ -184,7 +184,7 @@ fn pub_dev_dependency() {
         )
         .build();
 
-    p.cargo("build --message-format=short")
+    p.cargo("check --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .with_status(101)
         .with_stderr(

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -53,14 +53,14 @@ fn simple() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -71,11 +71,11 @@ fn simple() {
     assert!(paths::home().join(".cargo/registry/CACHEDIR.TAG").is_file());
 
     // Don't download a second time
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -113,16 +113,16 @@ fn deps() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
-[COMPILING] baz v0.0.1
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.0.1
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -161,7 +161,7 @@ fn nonexistent() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -205,7 +205,7 @@ fn wrong_case() {
         .build();
 
     // #5678 to make this work
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -251,7 +251,7 @@ fn mis_hyphenated() {
         .build();
 
     // #2775 to make this work
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -297,7 +297,7 @@ fn wrong_version() {
     Package::new("foo", "0.0.1").publish();
     Package::new("foo", "0.0.2").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -312,7 +312,7 @@ required by package `foo v0.0.1 ([..])`
     Package::new("foo", "0.0.3").publish();
     Package::new("foo", "0.0.4").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -357,7 +357,7 @@ fn bad_cksum() {
     pkg.publish();
     t!(File::create(&pkg.archive_dst()));
 
-    p.cargo("build -v")
+    p.cargo("check -v")
         .with_status(101)
         .with_stderr(
             "\
@@ -403,7 +403,7 @@ fn update_registry() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -416,14 +416,14 @@ required by package `foo v0.0.1 ([..])`
 
     Package::new("notyet", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
-[COMPILING] notyet v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] notyet v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -531,14 +531,14 @@ fn lockfile_locks() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -547,7 +547,7 @@ fn lockfile_locks() {
     p.root().move_into_the_past();
     Package::new("bar", "0.0.2").publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -581,16 +581,16 @@ fn lockfile_locks_transitively() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dep("baz", "*").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
-[COMPILING] baz v0.0.1
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.0.1
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -600,7 +600,7 @@ fn lockfile_locks_transitively() {
     Package::new("baz", "0.0.2").publish();
     Package::new("bar", "0.0.2").dep("baz", "*").publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -639,16 +639,16 @@ fn yanks_are_not_used() {
         .yanked(true)
         .publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
-[COMPILING] baz v0.0.1
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.0.1
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -687,7 +687,7 @@ fn relying_on_a_yank_is_bad() {
     Package::new("baz", "0.0.2").yanked(true).publish();
     Package::new("bar", "0.0.1").dep("baz", "=0.0.2").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -731,13 +731,13 @@ fn yanks_in_lockfiles_are_ok() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     registry_path().join("3").rm_rf();
 
     Package::new("bar", "0.0.1").yanked(true).publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 
     p.cargo("update")
         .with_status(101)
@@ -783,14 +783,14 @@ fn yanks_in_lockfiles_are_ok_for_other_update() {
     Package::new("bar", "0.0.1").publish();
     Package::new("baz", "0.0.1").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     registry_path().join("3").rm_rf();
 
     Package::new("bar", "0.0.1").yanked(true).publish();
     Package::new("baz", "0.0.1").publish();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 
     Package::new("baz", "0.0.2").publish();
 
@@ -845,7 +845,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     registry_path().join("3").rm_rf();
 
@@ -866,7 +866,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep() {
         "#,
     );
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -898,11 +898,11 @@ fn update_with_lockfile_if_packages_missing() {
         .build();
 
     Package::new("bar", "0.0.1").publish();
-    p.cargo("build").run();
+    p.cargo("check").run();
     p.root().move_into_the_past();
 
     paths::home().join(".cargo/registry").rm_rf();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
@@ -944,7 +944,7 @@ fn update_lockfile() {
 
     println!("0.0.1");
     Package::new("bar", "0.0.1").publish();
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("bar", "0.0.2").publish();
     Package::new("bar", "0.0.3").publish();
@@ -960,13 +960,13 @@ fn update_lockfile() {
         .run();
 
     println!("0.0.2 build");
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.2 (registry `dummy-registry`)
-[COMPILING] bar v0.0.2
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.2
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -983,13 +983,13 @@ fn update_lockfile() {
         .run();
 
     println!("0.0.3 build");
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.3 (registry `dummy-registry`)
-[COMPILING] bar v0.0.3
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.3
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1052,14 +1052,14 @@ fn dev_dependency_not_used() {
     Package::new("baz", "0.0.1").publish();
     Package::new("bar", "0.0.1").dev_dep("baz", "*").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1145,15 +1145,15 @@ fn updating_a_dep() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
-[COMPILING] bar v0.0.1
-[COMPILING] a v0.0.1 ([CWD]/a)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] a v0.0.1 ([CWD]/a)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1181,15 +1181,15 @@ fn updating_a_dep() {
     Package::new("bar", "0.1.0").publish();
 
     println!("second");
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
-[COMPILING] bar v0.1.0
-[COMPILING] a v0.0.1 ([CWD]/a)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0
+[CHECKING] a v0.0.1 ([CWD]/a)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1253,16 +1253,16 @@ fn git_and_registry_dep() {
     Package::new("a", "0.0.1").publish();
 
     p.root().move_into_the_past();
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..]
 [UPDATING] [..]
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
-[COMPILING] a v0.0.1
-[COMPILING] b v0.0.1 ([..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] a v0.0.1
+[CHECKING] b v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1270,7 +1270,7 @@ fn git_and_registry_dep() {
     p.root().move_into_the_past();
 
     println!("second");
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -1440,14 +1440,14 @@ fn update_transitive_dependency() {
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
 [DOWNLOADED] b v0.1.1 (registry `dummy-registry`)
-[COMPILING] b v0.1.1
-[COMPILING] a v0.1.0
-[COMPILING] foo v0.5.0 ([..])
+[CHECKING] b v0.1.1
+[CHECKING] a v0.1.0
+[CHECKING] foo v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1572,14 +1572,14 @@ fn update_multiple_packages() {
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr_contains("[DOWNLOADED] a v0.1.1 (registry `dummy-registry`)")
         .with_stderr_contains("[DOWNLOADED] b v0.1.1 (registry `dummy-registry`)")
         .with_stderr_contains("[DOWNLOADED] c v0.1.1 (registry `dummy-registry`)")
-        .with_stderr_contains("[COMPILING] a v0.1.1")
-        .with_stderr_contains("[COMPILING] b v0.1.1")
-        .with_stderr_contains("[COMPILING] c v0.1.1")
-        .with_stderr_contains("[COMPILING] foo v0.5.0 ([..])")
+        .with_stderr_contains("[CHECKING] a v0.1.1")
+        .with_stderr_contains("[CHECKING] b v0.1.1")
+        .with_stderr_contains("[CHECKING] c v0.1.1")
+        .with_stderr_contains("[CHECKING] foo v0.5.0 ([..])")
         .run();
 }
 
@@ -1702,7 +1702,7 @@ fn use_semver() {
 
     Package::new("foo", "1.2.3-alpha.0").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1750,7 +1750,7 @@ fn use_semver_package_incorrectly() {
         .file("b/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1801,14 +1801,14 @@ fn only_download_relevant() {
     Package::new("bar", "0.1.0").publish();
     Package::new("baz", "0.1.0").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 ([..])
-[COMPILING] baz v0.1.0
-[COMPILING] bar v0.5.0 ([..])
+[CHECKING] baz v0.1.0
+[CHECKING] bar v0.5.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
@@ -1848,7 +1848,7 @@ fn resolve_and_backtracking() {
         .publish();
     Package::new("foo", "0.1.0").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1883,7 +1883,7 @@ fn upstream_warnings_on_extra_verbose() {
         .file("src/lib.rs", "fn unused() {}")
         .publish();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .with_stderr_contains("[WARNING] [..]unused[..]")
         .run();
 }
@@ -1907,7 +1907,7 @@ fn disallow_network_http() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --frozen")
+    p.cargo("check --frozen")
         .with_status(101)
         .with_stderr(
             "\
@@ -1942,7 +1942,7 @@ fn disallow_network_git() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build --frozen")
+    p.cargo("check --frozen")
         .with_status(101)
         .with_stderr(
             "\
@@ -2004,7 +2004,7 @@ fn add_dep_dont_update_registry() {
 
     Package::new("remote", "0.3.4").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     p.change_file(
         "Cargo.toml",
@@ -2020,10 +2020,10 @@ fn add_dep_dont_update_registry() {
         "#,
     );
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.5.0 ([..])
+[CHECKING] bar v0.5.0 ([..])
 [FINISHED] [..]
 ",
         )
@@ -2073,7 +2073,7 @@ fn bump_version_dont_update_registry() {
 
     Package::new("remote", "0.3.4").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     p.change_file(
         "Cargo.toml",
@@ -2088,10 +2088,10 @@ fn bump_version_dont_update_registry() {
         "#,
     );
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
-[COMPILING] bar v0.6.0 ([..])
+[CHECKING] bar v0.6.0 ([..])
 [FINISHED] [..]
 ",
         )
@@ -2144,7 +2144,7 @@ fn toml_lies_but_index_is_truth() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -2182,7 +2182,7 @@ fn vv_prints_warnings() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -vv").run();
+    p.cargo("check -vv").run();
 }
 
 #[cargo_test]
@@ -2217,7 +2217,7 @@ fn bad_and_or_malicious_packages_rejected() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -vv")
+    p.cargo("check -vv")
         .with_status(101)
         .with_stderr(
             "\
@@ -2267,7 +2267,7 @@ fn git_init_templatedir_missing() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     remove_dir_all(paths::home().join(".cargo/registry")).unwrap();
     fs::write(
@@ -2279,8 +2279,8 @@ fn git_init_templatedir_missing() {
     )
     .unwrap();
 
-    p.cargo("build").run();
-    p.cargo("build").run();
+    p.cargo("check").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -2347,9 +2347,9 @@ fn rename_deps_and_features() {
         )
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build --features bar/foo01").run();
-    p.cargo("build --features bar/another").run();
+    p.cargo("check").run();
+    p.cargo("check --features bar/foo01").run();
+    p.cargo("check --features bar/another").run();
 }
 
 #[cargo_test]
@@ -2385,7 +2385,7 @@ fn ignore_invalid_json_lines() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -2421,7 +2421,7 @@ fn readonly_registry_still_works() {
     p.cargo("generate-lockfile").run();
     p.cargo("fetch --locked").run();
     chmod_readonly(&paths::home(), true);
-    p.cargo("build").run();
+    p.cargo("check").run();
     // make sure we un-readonly the files afterwards so "cargo clean" can remove them (#6934)
     chmod_readonly(&paths::home(), false);
 
@@ -2529,7 +2529,7 @@ fn package_lock_inside_package_is_overwritten() {
         .file(".cargo-ok", "")
         .publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let id = SourceId::for_registry(registry.index_url()).unwrap();
     let hash = cargo::util::hex::short_hash(&id);
@@ -2567,7 +2567,7 @@ fn package_lock_as_a_symlink_inside_package_is_overwritten() {
         .symlink(".cargo-ok", "src/lib.rs")
         .publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let id = SourceId::for_registry(registry.index_url()).unwrap();
     let hash = cargo::util::hex::short_hash(&id);
@@ -2663,7 +2663,7 @@ fn reach_max_unpack_size() {
     // Size of bar.crate is around 180 bytes.
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("__CARGO_TEST_MAX_UNPACK_SIZE", "8") // hit 8 bytes limit and boom!
         .env("__CARGO_TEST_MAX_UNPACK_RATIO", "0")
         .with_status(101)
@@ -2687,12 +2687,12 @@ Caused by:
         .run();
 
     // Restore to the default ratio and it should compile.
-    p.cargo("build")
+    p.cargo("check")
         .env("__CARGO_TEST_MAX_UNPACK_SIZE", "8")
         .with_stderr(
             "\
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([..])
 [FINISHED] dev [..]
 ",
         )
@@ -2733,7 +2733,7 @@ fn sparse_retry() {
 
     Package::new("bar", "0.0.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
@@ -2745,8 +2745,8 @@ body:
 internal server error
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
-[COMPILING] bar v0.0.1
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.0.1
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 ",
         )

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -49,7 +49,7 @@ fn requires_nightly() {
         .build();
 
     let p = make_project();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             r#"[UPDATING] `alternative` index

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -39,13 +39,13 @@ fn override_simple() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 (file://[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -86,15 +86,15 @@ fn override_with_features() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..] index
 [UPDATING] git repository `[..]`
 [WARNING] replacement for `bar` uses the features mechanism. default-features and features \
 will not take effect because the replacement dependency does not support this mechanism
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 (file://[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -135,15 +135,15 @@ fn override_with_setting_default_features() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] [..] index
 [UPDATING] git repository `[..]`
 [WARNING] replacement for `bar` uses the features mechanism. default-features and features \
 will not take effect because the replacement dependency does not support this mechanism
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 (file://[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -171,7 +171,7 @@ fn missing_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -205,7 +205,7 @@ fn invalid_semver_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains(
             "\
@@ -242,7 +242,7 @@ fn different_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -290,22 +290,22 @@ fn transitive() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.2.0 (registry [..])
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] baz v0.2.0
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 (file://[..])
+[CHECKING] baz v0.2.0
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -342,19 +342,19 @@ fn persists_across_rebuilds() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `file://[..]`
-[COMPILING] bar v0.1.0 (file://[..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 (file://[..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -389,12 +389,12 @@ fn replace_registry_with_path() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[COMPILING] bar v0.1.0 ([ROOT][..]/bar)
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] bar v0.1.0 ([ROOT][..]/bar)
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -454,7 +454,7 @@ fn use_a_spec_to_select() {
         )
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
@@ -462,10 +462,10 @@ fn use_a_spec_to_select() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [DOWNLOADED] [..]
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] [..]
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] [..]
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -515,22 +515,22 @@ fn override_adds_some_deps() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry [..])
-[COMPILING] baz v0.1.1
-[COMPILING] bar v0.1.0 ([..])
-[COMPILING] foo v0.0.1 ([CWD])
+[CHECKING] baz v0.1.1
+[CHECKING] bar v0.1.0 ([..])
+[CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 
     Package::new("baz", "0.1.2").publish();
     p.cargo("update -p")
@@ -550,7 +550,7 @@ fn override_adds_some_deps() {
         )
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -599,10 +599,10 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
-    p.cargo("build").with_stdout("").run();
-    p.cargo("build").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stdout("").run();
 }
 
 #[cargo_test]
@@ -636,7 +636,7 @@ fn override_wrong_name() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -683,7 +683,7 @@ fn override_with_nothing() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -722,7 +722,7 @@ fn override_wrong_version() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -769,7 +769,7 @@ fn multiple_specs() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -919,7 +919,7 @@ fn no_override_self() {
         .file("src/lib.rs", "#![no_std] pub extern crate near;")
         .build();
 
-    p.cargo("build --verbose").run();
+    p.cargo("check --verbose").run();
 }
 
 #[cargo_test]
@@ -1029,7 +1029,7 @@ fn override_an_override() {
         .file("serde/src/lib.rs", "pub fn serde08_override() {}")
         .build();
 
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -1078,8 +1078,8 @@ fn overriding_nonexistent_no_spurious() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build")
+    p.cargo("check").run();
+    p.cargo("check")
         .with_stderr(
             "\
 [WARNING] package replacement is not used: [..]baz@0.1.0
@@ -1127,24 +1127,24 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .file("local_bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("first_crate")
         .with_stdout("")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[COMPILING] bar v0.1.0 ([..])
-[COMPILING] first_crate v0.1.0 ([..])
+[CHECKING] bar v0.1.0 ([..])
+[CHECKING] first_crate v0.1.0 ([..])
 [FINISHED] [..]",
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("second_crate")
         .with_stdout("")
         .with_stderr(
             "\
-[COMPILING] second_crate v0.1.0 ([..])
+[CHECKING] second_crate v0.1.0 ([..])
 [FINISHED] [..]",
         )
         .run();
@@ -1192,7 +1192,7 @@ fn replace_to_path_dep() {
         .file("bar/baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1293,7 +1293,7 @@ fn override_plus_dep() {
         .file("bar/src/lib.rs", "")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("error: cyclic package dependency: [..]")
         .run();

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -20,8 +20,8 @@ fn rust_version_satisfied() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build").run();
-    p.cargo("build --ignore-rust-version").run();
+    p.cargo("check").run();
+    p.cargo("check --ignore-rust-version").run();
 }
 
 #[cargo_test]
@@ -41,7 +41,7 @@ fn rust_version_bad_caret() {
         )
         .file("src/main.rs", "fn main() {}")
         .build()
-        .cargo("build")
+        .cargo("check")
         .with_status(101)
         .with_stderr(
             "error: failed to parse manifest at `[..]`\n\n\
@@ -67,7 +67,7 @@ fn rust_version_bad_pre_release() {
         )
         .file("src/main.rs", "fn main() {}")
         .build()
-        .cargo("build")
+        .cargo("check")
         .with_status(101)
         .with_stderr(
             "error: failed to parse manifest at `[..]`\n\n\
@@ -93,7 +93,7 @@ fn rust_version_bad_nonsense() {
         )
         .file("src/main.rs", "fn main() {}")
         .build()
-        .cargo("build")
+        .cargo("check")
         .with_status(101)
         .with_stderr(
             "error: failed to parse manifest at `[..]`\n\n\
@@ -120,14 +120,14 @@ fn rust_version_too_high() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "error: package `foo v0.0.1 ([..])` cannot be built because it requires \
              rustc 1.9876.0 or newer, while the currently active rustc version is [..]\n\n",
         )
         .run();
-    p.cargo("build --ignore-rust-version").run();
+    p.cargo("check --ignore-rust-version").run();
 }
 
 #[cargo_test]
@@ -152,7 +152,7 @@ fn rust_version_dependency_fails() {
         .file("src/main.rs", "fn main(){}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "    Updating `[..]` index\n \
@@ -165,7 +165,7 @@ fn rust_version_dependency_fails() {
              where `ver` is the latest version of `bar` supporting rustc [..]",
         )
         .run();
-    p.cargo("build --ignore-rust-version").run();
+    p.cargo("check --ignore-rust-version").run();
 }
 
 #[cargo_test]
@@ -186,7 +186,7 @@ fn rust_version_older_than_edition() {
         )
         .file("src/main.rs", "fn main() {}")
         .build()
-        .cargo("build")
+        .cargo("check")
         .with_status(101)
         .with_stderr_contains("  rust-version 1.1 is older than first version (1.31.0) required by the specified edition (2018)",
         )

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -24,17 +24,17 @@ fn env_rustflags_normal_source() {
         .build();
 
     // Use RUSTFLAGS to pass an argument that will generate an error
-    p.cargo("build --lib")
+    p.cargo("check --lib")
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --bin=a")
+    p.cargo("check --bin=a")
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --example=b")
+    p.cargo("check --example=b")
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
@@ -74,7 +74,7 @@ fn env_rustflags_build_script() {
         )
         .build();
 
-    p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
+    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
 }
 
 #[cargo_test]
@@ -111,7 +111,7 @@ fn env_rustflags_build_script_dep() {
         )
         .build();
 
-    foo.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
+    foo.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
 }
 
 #[cargo_test]
@@ -142,7 +142,7 @@ fn env_rustflags_plugin() {
         )
         .build();
 
-    p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
+    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
 }
 
 #[cargo_test]
@@ -181,7 +181,7 @@ fn env_rustflags_plugin_dep() {
         )
         .build();
 
-    foo.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
+    foo.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
 }
 
 #[cargo_test]
@@ -204,19 +204,19 @@ fn env_rustflags_normal_source_with_target() {
     let host = &rustc_host();
 
     // Use RUSTFLAGS to pass an argument that will generate an error
-    p.cargo("build --lib --target")
+    p.cargo("check --lib --target")
         .arg(host)
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --bin=a --target")
+    p.cargo("check --bin=a --target")
         .arg(host)
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --example=b --target")
+    p.cargo("check --example=b --target")
         .arg(host)
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
@@ -260,7 +260,7 @@ fn env_rustflags_build_script_with_target() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .env("RUSTFLAGS", "--cfg foo")
         .run();
@@ -296,7 +296,7 @@ fn env_rustflags_build_script_with_target_doesnt_apply_to_host_kind() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build --target")
+    p.cargo("check --target")
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg(host)
         .arg("-Ztarget-applies-to-host")
@@ -339,7 +339,7 @@ fn env_rustflags_build_script_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    foo.cargo("build --target")
+    foo.cargo("check --target")
         .arg(host)
         .env("RUSTFLAGS", "--cfg foo")
         .run();
@@ -374,7 +374,7 @@ fn env_rustflags_plugin_with_target() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .env("RUSTFLAGS", "--cfg foo")
         .run();
@@ -417,7 +417,7 @@ fn env_rustflags_plugin_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    foo.cargo("build --target")
+    foo.cargo("check --target")
         .arg(host)
         .env("RUSTFLAGS", "--cfg foo")
         .run();
@@ -427,9 +427,9 @@ fn env_rustflags_plugin_dep_with_target() {
 fn env_rustflags_recompile() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     // Setting RUSTFLAGS forces a recompile
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
@@ -440,9 +440,9 @@ fn env_rustflags_recompile() {
 fn env_rustflags_recompile2() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
+    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
     // Setting RUSTFLAGS forces a recompile
-    p.cargo("build")
+    p.cargo("check")
         .env("RUSTFLAGS", "-Z bogus")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
@@ -453,8 +453,8 @@ fn env_rustflags_recompile2() {
 fn env_rustflags_no_recompile() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
-    p.cargo("build")
+    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
+    p.cargo("check")
         .env("RUSTFLAGS", "--cfg foo")
         .with_stdout("")
         .run();
@@ -484,15 +484,15 @@ fn build_rustflags_normal_source() {
         )
         .build();
 
-    p.cargo("build --lib")
+    p.cargo("check --lib")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --bin=a")
+    p.cargo("check --bin=a")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --example=b")
+    p.cargo("check --example=b")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
@@ -536,7 +536,7 @@ fn build_rustflags_build_script() {
         )
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -580,7 +580,7 @@ fn build_rustflags_build_script_dep() {
         )
         .build();
 
-    foo.cargo("build").run();
+    foo.cargo("check").run();
 }
 
 #[cargo_test]
@@ -618,7 +618,7 @@ fn build_rustflags_plugin() {
         )
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -664,7 +664,7 @@ fn build_rustflags_plugin_dep() {
         )
         .build();
 
-    foo.cargo("build").run();
+    foo.cargo("check").run();
 }
 
 #[cargo_test]
@@ -694,17 +694,17 @@ fn build_rustflags_normal_source_with_target() {
     let host = &rustc_host();
 
     // Use build.rustflags to pass an argument that will generate an error
-    p.cargo("build --lib --target")
+    p.cargo("check --lib --target")
         .arg(host)
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --bin=a --target")
+    p.cargo("check --bin=a --target")
         .arg(host)
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --example=b --target")
+    p.cargo("check --example=b --target")
         .arg(host)
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
@@ -752,7 +752,7 @@ fn build_rustflags_build_script_with_target() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build --target").arg(host).run();
+    p.cargo("check --target").arg(host).run();
 }
 
 #[cargo_test]
@@ -797,7 +797,7 @@ fn build_rustflags_build_script_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    foo.cargo("build --target").arg(host).run();
+    foo.cargo("check --target").arg(host).run();
 }
 
 #[cargo_test]
@@ -836,7 +836,7 @@ fn build_rustflags_plugin_with_target() {
         .build();
 
     let host = rustc_host();
-    p.cargo("build --target").arg(host).run();
+    p.cargo("check --target").arg(host).run();
 }
 
 #[cargo_test]
@@ -883,14 +883,14 @@ fn build_rustflags_plugin_dep_with_target() {
         .build();
 
     let host = rustc_host();
-    foo.cargo("build --target").arg(host).run();
+    foo.cargo("check --target").arg(host).run();
 }
 
 #[cargo_test]
 fn build_rustflags_recompile() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // Setting RUSTFLAGS forces a recompile
     let config = r#"
@@ -901,7 +901,7 @@ fn build_rustflags_recompile() {
     fs::create_dir_all(config_file.parent().unwrap()).unwrap();
     fs::write(config_file, config).unwrap();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
@@ -911,7 +911,7 @@ fn build_rustflags_recompile() {
 fn build_rustflags_recompile2() {
     let p = project().file("src/lib.rs", "").build();
 
-    p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
+    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
 
     // Setting RUSTFLAGS forces a recompile
     let config = r#"
@@ -922,7 +922,7 @@ fn build_rustflags_recompile2() {
     fs::create_dir_all(config_file.parent().unwrap()).unwrap();
     fs::write(config_file, config).unwrap();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
@@ -941,8 +941,8 @@ fn build_rustflags_no_recompile() {
         )
         .build();
 
-    p.cargo("build").env("RUSTFLAGS", "--cfg foo").run();
-    p.cargo("build")
+    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
+    p.cargo("check")
         .env("RUSTFLAGS", "--cfg foo")
         .with_stdout("")
         .run();
@@ -967,7 +967,7 @@ fn build_rustflags_with_home_config() {
     // so the walking process finds the home project twice.
     let p = project_in_home("foo").file("src/lib.rs", "").build();
 
-    p.cargo("build -v").run();
+    p.cargo("check -v").run();
 }
 
 #[cargo_test]
@@ -997,15 +997,15 @@ fn target_rustflags_normal_source() {
         )
         .build();
 
-    p.cargo("build --lib")
+    p.cargo("check --lib")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --bin=a")
+    p.cargo("check --bin=a")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --example=b")
+    p.cargo("check --example=b")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
@@ -1041,7 +1041,7 @@ fn target_rustflags_also_for_build_scripts() {
         )
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1067,10 +1067,10 @@ fn target_rustflags_not_for_build_scripts_with_target() {
         )
         .build();
 
-    p.cargo("build --target").arg(host).run();
+    p.cargo("check --target").arg(host).run();
 
     // Enabling -Ztarget-applies-to-host should not make a difference without the config setting
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
@@ -1090,7 +1090,7 @@ fn target_rustflags_not_for_build_scripts_with_target() {
             host
         ),
     );
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
@@ -1118,21 +1118,21 @@ fn build_rustflags_for_build_scripts() {
         .build();
 
     // With "legacy" behavior, build.rustflags should apply to build scripts without --target
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     // But should _not_ apply _with_ --target
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .with_status(101)
         .with_stderr_contains("[..]assertion failed[..]")
         .run();
 
     // Enabling -Ztarget-applies-to-host should not make a difference without the config setting
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .run();
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
@@ -1151,13 +1151,13 @@ fn build_rustflags_for_build_scripts() {
         rustflags = [\"--cfg=foo\"]
         ",
     );
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
         .with_status(101)
         .with_stderr_contains("[..]assertion failed[..]")
         .run();
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .masquerade_as_nightly_cargo(&["target-applies-to-host"])
         .arg("-Ztarget-applies-to-host")
@@ -1192,7 +1192,7 @@ fn host_rustflags_for_build_scripts() {
         )
         .build();
 
-    p.cargo("build --target")
+    p.cargo("check --target")
         .arg(host)
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .arg("-Ztarget-applies-to-host")
@@ -1223,15 +1223,15 @@ fn target_rustflags_precedence() {
         )
         .build();
 
-    p.cargo("build --lib")
+    p.cargo("check --lib")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --bin=a")
+    p.cargo("check --bin=a")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
-    p.cargo("build --example=b")
+    p.cargo("check --example=b")
         .with_status(101)
         .with_stderr_contains("[..]bogus[..]")
         .run();
@@ -1428,10 +1428,10 @@ fn target_rustflags_string_and_array_form1() {
         )
         .build();
 
-    p1.cargo("build -v")
+    p1.cargo("check -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1449,10 +1449,10 @@ fn target_rustflags_string_and_array_form1() {
         )
         .build();
 
-    p2.cargo("build -v")
+    p2.cargo("check -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1476,10 +1476,10 @@ fn target_rustflags_string_and_array_form2() {
         .file("src/lib.rs", "")
         .build();
 
-    p1.cargo("build -v")
+    p1.cargo("check -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1500,10 +1500,10 @@ fn target_rustflags_string_and_array_form2() {
         .file("src/lib.rs", "")
         .build();
 
-    p2.cargo("build -v")
+    p2.cargo("check -v")
         .with_stderr(
             "\
-[COMPILING] foo v0.0.1 ([..])
+[CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1575,7 +1575,7 @@ fn env_rustflags_misspelled_build_script() {
         .file("build.rs", "fn main() { }")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("RUST_FLAGS", "foo")
         .with_stderr_contains("[WARNING] Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?")
         .run();
@@ -1662,7 +1662,7 @@ fn host_config_rustflags_with_target() {
         .file(".cargo/config.toml", "target-applies-to-host = false")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .masquerade_as_nightly_cargo(&["target-applies-to-host", "host-config"])
         .arg("-Zhost-config")
         .arg("-Ztarget-applies-to-host")

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -36,7 +36,7 @@ fn minor_update_two_places() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     Package::new("log", "0.1.1").publish();
 
     p.change_file(
@@ -52,7 +52,7 @@ fn minor_update_two_places() {
         "#,
     );
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -91,7 +91,7 @@ fn transitive_minor_update() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("log", "0.1.1").publish();
     Package::new("serde", "0.1.1").dep("log", "0.1.1").publish();
@@ -150,7 +150,7 @@ fn conservative() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("log", "0.1.1").publish();
     Package::new("serde", "0.1.1").dep("log", "0.1").publish();
@@ -198,11 +198,11 @@ fn update_via_new_dep() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     Package::new("log", "0.1.1").publish();
 
     p.uncomment_root_manifest();
-    p.cargo("build").env("CARGO_LOG", "cargo=trace").run();
+    p.cargo("check").env("CARGO_LOG", "cargo=trace").run();
 }
 
 #[cargo_test]
@@ -240,11 +240,11 @@ fn update_via_new_member() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     Package::new("log", "0.1.1").publish();
 
     p.uncomment_root_manifest();
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -267,13 +267,13 @@ fn add_dep_deep_new_requirement() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("log", "0.1.1").publish();
     Package::new("bar", "0.1.0").dep("log", "0.1.1").publish();
 
     p.uncomment_root_manifest();
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -297,13 +297,13 @@ fn everything_real_deep() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("log", "0.1.1").publish();
     Package::new("bar", "0.1.0").dep("log", "0.1.1").publish();
 
     p.uncomment_root_manifest();
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -339,7 +339,7 @@ fn change_package_version() {
         )
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -377,7 +377,7 @@ fn update_precise() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("serde", "0.2.0").publish();
 
@@ -412,7 +412,7 @@ fn update_precise_do_not_force_update_deps() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("log", "0.1.1").publish();
     Package::new("serde", "0.2.2").dep("log", "0.1").publish();
@@ -448,7 +448,7 @@ fn update_aggressive() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     Package::new("log", "0.1.1").publish();
     Package::new("serde", "0.2.2").dep("log", "0.1").publish();
@@ -709,7 +709,7 @@ fn dry_run_update() {
         .file("foo/src/lib.rs", "")
         .build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     let old_lockfile = p.read_lockfile();
 
     Package::new("log", "0.1.1").publish();

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -34,7 +34,7 @@ fn vendor_simple() {
     assert!(lock.contains("version = \"0.3.5\""));
 
     add_vendor_config(&p);
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -247,7 +247,7 @@ fn two_versions() {
     assert!(lock.contains("version = \"0.7.0\""));
 
     add_vendor_config(&p);
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -292,7 +292,7 @@ fn two_explicit_versions() {
     assert!(lock.contains("version = \"0.7.0\""));
 
     add_vendor_config(&p);
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -385,8 +385,8 @@ fn two_lockfiles() {
     assert!(lock.contains("version = \"0.7.0\""));
 
     add_vendor_config(&p);
-    p.cargo("build").cwd("foo").run();
-    p.cargo("build").cwd("bar").run();
+    p.cargo("check").cwd("foo").run();
+    p.cargo("check").cwd("bar").run();
 }
 
 #[cargo_test]
@@ -642,7 +642,7 @@ fn vendoring_git_crates() {
     p.read_file("vendor/serde_derive/src/wut.rs");
 
     add_vendor_config(&p);
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -104,16 +104,16 @@ fn non_virtual_default_members_build_other_member() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[..] Compiling baz v0.1.0 ([..])\n\
+            "[CHECKING] baz v0.1.0 ([..])\n\
              [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 
-    p.cargo("build --manifest-path bar/Cargo.toml")
+    p.cargo("check --manifest-path bar/Cargo.toml")
         .with_stderr(
-            "[..] Compiling bar v0.1.0 ([..])\n\
+            "[CHECKING] bar v0.1.0 ([..])\n\
              [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
@@ -140,9 +140,9 @@ fn non_virtual_default_members_build_root_project() {
         .file("bar/src/lib.rs", "pub fn bar() {}")
         .build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
-            "[..] Compiling foo v0.1.0 ([..])\n\
+            "[CHECKING] foo v0.1.0 ([..])\n\
              [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
@@ -339,7 +339,7 @@ fn same_names_in_workspace() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -370,7 +370,7 @@ fn parent_doesnt_point_to_child() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -402,7 +402,7 @@ fn invalid_parent_pointer() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -433,7 +433,7 @@ fn invalid_members() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -466,7 +466,7 @@ fn bare_workspace_ok() {
         .file("src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -500,7 +500,7 @@ fn two_roots() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -530,7 +530,7 @@ fn workspace_isnt_root() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr("error: root of a workspace inferred but wasn't a root: [..]")
         .run();
@@ -576,7 +576,7 @@ fn dangling_member() {
         .file("baz/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -615,7 +615,7 @@ fn cycle() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "[ERROR] root of a workspace inferred but wasn't a root: [..]/foo/bar/Cargo.toml",
@@ -660,14 +660,14 @@ fn share_dependencies() {
     Package::new("dep1", "0.1.3").publish();
     Package::new("dep1", "0.1.8").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 ([..])
-[COMPILING] dep1 v0.1.3
-[COMPILING] foo v0.1.0 ([..])
+[CHECKING] dep1 v0.1.3
+[CHECKING] foo v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -762,26 +762,26 @@ fn lock_works_for_everyone() {
     Package::new("dep1", "0.1.1").publish();
     Package::new("dep2", "0.1.1").publish();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep2 v0.1.0 ([..])
-[COMPILING] dep2 v0.1.0
-[COMPILING] foo v0.1.0 ([..])
+[CHECKING] dep2 v0.1.0
+[CHECKING] foo v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_stderr(
             "\
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.0 ([..])
-[COMPILING] dep1 v0.1.0
-[COMPILING] bar v0.1.0 ([..])
+[CHECKING] dep1 v0.1.0
+[CHECKING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -838,7 +838,7 @@ fn virtual_misconfigure() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr(
@@ -868,7 +868,7 @@ fn virtual_build_all_implied() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -906,7 +906,7 @@ fn virtual_default_member_is_not_a_member() {
         .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -934,9 +934,9 @@ fn virtual_default_members_build_other_member() {
         .file("baz/src/lib.rs", "pub fn baz() {}")
         .build();
 
-    p.cargo("build --manifest-path bar/Cargo.toml")
+    p.cargo("check --manifest-path bar/Cargo.toml")
         .with_stderr(
-            "[..] Compiling bar v0.1.0 ([..])\n\
+            "[CHECKING] bar v0.1.0 ([..])\n\
              [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
@@ -951,7 +951,7 @@ fn virtual_build_no_members() {
         "#,
     );
     let p = p.build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -984,7 +984,7 @@ fn include_virtual() {
             "#,
         );
     let p = p.build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1034,10 +1034,10 @@ fn members_include_path_deps() {
         .file("p3/src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").cwd("p1").run();
-    p.cargo("build").cwd("p2").run();
-    p.cargo("build").cwd("p3").run();
-    p.cargo("build").run();
+    p.cargo("check").cwd("p1").run();
+    p.cargo("check").cwd("p2").run();
+    p.cargo("check").cwd("p3").run();
+    p.cargo("check").run();
 
     assert!(p.root().join("target").is_dir());
     assert!(!p.root().join("p1/target").is_dir());
@@ -1142,11 +1142,11 @@ fn lock_doesnt_change_depending_on_crate() {
     Package::new("foo", "1.0.0").publish();
     Package::new("bar", "1.0.0").publish();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 
     let lockfile = p.read_lockfile();
 
-    p.cargo("build").cwd("baz").run();
+    p.cargo("check").cwd("baz").run();
 
     let lockfile2 = p.read_lockfile();
 
@@ -1245,7 +1245,7 @@ fn workspace_in_git() {
         );
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
 }
 
 #[cargo_test]
@@ -1275,7 +1275,7 @@ fn lockfile_can_specify_nonexistent_members() {
 
     let p = p.build();
 
-    p.cargo("build").cwd("a").run();
+    p.cargo("check").cwd("a").run();
 }
 
 #[cargo_test]
@@ -1356,7 +1356,7 @@ fn error_if_parent_cargo_toml_is_invalid() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .cwd("bar")
         .with_status(101)
         .with_stderr_contains("[ERROR] failed to parse manifest at `[..]`")
@@ -1392,8 +1392,8 @@ fn relative_path_for_member_works() {
         .file("bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build").cwd("foo").run();
-    p.cargo("build").cwd("bar").run();
+    p.cargo("check").cwd("foo").run();
+    p.cargo("check").cwd("bar").run();
 }
 
 #[cargo_test]
@@ -1418,9 +1418,9 @@ fn relative_path_for_root_works() {
         .file("subproj/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build --manifest-path ./Cargo.toml").run();
+    p.cargo("check --manifest-path ./Cargo.toml").run();
 
-    p.cargo("build --manifest-path ../Cargo.toml")
+    p.cargo("check --manifest-path ../Cargo.toml")
         .cwd("subproj")
         .run();
 }
@@ -1448,7 +1448,7 @@ fn path_dep_outside_workspace_is_not_member() {
         .file("foo/src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").cwd("ws").run();
+    p.cargo("check").cwd("ws").run();
 }
 
 #[cargo_test]
@@ -1500,7 +1500,7 @@ fn test_in_and_out_of_workspace() {
         .file("bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
 
-    p.cargo("build").cwd("ws").run();
+    p.cargo("check").cwd("ws").run();
 
     assert!(p.root().join("ws/Cargo.lock").is_file());
     assert!(p.root().join("ws/target").is_dir());
@@ -1509,7 +1509,7 @@ fn test_in_and_out_of_workspace() {
     assert!(!p.root().join("bar/Cargo.lock").is_file());
     assert!(!p.root().join("bar/target").is_dir());
 
-    p.cargo("build").cwd("foo").run();
+    p.cargo("check").cwd("foo").run();
     assert!(p.root().join("foo/Cargo.lock").is_file());
     assert!(p.root().join("foo/target").is_dir());
     assert!(!p.root().join("bar/Cargo.lock").is_file());
@@ -1555,12 +1555,12 @@ fn test_path_dependency_under_member() {
         .file("foo/bar/src/lib.rs", "pub fn f() { }");
     let p = p.build();
 
-    p.cargo("build").cwd("ws").run();
+    p.cargo("check").cwd("ws").run();
 
     assert!(!p.root().join("foo/bar/Cargo.lock").is_file());
     assert!(!p.root().join("foo/bar/target").is_dir());
 
-    p.cargo("build").cwd("foo/bar").run();
+    p.cargo("check").cwd("foo/bar").run();
 
     assert!(!p.root().join("foo/bar/Cargo.lock").is_file());
     assert!(!p.root().join("foo/bar/target").is_dir());
@@ -1586,9 +1586,9 @@ fn excluded_simple() {
         .file("foo/src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     assert!(p.root().join("target").is_dir());
-    p.cargo("build").cwd("foo").run();
+    p.cargo("check").cwd("foo").run();
     assert!(p.root().join("foo/target").is_dir());
 }
 
@@ -1615,11 +1615,11 @@ fn exclude_members_preferred() {
         .file("foo/bar/src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     assert!(p.root().join("target").is_dir());
-    p.cargo("build").cwd("foo").run();
+    p.cargo("check").cwd("foo").run();
     assert!(p.root().join("foo/target").is_dir());
-    p.cargo("build").cwd("foo/bar").run();
+    p.cargo("check").cwd("foo/bar").run();
     assert!(!p.root().join("foo/bar/target").is_dir());
 }
 
@@ -1648,11 +1648,11 @@ fn exclude_but_also_depend() {
         .file("foo/bar/src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").run();
+    p.cargo("check").run();
     assert!(p.root().join("target").is_dir());
-    p.cargo("build").cwd("foo").run();
+    p.cargo("check").cwd("foo").run();
     assert!(p.root().join("foo/target").is_dir());
-    p.cargo("build").cwd("foo/bar").run();
+    p.cargo("check").cwd("foo/bar").run();
     assert!(p.root().join("foo/bar/target").is_dir());
 }
 
@@ -1672,7 +1672,7 @@ fn excluded_default_members_still_must_be_members() {
         .file("foo/src/lib.rs", "")
         .file("bar/something.txt", "");
     let p = p.build();
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -1901,7 +1901,7 @@ fn glob_syntax_invalid_members() {
         .file("crates/bar/src/main.rs", "fn main() {}");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .with_status(101)
         .with_stderr(
             "\
@@ -2073,7 +2073,7 @@ fn dont_recurse_out_of_cargo_home() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build")
+    p.cargo("check")
         .env("CARGO_HOME", p.root().join(".cargo"))
         .run();
 }
@@ -2121,8 +2121,8 @@ fn cargo_home_at_root_works() {
         .file("a/src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("build").run();
-    p.cargo("build --frozen").env("CARGO_HOME", p.root()).run();
+    p.cargo("check").run();
+    p.cargo("check --frozen").env("CARGO_HOME", p.root()).run();
 }
 
 #[cargo_test]
@@ -2335,7 +2335,7 @@ fn invalid_missing() {
         .file("src/lib.rs", "")
         .build();
 
-    p.cargo("build -q")
+    p.cargo("check -q")
         .with_status(101)
         .with_stderr(
             "\
@@ -2387,7 +2387,7 @@ fn member_dep_missing() {
         .file("bar/src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("build -q")
+    p.cargo("check -q")
         .with_status(101)
         .with_stderr(
             "\


### PR DESCRIPTION
#11341 brought up issues with cargo's `testsute` size and speed. One of the suggested fixes was switching most tests to `check` instead of `build`. This PR did that.


Before size on `nightly`: 4.4GB

After size on `nightly`: 4.2GB

Regex to find `build` in `tests/testsuite`: `cargo\(".*build.*\)`
Before: 1607
After: 626


Note I did not remove all `build` I only did the easy ones that required minimal changes. I also tried not to touch systems I was unsure about. There could be other uses of `build` I missed as well.

I still need to play around with `opt-level`, `debug=0`, and a few other tweaks, but there should be more time/memory to drop.

Each test file changed is in a commit of its own, so you should look commit by commit.