### PR TITLE
Fix warning with tempfile

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -308,7 +308,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
         let compile = ops::compile_ws(&self.ws, &self.opts, &exec).with_context(|| {
             if let Some(td) = td_opt.take() {
                 // preserve the temporary directory, so the user can inspect it
-                td.into_path();
+                drop(td.into_path());
             }
 
             format!(


### PR DESCRIPTION
A recent release of the tempfile crate added a `#[must_use]` attribute to the `into_path` method. This triggers a warning when building.

This also adds a test to verify that the intermediate artifacts persist in the temp directory.
