### PR TITLE
chore: Use sparse protocol on stable CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ defaults:
 permissions:
   contents: read
 
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+
 jobs:
   # Check Code style quickly by running `rustfmt` over all code
   rustfmt:
@@ -97,9 +100,6 @@ jobs:
     - name: Configure extra test environment
       run: echo CARGO_CONTAINER_TESTS=1 >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'
-    - name: Enable sparse
-      run: echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV
-      if: "!contains(matrix.rust, 'stable')"
 
     - run: cargo test
     - name: Clear intermediate test output


### PR DESCRIPTION
[Rust `1.68.0`](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html) was released yesterday and it stabilized [Cargo's sparse protocol](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol). 

The protocol has been used in [CI on nightly](https://github.com/rust-lang/cargo/blob/3c35bf10ad21083f04a033d2abd8179cfbd0380b/.github/workflows/main.yml#L100-L102) for some time. This PR enables the protocol for stable CI runs.