### PR TITLE
Add `try_canonicalize` and use it over `std::fs::canonicalize`

### DIFF
--- a/src/cargo/core/compiler/compile_kind.rs
+++ b/src/cargo/core/compiler/compile_kind.rs
@@ -3,7 +3,7 @@
 use crate::core::Target;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
-use crate::util::{Config, StableHasher};
+use crate::util::{try_canonicalize, Config, StableHasher};
 use anyhow::Context as _;
 use serde::Serialize;
 use std::collections::BTreeSet;
@@ -138,8 +138,7 @@ impl CompileTarget {
         // If `name` ends in `.json` then it's likely a custom target
         // specification. Canonicalize the path to ensure that different builds
         // with different paths always produce the same result.
-        let path = Path::new(name)
-            .canonicalize()
+        let path = try_canonicalize(Path::new(name))
             .with_context(|| format!("target path {:?} is not a valid file", name))?;
 
         let name = path

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -4,7 +4,7 @@ use crate::core::{GitReference, Package, Workspace};
 use crate::ops;
 use crate::sources::path::PathSource;
 use crate::sources::CRATES_IO_REGISTRY;
-use crate::util::{CargoResult, Config};
+use crate::util::{try_canonicalize, CargoResult, Config};
 use anyhow::{bail, Context as _};
 use cargo_util::{paths, Sha256};
 use serde::Serialize;
@@ -83,7 +83,7 @@ fn sync(
     workspaces: &[&Workspace<'_>],
     opts: &VendorOptions<'_>,
 ) -> CargoResult<VendorConfig> {
-    let canonical_destination = opts.destination.canonicalize();
+    let canonical_destination = try_canonicalize(opts.destination);
     let canonical_destination = canonical_destination.as_deref().unwrap_or(opts.destination);
     let dest_dir_already_exists = canonical_destination.exists();
 
@@ -125,7 +125,7 @@ fn sync(
             // Don't delete actual source code!
             if pkg.source_id().is_path() {
                 if let Ok(path) = pkg.source_id().url().to_file_path() {
-                    if let Ok(path) = path.canonicalize() {
+                    if let Ok(path) = try_canonicalize(path) {
                         to_remove.remove(&path);
                     }
                 }

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -157,7 +157,7 @@ pub fn try_canonicalize<P: AsRef<Path>>(path: P) -> std::io::Result<PathBuf> {
             return Err(Error::new(ErrorKind::NotFound, "the path was not found"));
         }
 
-        // This code is based on the unstable `std::path::aboslute` and could be replaced with it
+        // This code is based on the unstable `std::path::absolute` and could be replaced with it
         // if it's stabilized.
 
         let path = path.as_ref().as_os_str();


### PR DESCRIPTION
This adds a `try_canonicalize` function that calls `std::fs::canonicalize` and on Windows falls back to getting an absolute path. Uses of `canonicalize` have been replaced with `std::fs::canonicalize`. On Windows `std::fs::canonicalize` may fail due to incomplete drivers. In particular `ImDisk` does not support it.

Combined with https://github.com/rust-lang/rust/pull/109231 this allows compiling crates on an `ImDisk` RAM disk and I've tested that it works with various configuration using [rcb](https://github.com/Zoxc/rcb).
