### PR TITLE
chore: fix missing files in autolabel trigger_files

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -40,8 +40,7 @@ warn_non_default_branch = true
 [autolabel."A-build-execution"]
 trigger_files = [
   "src/cargo/core/compiler/compilation.rs",
-  "src/cargo/core/compiler/job.rs",
-  "src/cargo/core/compiler/job_queue.rs",
+  "src/cargo/core/compiler/job_queue/",
   "src/cargo/core/compiler/mod.rs",
 ]
 
@@ -209,7 +208,7 @@ trigger_files = [
 ]
 
 [autolabel."Command-add"]
-trigger_files = ["src/bin/cargo/commands/add.rs", "src/cargo/ops/cargo_add/*"]
+trigger_files = ["src/bin/cargo/commands/add.rs", "src/cargo/ops/cargo_add/"]
 
 [autolabel."Command-bench"]
 trigger_files = ["src/bin/cargo/commands/bench.rs"]
@@ -300,7 +299,7 @@ trigger_files = ["src/bin/cargo/commands/search.rs"]
 trigger_files = ["src/bin/cargo/commands/test.rs", "src/cargo/ops/cargo_test.rs"]
 
 [autolabel."Command-tree"]
-trigger_files = ["src/bin/cargo/commands/tree.rs", "src/cargo/ops/tree/*"]
+trigger_files = ["src/bin/cargo/commands/tree.rs", "src/cargo/ops/tree/"]
 
 [autolabel."Command-uninstall"]
 trigger_files = ["src/bin/cargo/commands/uninstall.rs", "src/cargo/ops/cargo_uninstall.rs"]


### PR DESCRIPTION


<!-- homu-ignore:start -->
### What does this PR try to resolve?

Some definitions got stale after module rename (i.e. #11758).

Also, triagebot checks with `starts_with` only. No glob support so far I see it. See https://github.com/rust-lang/triagebot/blob/add83c3ad979cee9e6120a086e36a37b5ff9edfd/src/handlers/autolabel.rs#L45


### Additional information
Wrote a [simple tool](https://github.com/weihanglo/stale-autolabel) for this. I believe there must exist a similar tool already. In the future we could probably integrate this into cargo's own xtask workflow.

<!-- homu-ignore:end -->
