### PR TITLE
[beta-1.69] backport #11820

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.3" }
 clap = "4.1.3"
-crates-io = { path = "crates/crates-io", version = "0.35.1" }
+crates-io = { path = "crates/crates-io", version = "0.36.0" }
 curl = { version = "0.4.44", features = ["http2"] }
 curl-sys = "0.4.59"
 env_logger = "0.10.0"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.35.1"
+version = "0.36.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -702,7 +702,7 @@ impl Trait for Foo {}
 
 fn main() {
     let x = Foo;
-    x.foo(1); // Error: this function takes 0 arguments
+    x.foo(1); // Error: this method takes 0 arguments but 1 argument was supplied
 }
 ```
 


### PR DESCRIPTION
Beta backports:

- https://github.com/rust-lang/cargo/pull/11820

In order to make CI pass, the following PRs are also cherry-picked:

- https://github.com/rust-lang/cargo/pull/11817