### PR TITLE
path dependency: fix cargo-util version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.47"
 base64 = "0.21.0"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
-cargo-util = { path = "crates/cargo-util", version = "0.2.3" }
+cargo-util = { path = "crates/cargo-util", version = "0.2.4" }
 clap = "4.1.3"
 crates-io = { path = "crates/crates-io", version = "0.35.1" }
 curl = { version = "0.4.44", features = ["http2"] }


### PR DESCRIPTION
The update of the version in workspace `Cargo.toml` file slipped through my last PR.

This change has no real effect, as the version is ignored for path dependencies.

Since all other path dependencies have the correct version specified  we should either do it for all or remove the versions for path dependencies.