### PR TITLE
Fix `CARGO_CFG_` vars for configs defined both with and without value

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -231,14 +231,11 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     for cfg in bcx.target_data.cfg(unit.kind) {
         match *cfg {
             Cfg::Name(ref n) => {
-                cfg_map.insert(n.clone(), None);
+                cfg_map.insert(n.clone(), Vec::new());
             }
             Cfg::KeyPair(ref k, ref v) => {
-                if let Some(ref mut values) =
-                    *cfg_map.entry(k.clone()).or_insert_with(|| Some(Vec::new()))
-                {
-                    values.push(v.clone())
-                }
+                let values = cfg_map.entry(k.clone()).or_default();
+                values.push(v.clone());
             }
         }
     }
@@ -249,14 +246,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
             continue;
         }
         let k = format!("CARGO_CFG_{}", super::envify(&k));
-        match v {
-            Some(list) => {
-                cmd.env(&k, list.join(","));
-            }
-            None => {
-                cmd.env(&k, "");
-            }
-        }
+        cmd.env(&k, v.join(","));
     }
 
     // Also inform the build script of the rustc compiler context.


### PR DESCRIPTION
When a rustc cfg is defined both with and without value, the environment variable should provide all the values. Before this change, it ended up being empty.

Fixes: #11789

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
