### PR TITLE
doc: clarify implications of `cargo-yank`

### DIFF
--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -27,26 +27,26 @@ current directory.
 
 ### How yank works
 
-For example, the `foo` crate published version `0.22.0` and another crate `bar`
-declared a dependency on version `foo = 0.22`. Now `foo` releases a new, but
-not semver compatible, version `0.23.0`, and finds a critical issue with `0.22.0`.
-If `0.22.0` is yanked, no new project or checkout without an existing lockfile will be
-able to use crate `bar` as it relies on `0.22`.
+For example, the `foo` crate published version `1.5.0` and another crate `bar`
+declared a dependency on version `foo = "1.5"`. Now `foo` releases a new, but
+not semver compatible, version `2.0.0`, and finds a critical issue with `1.5.0`.
+If `1.5.0` is yanked, no new project or checkout without an existing lockfile
+will be able to use crate `bar` as it relies on `1.5`.
 
-In this case, the maintainers of `foo` should first publish a semver compatible version
-such as `0.22.1` prior to yanking `0.22.0` so that `bar` and all projects that depend
-on `bar` will continue to work.
+In this case, the maintainers of `foo` should first publish a semver compatible
+version such as `1.5.1` prior to yanking `1.5.0` so that `bar` and all projects
+that depend on `bar` will continue to work.
 
-As another example, consider a crate `bar` with published versions `0.22.0`, `0.22.1`, 
-`0.22.2`, `0.23.0` and `0.24.0`. The following table identifies the versions
-cargo could use in the absence of a lockfile for different SemVer requirements,
-following a given release being yanked:
+As another example, consider a crate `bar` with published versions `1.5.0`,
+`1.5.1`, `1.5.2`, `2.0.0` and `3.0.0`. The following table identifies the
+versions cargo could use in the absence of a lockfile for different SemVer
+requirements, following a given release being yanked:
 
-| Yanked Version / SemVer requirement | `bar = "0.22.0"`                          | `bar = "=0.22.0"` | `bar = "0.23.0"` |
-|-------------------------------------|-------------------------------------------|-------------------|------------------|
-| `0.22.0`                            | Use either `0.22.1` or `0.22.2`           | **Return Error**  | Use `0.23.0`     |
-| `0.22.1`                            | Use either `0.22.0` or `0.22.2`           | Use `0.22.0`      | Use `0.23.0`     |
-| `0.23.0`                            | Use either `0.22.0`, `0.21.0` or `0.22.2` | Use `0.22.0`      | **Return Error** |
+| Yanked Version / SemVer requirement | `bar = "1.5.0"`                         | `bar = "=1.5.0"` | `bar = "2.0.0"`  |
+|-------------------------------------|-----------------------------------------|------------------|------------------|
+| `1.5.0`                             | Use either `1.5.1` or `1.5.2`           | **Return Error** | Use `2.0.0`      |
+| `1.5.1`                             | Use either `1.5.0` or `1.5.2`           | Use `1.5.0`      | Use `2.0.0`      |
+| `2.0.0`                             | Use either `1.5.0`, `1.5.1` or `0.22.2` | Use `1.5.0`      | **Return Error** |
 
 ### When to yank
 
@@ -58,8 +58,9 @@ typically a less disruptive mechanism to inform users and encourage them to
 upgrade, and avoids the possibility of significant downstream disruption
 irrespective of susceptibility to the vulnerability in question.
 
-A common workflow is to yank a crate having already published a semver compatible version,
-to reduce the probability of preventing dependent crates from compiling.
+A common workflow is to yank a crate having already published a semver
+compatible version, to reduce the probability of preventing dependent
+crates from compiling.
 
 ## OPTIONS
 

--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -15,9 +15,39 @@ The yank command removes a previously published crate's version from the
 server's index. This command does not delete any data, and the crate will
 still be available for download via the registry's download link.
 
