### PR TITLE
Allow patch to point to the same source

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -360,13 +360,11 @@ impl<'cfg> PackageRegistry<'cfg> {
                 }
 
                 if *summary.package_id().source_id().canonical_url() == canonical {
-                    return Err(anyhow::anyhow!(
-                        "patch for `{}` in `{}` points to the same source, but \
-                        patches must point to different sources",
+                    log::warn!(
+                        "patch for `{}` in `{}` points to the same source",
                         dep.package_name(),
                         url
-                    ))
-                    .context(format!("failed to resolve patches for `{}`", url));
+                    )
                 }
                 unlocked_summaries.push(summary);
             }


### PR DESCRIPTION
Cargo currently disallows patching a git dependency to use a different branch of the same source URL. This  behaviour is unnecessarily restrictive: a same-URL patch simply has no effect if the branch/tag/commit are the same. 

In a project depending on another git-hosted (unpublished) crate, patch should allow to specify another branch of the crate. This scenario occurs naturally when team-developing private projects across multiple crates. A current workaround is to fork the the crate's repository (including alternate branch) just to give it a different URL. 

Recognizing that the same-URL situation could also be the result of unintended configuration, this PR preserves the check but relaxes the error into a warning. 