### PR TITLE
Fix Cargo removing the sparse+ prefix from sparse URLs in .crates.toml

### DIFF
--- a/src/cargo/util/canonical_url.rs
+++ b/src/cargo/util/canonical_url.rs
@@ -1,4 +1,4 @@
-use crate::util::{errors::CargoResult, IntoUrl};
+use crate::util::errors::CargoResult;
 use std::hash::{self, Hash};
 use url::Url;
 
@@ -54,17 +54,6 @@ impl CanonicalUrl {
                 last[..last.len() - 4].to_owned()
             };
             url.path_segments_mut().unwrap().pop().push(&last);
-        }
-
-        // Ignore the protocol specifier (if any).
-        if url.scheme().starts_with("sparse+") {
-            // NOTE: it is illegal to use set_scheme to change sparse+http(s) to http(s).
-            url = url
-                .to_string()
-                .strip_prefix("sparse+")
-                .expect("we just found that prefix")
-                .into_url()
-                .expect("a valid url without a protocol specifier should still be valid");
         }
 
         Ok(CanonicalUrl(url))

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2163,8 +2163,8 @@ fn sparse_install() {
 [UPDATING] `dummy-registry` index
 [COMPILING] foo v0.0.1 (registry `dummy-registry`)
 [FINISHED] release [optimized] target(s) in [..]
-[INSTALLING] [ROOT]/home/.cargo/bin/foo
-[INSTALLED] package `foo v0.0.1 (registry `dummy-registry`)` (executable `foo`)
+[INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1 (registry `dummy-registry`)` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         )
@@ -2176,15 +2176,15 @@ fn sparse_install() {
     };
     assert_v1(
         r#"[v1]
-"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo"]
+"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo[EXE]"]
 "#,
     );
     cargo_process("install bar").run();
     assert_has_installed_exe(cargo_home(), "bar");
     assert_v1(
         r#"[v1]
-"bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = ["bar"]
-"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo"]
+"bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = ["bar[EXE]"]
+"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo[EXE]"]
 "#,
     );
 
@@ -2194,7 +2194,7 @@ fn sparse_install() {
     assert_has_not_installed_exe(cargo_home(), "bar");
     assert_v1(
         r#"[v1]
-"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo"]
+"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo[EXE]"]
 "#,
     );
     cargo_process("uninstall foo")

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2142,3 +2142,67 @@ fn failed_install_retains_temp_directory() {
     assert!(path.exists());
     assert!(path.join("release/deps").exists());
 }
+
+#[cargo_test]
+fn sparse_install() {
+    // Checks for an issue where uninstalling something corrupted
+    // the SourceIds of sparse registries.
+    // See https://github.com/rust-lang/cargo/issues/11751
+    let _registry = registry::RegistryBuilder::new().http_index().build();
+
+    pkg("foo", "0.0.1");
+    pkg("bar", "0.0.1");
+
+    cargo_process("install foo --registry dummy-registry")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry `dummy-registry`)
+[INSTALLING] foo v0.0.1 (registry `dummy-registry`)
+[UPDATING] `dummy-registry` index
+[COMPILING] foo v0.0.1 (registry `dummy-registry`)
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] [ROOT]/home/.cargo/bin/foo
+[INSTALLED] package `foo v0.0.1 (registry `dummy-registry`)` (executable `foo`)
+[WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
+",
+        )
+        .run();
+    assert_has_installed_exe(cargo_home(), "foo");
+    let assert_v1 = |expected| {
+        let v1 = fs::read_to_string(paths::home().join(".cargo/.crates.toml")).unwrap();
+        compare::assert_match_exact(expected, &v1);
+    };
+    assert_v1(
+        r#"[v1]
+"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo"]
+"#,
+    );
+    cargo_process("install bar").run();
+    assert_has_installed_exe(cargo_home(), "bar");
+    assert_v1(
+        r#"[v1]
+"bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = ["bar"]
+"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo"]
+"#,
+    );
+
+    cargo_process("uninstall bar")
+        .with_stderr("[REMOVING] [CWD]/home/.cargo/bin/bar[EXE]")
+        .run();
+    assert_has_not_installed_exe(cargo_home(), "bar");
+    assert_v1(
+        r#"[v1]
+"foo 0.0.1 (sparse+http://127.0.0.1:[..]/index/)" = ["foo"]
+"#,
+    );
+    cargo_process("uninstall foo")
+        .with_stderr("[REMOVING] [CWD]/home/.cargo/bin/foo[EXE]")
+        .run();
+    assert_has_not_installed_exe(cargo_home(), "foo");
+    assert_v1(
+        r#"[v1]
+"#,
+    );
+}


### PR DESCRIPTION
The URL associated with a `SourceId` for a sparse registry includes the `sparse+` prefix in the URL to differentiate from git (non-sparse) registries.

`SourceId::from_url` was not including the `sparse+` prefix of sparse registry URLs on construction, which caused roundtrips of `as_url` and `from_url` to fail by losing the prefix.

Fixes #11751 by:
* Including the prefix in the URL
* Adding a test that verifies round-trip behavior for sparse `SourceId`s
* Modifying `CanonicalUrl` so it no longer considers `sparse+` and non-`sparse+` URLs to be equivalent 