-Note that existing crates locked to a yanked version will still be able to
-download the yanked version to use it. Cargo will, however, not allow any new
-crates to be locked to any yanked version.
+Crates should only be yanked in exceptional circumstances, for example, license/copyright issues, accidental
+inclusion of [PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc... In the case of security
+vulnerabilities, [RustSec](https://rustsec.org/) is typically a less disruptive mechanism to inform users
+and encourage them to upgrade, and avoids the possibility of significant downstream disruption irrespective
+of susceptibility to the vulnerability in question.
+
+Cargo will not use a yanked version for any new project or checkout without a
+pre-existing lockfile, and will generate an error if there are no longer
+any compatible versions for your crate.
+
+For example, the `foo` crate published version `0.22.0` and another crate `bar`
+declared a dependency on version `foo = 0.22`. Now `foo` releases a new, but
+not semver compatible, version `0.23.0`, and finds a critical issue with `0.22.0`.
+If `0.22.0` is yanked, no new project or checkout without an existing lockfile will be
+able to use crate `bar` as it relies on `0.22`.
+
+In this case, the maintainers of `foo` should first publish a semver compatible version
+such as `0.22.1` prior to yanking `0.22.0` so that `bar` and all projects that depend
+on `bar` will continue to work.
+
+As another example, consider a crate `bar` with published versions `0.22.0`, `0.22.1`, 
+`0.22.2`, `0.23.0` and `0.24.0`. The following table identifies the versions
+cargo could use in the absence of a lockfile for different SemVer requirements,
+following a given release being yanked:
+
+| Yanked Version / SemVer requirement | `bar = "0.22.0"`                          | `bar = "=0.22.0"` | `bar = "0.23.0"` |
+|-------------------------------------|-------------------------------------------|-------------------|------------------|
+| `0.22.0`                            | Use either `0.22.1` or `0.22.2`           | **Return Error**  | Use `0.23.0`     |
+| `0.22.1`                            | Use either `0.22.0` or `0.22.2`           | Use `0.22.0`      | Use `0.23.0`     |
+| `0.23.0`                            | Use either `0.22.0`, `0.21.0` or `0.22.2` | Use `0.22.0`      | **Return Error** |
+
+A common workflow is to yank a crate having already published a semver compatible version,
+to reduce the probability of preventing dependent crates from compiling.
 
 This command requires you to be authenticated with either the `--token` option
 or using {{man "cargo-login" 1}}.

--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -50,17 +50,18 @@ requirements, following a given release being yanked:
 
 ### When to yank
 
-Crates should only be yanked in exceptional circumstances, for example,
-license/copyright issues, accidental inclusion of
-[PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc...
-In the case of security vulnerabilities, [RustSec](https://rustsec.org/) is
-typically a less disruptive mechanism to inform users and encourage them to
-upgrade, and avoids the possibility of significant downstream disruption
+Crates should only be yanked in exceptional circumstances, for example, an
+accidental publish, an unintentional SemVer breakages, or a significantly
+broken and unusable crate. In the case of security vulnerabilities, [RustSec]
+is typically a less disruptive mechanism to inform users and encourage them
+to upgrade, and avoids the possibility of significant downstream disruption
 irrespective of susceptibility to the vulnerability in question.
 
 A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
+
+[RustSec]: https://rustsec.org/
 
 ## OPTIONS
 

--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -15,15 +15,17 @@ The yank command removes a previously published crate's version from the
 server's index. This command does not delete any data, and the crate will
 still be available for download via the registry's download link.
 
-Crates should only be yanked in exceptional circumstances, for example, license/copyright issues, accidental
-inclusion of [PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc... In the case of security
-vulnerabilities, [RustSec](https://rustsec.org/) is typically a less disruptive mechanism to inform users
-and encourage them to upgrade, and avoids the possibility of significant downstream disruption irrespective
-of susceptibility to the vulnerability in question.
-
 Cargo will not use a yanked version for any new project or checkout without a
 pre-existing lockfile, and will generate an error if there are no longer
 any compatible versions for your crate.
+
+This command requires you to be authenticated with either the `--token` option
+or using {{man "cargo-login" 1}}.
+
+If the crate name is not specified, it will use the package name from the
+current directory.
+
+### How yank works
 
 For example, the `foo` crate published version `0.22.0` and another crate `bar`
 declared a dependency on version `foo = 0.22`. Now `foo` releases a new, but
@@ -46,14 +48,18 @@ following a given release being yanked:
 | `0.22.1`                            | Use either `0.22.0` or `0.22.2`           | Use `0.22.0`      | Use `0.23.0`     |
 | `0.23.0`                            | Use either `0.22.0`, `0.21.0` or `0.22.2` | Use `0.22.0`      | **Return Error** |
 
+### When to yank
+
+Crates should only be yanked in exceptional circumstances, for example,
+license/copyright issues, accidental inclusion of
+[PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc...
+In the case of security vulnerabilities, [RustSec](https://rustsec.org/) is
+typically a less disruptive mechanism to inform users and encourage them to
+upgrade, and avoids the possibility of significant downstream disruption
+irrespective of susceptibility to the vulnerability in question.
+
 A common workflow is to yank a crate having already published a semver compatible version,
 to reduce the probability of preventing dependent crates from compiling.
-
-This command requires you to be authenticated with either the `--token` option
-or using {{man "cargo-login" 1}}.
-
-If the crate name is not specified, it will use the package name from the
-current directory.
 
 ## OPTIONS
 

--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -61,7 +61,16 @@ A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
 
+To address copyright, licensing, or personal data issues with your published
+crate, contact the maintainers of the registry you used. For crates.io, refer
+to their [policies] and contact them at <help@crates.io>.
+
+If your credentials have been leaked, the recommended process is to revoke them
+immediately. Once a crate is published, it's impossible to know if those leaked
+credentials have been copied, so taking swift action is crucial.
+
 [RustSec]: https://rustsec.org/
+[policies]: https://crates.io/policies
 
 ## OPTIONS
 

--- a/src/doc/man/cargo-yank.md
+++ b/src/doc/man/cargo-yank.md
@@ -61,13 +61,16 @@ A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
 
-To address copyright, licensing, or personal data issues with your published
-crate, contact the maintainers of the registry you used. For crates.io, refer
-to their [policies] and contact them at <help@crates.io>.
+When addressing copyright, licensing, or personal data issues with a published
+crate, simply yanking it may not suffice. In such cases, contact the maintainers
+of the registry you used. For crates.io, refer to their [policies] and contact
+them at <help@crates.io>.
 
-If your credentials have been leaked, the recommended process is to revoke them
-immediately. Once a crate is published, it's impossible to know if those leaked
-credentials have been copied, so taking swift action is crucial.
+If credentials have been leaked, the recommended course of action is to revoke
+them immediately. Once a crate has been published, it is impossible to determine
+if the leaked credentials have been copied. Yanking the crate only prevents new
+users from downloading it, but cannot stop those who have already downloaded it
+from keeping or even spreading the leaked credentials.
 
 [RustSec]: https://rustsec.org/
 [policies]: https://crates.io/policies

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -13,9 +13,51 @@ DESCRIPTION
        crate will still be available for download via the registry’s download
        link.
 
-       Note that existing crates locked to a yanked version will still be able
-       to download the yanked version to use it. Cargo will, however, not allow
-       any new crates to be locked to any yanked version.
+       Crates should only be yanked in exceptional circumstances, for example,
+       license/copyright issues, accidental inclusion of PII
+       <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc... In
+       the case of security vulnerabilities, RustSec <https://rustsec.org/> is
+       typically a less disruptive mechanism to inform users and encourage them
+       to upgrade, and avoids the possibility of significant downstream
+       disruption irrespective of susceptibility to the vulnerability in
+       question.
+
+       Cargo will not use a yanked version for any new project or checkout
+       without a pre-existing lockfile, and will generate an error if there are
+       no longer any compatible versions for your crate.
+
+       For example, the foo crate published version 0.22.0 and another crate
+       bar declared a dependency on version foo = 0.22. Now foo releases a new,
+       but not semver compatible, version 0.23.0, and finds a critical issue
+       with 0.22.0. If 0.22.0 is yanked, no new project or checkout without an
+       existing lockfile will be able to use crate bar as it relies on 0.22.
+
+       In this case, the maintainers of foo should first publish a semver
+       compatible version such as 0.22.1 prior to yanking 0.22.0 so that bar
+       and all projects that depend on bar will continue to work.
+
+       As another example, consider a crate bar with published versions 0.22.0,
+       0.22.1, 0.22.2, 0.23.0 and 0.24.0. The following table identifies the
+       versions cargo could use in the absence of a lockfile for different
+       SemVer requirements, following a given release being yanked:
+
+       +-----------------------+-----------------------+-----------+----------+
+       | Yanked Version /      | bar = "0.22.0"        | bar =     | bar =    |
+       | SemVer requirement    |                       | "=0.22.0" | "0.23.0" |
+       +-----------------------+-----------------------+-----------+----------+
+       | 0.22.0                | Use either 0.22.1 or  | Return    | Use      |
+       |                       | 0.22.2                | Error     | 0.23.0   |
+       +-----------------------+-----------------------+-----------+----------+
+       | 0.22.1                | Use either 0.22.0 or  | Use       | Use      |
+       |                       | 0.22.2                | 0.22.0    | 0.23.0   |
+       +-----------------------+-----------------------+-----------+----------+
+       | 0.23.0                | Use either 0.22.0,    | Use       | Return   |
+       |                       | 0.21.0 or 0.22.2      | 0.22.0    | Error    |
+       +-----------------------+-----------------------+-----------+----------+
+
+       A common workflow is to yank a crate having already published a semver
+       compatible version, to reduce the probability of preventing dependent
+       crates from compiling.
 
        This command requires you to be authenticated with either the --token
        option or using cargo-login(1).

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -13,19 +13,17 @@ DESCRIPTION
        crate will still be available for download via the registry’s download
        link.
 
-       Crates should only be yanked in exceptional circumstances, for example,
-       license/copyright issues, accidental inclusion of PII
-       <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc... In
-       the case of security vulnerabilities, RustSec <https://rustsec.org/> is
-       typically a less disruptive mechanism to inform users and encourage them
-       to upgrade, and avoids the possibility of significant downstream
-       disruption irrespective of susceptibility to the vulnerability in
-       question.
-
        Cargo will not use a yanked version for any new project or checkout
        without a pre-existing lockfile, and will generate an error if there are
        no longer any compatible versions for your crate.
 
+       This command requires you to be authenticated with either the --token
+       option or using cargo-login(1).
+
+       If the crate name is not specified, it will use the package name from
+       the current directory.
+
+   How yank works
        For example, the foo crate published version 0.22.0 and another crate
        bar declared a dependency on version foo = 0.22. Now foo releases a new,
        but not semver compatible, version 0.23.0, and finds a critical issue
@@ -55,15 +53,19 @@ DESCRIPTION
        |                       | 0.21.0 or 0.22.2      | 0.22.0    | Error    |
        +-----------------------+-----------------------+-----------+----------+
 
+   When to yank
+       Crates should only be yanked in exceptional circumstances, for example,
+       license/copyright issues, accidental inclusion of PII
+       <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc… In
+       the case of security vulnerabilities, RustSec <https://rustsec.org/> is
+       typically a less disruptive mechanism to inform users and encourage them
+       to upgrade, and avoids the possibility of significant downstream
+       disruption irrespective of susceptibility to the vulnerability in
+       question.
+
        A common workflow is to yank a crate having already published a semver
        compatible version, to reduce the probability of preventing dependent
        crates from compiling.
-
-       This command requires you to be authenticated with either the --token
-       option or using cargo-login(1).
-
-       If the crate name is not specified, it will use the package name from
-       the current directory.
 
 OPTIONS
    Yank Options

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -24,34 +24,34 @@ DESCRIPTION
        the current directory.
 
    How yank works
-       For example, the foo crate published version 0.22.0 and another crate
-       bar declared a dependency on version foo = 0.22. Now foo releases a new,
-       but not semver compatible, version 0.23.0, and finds a critical issue
-       with 0.22.0. If 0.22.0 is yanked, no new project or checkout without an
-       existing lockfile will be able to use crate bar as it relies on 0.22.
+       For example, the foo crate published version 1.5.0 and another crate bar
+       declared a dependency on version foo = "1.5". Now foo releases a new,
+       but not semver compatible, version 2.0.0, and finds a critical issue
+       with 1.5.0. If 1.5.0 is yanked, no new project or checkout without an
+       existing lockfile will be able to use crate bar as it relies on 1.5.
 
        In this case, the maintainers of foo should first publish a semver
-       compatible version such as 0.22.1 prior to yanking 0.22.0 so that bar
-       and all projects that depend on bar will continue to work.
+       compatible version such as 1.5.1 prior to yanking 1.5.0 so that bar and
+       all projects that depend on bar will continue to work.
 
-       As another example, consider a crate bar with published versions 0.22.0,
-       0.22.1, 0.22.2, 0.23.0 and 0.24.0. The following table identifies the
+       As another example, consider a crate bar with published versions 1.5.0,
+       1.5.1, 1.5.2, 2.0.0 and 3.0.0. The following table identifies the
        versions cargo could use in the absence of a lockfile for different
        SemVer requirements, following a given release being yanked:
 
-       +-----------------------+-----------------------+-----------+----------+
-       | Yanked Version /      | bar = "0.22.0"        | bar =     | bar =    |
-       | SemVer requirement    |                       | "=0.22.0" | "0.23.0" |
-       +-----------------------+-----------------------+-----------+----------+
-       | 0.22.0                | Use either 0.22.1 or  | Return    | Use      |
-       |                       | 0.22.2                | Error     | 0.23.0   |
-       +-----------------------+-----------------------+-----------+----------+
-       | 0.22.1                | Use either 0.22.0 or  | Use       | Use      |
-       |                       | 0.22.2                | 0.22.0    | 0.23.0   |
-       +-----------------------+-----------------------+-----------+----------+
-       | 0.23.0                | Use either 0.22.0,    | Use       | Return   |
-       |                       | 0.21.0 or 0.22.2      | 0.22.0    | Error    |
-       +-----------------------+-----------------------+-----------+----------+
+       +------------------------+----------------------+----------+----------+
+       | Yanked Version /       | bar = "1.5.0"        | bar =    | bar =    |
+       | SemVer requirement     |                      | "=1.5.0" | "2.0.0"  |
+       +------------------------+----------------------+----------+----------+
+       | 1.5.0                  | Use either 1.5.1 or  | Return   | Use      |
+       |                        | 1.5.2                | Error    | 2.0.0    |
+       +------------------------+----------------------+----------+----------+
+       | 1.5.1                  | Use either 1.5.0 or  | Use      | Use      |
+       |                        | 1.5.2                | 1.5.0    | 2.0.0    |
+       +------------------------+----------------------+----------+----------+
+       | 2.0.0                  | Use either 1.5.0,    | Use      | Return   |
+       |                        | 1.5.1 or 0.22.2      | 1.5.0    | Error    |
+       +------------------------+----------------------+----------+----------+
 
    When to yank
        Crates should only be yanked in exceptional circumstances, for example,
@@ -169,4 +169,3 @@ EXAMPLES
 
 SEE ALSO
        cargo(1), cargo-login(1), cargo-publish(1)
-

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -55,13 +55,12 @@ DESCRIPTION
 
    When to yank
        Crates should only be yanked in exceptional circumstances, for example,
-       license/copyright issues, accidental inclusion of PII
-       <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc… In
-       the case of security vulnerabilities, RustSec <https://rustsec.org/> is
-       typically a less disruptive mechanism to inform users and encourage them
-       to upgrade, and avoids the possibility of significant downstream
-       disruption irrespective of susceptibility to the vulnerability in
-       question.
+       an accidental publish, an unintentional SemVer breakages, or a
+       significantly broken and unusable crate. In the case of security
+       vulnerabilities, RustSec <https://rustsec.org/> is typically a less
+       disruptive mechanism to inform users and encourage them to upgrade, and
+       avoids the possibility of significant downstream disruption irrespective
+       of susceptibility to the vulnerability in question.
 
        A common workflow is to yank a crate having already published a semver
        compatible version, to reduce the probability of preventing dependent
@@ -169,3 +168,4 @@ EXAMPLES
 
 SEE ALSO
        cargo(1), cargo-login(1), cargo-publish(1)
+

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -66,6 +66,16 @@ DESCRIPTION
        compatible version, to reduce the probability of preventing dependent
        crates from compiling.
 
+       To address copyright, licensing, or personal data issues with your
+       published crate, contact the maintainers of the registry you used. For
+       crates.io, refer to their policies <https://crates.io/policies> and
+       contact them at <help@crates.io>.
+
+       If your credentials have been leaked, the recommended process is to
+       revoke them immediately. Once a crate is published, it’s impossible to
+       know if those leaked credentials have been copied, so taking swift
+       action is crucial.
+
 OPTIONS
    Yank Options
        --vers version, --version version

--- a/src/doc/man/generated_txt/cargo-yank.txt
+++ b/src/doc/man/generated_txt/cargo-yank.txt
@@ -66,15 +66,18 @@ DESCRIPTION
        compatible version, to reduce the probability of preventing dependent
        crates from compiling.
 
-       To address copyright, licensing, or personal data issues with your
-       published crate, contact the maintainers of the registry you used. For
-       crates.io, refer to their policies <https://crates.io/policies> and
-       contact them at <help@crates.io>.
+       When addressing copyright, licensing, or personal data issues with a
+       published crate, simply yanking it may not suffice. In such cases,
+       contact the maintainers of the registry you used. For crates.io, refer
+       to their policies <https://crates.io/policies> and contact them at
+       <help@crates.io>.
 
-       If your credentials have been leaked, the recommended process is to
-       revoke them immediately. Once a crate is published, it’s impossible to
-       know if those leaked credentials have been copied, so taking swift
-       action is crucial.
+       If credentials have been leaked, the recommended course of action is to
+       revoke them immediately. Once a crate has been published, it is
+       impossible to determine if the leaked credentials have been copied.
+       Yanking the crate only prevents new users from downloading it, but
+       cannot stop those who have already downloaded it from keeping or even
+       spreading the leaked credentials.
 
 OPTIONS
    Yank Options

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -15,9 +15,39 @@ The yank command removes a previously published crate's version from the
 server's index. This command does not delete any data, and the crate will
 still be available for download via the registry's download link.
 
-Note that existing crates locked to a yanked version will still be able to
-download the yanked version to use it. Cargo will, however, not allow any new
-crates to be locked to any yanked version.
+Crates should only be yanked in exceptional circumstances, for example, license/copyright issues, accidental
+inclusion of [PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc... In the case of security
+vulnerabilities, [RustSec](https://rustsec.org/) is typically a less disruptive mechanism to inform users
+and encourage them to upgrade, and avoids the possibility of significant downstream disruption irrespective
+of susceptibility to the vulnerability in question.
+
+Cargo will not use a yanked version for any new project or checkout without a
+pre-existing lockfile, and will generate an error if there are no longer
+any compatible versions for your crate.
+
+For example, the `foo` crate published version `0.22.0` and another crate `bar`
+declared a dependency on version `foo = 0.22`. Now `foo` releases a new, but
+not semver compatible, version `0.23.0`, and finds a critical issue with `0.22.0`.
+If `0.22.0` is yanked, no new project or checkout without an existing lockfile will be
+able to use crate `bar` as it relies on `0.22`.
+
+In this case, the maintainers of `foo` should first publish a semver compatible version
+such as `0.22.1` prior to yanking `0.22.0` so that `bar` and all projects that depend
+on `bar` will continue to work.
+
+As another example, consider a crate `bar` with published versions `0.22.0`, `0.22.1`, 
+`0.22.2`, `0.23.0` and `0.24.0`. The following table identifies the versions
+cargo could use in the absence of a lockfile for different SemVer requirements,
+following a given release being yanked:
+
+| Yanked Version / SemVer requirement | `bar = "0.22.0"`                          | `bar = "=0.22.0"` | `bar = "0.23.0"` |
+|-------------------------------------|-------------------------------------------|-------------------|------------------|
+| `0.22.0`                            | Use either `0.22.1` or `0.22.2`           | **Return Error**  | Use `0.23.0`     |
+| `0.22.1`                            | Use either `0.22.0` or `0.22.2`           | Use `0.22.0`      | Use `0.23.0`     |
+| `0.23.0`                            | Use either `0.22.0`, `0.21.0` or `0.22.2` | Use `0.22.0`      | **Return Error** |
+
+A common workflow is to yank a crate having already published a semver compatible version,
+to reduce the probability of preventing dependent crates from compiling.
 
 This command requires you to be authenticated with either the `--token` option
 or using [cargo-login(1)](cargo-login.html).

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -50,16 +50,18 @@ requirements, following a given release being yanked:
 
 ### When to yank
 
-Crates should only be yanked in exceptional circumstances, for example,
-license/copyright issues, accidental inclusion of
-[PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc...
-In the case of security vulnerabilities, [RustSec](https://rustsec.org/) is
-typically a less disruptive mechanism to inform users and encourage them to
-upgrade, and avoids the possibility of significant downstream disruption
+Crates should only be yanked in exceptional circumstances, for example, an
+accidental publish, an unintentional SemVer breakages, or a significantly
+broken and unusable crate. In the case of security vulnerabilities, [RustSec]
+is typically a less disruptive mechanism to inform users and encourage them
+to upgrade, and avoids the possibility of significant downstream disruption
 irrespective of susceptibility to the vulnerability in question.
 
-A common workflow is to yank a crate having already published a semver compatible version,
-to reduce the probability of preventing dependent crates from compiling.
+A common workflow is to yank a crate having already published a semver
+compatible version, to reduce the probability of preventing dependent
+crates from compiling.
+
+[RustSec]: https://rustsec.org/
 
 ## OPTIONS
 

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -27,26 +27,26 @@ current directory.
 
 ### How yank works
 
-For example, the `foo` crate published version `0.22.0` and another crate `bar`
-declared a dependency on version `foo = 0.22`. Now `foo` releases a new, but
-not semver compatible, version `0.23.0`, and finds a critical issue with `0.22.0`.
-If `0.22.0` is yanked, no new project or checkout without an existing lockfile will be
-able to use crate `bar` as it relies on `0.22`.
+For example, the `foo` crate published version `1.5.0` and another crate `bar`
+declared a dependency on version `foo = "1.5"`. Now `foo` releases a new, but
+not semver compatible, version `2.0.0`, and finds a critical issue with `1.5.0`.
+If `1.5.0` is yanked, no new project or checkout without an existing lockfile
+will be able to use crate `bar` as it relies on `1.5`.
 
-In this case, the maintainers of `foo` should first publish a semver compatible version
-such as `0.22.1` prior to yanking `0.22.0` so that `bar` and all projects that depend
-on `bar` will continue to work.
+In this case, the maintainers of `foo` should first publish a semver compatible
+version such as `1.5.1` prior to yanking `1.5.0` so that `bar` and all projects
+that depend on `bar` will continue to work.
 
-As another example, consider a crate `bar` with published versions `0.22.0`, `0.22.1`, 
-`0.22.2`, `0.23.0` and `0.24.0`. The following table identifies the versions
-cargo could use in the absence of a lockfile for different SemVer requirements,
-following a given release being yanked:
+As another example, consider a crate `bar` with published versions `1.5.0`,
+`1.5.1`, `1.5.2`, `2.0.0` and `3.0.0`. The following table identifies the
+versions cargo could use in the absence of a lockfile for different SemVer
+requirements, following a given release being yanked:
 
-| Yanked Version / SemVer requirement | `bar = "0.22.0"`                          | `bar = "=0.22.0"` | `bar = "0.23.0"` |
-|-------------------------------------|-------------------------------------------|-------------------|------------------|
-| `0.22.0`                            | Use either `0.22.1` or `0.22.2`           | **Return Error**  | Use `0.23.0`     |
-| `0.22.1`                            | Use either `0.22.0` or `0.22.2`           | Use `0.22.0`      | Use `0.23.0`     |
-| `0.23.0`                            | Use either `0.22.0`, `0.21.0` or `0.22.2` | Use `0.22.0`      | **Return Error** |
+| Yanked Version / SemVer requirement | `bar = "1.5.0"`                         | `bar = "=1.5.0"` | `bar = "2.0.0"`  |
+|-------------------------------------|-----------------------------------------|------------------|------------------|
+| `1.5.0`                             | Use either `1.5.1` or `1.5.2`           | **Return Error** | Use `2.0.0`      |
+| `1.5.1`                             | Use either `1.5.0` or `1.5.2`           | Use `1.5.0`      | Use `2.0.0`      |
+| `2.0.0`                             | Use either `1.5.0`, `1.5.1` or `0.22.2` | Use `1.5.0`      | **Return Error** |
 
 ### When to yank
 

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -15,15 +15,17 @@ The yank command removes a previously published crate's version from the
 server's index. This command does not delete any data, and the crate will
 still be available for download via the registry's download link.
 
-Crates should only be yanked in exceptional circumstances, for example, license/copyright issues, accidental
-inclusion of [PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc... In the case of security
-vulnerabilities, [RustSec](https://rustsec.org/) is typically a less disruptive mechanism to inform users
-and encourage them to upgrade, and avoids the possibility of significant downstream disruption irrespective
-of susceptibility to the vulnerability in question.
-
 Cargo will not use a yanked version for any new project or checkout without a
 pre-existing lockfile, and will generate an error if there are no longer
 any compatible versions for your crate.
+
+This command requires you to be authenticated with either the `--token` option
+or using [cargo-login(1)](cargo-login.html).
+
+If the crate name is not specified, it will use the package name from the
+current directory.
+
+### How yank works
 
 For example, the `foo` crate published version `0.22.0` and another crate `bar`
 declared a dependency on version `foo = 0.22`. Now `foo` releases a new, but
@@ -46,14 +48,18 @@ following a given release being yanked:
 | `0.22.1`                            | Use either `0.22.0` or `0.22.2`           | Use `0.22.0`      | Use `0.23.0`     |
 | `0.23.0`                            | Use either `0.22.0`, `0.21.0` or `0.22.2` | Use `0.22.0`      | **Return Error** |
 
+### When to yank
+
+Crates should only be yanked in exceptional circumstances, for example,
+license/copyright issues, accidental inclusion of
+[PII](https://en.wikipedia.org/wiki/Personal_data), credentials, etc...
+In the case of security vulnerabilities, [RustSec](https://rustsec.org/) is
+typically a less disruptive mechanism to inform users and encourage them to
+upgrade, and avoids the possibility of significant downstream disruption
+irrespective of susceptibility to the vulnerability in question.
+
 A common workflow is to yank a crate having already published a semver compatible version,
 to reduce the probability of preventing dependent crates from compiling.
-
-This command requires you to be authenticated with either the `--token` option
-or using [cargo-login(1)](cargo-login.html).
-
-If the crate name is not specified, it will use the package name from the
-current directory.
 
 ## OPTIONS
 

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -61,7 +61,16 @@ A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
 
+To address copyright, licensing, or personal data issues with your published
+crate, contact the maintainers of the registry you used. For crates.io, refer
+to their [policies] and contact them at <help@crates.io>.
+
+If your credentials have been leaked, the recommended process is to revoke them
+immediately. Once a crate is published, it's impossible to know if those leaked
+credentials have been copied, so taking swift action is crucial.
+
 [RustSec]: https://rustsec.org/
+[policies]: https://crates.io/policies
 
 ## OPTIONS
 

--- a/src/doc/src/commands/cargo-yank.md
+++ b/src/doc/src/commands/cargo-yank.md
@@ -61,13 +61,16 @@ A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
 
-To address copyright, licensing, or personal data issues with your published
-crate, contact the maintainers of the registry you used. For crates.io, refer
-to their [policies] and contact them at <help@crates.io>.
+When addressing copyright, licensing, or personal data issues with a published
+crate, simply yanking it may not suffice. In such cases, contact the maintainers
+of the registry you used. For crates.io, refer to their [policies] and contact
+them at <help@crates.io>.
 
-If your credentials have been leaked, the recommended process is to revoke them
-immediately. Once a crate is published, it's impossible to know if those leaked
-credentials have been copied, so taking swift action is crucial.
+If credentials have been leaked, the recommended course of action is to revoke
+them immediately. Once a crate has been published, it is impossible to determine
+if the leaked credentials have been copied. Yanking the crate only prevents new
+users from downloading it, but cannot stop those who have already downloaded it
+from keeping or even spreading the leaked credentials.
 
 [RustSec]: https://rustsec.org/
 [policies]: https://crates.io/policies

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -14,16 +14,16 @@ The yank command removes a previously published crate\[cq]s version from the
 server\[cq]s index. This command does not delete any data, and the crate will
 still be available for download via the registry\[cq]s download link.
 .sp
-Crates should only be yanked in exceptional circumstances, for example, license/copyright issues, accidental
-inclusion of \fIPII\fR <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc... In the case of security
-vulnerabilities, \fIRustSec\fR <https://rustsec.org/> is typically a less disruptive mechanism to inform users
-and encourage them to upgrade, and avoids the possibility of significant downstream disruption irrespective
-of susceptibility to the vulnerability in question.
-.sp
 Cargo will not use a yanked version for any new project or checkout without a
 pre\-existing lockfile, and will generate an error if there are no longer
 any compatible versions for your crate.
 .sp
+This command requires you to be authenticated with either the \fB\-\-token\fR option
+or using \fBcargo\-login\fR(1).
+.sp
+If the crate name is not specified, it will use the package name from the
+current directory.
+.SS "How yank works"
 For example, the \fBfoo\fR crate published version \fB0.22.0\fR and another crate \fBbar\fR
 declared a dependency on version \fBfoo = 0.22\fR\&. Now \fBfoo\fR releases a new, but
 not semver compatible, version \fB0.23.0\fR, and finds a critical issue with \fB0.22.0\fR\&.
@@ -80,15 +80,17 @@ T}:T{
 T}
 .TE
 .sp
+.SS "When to yank"
+Crates should only be yanked in exceptional circumstances, for example,
+license/copyright issues, accidental inclusion of
+\fIPII\fR <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc\[u2026]
+In the case of security vulnerabilities, \fIRustSec\fR <https://rustsec.org/> is
+typically a less disruptive mechanism to inform users and encourage them to
+upgrade, and avoids the possibility of significant downstream disruption
+irrespective of susceptibility to the vulnerability in question.
 .sp
 A common workflow is to yank a crate having already published a semver compatible version,
 to reduce the probability of preventing dependent crates from compiling.
-.sp
-This command requires you to be authenticated with either the \fB\-\-token\fR option
-or using \fBcargo\-login\fR(1).
-.sp
-If the crate name is not specified, it will use the package name from the
-current directory.
 .SH "OPTIONS"
 .SS "Yank Options"
 .sp

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -91,6 +91,14 @@ irrespective of susceptibility to the vulnerability in question.
 A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
+.sp
+To address copyright, licensing, or personal data issues with your published
+crate, contact the maintainers of the registry you used. For crates.io, refer
+to their \fIpolicies\fR <https://crates.io/policies> and contact them at <help@crates.io>\&.
+.sp
+If your credentials have been leaked, the recommended process is to revoke them
+immediately. Once a crate is published, it\[cq]s impossible to know if those leaked
+credentials have been copied, so taking swift action is crucial.
 .SH "OPTIONS"
 .SS "Yank Options"
 .sp

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -81,16 +81,16 @@ T}
 .TE
 .sp
 .SS "When to yank"
-Crates should only be yanked in exceptional circumstances, for example,
-license/copyright issues, accidental inclusion of
-\fIPII\fR <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc\[u2026]
-In the case of security vulnerabilities, \fIRustSec\fR <https://rustsec.org/> is
-typically a less disruptive mechanism to inform users and encourage them to
-upgrade, and avoids the possibility of significant downstream disruption
+Crates should only be yanked in exceptional circumstances, for example, an
+accidental publish, an unintentional SemVer breakages, or a significantly
+broken and unusable crate. In the case of security vulnerabilities, \fIRustSec\fR <https://rustsec.org/>
+is typically a less disruptive mechanism to inform users and encourage them
+to upgrade, and avoids the possibility of significant downstream disruption
 irrespective of susceptibility to the vulnerability in question.
 .sp
-A common workflow is to yank a crate having already published a semver compatible version,
-to reduce the probability of preventing dependent crates from compiling.
+A common workflow is to yank a crate having already published a semver
+compatible version, to reduce the probability of preventing dependent
+crates from compiling.
 .SH "OPTIONS"
 .SS "Yank Options"
 .sp

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -14,9 +14,75 @@ The yank command removes a previously published crate\[cq]s version from the
 server\[cq]s index. This command does not delete any data, and the crate will
 still be available for download via the registry\[cq]s download link.
 .sp
-Note that existing crates locked to a yanked version will still be able to
-download the yanked version to use it. Cargo will, however, not allow any new
-crates to be locked to any yanked version.
+Crates should only be yanked in exceptional circumstances, for example, license/copyright issues, accidental
+inclusion of \fIPII\fR <https://en.wikipedia.org/wiki/Personal_data>, credentials, etc... In the case of security
+vulnerabilities, \fIRustSec\fR <https://rustsec.org/> is typically a less disruptive mechanism to inform users
+and encourage them to upgrade, and avoids the possibility of significant downstream disruption irrespective
+of susceptibility to the vulnerability in question.
+.sp
+Cargo will not use a yanked version for any new project or checkout without a
+pre\-existing lockfile, and will generate an error if there are no longer
+any compatible versions for your crate.
+.sp
+For example, the \fBfoo\fR crate published version \fB0.22.0\fR and another crate \fBbar\fR
+declared a dependency on version \fBfoo = 0.22\fR\&. Now \fBfoo\fR releases a new, but
+not semver compatible, version \fB0.23.0\fR, and finds a critical issue with \fB0.22.0\fR\&.
+If \fB0.22.0\fR is yanked, no new project or checkout without an existing lockfile will be
+able to use crate \fBbar\fR as it relies on \fB0.22\fR\&.
+.sp
+In this case, the maintainers of \fBfoo\fR should first publish a semver compatible version
+such as \fB0.22.1\fR prior to yanking \fB0.22.0\fR so that \fBbar\fR and all projects that depend
+on \fBbar\fR will continue to work.
+.sp
+As another example, consider a crate \fBbar\fR with published versions \fB0.22.0\fR, \fB0.22.1\fR, 
+\fB0.22.2\fR, \fB0.23.0\fR and \fB0.24.0\fR\&. The following table identifies the versions
+cargo could use in the absence of a lockfile for different SemVer requirements,
+following a given release being yanked:
+
+.TS
+allbox tab(:);
+lt lt lt lt.
+T{
+Yanked Version / SemVer requirement
+T}:T{
+\fBbar = "0.22.0"\fR
+T}:T{
+\fBbar = "=0.22.0"\fR
+T}:T{
+\fBbar = "0.23.0"\fR
+T}
+T{
+\fB0.22.0\fR
+T}:T{
+Use either \fB0.22.1\fR or \fB0.22.2\fR
+T}:T{
+\fBReturn Error\fR
+T}:T{
+Use \fB0.23.0\fR
+T}
+T{
+\fB0.22.1\fR
+T}:T{
+Use either \fB0.22.0\fR or \fB0.22.2\fR
+T}:T{
+Use \fB0.22.0\fR
+T}:T{
+Use \fB0.23.0\fR
+T}
+T{
+\fB0.23.0\fR
+T}:T{
+Use either \fB0.22.0\fR, \fB0.21.0\fR or \fB0.22.2\fR
+T}:T{
+Use \fB0.22.0\fR
+T}:T{
+\fBReturn Error\fR
+T}
+.TE
+.sp
+.sp
+A common workflow is to yank a crate having already published a semver compatible version,
+to reduce the probability of preventing dependent crates from compiling.
 .sp
 This command requires you to be authenticated with either the \fB\-\-token\fR option
 or using \fBcargo\-login\fR(1).

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -24,20 +24,20 @@ or using \fBcargo\-login\fR(1).
 If the crate name is not specified, it will use the package name from the
 current directory.
 .SS "How yank works"
-For example, the \fBfoo\fR crate published version \fB0.22.0\fR and another crate \fBbar\fR
-declared a dependency on version \fBfoo = 0.22\fR\&. Now \fBfoo\fR releases a new, but
-not semver compatible, version \fB0.23.0\fR, and finds a critical issue with \fB0.22.0\fR\&.
-If \fB0.22.0\fR is yanked, no new project or checkout without an existing lockfile will be
-able to use crate \fBbar\fR as it relies on \fB0.22\fR\&.
+For example, the \fBfoo\fR crate published version \fB1.5.0\fR and another crate \fBbar\fR
+declared a dependency on version \fBfoo = "1.5"\fR\&. Now \fBfoo\fR releases a new, but
+not semver compatible, version \fB2.0.0\fR, and finds a critical issue with \fB1.5.0\fR\&.
+If \fB1.5.0\fR is yanked, no new project or checkout without an existing lockfile
+will be able to use crate \fBbar\fR as it relies on \fB1.5\fR\&.
 .sp
-In this case, the maintainers of \fBfoo\fR should first publish a semver compatible version
-such as \fB0.22.1\fR prior to yanking \fB0.22.0\fR so that \fBbar\fR and all projects that depend
-on \fBbar\fR will continue to work.
+In this case, the maintainers of \fBfoo\fR should first publish a semver compatible
+version such as \fB1.5.1\fR prior to yanking \fB1.5.0\fR so that \fBbar\fR and all projects
+that depend on \fBbar\fR will continue to work.
 .sp
-As another example, consider a crate \fBbar\fR with published versions \fB0.22.0\fR, \fB0.22.1\fR, 
-\fB0.22.2\fR, \fB0.23.0\fR and \fB0.24.0\fR\&. The following table identifies the versions
-cargo could use in the absence of a lockfile for different SemVer requirements,
-following a given release being yanked:
+As another example, consider a crate \fBbar\fR with published versions \fB1.5.0\fR,
+\fB1.5.1\fR, \fB1.5.2\fR, \fB2.0.0\fR and \fB3.0.0\fR\&. The following table identifies the
+versions cargo could use in the absence of a lockfile for different SemVer
+requirements, following a given release being yanked:
 
 .TS
 allbox tab(:);
@@ -45,36 +45,36 @@ lt lt lt lt.
 T{
 Yanked Version / SemVer requirement
 T}:T{
-\fBbar = "0.22.0"\fR
+\fBbar = "1.5.0"\fR
 T}:T{
-\fBbar = "=0.22.0"\fR
+\fBbar = "=1.5.0"\fR
 T}:T{
-\fBbar = "0.23.0"\fR
+\fBbar = "2.0.0"\fR
 T}
 T{
-\fB0.22.0\fR
+\fB1.5.0\fR
 T}:T{
-Use either \fB0.22.1\fR or \fB0.22.2\fR
+Use either \fB1.5.1\fR or \fB1.5.2\fR
 T}:T{
 \fBReturn Error\fR
 T}:T{
-Use \fB0.23.0\fR
+Use \fB2.0.0\fR
 T}
 T{
-\fB0.22.1\fR
+\fB1.5.1\fR
 T}:T{
-Use either \fB0.22.0\fR or \fB0.22.2\fR
+Use either \fB1.5.0\fR or \fB1.5.2\fR
 T}:T{
-Use \fB0.22.0\fR
+Use \fB1.5.0\fR
 T}:T{
-Use \fB0.23.0\fR
+Use \fB2.0.0\fR
 T}
 T{
-\fB0.23.0\fR
+\fB2.0.0\fR
 T}:T{
-Use either \fB0.22.0\fR, \fB0.21.0\fR or \fB0.22.2\fR
+Use either \fB1.5.0\fR, \fB1.5.1\fR or \fB0.22.2\fR
 T}:T{
-Use \fB0.22.0\fR
+Use \fB1.5.0\fR
 T}:T{
 \fBReturn Error\fR
 T}

--- a/src/etc/man/cargo-yank.1
+++ b/src/etc/man/cargo-yank.1
@@ -92,13 +92,16 @@ A common workflow is to yank a crate having already published a semver
 compatible version, to reduce the probability of preventing dependent
 crates from compiling.
 .sp
-To address copyright, licensing, or personal data issues with your published
-crate, contact the maintainers of the registry you used. For crates.io, refer
-to their \fIpolicies\fR <https://crates.io/policies> and contact them at <help@crates.io>\&.
+When addressing copyright, licensing, or personal data issues with a published
+crate, simply yanking it may not suffice. In such cases, contact the maintainers
+of the registry you used. For crates.io, refer to their \fIpolicies\fR <https://crates.io/policies> and contact
+them at <help@crates.io>\&.
 .sp
-If your credentials have been leaked, the recommended process is to revoke them
-immediately. Once a crate is published, it\[cq]s impossible to know if those leaked
-credentials have been copied, so taking swift action is crucial.
+If credentials have been leaked, the recommended course of action is to revoke
+them immediately. Once a crate has been published, it is impossible to determine
+if the leaked credentials have been copied. Yanking the crate only prevents new
+users from downloading it, but cannot stop those who have already downloaded it
+from keeping or even spreading the leaked credentials.
 .SH "OPTIONS"
 .SS "Yank Options"
 .sp


### PR DESCRIPTION
<!-- homu-ignore:start -->
A continuation of #11071. Below are copied from there.

r? @Muscraft if you have time to review
<!-- homu-ignore:end -->

### What does this PR try to resolve?

I found the documentation for `cargo yank` was not especially clear on the implications of yanking a crate, and I have seen this causing confusion within the community - https://github.com/tafia/quick-xml/issues/475.

On a somewhat related note, I have been observing lots more crates getting yanked recently and this is resulting in a fair amount of dependency upgrade busywork. I think/hope part of this is a documentation issue.
