### PR TITLE
Disable flaky auth tests when `gitoxide` runs them

### DIFF
--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -105,6 +105,11 @@ fn setup_failed_auth_test() -> (SocketAddr, JoinHandle<()>, Arc<AtomicUsize>) {
 // Tests that HTTP auth is offered from `credential.helper`.
 #[cargo_test]
 fn http_auth_offered() {
+    // TODO(Seb): remove this once possible.
+    if cargo_uses_gitoxide() {
+        // Without the fixes in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0 this test is flaky.
+        return;
+    }
     let (addr, t, connections) = setup_failed_auth_test();
     let p = project()
         .file(
@@ -366,6 +371,11 @@ Caused by:
 
 #[cargo_test]
 fn instead_of_url_printed() {
+    // TODO(Seb): remove this once possible.
+    if cargo_uses_gitoxide() {
+        // Without the fixes in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0 this test is flaky.
+        return;
+    }
     let (addr, t, _connections) = setup_failed_auth_test();
     let config = paths::home().join(".gitconfig");
     let mut config = git2::Config::open(&config).unwrap();


### PR DESCRIPTION
The proper fix is in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0
which unfortunately can't be used as it also comes with the latest `tempfile` v3.4
which causes other issues when compiling on some platforms.

Thus we first disable the flaky tests, and re-enable them with the `gix` upgrade
which should be possible once `tempfile` doesn't hinder `cargo` on some platforms
anymore.

Related to https://github.com/rust-lang/cargo/issues/11821

This PR is supposed to be followed up by #11831 which re-enables the flaky tests and fixes them properly by upgrading `gix` which contains the fix.