### PR TITLE
align semantics of generated vcs ignore files

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -742,7 +742,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
     // Using the push method with multiple arguments ensures that the entries
     // for all mutually-incompatible VCS in terms of syntax are in sync.
     let mut ignore = IgnoreList::new();
-    ignore.push("/target", "^target/", "target");
+    ignore.push("/target", "^target$", "target");
     if !opts.bin {
         ignore.push("/Cargo.lock", "^Cargo.lock$", "Cargo.lock");
     }

--- a/tests/testsuite/init/mercurial_autodetect/out/.hgignore
+++ b/tests/testsuite/init/mercurial_autodetect/out/.hgignore
@@ -1,2 +1,2 @@
-^target/
+^target$
 ^Cargo.lock$

--- a/tests/testsuite/init/simple_hg/out/.hgignore
+++ b/tests/testsuite/init/simple_hg/out/.hgignore
@@ -1,2 +1,2 @@
-^target/
+^target$
 ^Cargo.lock$

--- a/tests/testsuite/init/simple_hg_ignore_exists/out/.hgignore
+++ b/tests/testsuite/init/simple_hg_ignore_exists/out/.hgignore
@@ -2,5 +2,5 @@
 
 # Added by cargo
 
-^target/
+^target$
 ^Cargo.lock$

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -100,6 +100,23 @@ fn simple_git() {
     cargo_process("build").cwd(&paths::root().join("foo")).run();
 }
 
+#[cargo_test(requires_hg)]
+fn simple_hg() {
+    cargo_process("new --lib foo --edition 2015 --vcs hg").run();
+
+    assert!(paths::root().is_dir());
+    assert!(paths::root().join("foo/Cargo.toml").is_file());
+    assert!(paths::root().join("foo/src/lib.rs").is_file());
+    assert!(paths::root().join("foo/.hg").is_dir());
+    assert!(paths::root().join("foo/.hgignore").is_file());
+
+    let fp = paths::root().join("foo/.hgignore");
+    let contents = fs::read_to_string(&fp).unwrap();
+    assert_eq!(contents, "^target$\n^Cargo.lock$\n",);
+
+    cargo_process("build").cwd(&paths::root().join("foo")).run();
+}
+
 #[cargo_test]
 fn no_argument() {
     cargo_process("new")


### PR DESCRIPTION
### What does this PR try to resolve?

The currently generated `^target/` spec in a hg ignore will only ignore dirs of that name at the root.

This change matches the behavior of the gitignore spec next to it, by only ignoring both files/symlinks and dirs of name "target".

### How should we test and review this PR?

Run `cargo new`
