### PR TITLE
Improve error for missing crate in --offline mode for sparse index

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -438,6 +438,13 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
             return Poll::Ready(Ok(LoadResponse::NotFound));
         }
 
+        if self.config.offline() || self.config.cli_unstable().no_index_update {
+            // Return NotFound in offline mode when the file doesn't exist in the cache.
+            // If this results in resolution failure, the resolver will suggest
+            // removing the --offline flag.
+            return Poll::Ready(Ok(LoadResponse::NotFound));
+        }
+
         if let Some(result) = self.downloads.results.remove(path) {
             let result =
                 result.with_context(|| format!("download of {} failed", path.display()))?;

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -1,6 +1,6 @@
 //! Tests for the `cargo generate-lockfile` command.
 
-use cargo_test_support::registry::Package;
+use cargo_test_support::registry::{Package, RegistryBuilder};
 use cargo_test_support::{basic_manifest, paths, project, ProjectBuilder};
 use std::fs;
 
@@ -57,6 +57,16 @@ fn adding_and_removing_packages() {
 }
 
 #[cargo_test]
+fn no_index_update_sparse() {
+    let _registry = RegistryBuilder::new().http_index().build();
+    no_index_update();
+}
+
+#[cargo_test]
+fn no_index_update_git() {
+    no_index_update();
+}
+
 fn no_index_update() {
     Package::new("serde", "1.0.0").publish();
 

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -1,6 +1,9 @@
 //! Tests for --offline flag.
 
-use cargo_test_support::{basic_manifest, git, main_file, path2url, project, registry::Package};
+use cargo_test_support::{
+    basic_manifest, git, main_file, path2url, project,
+    registry::{Package, RegistryBuilder},
+};
 use std::fs;
 
 #[cargo_test]
@@ -331,7 +334,6 @@ Caused by:
         .run();
 }
 
-#[cargo_test]
 fn update_offline_not_cached() {
     let p = project()
         .file(
@@ -360,6 +362,17 @@ surprising resolution failures, if this error is too confusing you may wish to \
 retry without the offline flag.",
         )
         .run();
+}
+
+#[cargo_test]
+fn update_offline_not_cached_sparse() {
+    let _registry = RegistryBuilder::new().http_index().build();
+    update_offline_not_cached()
+}
+
+#[cargo_test]
+fn update_offline_not_cached_git() {
+    update_offline_not_cached()
 }
 
 #[cargo_test]


### PR DESCRIPTION
This changes sparse registries to instead return `NotFound` when a non-cached crate is requested in `--offline` mode. 

The resolver can then suggest removing the `--offline` flag if resolution fails, which is a more helpful error than the one currently issued: `attempting to make an HTTP request, but --offline was specified`.

With this change, the behavior matches what is already done for git-based registries.

Closes #11276