### PR TITLE
Add more information to HTTP errors to help with debugging.

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -880,13 +880,12 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
 
                     let code = handle.response_code()?;
                     if code != 200 && code != 0 {
-                        let url = handle.effective_url()?.unwrap_or(url);
-                        return Err(HttpNotSuccessful {
-                            code,
-                            url: url.to_string(),
-                            body: data,
+                        return Err(HttpNotSuccessful::new_from_handle(
+                            &mut handle,
+                            &url,
+                            data,
                             headers,
-                        }
+                        )
                         .into());
                     }
                     Ok(data)

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -26,7 +26,7 @@ use crate::core::{Dependency, Manifest, PackageId, SourceId, Target};
 use crate::core::{SourceMap, Summary, Workspace};
 use crate::ops;
 use crate::util::config::PackageCacheLock;
-use crate::util::errors::{CargoResult, HttpNotSuccessful};
+use crate::util::errors::{CargoResult, HttpNotSuccessful, DEBUG_HEADERS};
 use crate::util::interning::InternedString;
 use crate::util::network::retry::{Retry, RetryResult};
 use crate::util::network::sleep::SleepTracker;
@@ -378,6 +378,9 @@ struct Download<'cfg> {
 
     /// Actual downloaded data, updated throughout the lifetime of this download.
     data: RefCell<Vec<u8>>,
+
+    /// HTTP headers for debugging.
+    headers: RefCell<Vec<String>>,
 
     /// The URL that we're downloading from, cached here for error messages and
     /// reenqueuing.
@@ -762,6 +765,19 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
             });
             Ok(buf.len())
         })?;
+        handle.header_function(move |data| {
+            tls::with(|downloads| {
+                if let Some(downloads) = downloads {
+                    // Headers contain trailing \r\n, trim them to make it easier
+                    // to work with.
+                    let h = String::from_utf8_lossy(data).trim().to_string();
+                    if DEBUG_HEADERS.iter().any(|p| h.starts_with(p)) {
+                        downloads.pending[&token].0.headers.borrow_mut().push(h);
+                    }
+                }
+            });
+            true
+        })?;
 
         handle.progress(true)?;
         handle.progress_function(move |dl_total, dl_cur, _, _| {
@@ -787,6 +803,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
         let dl = Download {
             token,
             data: RefCell::new(Vec::new()),
+            headers: RefCell::new(Vec::new()),
             id,
             url,
             descriptor,
@@ -826,6 +843,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                 .remove(&token)
                 .expect("got a token for a non-in-progress transfer");
             let data = mem::take(&mut *dl.data.borrow_mut());
+            let headers = mem::take(&mut *dl.headers.borrow_mut());
             let mut handle = self.set.multi.remove(handle)?;
             self.pending_ids.remove(&dl.id);
 
@@ -867,6 +885,7 @@ impl<'a, 'cfg> Downloads<'a, 'cfg> {
                             code,
                             url: url.to_string(),
                             body: data,
+                            headers,
                         }
                         .into());
                     }

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -288,14 +288,13 @@ impl<'cfg> HttpRegistry<'cfg> {
                     304 => StatusCode::NotModified,
                     401 => StatusCode::Unauthorized,
                     404 | 410 | 451 => StatusCode::NotFound,
-                    code => {
-                        let url = handle.effective_url()?.unwrap_or(&url);
-                        return Err(HttpNotSuccessful {
-                            code,
-                            url: url.to_owned(),
-                            body: data,
-                            headers: download.header_map.take().others,
-                        }
+                    _ => {
+                        return Err(HttpNotSuccessful::new_from_handle(
+                            &mut handle,
+                            &url,
+                            data,
+                            download.header_map.take().others,
+                        )
                         .into());
                     }
                 };
@@ -548,6 +547,7 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
                         code: 401,
                         body: result.data,
                         url: self.full_url(path),
+                        ip: None,
                         headers: result.header_map.others,
                     }
                     .into());

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -12,10 +12,20 @@ pub type CargoResult<T> = anyhow::Result<T>;
 /// These are headers that are included in error messages to help with
 /// diagnosing issues.
 pub const DEBUG_HEADERS: &[&str] = &[
+    // This is the unique ID that identifies the request in CloudFront which
+    // can be used for looking at the AWS logs.
     "x-amz-cf-id",
+    // This is the CloudFront POP (Point of Presence) that identifies the
+    // region where the request was routed. This can help identify if an issue
+    // is region-specific.
     "x-amz-cf-pop",
+    // The unique token used for troubleshooting S3 requests via AWS logs or support.
+    "x-amz-request-id",
+    // Another token used in conjunction with x-amz-request-id.
     "x-amz-id-2",
+    // Whether or not there was a cache hit or miss (both CloudFront and Fastly).
     "x-cache",
+    // The cache server that processed the request (Fastly).
     "x-served-by",
 ];
 

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -8,11 +8,22 @@ use super::truncate_with_ellipsis;
 
 pub type CargoResult<T> = anyhow::Result<T>;
 
+/// These are headers that are included in error messages to help with
+/// diagnosing issues.
+pub const DEBUG_HEADERS: &[&str] = &[
+    "x-amz-cf-id",
+    "x-amz-cf-pop",
+    "x-amz-id-2",
+    "x-cache",
+    "x-served-by",
+];
+
 #[derive(Debug)]
 pub struct HttpNotSuccessful {
     pub code: u32,
     pub url: String,
     pub body: Vec<u8>,
+    pub headers: Vec<String>,
 }
 
 impl fmt::Display for HttpNotSuccessful {
@@ -23,9 +34,13 @@ impl fmt::Display for HttpNotSuccessful {
 
         write!(
             f,
-            "failed to get successful HTTP response from `{}`, got {}\nbody:\n{body}",
-            self.url, self.code
-        )
+            "failed to get successful HTTP response from `{}`, got {}\n",
+            self.url, self.code,
+        )?;
+        if !self.headers.is_empty() {
+            write!(f, "debug headers:\n{}\n", self.headers.join("\n"))?;
+        }
+        write!(f, "body:\n{body}",)
     }
 }
 

