### PR TITLE
Fix tests with nondeterministic ordering

### DIFF
--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -283,7 +283,8 @@ fn inherit_own_dependencies() {
     Package::new("dep-dev", "0.5.2").publish();
 
     p.cargo("check")
-        .with_stderr(
+        // Unordered because the download order is nondeterministic.
+        .with_stderr_unordered(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
@@ -813,7 +814,8 @@ fn inherit_dependencies() {
     Package::new("dep-dev", "0.5.2").publish();
 
     p.cargo("check")
-        .with_stderr(
+        // Unordered because the download order is nondeterministic.
+        .with_stderr_unordered(
             "\
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...


### PR DESCRIPTION
A couple tests updated in #11650 started using curl's http API. It appears to have a nondeterministic order for when crates will finish downloading. This addresses it by ignoring the order, which is not important for these tests.
