### PR TITLE
ci: make clean-test-output a script for reuse

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,10 +103,7 @@ jobs:
 
     - run: cargo test
     - name: Clear intermediate test output
-      run: |
-          df -h
-          rm -rf target/tmp
-          df -h
+      run: ci/clean-test-output.sh
     - name: gitoxide tests (all git-related tests)
       run: cargo test git
       env:
@@ -114,10 +111,7 @@ jobs:
       # The testsuite generates a huge amount of data, and fetch-smoke-test was
     # running out of disk space.
     - name: Clear test output
-      run: |
-        df -h
-        rm -rf target/tmp
-        df -h
+      run: ci/clean-test-output.sh
     - name: Check operability of rustc invocation with argfile
       env:
         __CARGO_TEST_FORCE_ARGFILE: 1
@@ -151,10 +145,7 @@ jobs:
     # The testsuite generates a huge amount of data, and fetch-smoke-test was
     # running out of disk space.
     - name: Clear benchmark output
-      run: |
-        df -h
-        rm -rf target/tmp
-        df -h
+      run: ci/clean-test-output.sh
     - name: Fetch smoke test
       run: ci/fetch-smoke-test.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,8 +170,6 @@ jobs:
 
   build_std:
     runs-on: ubuntu-latest
-    env:
-      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     steps:
     - uses: actions/checkout@v3
     - run: rustup update nightly && rustup default nightly

--- a/ci/clean-test-output.sh
+++ b/ci/clean-test-output.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# This script remove test and benchmark output and displays disk usage.
+
+set -euo pipefail
+
+df -h
+rm -rf target/tmp
+df -h


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Just make CI workflow yaml a bit clear by reusing a script.

### How should we test and review this PR?

Let CI pass.
<!-- homu-ignore:end -->
