### PR TITLE
Fix help string for  "--charset" option of "cargo tree"

### DIFF
--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -79,7 +79,7 @@ pub fn cli() -> Command {
             .alias("duplicate"),
         )
         .arg(
-            opt("charset", "Character set to use in output: utf8, ascii")
+            opt("charset", "Character set to use in output")
                 .value_name("CHARSET")
                 .value_parser(["utf8", "ascii"])
                 .default_value("utf8"),


### PR DESCRIPTION
The help text for the `cargo tree` subcommand currently is:

```console
> cargo --version
cargo 1.67.1 (8ecd4f20a 2023-01-10)
> cargo tree --help
Display a tree visualization of a dependency graph

Usage: cargo tree [OPTIONS]

Options:
  -q, --quiet                 Do not print cargo log messages
      --manifest-path <PATH>  Path to Cargo.toml
  -p, --package [<SPEC>]      Package to be used as the root of the tree
  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
      --workspace             Display the tree for all packages in the workspace
      --exclude <SPEC>        Exclude specific workspace members
      --color <WHEN>          Coloring: auto, always, never
      --frozen                Require Cargo.lock and cache are up to date
  -F, --features <FEATURES>   Space or comma separated list of features to activate
      --locked                Require Cargo.lock is up to date
      --all-features          Activate all available features
      --offline               Run without accessing the network
      --config <KEY=VALUE>    Override a configuration value
      --no-default-features   Do not activate the `default` feature
      --target <TRIPLE>       Filter dependencies matching the given target-triple (default host platform). Pass `all` to include all targets.
  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
  -e, --edges <KINDS>         The kinds of dependencies to display (features, normal, build, dev, all, no-normal, no-build, no-dev, no-proc-macro)
  -i, --invert [<SPEC>]       Invert the tree direction and focus on the given package
      --prune <SPEC>          Prune the given package from the display of the dependency tree
      --depth <DEPTH>         Maximum display depth of the dependency tree
      --prefix <PREFIX>       Change the prefix (indentation) of how each entry is displayed [default: indent] [possible values: depth, indent, none]
      --no-dedupe             Do not de-duplicate (repeats all shared dependencies)
  -d, --duplicates            Show only dependencies which come in multiple versions (implies -i)
      --charset <CHARSET>     Character set to use in output: utf8, ascii [default: utf8] [possible values: utf8, ascii]
  -f, --format <FORMAT>       Format string used for printing dependencies [default: {p}]
  -h, --help                  Print help information
```

Note that for the `--charset` option, the information about available encodings is duplicated. This PR removes the duplication.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