--- a/src/cargo/util/network/retry.rs
+++ b/src/cargo/util/network/retry.rs
@@ -151,12 +151,14 @@ fn with_retry_repeats_the_call_then_works() {
         code: 501,
         url: "Uri".to_string(),
         body: Vec::new(),
+        headers: Vec::new(),
     }
     .into();
     let error2 = HttpNotSuccessful {
         code: 502,
         url: "Uri".to_string(),
         body: Vec::new(),
+        headers: Vec::new(),
     }
     .into();
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
@@ -176,12 +178,14 @@ fn with_retry_finds_nested_spurious_errors() {
         code: 501,
         url: "Uri".to_string(),
         body: Vec::new(),
+        headers: Vec::new(),
     });
     let error1 = anyhow::Error::from(error1.context("A non-spurious wrapping err"));
     let error2 = anyhow::Error::from(HttpNotSuccessful {
         code: 502,
         url: "Uri".to_string(),
         body: Vec::new(),
+        headers: Vec::new(),
     });
     let error2 = anyhow::Error::from(error2.context("A second chained error"));
     let mut results: Vec<CargoResult<()>> = vec![Ok(()), Err(error1), Err(error2)];
@@ -200,6 +204,7 @@ fn default_retry_schedule() {
             code: 500,
             url: "Uri".to_string(),
             body: Vec::new(),
+            headers: Vec::new(),
         }))
     };
     let config = Config::default().unwrap();

