### PR TITLE
Update curl-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cargo-util = { path = "crates/cargo-util", version = "0.2.4" }
 clap = "4.1.3"
 crates-io = { path = "crates/crates-io", version = "0.36.0" }
 curl = { version = "0.4.44", features = ["http2"] }
-curl-sys = "0.4.59"
+curl-sys = "0.4.61"
 env_logger = "0.10.0"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }


### PR DESCRIPTION
This updates curl-sys from 0.4.59 to 0.4.61. This corresponds to curl 7.86.0 to 8.0.1.
Changelog: https://curl.se/changes.html

Closes #11746