### PR TITLE
Make more reads of environment variables go through the `Config`

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -426,6 +426,7 @@ impl Config {
             } else {
                 None
             },
+            self,
         )
     }
 


### PR DESCRIPTION
As discussed in #11588, it's better to make reads of environment variables go through the `Config` instead of calling `std::env::var` or `env::var_os` everywhere.

Most of the "easy" places to change this in `src/` were handled in https://github.com/rust-lang/cargo/pull/11727. This PR fixes a few remaining call sites that were missed in #11727, namely:

- `LocalFingerprint::find_stale_item`
- `util::profile::start` and `Profiler`
- `util::rustc::rustc_fingerprint`

After doing this, there are a few remaining calls to `env::var` in `src/` but those probably require more discussion to fix.