### PR TITLE
Enhance help texts of position args

### DIFF
--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -12,6 +12,7 @@ pub fn cli() -> Command {
         .arg_quiet()
         .arg(
             Arg::new("args")
+                .help("Arguments for the binary or example to run")
                 .value_parser(value_parser!(std::ffi::OsString))
                 .num_args(0..)
                 .trailing_var_arg(true),

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -12,7 +12,7 @@ pub fn cli() -> Command {
         .arg(
             Arg::new("args")
                 .num_args(0..)
-                .help("Rustc flags")
+                .help("Extra rustc flags")
                 .trailing_var_arg(true),
         )
         .arg_package("Package to build")

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -6,7 +6,12 @@ pub fn cli() -> Command {
     subcommand("rustdoc")
         .about("Build a package's documentation, using specified custom flags.")
         .arg_quiet()
-        .arg(Arg::new("args").num_args(0..).trailing_var_arg(true))
+        .arg(
+            Arg::new("args")
+                .help("Extra rustdoc flags")
+                .num_args(0..)
+                .trailing_var_arg(true),
+        )
         .arg(flag(
             "open",
             "Opens the docs in a browser after the operation",


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fixes #9707

In #9707, there is an assumption that people tend to run `cargo run --help` and expect it shows the help text of the binary to run. However, the two proposed solution there both may lead to a false positive. I personally don't feel like any of them is a solution we would consider.

### How should we test and review this PR?

Run each command below and check its help text.

```
cargo run --help
cargo rustdoc --help
cargo rustc --help
```

<!-- homu-ignore:end -->
