### PR TITLE
docs(contrib): Move Design Principles earlier in the book

### DIFF
--- a/src/doc/contrib/src/SUMMARY.md
+++ b/src/doc/contrib/src/SUMMARY.md
@@ -6,6 +6,7 @@
     - [Working on Cargo](./process/working-on-cargo.md)
     - [Release process](./process/release.md)
     - [Unstable features](./process/unstable.md)
+- [Design Principles](./design.md)
 - [Architecture](./architecture/index.md)
     - [Codebase Overview](./architecture/codebase.md)
     - [SubCommands](./architecture/subcommands.md)
@@ -18,4 +19,3 @@
     - [Writing Tests](./tests/writing.md)
     - [Benchmarking and Profiling](./tests/profiling.md)
     - [Crater](./tests/crater.md)
-- [Design Principles](./design.md)


### PR DESCRIPTION
This is the framing by which all contributions should happen, so this should come first before getting into what is needed to know to implement a change and test it.

This is also prep for adding a new Implementations Practices section to pull out various tips spread through the Architecture section.  See #11841