### PR TITLE
reuse url encoding from `url` crate, don't use separate `percent-encoding`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ openssl = { version = '0.10.11', optional = true }
 os_info = "3.5.0"
 pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"
-percent-encoding = "2.0"
 pretty_env_logger = { version = "0.4", optional = true }
 rustfix = "0.6.0"
 semver = { version = "1.0.3", features = ["serde"] }

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -15,9 +15,9 @@ use curl::easy::{Easy, InfoType, SslOpt, SslVersion};
 use log::{log, Level};
 use pasetors::keys::{AsymmetricKeyPair, Generate};
 use pasetors::paserk::FormatAsPaserk;
-use percent_encoding::{percent_encode, NON_ALPHANUMERIC};
 use termcolor::Color::Green;
 use termcolor::ColorSpec;
+use url::Url;
 
 use crate::core::dependency::DepKind;
 use crate::core::dependency::Dependency;
@@ -1201,10 +1201,8 @@ pub fn search(
         );
     } else if total_crates > limit && limit >= search_max_limit {
         let extra = if source_ids.original.is_crates_io() {
-            format!(
-                " (go to https://crates.io/search?q={} to see more)",
-                percent_encode(query.as_bytes(), NON_ALPHANUMERIC)
-            )
+            let url = Url::parse_with_params("https://crates.io/search", &[("q", query)])?;
+            format!(" (go to {url} to see more)")
         } else {
             String::new()
         };


### PR DESCRIPTION
Reuse encoding from `url`, don't use separate `percent-encoding`.