### PR TITLE
Notice for potential unexpected shell expansions in help text of `cargo-add`

### DIFF
--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -81,6 +81,8 @@ Add as a [build dependency](../reference/specifying-dependencies.html#build-depe
 
 {{#option "`--target` _target_" }}
 Add as a dependency to the [given target platform](../reference/specifying-dependencies.html#platform-specific-dependencies).
+
+To avoid unexpected shell expansions, you may use quotes around each target, e.g., `--target 'cfg(unix)'`.
 {{/option}}
 
 {{/options}}
@@ -165,6 +167,10 @@ Add dependencies to only the specified package.
 4. Add support for serializing data structures to json with `derive`s
 
        cargo add serde serde_json -F serde/derive
+
+5. Add `windows` as a platform specific dependency on `cfg(windows)`
+
+       cargo add windows --target 'cfg(windows)'
 
 ## SEE ALSO
 {{man "cargo" 1}}, {{man "cargo-remove" 1}}

--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -85,9 +85,6 @@ Add as a dependency to the [given target platform](../reference/specifying-depen
 
 {{/options}}
 
-
-</dl>
-
 ### Dependency options
 
 {{#options}}

--- a/src/doc/man/cargo-remove.md
+++ b/src/doc/man/cargo-remove.md
@@ -30,6 +30,8 @@ Remove as a [build dependency](../reference/specifying-dependencies.html#build-d
 
 {{#option "`--target` _target_" }}
 Remove as a dependency to the [given target platform](../reference/specifying-dependencies.html#platform-specific-dependencies).
+
+To avoid unexpected shell expansions, you may use quotes around each target, e.g., `--target 'cfg(unix)'`.
 {{/option}}
 
 {{/options}}

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -76,6 +76,9 @@ OPTIONS
            Add as a dependency to the given target platform
            <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies>.
 
+           To avoid unexpected shell expansions, you may use quotes around each
+           target, e.g., --target 'cfg(unix)'.
+
    Dependency options
        --dry-run
            Don’t actually write the manifest
@@ -224,5 +227,10 @@ EXAMPLES
 
               cargo add serde serde_json -F serde/derive
 
+       5. Add windows as a platform specific dependency on cfg(windows)
+
+              cargo add windows --target 'cfg(windows)'
+
 SEE ALSO
        cargo(1), cargo-remove(1)
+

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -76,8 +76,6 @@ OPTIONS
            Add as a dependency to the given target platform
            <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies>.
 
-</dl>
-
    Dependency options
        --dry-run
            Don’t actually write the manifest
@@ -228,4 +226,3 @@ EXAMPLES
 
 SEE ALSO
        cargo(1), cargo-remove(1)
-

--- a/src/doc/man/generated_txt/cargo-remove.txt
+++ b/src/doc/man/generated_txt/cargo-remove.txt
@@ -23,6 +23,9 @@ OPTIONS
            Remove as a dependency to the given target platform
            <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies>.
 
+           To avoid unexpected shell expansions, you may use quotes around each
+           target, e.g., --target 'cfg(unix)'.
+
    Miscellaneous Options
        --dry-run
            Don’t actually write to the manifest.

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -86,7 +86,8 @@ which is defined by the <code>registry.default</code> config key which defaults 
 
 
 <dt class="option-term" id="option-cargo-add---target"><a class="option-anchor" href="#option-cargo-add---target"></a><code>--target</code> <em>target</em></dt>
-<dd class="option-desc">Add as a dependency to the <a href="../reference/specifying-dependencies.html#platform-specific-dependencies">given target platform</a>.</dd>
+<dd class="option-desc">Add as a dependency to the <a href="../reference/specifying-dependencies.html#platform-specific-dependencies">given target platform</a>.</p>
+<p>To avoid unexpected shell expansions, you may use quotes around each target, e.g., <code>--target 'cfg(unix)'</code>.</dd>
 
 
 </dl>
@@ -268,6 +269,10 @@ details on environment variables that Cargo reads.
 4. Add support for serializing data structures to json with `derive`s
 
        cargo add serde serde_json -F serde/derive
+
+5. Add `windows` as a platform specific dependency on `cfg(windows)`
+
+       cargo add windows --target 'cfg(windows)'
 
 ## SEE ALSO
 [cargo(1)](cargo.html), [cargo-remove(1)](cargo-remove.html)

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -91,9 +91,6 @@ which is defined by the <code>registry.default</code> config key which defaults 
 
 </dl>
 
-
-</dl>
-
 ### Dependency options
 
 <dl>

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -29,7 +29,8 @@ Remove one or more dependencies from a `Cargo.toml` manifest.
 
 
 <dt class="option-term" id="option-cargo-remove---target"><a class="option-anchor" href="#option-cargo-remove---target"></a><code>--target</code> <em>target</em></dt>
-<dd class="option-desc">Remove as a dependency to the <a href="../reference/specifying-dependencies.html#platform-specific-dependencies">given target platform</a>.</dd>
+<dd class="option-desc">Remove as a dependency to the <a href="../reference/specifying-dependencies.html#platform-specific-dependencies">given target platform</a>.</p>
+<p>To avoid unexpected shell expansions, you may use quotes around each target, e.g., <code>--target 'cfg(unix)'</code>.</dd>
 
 
 </dl>

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -97,7 +97,6 @@ Add as a \fIbuild dependency\fR <https://doc.rust\-lang.org/cargo/reference/spec
 .RS 4
 Add as a dependency to the \fIgiven target platform\fR <https://doc.rust\-lang.org/cargo/reference/specifying\-dependencies.html#platform\-specific\-dependencies>\&.
 .RE
-</dl>
 .SS "Dependency options"
 .sp
 \fB\-\-dry\-run\fR

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -96,6 +96,8 @@ Add as a \fIbuild dependency\fR <https://doc.rust\-lang.org/cargo/reference/spec
 \fB\-\-target\fR \fItarget\fR
 .RS 4
 Add as a dependency to the \fIgiven target platform\fR <https://doc.rust\-lang.org/cargo/reference/specifying\-dependencies.html#platform\-specific\-dependencies>\&.
+.sp
+To avoid unexpected shell expansions, you may use quotes around each target, e.g., \fB\-\-target 'cfg(unix)'\fR\&.
 .RE
 .SS "Dependency options"
 .sp
@@ -304,6 +306,16 @@ cargo add nom@5
 .RS 4
 .nf
 cargo add serde serde_json \-F serde/derive
+.fi
+.RE
+.RE
+.sp
+.RS 4
+\h'-04' 5.\h'+01'Add \fBwindows\fR as a platform specific dependency on \fBcfg(windows)\fR
+.sp
+.RS 4
+.nf
+cargo add windows \-\-target 'cfg(windows)'
 .fi
 .RE
 .RE

--- a/src/etc/man/cargo-remove.1
+++ b/src/etc/man/cargo-remove.1
@@ -25,6 +25,8 @@ Remove as a \fIbuild dependency\fR <https://doc.rust\-lang.org/cargo/reference/s
 \fB\-\-target\fR \fItarget\fR
 .RS 4
 Remove as a dependency to the \fIgiven target platform\fR <https://doc.rust\-lang.org/cargo/reference/specifying\-dependencies.html#platform\-specific\-dependencies>\&.
+.sp
+To avoid unexpected shell expansions, you may use quotes around each target, e.g., \fB\-\-target 'cfg(unix)'\fR\&.
 .RE
 .SS "Miscellaneous Options"
 .sp


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #11720.

Add a notice for potential unexpected shell expansions in help text of `cargo-add` and `cargo-remove`.

### How should we test and review this PR?

* `cargo run help add`
* `cargo run help remove`

Maybe we shouldn't add anything and instead assume users to know shell expansion existing.
<!-- homu-ignore:end -->
