### PR TITLE
Read environment variables through `Config` instead of `std::env::var(_os)`

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -235,7 +235,7 @@ fn is_executable<P: AsRef<Path>>(path: P) -> bool {
 }
 
 fn search_directories(config: &Config) -> Vec<PathBuf> {
-    let mut path_dirs = if let Some(val) = env::var_os("PATH") {
+    let mut path_dirs = if let Some(val) = config.get_env_os("PATH") {
         env::split_paths(&val).collect()
     } else {
         vec![]

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -20,7 +20,6 @@ use cargo_util::{paths, ProcessBuilder};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::collections::hash_map::{Entry, HashMap};
-use std::env;
 use std::path::{Path, PathBuf};
 use std::str::{self, FromStr};
 
@@ -731,7 +730,7 @@ fn extra_args(
     // NOTE: It is impossible to have a [host] section and reach this logic with kind.is_host(),
     // since [host] implies `target-applies-to-host = false`, which always early-returns above.
 
-    if let Some(rustflags) = rustflags_from_env(flags) {
+    if let Some(rustflags) = rustflags_from_env(config, flags) {
         Ok(rustflags)
     } else if let Some(rustflags) =
         rustflags_from_target(config, host_triple, target_cfg, kind, flags)?
@@ -746,10 +745,10 @@ fn extra_args(
 
 /// Gets compiler flags from environment variables.
 /// See [`extra_args`] for more.
-fn rustflags_from_env(flags: Flags) -> Option<Vec<String>> {
+fn rustflags_from_env(config: &Config, flags: Flags) -> Option<Vec<String>> {
     // First try CARGO_ENCODED_RUSTFLAGS from the environment.
     // Prefer this over RUSTFLAGS since it's less prone to encoding errors.
-    if let Ok(a) = env::var(format!("CARGO_ENCODED_{}", flags.as_env())) {
+    if let Ok(a) = config.get_env(format!("CARGO_ENCODED_{}", flags.as_env())) {
         if a.is_empty() {
             return Some(Vec::new());
         }
@@ -757,7 +756,7 @@ fn rustflags_from_env(flags: Flags) -> Option<Vec<String>> {
     }
 
     // Then try RUSTFLAGS from the environment
-    if let Ok(a) = env::var(flags.as_env()) {
+    if let Ok(a) = config.get_env(flags.as_env()) {
         let args = a
             .split(' ')
             .map(str::trim)
@@ -855,7 +854,7 @@ pub struct RustcTargetData<'cfg> {
     pub rustc: Rustc,
 
     /// Config
-    config: &'cfg Config,
+    pub config: &'cfg Config,
     requested_kinds: Vec<CompileKind>,
 
     /// Build information for the "host", which is information about when

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -1,7 +1,6 @@
 //! Type definitions for the result of a compilation.
 
 use std::collections::{BTreeSet, HashMap};
-use std::env;
 use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
@@ -295,7 +294,7 @@ impl<'cfg> Compilation<'cfg> {
             // These are the defaults when DYLD_FALLBACK_LIBRARY_PATH isn't
             // set or set to an empty string. Since Cargo is explicitly setting
             // the value, make sure the defaults still work.
-            if let Some(home) = env::var_os("HOME") {
+            if let Some(home) = self.config.get_env_os("HOME") {
                 search_path.push(PathBuf::from(home).join("lib"));
             }
             search_path.push(PathBuf::from("/usr/local/lib"));
@@ -362,7 +361,7 @@ impl<'cfg> Compilation<'cfg> {
                 continue;
             }
 
-            if value.is_force() || env::var_os(key).is_none() {
+            if value.is_force() || self.config.get_env_os(key).is_none() {
                 cmd.env(key, value.resolve(self.config));
             }
         }

--- a/src/cargo/core/compiler/context/compilation_files.rs
+++ b/src/cargo/core/compiler/context/compilation_files.rs
@@ -1,7 +1,6 @@
 //! See [`CompilationFiles`].
 
 use std::collections::HashMap;
-use std::env;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
@@ -628,7 +627,7 @@ fn compute_metadata(
 
     // Seed the contents of `__CARGO_DEFAULT_LIB_METADATA` to the hasher if present.
     // This should be the release channel, to get a different hash for each channel.
-    if let Ok(ref channel) = env::var("__CARGO_DEFAULT_LIB_METADATA") {
+    if let Ok(ref channel) = cx.bcx.config.get_env("__CARGO_DEFAULT_LIB_METADATA") {
         channel.hash(&mut hasher);
     }
 
@@ -717,7 +716,7 @@ fn should_use_metadata(bcx: &BuildContext<'_, '_>, unit: &Unit) -> bool {
         || (unit.target.is_executable() && short_name == "wasm32-unknown-emscripten")
         || (unit.target.is_executable() && short_name.contains("msvc")))
         && unit.pkg.package_id().source_id().is_path()
-        && env::var("__CARGO_DEFAULT_LIB_METADATA").is_err()
+        && bcx.config.get_env("__CARGO_DEFAULT_LIB_METADATA").is_err()
     {
         return false;
     }

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -11,7 +11,6 @@ use crate::ops::{self, Packages};
 use crate::util::errors::CargoResult;
 use crate::Config;
 use std::collections::{HashMap, HashSet};
-use std::env;
 use std::path::PathBuf;
 
 use super::BuildConfig;
@@ -222,7 +221,7 @@ pub fn generate_std_roots(
 }
 
 fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<PathBuf> {
-    if let Some(s) = env::var_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
+    if let Some(s) = target_data.config.get_env_os("__CARGO_TESTS_ONLY_SRC_ROOT") {
         return Ok(s.into());
     }
 
@@ -241,7 +240,7 @@ fn detect_sysroot_src_path(target_data: &RustcTargetData<'_>) -> CargoResult<Pat
              library, try:\n        rustup component add rust-src",
             lock
         );
-        match env::var("RUSTUP_TOOLCHAIN") {
+        match target_data.config.get_env("RUSTUP_TOOLCHAIN") {
             Ok(rustup_toolchain) => {
                 anyhow::bail!("{} --toolchain {}", msg, rustup_toolchain);
             }

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -31,7 +31,7 @@ use crate::util::{closest_msg, config, CargoResult, Config};
 use anyhow::{bail, Context as _};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::hash::Hash;
-use std::{cmp, env, fmt, hash};
+use std::{cmp, fmt, hash};
 
 /// Collection of all profiles.
 ///
@@ -62,7 +62,7 @@ pub struct Profiles {
 impl Profiles {
     pub fn new(ws: &Workspace<'_>, requested_profile: InternedString) -> CargoResult<Profiles> {
         let config = ws.config();
-        let incremental = match env::var_os("CARGO_INCREMENTAL") {
+        let incremental = match config.get_env_os("CARGO_INCREMENTAL") {
             Some(v) => Some(v == "1"),
             None => config.build_config()?.incremental,
         };

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -215,14 +215,14 @@ pub fn create_bcx<'a, 'cfg>(
         | CompileMode::Check { .. }
         | CompileMode::Bench
         | CompileMode::RunCustomBuild => {
-            if std::env::var("RUST_FLAGS").is_ok() {
+            if ws.config().get_env("RUST_FLAGS").is_ok() {
                 config.shell().warn(
                     "Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?",
                 )?;
             }
         }
         CompileMode::Doc { .. } | CompileMode::Doctest | CompileMode::Docscrape => {
-            if std::env::var("RUSTDOC_FLAGS").is_ok() {
+            if ws.config().get_env("RUSTDOC_FLAGS").is_ok() {
                 config.shell().warn(
                     "Cargo does not read `RUSTDOC_FLAGS` environment variable. Did you mean `RUSTDOCFLAGS`?"
                 )?;

--- a/src/cargo/ops/cargo_config.rs
+++ b/src/cargo/ops/cargo_config.rs
@@ -93,7 +93,7 @@ fn maybe_env<'config>(
     config: &'config Config,
     key: &ConfigKey,
     cv: &CV,
-) -> Option<Vec<(&'config String, &'config String)>> {
+) -> Option<Vec<(&'config str, &'config str)>> {
     // Only fetching a table is unable to load env values. Leaf entries should
     // work properly.
     match cv {
@@ -102,7 +102,6 @@ fn maybe_env<'config>(
     }
     let mut env: Vec<_> = config
         .env()
-        .iter()
         .filter(|(env_key, _val)| env_key.starts_with(&format!("{}_", key.as_env_key())))
         .collect();
     env.sort_by_key(|x| x.0);
@@ -162,7 +161,7 @@ fn print_toml(config: &Config, opts: &GetOptions<'_>, key: &ConfigKey, cv: &CV) 
     }
 }
 
-fn print_toml_env(config: &Config, env: &[(&String, &String)]) {
+fn print_toml_env(config: &Config, env: &[(&str, &str)]) {
     drop_println!(
         config,
         "# The following environment variables may affect the loaded values."
@@ -173,7 +172,7 @@ fn print_toml_env(config: &Config, env: &[(&String, &String)]) {
     }
 }
 
-fn print_json_env(config: &Config, env: &[(&String, &String)]) {
+fn print_json_env(config: &Config, env: &[(&str, &str)]) {
     drop_eprintln!(
         config,
         "note: The following environment variables may affect the loaded values."
@@ -287,7 +286,6 @@ fn print_toml_unmerged(config: &Config, opts: &GetOptions<'_>, key: &ConfigKey) 
     // special, and will just naturally get loaded as part of the config.
     let mut env: Vec<_> = config
         .env()
-        .iter()
         .filter(|(env_key, _val)| env_key.starts_with(key.as_env_key()))
         .collect();
     if !env.is_empty() {

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,6 +1,6 @@
 use crate::core::{Shell, Workspace};
 use crate::ops;
-use crate::util::config::PathAndArgs;
+use crate::util::config::{Config, PathAndArgs};
 use crate::util::CargoResult;
 use std::path::Path;
 use std::path::PathBuf;
@@ -37,7 +37,7 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
 
             let mut shell = ws.config().shell();
             shell.status("Opening", path.display())?;
-            open_docs(&path, &mut shell, config_browser)?;
+            open_docs(&path, &mut shell, config_browser, ws.config())?;
         }
     }
 
@@ -48,9 +48,10 @@ fn open_docs(
     path: &Path,
     shell: &mut Shell,
     config_browser: Option<(PathBuf, Vec<String>)>,
+    config: &Config,
 ) -> CargoResult<()> {
     let browser =
-        config_browser.or_else(|| Some((PathBuf::from(std::env::var_os("BROWSER")?), Vec::new())));
+        config_browser.or_else(|| Some((PathBuf::from(config.get_env_os("BROWSER")?), Vec::new())));
 
     match browser {
         Some((browser, initial_args)) => {

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -704,7 +704,7 @@ pub fn install(
     if installed_anything {
         // Print a warning that if this directory isn't in PATH that they won't be
         // able to run these commands.
-        let path = env::var_os("PATH").unwrap_or_default();
+        let path = config.get_env_os("PATH").unwrap_or_default();
         let dst_in_path = env::split_paths(&path).any(|path| path == dst);
 
         if !dst_in_path {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -463,7 +463,7 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
 
 pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<NewProjectKind> {
     // This is here just as a random location to exercise the internal error handling.
-    if std::env::var_os("__CARGO_TEST_INTERNAL_ERROR").is_some() {
+    if config.get_env_os("__CARGO_TEST_INTERNAL_ERROR").is_some() {
         return Err(crate::util::internal("internal error test"));
     }
 

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -506,7 +506,7 @@ pub fn resolve_root(flag: Option<&str>, config: &Config) -> CargoResult<Filesyst
     let config_root = config.get_path("install.root")?;
     Ok(flag
         .map(PathBuf::from)
-        .or_else(|| env::var_os("CARGO_INSTALL_ROOT").map(PathBuf::from))
+        .or_else(|| config.get_env_os("CARGO_INSTALL_ROOT").map(PathBuf::from))
         .or_else(move || config_root.map(|v| v.val))
         .map(Filesystem::new)
         .unwrap_or_else(|| config.home().clone()))

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -354,7 +354,8 @@ pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
     let args = FixArgs::get()?;
     trace!("cargo-fix as rustc got file {:?}", args.file);
 
-    let workspace_rustc = std::env::var("RUSTC_WORKSPACE_WRAPPER")
+    let workspace_rustc = config
+        .get_env("RUSTC_WORKSPACE_WRAPPER")
         .map(PathBuf::from)
         .ok();
     let mut rustc = ProcessBuilder::new(&args.rustc).wrapped(workspace_rustc.as_ref());
@@ -388,7 +389,7 @@ pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
                     file: path.clone(),
                     fixes: file.fixes_applied,
                 }
-                .post()?;
+                .post(config)?;
             }
         }
 
@@ -403,7 +404,7 @@ pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
         // user's code with our changes. Back out everything and fall through
         // below to recompile again.
         if !output.status.success() {
-            if env::var_os(BROKEN_CODE_ENV).is_none() {
+            if config.get_env_os(BROKEN_CODE_ENV).is_none() {
                 for (path, file) in fixes.files.iter() {
                     debug!("reverting {:?} due to errors", path);
                     paths::write(path, &file.original_code)?;
@@ -420,7 +421,7 @@ pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
                 }
                 krate
             };
-            log_failed_fix(krate, &output.stderr, output.status)?;
+            log_failed_fix(config, krate, &output.stderr, output.status)?;
         }
     }
 
@@ -510,7 +511,8 @@ fn rustfix_crate(
     //   definitely can't make progress, so bail out.
     let mut fixes = FixedCrate::default();
     let mut last_fix_counts = HashMap::new();
-    let iterations = env::var("CARGO_FIX_MAX_RETRIES")
+    let iterations = config
+        .get_env("CARGO_FIX_MAX_RETRIES")
         .ok()
         .and_then(|n| n.parse().ok())
         .unwrap_or(4);
@@ -547,7 +549,7 @@ fn rustfix_crate(
                 file: path.clone(),
                 message: error,
             }
-            .post()?;
+            .post(config)?;
         }
     }
 
@@ -576,7 +578,7 @@ fn rustfix_and_fix(
     // worse by applying fixes where a bug could cause *more* broken code.
     // Instead, punt upwards which will reexec rustc over the original code,
     // displaying pretty versions of the diagnostics we just read out.
-    if !output.status.success() && env::var_os(BROKEN_CODE_ENV).is_none() {
+    if !output.status.success() && config.get_env_os(BROKEN_CODE_ENV).is_none() {
         debug!(
             "rustfixing `{:?}` failed, rustc exited with {:?}",
             filename,
@@ -585,7 +587,8 @@ fn rustfix_and_fix(
         return Ok(());
     }
 
-    let fix_mode = env::var_os("__CARGO_FIX_YOLO")
+    let fix_mode = config
+        .get_env_os("__CARGO_FIX_YOLO")
         .map(|_| rustfix::Filter::Everything)
         .unwrap_or(rustfix::Filter::MachineApplicableOnly);
 
@@ -710,7 +713,12 @@ fn exit_with(status: ExitStatus) -> ! {
     process::exit(status.code().unwrap_or(3));
 }
 
-fn log_failed_fix(krate: Option<String>, stderr: &[u8], status: ExitStatus) -> CargoResult<()> {
+fn log_failed_fix(
+    config: &Config,
+    krate: Option<String>,
+    stderr: &[u8],
+    status: ExitStatus,
+) -> CargoResult<()> {
     let stderr = str::from_utf8(stderr).context("failed to parse rustc stderr as utf-8")?;
 
     let diagnostics = stderr
@@ -745,7 +753,7 @@ fn log_failed_fix(krate: Option<String>, stderr: &[u8], status: ExitStatus) -> C
         errors,
         abnormal_exit,
     }
-    .post()?;
+    .post(config)?;
 
     Ok(())
 }
@@ -895,7 +903,7 @@ impl FixArgs {
                 return Message::Fixing {
                     file: self.file.display().to_string(),
                 }
-                .post()
+                .post(config)
                 .and(Ok(true));
             }
         };
@@ -922,7 +930,7 @@ impl FixArgs {
                 message,
                 edition: to_edition.previous().unwrap(),
             }
-            .post()
+            .post(config)
             .and(Ok(false)); // Do not run rustfix for this the edition.
         }
         let from_edition = self.enabled_edition.unwrap_or(Edition::Edition2015);
@@ -937,14 +945,14 @@ impl FixArgs {
                 message,
                 edition: to_edition,
             }
-            .post()
+            .post(config)
         } else {
             Message::Migrating {
                 file: self.file.display().to_string(),
                 from_edition,
                 to_edition,
             }
-            .post()
+            .post(config)
         }
         .and(Ok(true))
     }

--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -100,7 +100,7 @@ impl<'cfg> SourceConfigMap<'cfg> {
                 },
             )?;
         }
-        if let Ok(url) = std::env::var("__CARGO_TEST_CRATES_IO_URL_DO_NOT_USE_THIS") {
+        if let Ok(url) = config.get_env("__CARGO_TEST_CRATES_IO_URL_DO_NOT_USE_THIS") {
             base.add(
                 CRATES_IO_REGISTRY,
                 SourceConfig {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -636,7 +636,7 @@ impl<'cfg> RegistrySource<'cfg> {
         }
         dst.create_dir()?;
         let mut tar = {
-            let size_limit = max_unpack_size(tarball.metadata()?.len());
+            let size_limit = max_unpack_size(self.config, tarball.metadata()?.len());
             let gz = GzDecoder::new(tarball);
             let gz = LimitErrorReader::new(gz, size_limit);
             Archive::new(gz)
@@ -880,21 +880,23 @@ impl<'cfg> Source for RegistrySource<'cfg> {
 /// * <https://cran.r-project.org/web/packages/brotli/vignettes/brotli-2015-09-22.pdf>
 /// * <https://blog.cloudflare.com/results-experimenting-brotli/>
 /// * <https://tukaani.org/lzma/benchmarks.html>
-fn max_unpack_size(size: u64) -> u64 {
+fn max_unpack_size(config: &Config, size: u64) -> u64 {
     const SIZE_VAR: &str = "__CARGO_TEST_MAX_UNPACK_SIZE";
     const RATIO_VAR: &str = "__CARGO_TEST_MAX_UNPACK_RATIO";
-    let max_unpack_size = if cfg!(debug_assertions) && std::env::var(SIZE_VAR).is_ok() {
+    let max_unpack_size = if cfg!(debug_assertions) && config.get_env(SIZE_VAR).is_ok() {
         // For integration test only.
-        std::env::var(SIZE_VAR)
+        config
+            .get_env(SIZE_VAR)
             .unwrap()
             .parse()
             .expect("a max unpack size in bytes")
     } else {
         MAX_UNPACK_SIZE
     };
-    let max_compression_ratio = if cfg!(debug_assertions) && std::env::var(RATIO_VAR).is_ok() {
+    let max_compression_ratio = if cfg!(debug_assertions) && config.get_env(RATIO_VAR).is_ok() {
         // For integration test only.
-        std::env::var(RATIO_VAR)
+        config
+            .get_env(RATIO_VAR)
             .unwrap()
             .parse()
             .expect("a max compression ratio in bytes")

--- a/src/cargo/util/auth.rs
+++ b/src/cargo/util/auth.rs
@@ -182,7 +182,6 @@ pub fn registry_credential_config(
         let index = sid.canonical_url();
         let mut names: Vec<_> = config
             .env()
-            .iter()
             .filter_map(|(k, v)| {
                 Some((
                     k.strip_prefix("CARGO_REGISTRIES_")?

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -215,7 +215,7 @@ impl<'config> ConfigMapAccess<'config> {
         if de.config.cli_unstable().advanced_env {
             // `CARGO_PROFILE_DEV_PACKAGE_`
             let env_prefix = format!("{}_", de.key.as_env_key());
-            for env_key in de.config.env.keys() {
+            for env_key in de.config.env_keys() {
                 if env_key.starts_with(&env_prefix) {
                     // `CARGO_PROFILE_DEV_PACKAGE_bar_OPT_LEVEL = 3`
                     let rest = &env_key[env_prefix.len()..];
@@ -265,7 +265,7 @@ impl<'config> ConfigMapAccess<'config> {
         for field in given_fields {
             let mut field_key = de.key.clone();
             field_key.push(field);
-            for env_key in de.config.env.keys() {
+            for env_key in de.config.env_keys() {
                 if env_key.starts_with(field_key.as_env_key()) {
                     fields.insert(KeyKind::Normal(field.to_string()));
                 }
@@ -424,7 +424,7 @@ impl<'config> ValueDeserializer<'config> {
         let definition = {
             let env = de.key.as_env_key();
             let env_def = Definition::Environment(env.to_string());
-            match (de.config.env.contains_key(env), de.config.get_cv(&de.key)?) {
+            match (de.config.env_has_key(env), de.config.get_cv(&de.key)?) {
                 (true, Some(cv)) => {
                     // Both, pick highest priority.
                     if env_def.is_higher_priority(cv.definition()) {

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -2,7 +2,6 @@
 //! cross-platform way for the `cargo fix` command.
 
 use std::collections::HashSet;
-use std::env;
 use std::io::{BufReader, Read, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -61,9 +60,10 @@ pub enum Message {
 }
 
 impl Message {
-    pub fn post(&self) -> Result<(), Error> {
-        let addr =
-            env::var(DIAGNOSTICS_SERVER_VAR).context("diagnostics collector misconfigured")?;
+    pub fn post(&self, config: &Config) -> Result<(), Error> {
+        let addr = config
+            .get_env(DIAGNOSTICS_SERVER_VAR)
+            .context("diagnostics collector misconfigured")?;
         let mut client =
             TcpStream::connect(&addr).context("failed to connect to parent diagnostics target")?;
 

--- a/src/cargo/util/progress.rs
+++ b/src/cargo/util/progress.rs
@@ -1,5 +1,4 @@
 use std::cmp;
-use std::env;
 use std::time::{Duration, Instant};
 
 use crate::core::shell::Verbosity;
@@ -44,7 +43,7 @@ impl<'cfg> Progress<'cfg> {
         // report no progress when -q (for quiet) or TERM=dumb are set
         // or if running on Continuous Integration service like Travis where the
         // output logs get mangled.
-        let dumb = match env::var("TERM") {
+        let dumb = match cfg.get_env("TERM") {
             Ok(term) => term == "dumb",
             Err(_) => false,
         };


### PR DESCRIPTION
### What does this PR try to resolve?

Adds two new methods `get_env` and `get_env_os` for reading environment variables from the `Config` and uses them to replace the many of the calls to `std::env::var` and `var_os`  (see the discussion in #11588).

Closes #11588