### PR TITLE
Cleanup tests

### DIFF
--- a/src/doc/contrib/src/tests/writing.md
+++ b/src/doc/contrib/src/tests/writing.md
@@ -171,7 +171,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn <name>() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -20,7 +20,7 @@ fn bad1() {
         .with_stderr(
             "\
 [ERROR] expected table for configuration key `target.nonexistent-target`, \
-but found string in [..]config
+but found string in [..]/config
 ",
         )
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3707,7 +3707,7 @@ fn panic_abort_with_build_scripts() {
     p.root().join("target").rm_rf();
 
     p.cargo("test --release -v")
-        .with_stderr_does_not_contain("[..]panic[..]")
+        .with_stderr_does_not_contain("[..]panic=abort[..]")
         .run();
 }
 

--- a/tests/testsuite/cargo_add/add_basic/mod.rs
+++ b/tests/testsuite/cargo_add/add_basic/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn add_basic() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/add_multiple/mod.rs
+++ b/tests/testsuite/cargo_add/add_multiple/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn add_multiple() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/add_normalized_name_external/mod.rs
+++ b/tests/testsuite/cargo_add/add_normalized_name_external/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn add_normalized_name_external() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/build/mod.rs
+++ b/tests/testsuite/cargo_add/build/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn build() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/build_prefer_existing_version/mod.rs
+++ b/tests/testsuite/cargo_add/build_prefer_existing_version/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use crate::cargo_add::init_alt_registry;
 
 #[cargo_test]
-fn build_prefer_existing_version() {
+fn case() {
     init_alt_registry();
     let project =
         Project::from_template("tests/testsuite/cargo_add/build_prefer_existing_version/in");

--- a/tests/testsuite/cargo_add/change_rename_target/mod.rs
+++ b/tests/testsuite/cargo_add/change_rename_target/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn change_rename_target() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/default_features/mod.rs
+++ b/tests/testsuite/cargo_add/default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/deprecated_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/deprecated_default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn deprecated_default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/deprecated_section/mod.rs
+++ b/tests/testsuite/cargo_add/deprecated_section/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn deprecated_section() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/detect_workspace_inherit/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn detect_workspace_inherit() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_features/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn detect_workspace_inherit_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_optional/mod.rs
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn detect_workspace_inherit_optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/dev/mod.rs
+++ b/tests/testsuite/cargo_add/dev/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn dev() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/dev_build_conflict/mod.rs
+++ b/tests/testsuite/cargo_add/dev_build_conflict/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn dev_build_conflict() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/dev_prefer_existing_version/mod.rs
+++ b/tests/testsuite/cargo_add/dev_prefer_existing_version/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_alt_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn dev_prefer_existing_version() {
+fn case() {
     init_alt_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/dry_run/mod.rs
+++ b/tests/testsuite/cargo_add/dry_run/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn dry_run() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features/mod.rs
+++ b/tests/testsuite/cargo_add/features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features_empty/mod.rs
+++ b/tests/testsuite/cargo_add/features_empty/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features_empty() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features_multiple_occurrences/mod.rs
+++ b/tests/testsuite/cargo_add/features_multiple_occurrences/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features_multiple_occurrences() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features_preserve/mod.rs
+++ b/tests/testsuite/cargo_add/features_preserve/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features_preserve() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features_spaced_values/mod.rs
+++ b/tests/testsuite/cargo_add/features_spaced_values/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features_spaced_values() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features_unknown/mod.rs
+++ b/tests/testsuite/cargo_add/features_unknown/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features_unknown() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/features_unknown_no_features/mod.rs
+++ b/tests/testsuite/cargo_add/features_unknown_no_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn features_unknown_no_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git/mod.rs
+++ b/tests/testsuite/cargo_add/git/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_branch/mod.rs
+++ b/tests/testsuite/cargo_add/git_branch/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_branch() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_conflicts_namever/mod.rs
+++ b/tests/testsuite/cargo_add/git_conflicts_namever/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_conflicts_namever() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_dev/mod.rs
+++ b/tests/testsuite/cargo_add/git_dev/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_dev() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_inferred_name/mod.rs
+++ b/tests/testsuite/cargo_add/git_inferred_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_inferred_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_inferred_name_multiple/mod.rs
+++ b/tests/testsuite/cargo_add/git_inferred_name_multiple/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_inferred_name_multiple() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_multiple_names/mod.rs
+++ b/tests/testsuite/cargo_add/git_multiple_names/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_multiple_names() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_normalized_name/mod.rs
+++ b/tests/testsuite/cargo_add/git_normalized_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_normalized_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_registry/mod.rs
+++ b/tests/testsuite/cargo_add/git_registry/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_alt_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_registry() {
+fn case() {
     init_alt_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_rev/mod.rs
+++ b/tests/testsuite/cargo_add/git_rev/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_rev() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/git_tag/mod.rs
+++ b/tests/testsuite/cargo_add/git_tag/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_tag() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/infer_prerelease/mod.rs
+++ b/tests/testsuite/cargo_add/infer_prerelease/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn infer_prerelease() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_arg/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_arg/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_arg() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_git_external/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_git_external/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_git_external() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_git_name/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_git_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_git_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_inherit_dependency/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_key_inherit_dependency() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_overwrite_inherit_dependency/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_key_overwrite_inherit_dependency() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_key_rename_inherit_dependency/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_key_rename_inherit_dependency() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/invalid_manifest/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_manifest/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_manifest() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_name_external/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_name_external/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_name_external() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_path/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_path/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_path() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_path_name/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_path_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_path_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_path_self/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_path_self/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_path_self() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_target_empty/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_target_empty/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_target_empty() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/invalid_vers/mod.rs
+++ b/tests/testsuite/cargo_add/invalid_vers/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_vers() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/list_features/mod.rs
+++ b/tests/testsuite/cargo_add/list_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn list_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/list_features_path/mod.rs
+++ b/tests/testsuite/cargo_add/list_features_path/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn list_features_path() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/list_features_path_no_default/mod.rs
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn list_features_path_no_default() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/locked_changed/mod.rs
+++ b/tests/testsuite/cargo_add/locked_changed/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn locked_changed() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/locked_unchanged/mod.rs
+++ b/tests/testsuite/cargo_add/locked_unchanged/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn locked_unchanged() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/lockfile_updated/mod.rs
+++ b/tests/testsuite/cargo_add/lockfile_updated/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn lockfile_updated() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/manifest_path_package/mod.rs
+++ b/tests/testsuite/cargo_add/manifest_path_package/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn manifest_path_package() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/merge_activated_features/mod.rs
+++ b/tests/testsuite/cargo_add/merge_activated_features/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn merge_activated_features() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_features/mod.rs
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn multiple_conflicts_with_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/multiple_conflicts_with_rename/mod.rs
+++ b/tests/testsuite/cargo_add/multiple_conflicts_with_rename/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn multiple_conflicts_with_rename() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/namever/mod.rs
+++ b/tests/testsuite/cargo_add/namever/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn namever() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/no_args/mod.rs
+++ b/tests/testsuite/cargo_add/no_args/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn no_args() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/no_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/no_default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn no_default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/no_optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn no_optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/offline_empty_cache/mod.rs
+++ b/tests/testsuite/cargo_add/offline_empty_cache/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn offline_empty_cache() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/optional/mod.rs
+++ b/tests/testsuite/cargo_add/optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_default_features_with_no_default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_git_with_path/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_git_with_path/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_git_with_path() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_inherit_features_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_features_noop/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_inherit_features_noop() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/overwrite_inherit_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_noop/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_inherit_noop() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_inherit_optional_noop() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_inline_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_inline_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_alt_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_name_dev_noop() {
+fn case() {
     init_alt_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_name_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_alt_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_name_noop() {
+fn case() {
     init_alt_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_no_default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_no_default_features_with_default_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_no_optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_no_optional_with_optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_optional_with_no_optional() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_path_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_alt_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_path_noop() {
+fn case() {
     init_alt_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_path_with_version() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_preserves_inline_table() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_rename_with_no_rename() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_rename_with_rename() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_rename_with_rename_noop() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_version_with_git() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_version_with_path/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_version_with_path/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_version_with_path() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_with_rename/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_with_rename() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_workspace_dep() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep_features/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep_features/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn overwrite_workspace_dep_features() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/path/mod.rs
+++ b/tests/testsuite/cargo_add/path/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn path() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/path_dev/mod.rs
+++ b/tests/testsuite/cargo_add/path_dev/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn path_dev() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/path_inferred_name/mod.rs
+++ b/tests/testsuite/cargo_add/path_inferred_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn path_inferred_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/mod.rs
+++ b/tests/testsuite/cargo_add/path_inferred_name_conflicts_full_feature/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn path_inferred_name_conflicts_full_feature() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/path_normalized_name/mod.rs
+++ b/tests/testsuite/cargo_add/path_normalized_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn path_normalized_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/preserve_sorted/mod.rs
+++ b/tests/testsuite/cargo_add/preserve_sorted/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn preserve_sorted() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/preserve_unsorted/mod.rs
+++ b/tests/testsuite/cargo_add/preserve_unsorted/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn preserve_unsorted() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/quiet/mod.rs
+++ b/tests/testsuite/cargo_add/quiet/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn quiet() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/registry/mod.rs
+++ b/tests/testsuite/cargo_add/registry/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_alt_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn registry() {
+fn case() {
     init_alt_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/rename/mod.rs
+++ b/tests/testsuite/cargo_add/rename/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn rename() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/require_weak/mod.rs
+++ b/tests/testsuite/cargo_add/require_weak/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn require_weak() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/sorted_table_with_dotted_item/mod.rs
+++ b/tests/testsuite/cargo_add/sorted_table_with_dotted_item/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn sorted_table_with_dotted_item() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/target/mod.rs
+++ b/tests/testsuite/cargo_add/target/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn target() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/target_cfg/mod.rs
+++ b/tests/testsuite/cargo_add/target_cfg/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn target_cfg() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
+++ b/tests/testsuite/cargo_add/unknown_inherited_feature/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn unknown_inherited_feature() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
     let cwd = &project_root;

--- a/tests/testsuite/cargo_add/vers/mod.rs
+++ b/tests/testsuite/cargo_add/vers/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn vers() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/workspace_name/mod.rs
+++ b/tests/testsuite/cargo_add/workspace_name/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn workspace_name() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/workspace_path/mod.rs
+++ b/tests/testsuite/cargo_add/workspace_path/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn workspace_path() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/workspace_path_dev/mod.rs
+++ b/tests/testsuite/cargo_add/workspace_path_dev/mod.rs
@@ -6,7 +6,7 @@ use crate::cargo_add::init_registry;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn workspace_path_dev() {
+fn case() {
     init_registry();
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -433,7 +433,6 @@ fn cargo_cmd_bins_vs_explicit_path() {
     }
 }
 
-#[test]
 #[cargo_test]
 fn cargo_subcommand_args() {
     let p = echo_subcommand();

--- a/tests/testsuite/init/auto_git/mod.rs
+++ b/tests/testsuite/init/auto_git/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn auto_git() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/bin_already_exists_explicit/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_explicit/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn bin_already_exists_explicit() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/bin_already_exists_explicit_nosrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_explicit_nosrc/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn bin_already_exists_explicit_nosrc() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/bin_already_exists_implicit/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn bin_already_exists_implicit() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/bin_already_exists_implicit_namenosrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit_namenosrc/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn bin_already_exists_implicit_namenosrc() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/bin_already_exists_implicit_namesrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit_namesrc/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn bin_already_exists_implicit_namesrc() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/bin_already_exists_implicit_nosrc/mod.rs
+++ b/tests/testsuite/init/bin_already_exists_implicit_nosrc/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn bin_already_exists_implicit_nosrc() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/both_lib_and_bin/mod.rs
+++ b/tests/testsuite/init/both_lib_and_bin/mod.rs
@@ -4,7 +4,7 @@ use cargo_test_support::prelude::*;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn both_lib_and_bin() {
+fn case() {
     let cwd = paths::root();
 
     snapbox::cmd::Command::cargo_ui()

--- a/tests/testsuite/init/cant_create_library_when_both_binlib_present/mod.rs
+++ b/tests/testsuite/init/cant_create_library_when_both_binlib_present/mod.rs
@@ -4,7 +4,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn cant_create_library_when_both_binlib_present() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/confused_by_multiple_lib_files/mod.rs
+++ b/tests/testsuite/init/confused_by_multiple_lib_files/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn confused_by_multiple_lib_files() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/creates_binary_when_both_binlib_present/mod.rs
+++ b/tests/testsuite/init/creates_binary_when_both_binlib_present/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn creates_binary_when_both_binlib_present() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/creates_binary_when_instructed_and_has_lib_file/mod.rs
+++ b/tests/testsuite/init/creates_binary_when_instructed_and_has_lib_file/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn creates_binary_when_instructed_and_has_lib_file() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/creates_library_when_instructed_and_has_bin_file/mod.rs
+++ b/tests/testsuite/init/creates_library_when_instructed_and_has_bin_file/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn creates_library_when_instructed_and_has_bin_file() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/explicit_bin_with_git/mod.rs
+++ b/tests/testsuite/init/explicit_bin_with_git/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn explicit_bin_with_git() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/formats_source/mod.rs
+++ b/tests/testsuite/init/formats_source/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::{process, Project};
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn formats_source() {
+fn case() {
     // This cannot use `requires_rustfmt` because rustfmt is not available in
     // the rust-lang/rust environment. Additionally, if running cargo without
     // rustup (but with rustup installed), this test also fails due to HOME

--- a/tests/testsuite/init/fossil_autodetect/mod.rs
+++ b/tests/testsuite/init/fossil_autodetect/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn fossil_autodetect() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/git_autodetect/mod.rs
+++ b/tests/testsuite/init/git_autodetect/mod.rs
@@ -6,7 +6,7 @@ use std::fs;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_autodetect() {
+fn case() {
     let project_root = &paths::root().join("foo");
     // Need to create `.git` dir manually because it cannot be tracked under a git repo
     fs::create_dir_all(project_root.join(".git")).unwrap();

--- a/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/mod.rs
+++ b/tests/testsuite/init/git_ignore_exists_no_conflicting_entries/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn git_ignore_exists_no_conflicting_entries() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/ignores_failure_to_format_source/mod.rs
+++ b/tests/testsuite/init/ignores_failure_to_format_source/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn ignores_failure_to_format_source() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/inferred_bin_with_git/mod.rs
+++ b/tests/testsuite/init/inferred_bin_with_git/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn inferred_bin_with_git() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/inferred_lib_with_git/mod.rs
+++ b/tests/testsuite/init/inferred_lib_with_git/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn inferred_lib_with_git() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/invalid_dir_name/mod.rs
+++ b/tests/testsuite/init/invalid_dir_name/mod.rs
@@ -5,7 +5,7 @@ use std::fs;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn invalid_dir_name() {
+fn case() {
     let foo = &paths::root().join("foo.bar");
     fs::create_dir_all(foo).unwrap();
 

--- a/tests/testsuite/init/lib_already_exists_nosrc/mod.rs
+++ b/tests/testsuite/init/lib_already_exists_nosrc/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn lib_already_exists_nosrc() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/lib_already_exists_src/mod.rs
+++ b/tests/testsuite/init/lib_already_exists_src/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn lib_already_exists_src() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/mercurial_autodetect/mod.rs
+++ b/tests/testsuite/init/mercurial_autodetect/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn mercurial_autodetect() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/multibin_project_name_clash/mod.rs
+++ b/tests/testsuite/init/multibin_project_name_clash/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn multibin_project_name_clash() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/no_filename/mod.rs
+++ b/tests/testsuite/init/no_filename/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::curr_dir;
 
 #[cfg(not(windows))]
 #[cargo_test]
-fn no_filename() {
+fn case() {
     snapbox::cmd::Command::cargo_ui()
         .arg_line("init /")
         .current_dir(paths::root())

--- a/tests/testsuite/init/path_contains_separator/mod.rs
+++ b/tests/testsuite/init/path_contains_separator/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::{t, Project};
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn path_contains_separator() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root().join("test:ing");
 

--- a/tests/testsuite/init/pijul_autodetect/mod.rs
+++ b/tests/testsuite/init/pijul_autodetect/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn pijul_autodetect() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/reserved_name/mod.rs
+++ b/tests/testsuite/init/reserved_name/mod.rs
@@ -5,7 +5,7 @@ use std::fs;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn reserved_name() {
+fn case() {
     let project_root = &paths::root().join("test");
     fs::create_dir_all(project_root).unwrap();
 

--- a/tests/testsuite/init/simple_bin/mod.rs
+++ b/tests/testsuite/init/simple_bin/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn simple_bin() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/simple_git/mod.rs
+++ b/tests/testsuite/init/simple_git/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn simple_git() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/simple_git_ignore_exists/mod.rs
+++ b/tests/testsuite/init/simple_git_ignore_exists/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn simple_git_ignore_exists() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/simple_hg/mod.rs
+++ b/tests/testsuite/init/simple_hg/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test(requires_hg)]
-fn simple_hg() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/simple_hg_ignore_exists/mod.rs
+++ b/tests/testsuite/init/simple_hg_ignore_exists/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn simple_hg_ignore_exists() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/simple_lib/mod.rs
+++ b/tests/testsuite/init/simple_lib/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn simple_lib() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 

--- a/tests/testsuite/init/unknown_flags/mod.rs
+++ b/tests/testsuite/init/unknown_flags/mod.rs
@@ -4,7 +4,7 @@ use cargo_test_support::prelude::*;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn unknown_flags() {
+fn case() {
     snapbox::cmd::Command::cargo_ui()
         .arg_line("init foo --flag")
         .current_dir(paths::root())

--- a/tests/testsuite/init/with_argument/mod.rs
+++ b/tests/testsuite/init/with_argument/mod.rs
@@ -5,7 +5,7 @@ use cargo_test_support::Project;
 use cargo_test_support::curr_dir;
 
 #[cargo_test]
-fn with_argument() {
+fn case() {
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = &project.root();
 


### PR DESCRIPTION
When working on #11738 I noticed a few tests that needed to be cleaned up. It [was suggested](https://github.com/rust-lang/cargo/pull/11738#discussion_r1111128128) to split the test changes into their own PR. 

- `bad_config::bad1`
  - This was trying to match `config` which would get matched in the wrong place due to the test name having `config` in it
  - Fixed by making the match `/config`
- `build_script::panic_abort_with_build_scripts`
  - This test was failing as it was making sure `panic` was not in the output. After this change, it could match the test name and fail. 
  - To fix this I updated it to look at `panic=abort` which appears to be what it was originally looking for (#5711). @ehuss please let me know if I misread what the test was testing.
- `cargo_command::cargo_subcommand_args`
  - This test had `#[test]` above `#[cargo_test]` which caused it to throw an error removing it fixed the issue

During this time I also ran into issues with `cargo_remove` tests being named `fn case()` which is different from how tests are normally named. I talked with @epage and it was decided that `fn case()` should probably be used for all `snapbox` tests since the unique test name is already the folder name. I went ahead and renamed all tests within `cargo_add/` and `init/` to match this style.

This PR should be reviewed commit by commit.