### PR TITLE
Accurately show status when downgrading dependencies

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -192,6 +192,7 @@ fn substitute_macros(input: &str) -> String {
         ("[CHECKING]", "    Checking"),
         ("[COMPLETED]", "   Completed"),
         ("[CREATED]", "     Created"),
+        ("[DOWNGRADING]", " Downgrading"),
         ("[FINISHED]", "    Finished"),
         ("[ERROR]", "error:"),
         ("[WARNING]", "warning:"),

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -8,7 +8,7 @@ use crate::util::CargoResult;
 use anyhow::Context;
 use log::debug;
 use std::collections::{BTreeMap, HashSet};
-use termcolor::Color::{self, Cyan, Green, Red};
+use termcolor::Color::{self, Cyan, Green, Red, Yellow};
 
 pub struct UpdateOptions<'a> {
     pub config: &'a Config,
@@ -142,7 +142,12 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             } else {
                 format!("{} -> v{}", removed[0], added[0].version())
             };
-            print_change("Updating", msg, Green)?;
+
+            if removed[0].version() > added[0].version() {
+                print_change("Downgrading", msg, Yellow)?;
+            } else {
+                print_change("Updating", msg, Green)?;
+            }
         } else {
             for package in removed.iter() {
                 print_change("Removing", format!("{}", package), Red)?;

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -657,7 +657,7 @@ fn main(){
         .with_status(0)
         .with_stderr(
             "\
-[UPDATING] present_dep v1.2.9 -> v1.2.3
+[DOWNGRADING] present_dep v1.2.9 -> v1.2.3
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -385,7 +385,7 @@ fn update_precise() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[UPDATING] serde v0.2.1 -> v0.2.0
+[DOWNGRADING] serde v0.2.1 -> v0.2.0
 ",
         )
         .run();
@@ -492,7 +492,7 @@ fn update_precise_first_run() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[UPDATING] serde v0.2.1 -> v0.2.0
+[DOWNGRADING] serde v0.2.1 -> v0.2.0
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

A few times now I've ran into issues where Cargo ends up downgrading a dependency in order to satisfy a pinned dependency somewhere in the dependency graph. Unfortunately this is not clear in the output of `cargo update`, which just shows all the changed dependencies as `Updating`.

References:

* #5702
* [Finding a pinned dependency edge](https://users.rust-lang.org/t/finding-a-pinned-dependency-edge/81157)
* https://github.com/tokio-rs/axum/issues/1814

### How should we test and review this PR?

This is a small change that tries to make dependency downgrades stand out more in the output of `cargo update`. I have not added any new tests since the existing tests seem to cover this functionality.

Some tests still fail, these refer to Git dependencies. I'm honestly not sure how to handle these, so I'd like to get some feedback on this before I fix those tests up. Git commits form a DAG, so one option is to see if the new commit is an ancestor of the old one (mark as "updating"), if the old commit is an ancestor of the new one (mark as "downgrading"), or neither (could be from parallel branches) we could compare based on timestamp in that case.

### To do

* Fix up tests for Git dependency updates