### PR TITLE
Update curl-sys to use libcurl 7.88.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cargo-util = { path = "crates/cargo-util", version = "0.2.3" }
 clap = "4.1.3"
 crates-io = { path = "crates/crates-io", version = "0.35.1" }
 curl = { version = "0.4.44", features = ["http2"] }
-curl-sys = "0.4.59"
+curl-sys = "0.4.60"
 env_logger = "0.10.0"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }


### PR DESCRIPTION
This updates curl-sys to update the vendored curl from 7.86.0 to 7.88.1. The changelog is at https://curl.se/changes.html.
