### PR TITLE
docs: Address warnings

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -593,13 +593,13 @@ pub struct HttpServer {
     custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
 }
 
-/// A helper struct that collects the arguments for [HttpServer::check_authorized].
+/// A helper struct that collects the arguments for [`HttpServer::check_authorized`].
 /// Based on looking at the request, these are the fields that the authentication header should attest to.
-pub struct Mutation<'a> {
-    pub mutation: &'a str,
-    pub name: Option<&'a str>,
-    pub vers: Option<&'a str>,
-    pub cksum: Option<&'a str>,
+struct Mutation<'a> {
+    mutation: &'a str,
+    name: Option<&'a str>,
+    vers: Option<&'a str>,
+    cksum: Option<&'a str>,
 }
 
 impl HttpServer {
@@ -1204,7 +1204,7 @@ impl Package {
     }
 
     /// Adds a platform-specific dependency. Example:
-    /// ```
+    /// ```toml
     /// [target.'cfg(windows)'.dependencies]
     /// foo = {version = "1.0"}
     /// ```


### PR DESCRIPTION
This is to help prepare for checking for doc warnings across the entire workspace being created in rust-lang/cargo#11851

`Mutation` was made `pub`, along with its fields, but they aren't actually usable with anything, so I went and made it private to match what its documentation references

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
