### PR TITLE
[BLOCKED] upgrade `gix` to v0.41 to fix flaky auth tests.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 git2 = "0.17.0"
 git2-curl = "0.18.0"
-gix = { version = "0.39.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix = { version = "0.41.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
 gix-features-for-configuration-only = { version = "0.28.0", package = "gix-features", features = [ "parallel" ] }
 glob = "0.3.0"
 hex = "0.4"

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -105,11 +105,6 @@ fn setup_failed_auth_test() -> (SocketAddr, JoinHandle<()>, Arc<AtomicUsize>) {
 // Tests that HTTP auth is offered from `credential.helper`.
 #[cargo_test]
 fn http_auth_offered() {
-    // TODO(Seb): remove this once possible.
-    if cargo_uses_gitoxide() {
-        // Without the fixes in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0 this test is flaky.
-        return;
-    }
     let (addr, t, connections) = setup_failed_auth_test();
     let p = project()
         .file(
@@ -372,11 +367,6 @@ Caused by:
 
 #[cargo_test]
 fn instead_of_url_printed() {
-    // TODO(Seb): remove this once possible.
-    if cargo_uses_gitoxide() {
-        // Without the fixes in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0 this test is flaky.
-        return;
-    }
     let (addr, t, _connections) = setup_failed_auth_test();
     let config = paths::home().join(".gitconfig");
     let mut config = git2::Config::open(&config).unwrap();


### PR DESCRIPTION
Follow-up of: #11830 which provides the first commit [c890c64](https://github.com/rust-lang/cargo/pull/11831/commits/c890c64080e193325584898369c729ab30994314).

The latest release (https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0) makes writing to the credential helper non-fallible which is useful if the helper program doesn't read from stdin and is in line with of `git` implements it as well.


### Blocked

This fix also undoes a pin `tempfile` to version 3.3 which at this time causes build issues for some platforms if `tempfile` version 3.4 or newer would be used.

Thus this PR cannot be merged until `tempfile` will not cause build failures.
This also means that `cargo` can't upgrade to any newer version of `gitoxide` until `tempfile` isn't an issue anymore, also blocking the shallow clone feature for example.

@weihanglo, maybe you can replace this line with references to issues to wait for.

Fixes #11821