--- a/src/cargo/util/network/retry.rs
+++ b/src/cargo/util/network/retry.rs
@@ -150,6 +150,7 @@ fn with_retry_repeats_the_call_then_works() {
     let error1 = HttpNotSuccessful {
         code: 501,
         url: "Uri".to_string(),
+        ip: None,
         body: Vec::new(),
         headers: Vec::new(),
     }
@@ -157,6 +158,7 @@ fn with_retry_repeats_the_call_then_works() {
     let error2 = HttpNotSuccessful {
         code: 502,
         url: "Uri".to_string(),
+        ip: None,
         body: Vec::new(),
         headers: Vec::new(),
     }
@@ -177,6 +179,7 @@ fn with_retry_finds_nested_spurious_errors() {
     let error1 = anyhow::Error::from(HttpNotSuccessful {
         code: 501,
         url: "Uri".to_string(),
+        ip: None,
         body: Vec::new(),
         headers: Vec::new(),
     });
@@ -184,6 +187,7 @@ fn with_retry_finds_nested_spurious_errors() {
     let error2 = anyhow::Error::from(HttpNotSuccessful {
         code: 502,
         url: "Uri".to_string(),
+        ip: None,
         body: Vec::new(),
         headers: Vec::new(),
     });
@@ -203,6 +207,7 @@ fn default_retry_schedule() {
         Err(anyhow::Error::from(HttpNotSuccessful {
             code: 500,
             url: "Uri".to_string(),
+            ip: None,
             body: Vec::new(),
             headers: Vec::new(),
         }))

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2743,10 +2743,10 @@ fn sparse_retry_single() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-warning: spurious network error (3 tries remaining): failed to get successful HTTP response from `[..]`, got 500
+warning: spurious network error (3 tries remaining): failed to get successful HTTP response from `[..]` (127.0.0.1), got 500
 body:
 internal server error
-warning: spurious network error (2 tries remaining): failed to get successful HTTP response from `[..]`, got 500
+warning: spurious network error (2 tries remaining): failed to get successful HTTP response from `[..]` (127.0.0.1), got 500
 body:
 internal server error
 [DOWNLOADING] crates ...
@@ -2816,7 +2816,7 @@ fn sparse_retry_multiple() {
                 &mut expected,
                 "warning: spurious network error ({remain} tries remaining): \
                 failed to get successful HTTP response from \
-                `http://127.0.0.1:[..]/{ab}/{cd}/{name}`, got 500\n\
+                `http://127.0.0.1:[..]/{ab}/{cd}/{name}` (127.0.0.1), got 500\n\
                 body:\n\
                 internal server error\n"
             )
@@ -2876,10 +2876,12 @@ fn dl_retry_single() {
         .with_stderr("\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-warning: spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`, got 500
+warning: spurious network error (3 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 500
 body:
 internal server error
-warning: spurious network error (2 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`, got 500
+warning: spurious network error (2 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 500
 body:
 internal server error
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
@@ -2954,7 +2956,7 @@ fn dl_retry_multiple() {
                 &mut expected,
                 "warning: spurious network error ({remain} tries remaining): \
                 failed to get successful HTTP response from \
-                `http://127.0.0.1:[..]/dl/{name}/1.0.0/download`, got 500\n\
+                `http://127.0.0.1:[..]/dl/{name}/1.0.0/download` (127.0.0.1), got 500\n\
                 body:\n\
                 internal server error\n"
             )
@@ -3315,21 +3317,24 @@ fn debug_header_message_index() {
         .build();
     p.cargo("fetch").with_status(101).with_stderr("\
 [UPDATING] `dummy-registry` index
-warning: spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar`, got 503
+warning: spurious network error (3 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
 debug headers:
 x-amz-cf-pop: SFO53-P2
 x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
 x-cache: Hit from cloudfront
 body:
 Please slow down
-warning: spurious network error (2 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar`, got 503
+warning: spurious network error (2 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
 debug headers:
 x-amz-cf-pop: SFO53-P2
 x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
 x-cache: Hit from cloudfront
 body:
 Please slow down
-warning: spurious network error (1 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar`, got 503
+warning: spurious network error (1 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
 debug headers:
 x-amz-cf-pop: SFO53-P2
 x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
@@ -3345,7 +3350,7 @@ Caused by:
   download of 3/b/bar failed
 
 Caused by:
-  failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar`, got 503
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
   debug headers:
   x-amz-cf-pop: SFO53-P2
   x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
@@ -3386,21 +3391,24 @@ fn debug_header_message_dl() {
     p.cargo("fetch").with_status(101).with_stderr("\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-warning: spurious network error (3 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`, got 503
+warning: spurious network error (3 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
 debug headers:
 x-amz-cf-pop: SFO53-P2
 x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
 x-cache: Hit from cloudfront
 body:
 Please slow down
-warning: spurious network error (2 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`, got 503
+warning: spurious network error (2 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
 debug headers:
 x-amz-cf-pop: SFO53-P2
 x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
 x-cache: Hit from cloudfront
 body:
 Please slow down
-warning: spurious network error (1 tries remaining): failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`, got 503
+warning: spurious network error (1 tries remaining): \
+    failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
 debug headers:
 x-amz-cf-pop: SFO53-P2
 x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
@@ -3410,7 +3418,7 @@ Please slow down
 error: failed to download from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`
 
 Caused by:
-  failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`, got 503
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
   debug headers:
   x-amz-cf-pop: SFO53-P2
   x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3319,26 +3319,14 @@ fn debug_header_message_index() {
 [UPDATING] `dummy-registry` index
 warning: spurious network error (3 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
-debug headers:
-x-amz-cf-pop: SFO53-P2
-x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
-x-cache: Hit from cloudfront
 body:
 Please slow down
 warning: spurious network error (2 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
-debug headers:
-x-amz-cf-pop: SFO53-P2
-x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
-x-cache: Hit from cloudfront
 body:
 Please slow down
 warning: spurious network error (1 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/index/3/b/bar` (127.0.0.1), got 503
-debug headers:
-x-amz-cf-pop: SFO53-P2
-x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
-x-cache: Hit from cloudfront
 body:
 Please slow down
 error: failed to get `bar` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
@@ -3393,26 +3381,14 @@ fn debug_header_message_dl() {
 [DOWNLOADING] crates ...
 warning: spurious network error (3 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
-debug headers:
-x-amz-cf-pop: SFO53-P2
-x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
-x-cache: Hit from cloudfront
 body:
 Please slow down
 warning: spurious network error (2 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
-debug headers:
-x-amz-cf-pop: SFO53-P2
-x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
-x-cache: Hit from cloudfront
 body:
 Please slow down
 warning: spurious network error (1 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
-debug headers:
-x-amz-cf-pop: SFO53-P2
-x-amz-cf-id: vEc3osJrCAXVaciNnF4Vev-hZFgnYwmNZtxMKRJ5bF6h9FTOtbTMnA==
-x-cache: Hit from cloudfront
 body:
 Please slow down
 error: failed to download from `http://127.0.0.1:[..]/dl/bar/1.0.0/download`

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -57,7 +57,7 @@ fn requires_nightly() {
 error: failed to download from `[..]/dl/bar/0.0.1/download`
 
 Caused by:
-  failed to get successful HTTP response from `[..]`, got 401
+  failed to get successful HTTP response from `[..]` (127.0.0.1), got 401
   body:
   Unauthorized message from server.
 "#,
@@ -415,7 +415,7 @@ fn incorrect_token_git() {
 [ERROR] failed to download from `http://[..]/dl/bar/0.0.1/download`
 
 Caused by:
-  failed to get successful HTTP response from `http://[..]/dl/bar/0.0.1/download`, got 401
+  failed to get successful HTTP response from `http://[..]/dl/bar/0.0.1/download` (127.0.0.1), got 401
   body:
   Unauthorized message from server.",
         )


### PR DESCRIPTION
This adds some extra information to the HTTP error message about some headers and the remote IP address that could potentially be useful in diagnosing issues.

Closes #8691