### PR TITLE
Bump crates-io to 0.36.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.4" }
 clap = "4.1.3"
-crates-io = { path = "crates/crates-io", version = "0.35.1" }
+crates-io = { path = "crates/crates-io", version = "0.36.0" }
 curl = { version = "0.4.44", features = ["http2"] }
 curl-sys = "0.4.59"
 env_logger = "0.10.0"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"


### PR DESCRIPTION
This was an overlook of https://github.com/rust-lang/cargo/pull/11600

Since we already got #11806 to backport, I guess it is not harmful to <https://github.com/rust-lang/cargo/labels/beta-nominated> this as well.  Maybe it do need a backport as `src/cargo/ops/registry.rs` use a new public API from that PR.

BTW, please help check if it is really a breaking change.

