### PR TITLE
doc: Fix registries.name.index for sparse

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -918,7 +918,7 @@ consists of a sub-table for each named registry.
 * Default: none
 * Environment: `CARGO_REGISTRIES_<name>_INDEX`
 
-Specifies the URL of the git index for the registry.
+Specifies the URL of the index for the registry.
 
 ##### `registries.<name>.token`
 * Type: string


### PR DESCRIPTION
A very minor documentation update. `registries.name.index` doesn't have to be a git URL, it can also be a sparse one.