### PR TITLE
Make `sparse` the default protocol for crates.io

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -725,7 +725,6 @@ unstable_cli_options!(
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     profile_rustflags: bool = ("Enable the `rustflags` option in profiles in .cargo/config.toml file"),
     host_config: bool = ("Enable the [host] section in the .cargo/config.toml file"),
-    sparse_registry: bool = ("Use the sparse protocol when accessing crates.io"),
     registry_auth: bool = ("Authentication for alternative registries, and generate registry authentication tokens using asymmetric cryptography"),
     target_applies_to_host: bool = ("Enable the `target-applies-to-host` key in the .cargo/config.toml file"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
@@ -795,10 +794,7 @@ const STABILISED_MULTITARGET: &str = "Multiple `--target` options are now always
 const STABILIZED_TERMINAL_WIDTH: &str =
     "The -Zterminal-width option is now always enabled for terminal output.";
 
-const STABILISED_SPARSE_REGISTRY: &str = "This flag currently still sets the default protocol \
-    to `sparse` when accessing crates.io. However, this will be removed in the future. \n\
-    The stable equivalent is to set the config value `registries.crates-io.protocol = 'sparse'`\n\
-    or environment variable `CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse`";
+const STABILISED_SPARSE_REGISTRY: &str = "The sparse protocol is now the default for crates.io";
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
@@ -1079,12 +1075,7 @@ impl CliUnstable {
             "multitarget" => stabilized_warn(k, "1.64", STABILISED_MULTITARGET),
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "terminal-width" => stabilized_warn(k, "1.68", STABILIZED_TERMINAL_WIDTH),
-            "sparse-registry" => {
-                // Once sparse-registry becomes the default for crates.io, `sparse_registry` should
-                // be removed entirely from `CliUnstable`.
-                stabilized_warn(k, "1.68", STABILISED_SPARSE_REGISTRY);
-                self.sparse_registry = parse_empty(k, v)?;
-            }
+            "sparse-registry" => stabilized_warn(k, "1.68", STABILISED_SPARSE_REGISTRY),
             "registry-auth" => self.registry_auth = parse_empty(k, v)?,
             "namespaced-features" => stabilized_warn(k, "1.60", STABILISED_NAMESPACED_FEATURES),
             "weak-dep-features" => stabilized_warn(k, "1.60", STABILIZED_WEAK_DEP_FEATURES),

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -254,7 +254,7 @@ impl SourceId {
                 "unsupported registry protocol `{unknown}` (defined in {})",
                 proto.as_ref().unwrap().definition
             ),
-            None => config.cli_unstable().sparse_registry,
+            None => true,
         };
         Ok(is_sparse)
     }

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -933,7 +933,7 @@ Can be overridden with the `--token` command-line option.
 
 ##### `registries.crates-io.protocol`
 * Type: string
-* Default: `git`
+* Default: `sparse`
 * Environment: `CARGO_REGISTRIES_CRATES_IO_PROTOCOL`
 
 Specifies the protocol used to access crates.io. Allowed values are `git` or `sparse`.

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1926,6 +1926,7 @@ Caused by:
 
 #[cargo_test]
 fn disallow_network_git() {
+    let _server = RegistryBuilder::new().build();
     let p = project()
         .file(
             "Cargo.toml",
@@ -1952,7 +1953,10 @@ Caused by:
   failed to load source for dependency `foo`
 
 Caused by:
-  Unable to update registry [..]
+  Unable to update registry `crates-io`
+
+Caused by:
+  failed to update replaced source registry `crates-io`
 
 Caused by:
   attempting to make an HTTP request, but --frozen was specified

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -404,8 +404,8 @@ fn alt_sparse_registry() {
             "#,
         )
         .build();
-    p.cargo("doc -v --no-deps -Zrustdoc-map -Zsparse-registry")
-        .masquerade_as_nightly_cargo(&["rustdoc-map", "sparse-registry"])
+    p.cargo("doc -v --no-deps -Zrustdoc-map")
+        .masquerade_as_nightly_cargo(&["rustdoc-map"])
         .with_stderr_contains(
             "[RUNNING] `rustdoc [..]--crate-name foo \
             [..]bar=https://example.com/bar/1.0.0/[..]grimm=https://docs.rs/grimm/1.0.0/[..]",

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -88,8 +88,7 @@ fn vendor_sample_config_alt_registry() {
 
     Package::new("log", "0.3.5").alternative(true).publish();
 
-    p.cargo("vendor --respect-source-config -Z sparse-registry")
-        .masquerade_as_nightly_cargo(&["sparse-registry"])
+    p.cargo("vendor --respect-source-config")
         .with_stdout(format!(
             r#"[source."{0}"]
 registry = "{0}"


### PR DESCRIPTION
Changes the default protocol for accessing crates.io to `sparse`.

The protocol can be switched back to `git` via the configuration key `registries.crates-io.protocol` = `git`

Closes #10965