### PR TITLE
Warnings for breaking changes to the configuration discovery of `cargo install` and `cargo uninstall` proposed in #11775

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -90,7 +90,12 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     if let Some(path) = &path {
         config.reload_rooted_at(path)?;
     } else {
-        // TODO: Consider calling set_search_stop_path(home).
+        config.shell().warn(
+            "the configuration discovery of `cargo install` will change in a \
+            future version.\n\
+            In the future, only the global configuration file \
+            `$CARGO_HOME/config.toml` will be considered by `cargo install`.",
+        )?;
         config.reload_rooted_at(config.home().clone().into_path_unlocked())?;
     }
 

--- a/src/bin/cargo/commands/uninstall.rs
+++ b/src/bin/cargo/commands/uninstall.rs
@@ -14,6 +14,13 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
+    config.shell().warn(
+        "the configuration discovery of `cargo uninstall` will change in a \
+        future version.\n\
+        In the future, only the global configuration file \
+        `$CARGO_HOME/config.toml` will be considered by `cargo uninstall`.",
+    )?;
+
     let root = args.get_one::<String>("root").map(String::as_str);
 
     if args.is_present_with_zero_values("package") {

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -377,6 +377,23 @@ fn bad_paths() {
 }
 
 #[cargo_test]
+fn warning_for_configuration_discovery_changes() {
+    pkg("foo", "0.0.1");
+
+    cargo_process("install foo")
+        .with_stderr_contains(
+            "warning: the configuration discovery of `cargo install` will change in a future version.",
+        )
+        .run();
+
+    cargo_process("uninstall foo")
+        .with_stderr_contains(
+            "warning: the configuration discovery of `cargo uninstall` will change in a future version.",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn install_location_precedence() {
     pkg("foo", "0.0.1");
 


### PR DESCRIPTION
#11775 tries to streamline the configuration discovery of `cargo uninstall` with `cargo install` and make both more intuitive and in sync with how crate-local [configuration discovery](https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure) works. Unfortunately, these are breaking changes. So this PR adds warning messages to `cargo install` and `cargo uninstall`, informing the user that the configuration discovery will change in a future version of cargo.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
