### PR TITLE
Add delays to network retries.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ os_info = "3.5.0"
 pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"
 pretty_env_logger = { version = "0.4", optional = true }
+rand = "0.8.5"
 rustfix = "0.6.0"
 semver = { version = "1.0.3", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -97,7 +97,7 @@ pub struct RegistryBuilder {
     /// Write the registry in configuration.
     configure_registry: bool,
     /// API responders.
-    custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
+    custom_responders: HashMap<String, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
     /// If nonzero, the git index update to be delayed by the given number of seconds.
     delayed_index_update: usize,
 }
@@ -167,10 +167,11 @@ impl RegistryBuilder {
     #[must_use]
     pub fn add_responder<R: 'static + Send + Fn(&Request, &HttpServer) -> Response>(
         mut self,
-        url: &'static str,
+        url: impl Into<String>,
         responder: R,
     ) -> Self {
-        self.custom_responders.insert(url, Box::new(responder));
+        self.custom_responders
+            .insert(url.into(), Box::new(responder));
         self
     }
 
@@ -601,7 +602,7 @@ pub struct HttpServer {
     addr: SocketAddr,
     token: Token,
     auth_required: bool,
-    custom_responders: HashMap<&'static str, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
+    custom_responders: HashMap<String, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
     delayed_index_update: usize,
 }
 
@@ -621,10 +622,7 @@ impl HttpServer {
         api_path: PathBuf,
         token: Token,
         auth_required: bool,
-        api_responders: HashMap<
-            &'static str,
-            Box<dyn Send + Fn(&Request, &HttpServer) -> Response>,
-        >,
+        api_responders: HashMap<String, Box<dyn Send + Fn(&Request, &HttpServer) -> Response>>,
         delayed_index_update: usize,
     ) -> HttpServerHandle {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -28,7 +28,7 @@ use crate::ops;
 use crate::util::config::PackageCacheLock;
 use crate::util::errors::{CargoResult, HttpNotSuccessful};
 use crate::util::interning::InternedString;
-use crate::util::network::Retry;
+use crate::util::network::retry::Retry;
 use crate::util::{self, internal, Config, Progress, ProgressStyle};
 
 pub const MANIFEST_PREAMBLE: &str = "\

--- a/src/cargo/sources/git/oxide.rs
+++ b/src/cargo/sources/git/oxide.rs
@@ -29,7 +29,7 @@ pub fn with_retry_and_progress(
 ) -> CargoResult<()> {
     std::thread::scope(|s| {
         let mut progress_bar = Progress::new("Fetch", config);
-        network::with_retry(config, || {
+        network::retry::with_retry(config, || {
             let progress_root: Arc<gix::progress::tree::Root> =
                 gix::progress::tree::root::Options {
                     initial_capacity: 10,

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -739,7 +739,7 @@ pub fn with_fetch_options(
     let ssh_config = config.net_config()?.ssh.as_ref();
     let config_known_hosts = ssh_config.and_then(|ssh| ssh.known_hosts.as_ref());
     let diagnostic_home_config = config.diagnostic_home_config();
-    network::with_retry(config, || {
+    network::retry::with_retry(config, || {
         with_authentication(config, url, git_config, |f| {
             let port = Url::parse(url).ok().and_then(|url| url.port());
             let mut last_update = Instant::now();

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -8,7 +8,7 @@ use crate::sources::registry::download;
 use crate::sources::registry::MaybeLock;
 use crate::sources::registry::{LoadResponse, RegistryConfig, RegistryData};
 use crate::util::errors::{CargoResult, HttpNotSuccessful};
-use crate::util::network::Retry;
+use crate::util::network::retry::Retry;
 use crate::util::{auth, Config, Filesystem, IntoUrl, Progress, ProgressStyle};
 use anyhow::Context;
 use cargo_util::paths;

--- a/src/cargo/util/network/mod.rs
+++ b/src/cargo/util/network/mod.rs
@@ -3,6 +3,7 @@
 use std::task::Poll;
 
 pub mod retry;
+pub mod sleep;
 
 pub trait PollExt<T> {
     fn expect(self, msg: &str) -> T;

--- a/src/cargo/util/network/mod.rs
+++ b/src/cargo/util/network/mod.rs
@@ -1,0 +1,37 @@
+//! Utilities for networking.
+
+use std::task::Poll;
+
+pub mod retry;
+
+pub trait PollExt<T> {
+    fn expect(self, msg: &str) -> T;
+}
+
+impl<T> PollExt<T> for Poll<T> {
+    #[track_caller]
+    fn expect(self, msg: &str) -> T {
+        match self {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("{}", msg),
+        }
+    }
+}
+
+// When dynamically linked against libcurl, we want to ignore some failures
+// when using old versions that don't support certain features.
+#[macro_export]
+macro_rules! try_old_curl {
+    ($e:expr, $msg:expr) => {
+        let result = $e;
+        if cfg!(target_os = "macos") {
+            if let Err(e) = result {
+                warn!("ignoring libcurl {} error: {}", $msg, e);
+            }
+        } else {
+            result.with_context(|| {
+                anyhow::format_err!("failed to enable {}, is curl not built right?", $msg)
+            })?;
+        }
+    };
+}

--- a/src/cargo/util/network/retry.rs
+++ b/src/cargo/util/network/retry.rs
@@ -20,16 +20,16 @@ pub enum RetryResult<T> {
 }
 
 /// Maximum amount of time a single retry can be delayed (milliseconds).
-const MAX_RETRY_SLEEP: u64 = 10 * 1000;
+const MAX_RETRY_SLEEP_MS: u64 = 10 * 1000;
 /// The minimum initial amount of time a retry will be delayed (milliseconds).
 ///
 /// The actual amount of time will be a random value above this.
-const INITIAL_RETRY_SLEEP_BASE: u64 = 500;
+const INITIAL_RETRY_SLEEP_BASE_MS: u64 = 500;
 /// The maximum amount of additional time the initial retry will take (milliseconds).
 ///
-/// The initial delay will be [`INITIAL_RETRY_SLEEP_BASE`] plus a random range
+/// The initial delay will be [`INITIAL_RETRY_SLEEP_BASE_MS`] plus a random range
 /// from 0 to this value.
-const INITIAL_RETRY_JITTER: u64 = 1000;
+const INITIAL_RETRY_JITTER_MS: u64 = 1000;
 
 impl<'a> Retry<'a> {
     pub fn new(config: &'a Config) -> CargoResult<Retry<'a>> {
@@ -55,11 +55,11 @@ impl<'a> Retry<'a> {
                 self.retries += 1;
                 let sleep = if self.retries == 1 {
                     let mut rng = rand::thread_rng();
-                    INITIAL_RETRY_SLEEP_BASE + rng.gen_range(0..INITIAL_RETRY_JITTER)
+                    INITIAL_RETRY_SLEEP_BASE_MS + rng.gen_range(0..INITIAL_RETRY_JITTER_MS)
                 } else {
                     min(
-                        ((self.retries - 1) * 3) * 1000 + INITIAL_RETRY_SLEEP_BASE,
-                        MAX_RETRY_SLEEP,
+                        ((self.retries - 1) * 3) * 1000 + INITIAL_RETRY_SLEEP_BASE_MS,
+                        MAX_RETRY_SLEEP_MS,
                     )
                 };
                 RetryResult::Retry(sleep)
@@ -208,8 +208,8 @@ fn default_retry_schedule() {
     match retry.r#try(|| spurious()) {
         RetryResult::Retry(sleep) => {
             assert!(
-                sleep >= INITIAL_RETRY_SLEEP_BASE
-                    && sleep < INITIAL_RETRY_SLEEP_BASE + INITIAL_RETRY_JITTER
+                sleep >= INITIAL_RETRY_SLEEP_BASE_MS
+                    && sleep < INITIAL_RETRY_SLEEP_BASE_MS + INITIAL_RETRY_JITTER_MS
             );
         }
         _ => panic!("unexpected non-retry"),

--- a/src/cargo/util/network/sleep.rs
+++ b/src/cargo/util/network/sleep.rs
@@ -4,12 +4,19 @@ use core::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::time::{Duration, Instant};
 
+/// A tracker for network requests that have failed, and are awaiting to be
+/// retried in the future.
 pub struct SleepTracker<T> {
+    /// This is a priority queue that tracks the time when the next sleeper
+    /// should awaken (based on the [`Sleeper::wakeup`] property).
     heap: BinaryHeap<Sleeper<T>>,
 }
 
+/// An individual network request that is waiting to be retried in the future.
 struct Sleeper<T> {
+    /// The time when this requests should be retried.
     wakeup: Instant,
+    /// Information about the network request.
     data: T,
 }
 
@@ -21,6 +28,8 @@ impl<T> PartialEq for Sleeper<T> {
 
 impl<T> PartialOrd for Sleeper<T> {
     fn partial_cmp(&self, other: &Sleeper<T>) -> Option<Ordering> {
+        // This reverses the comparison so that the BinaryHeap tracks the
+        // entry with the *lowest* wakeup time.
         Some(other.wakeup.cmp(&self.wakeup))
     }
 }

--- a/src/cargo/util/network/sleep.rs
+++ b/src/cargo/util/network/sleep.rs
@@ -1,0 +1,94 @@
+//! Utility for tracking network requests that will be retried in the future.
+
+use core::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::time::{Duration, Instant};
+
+pub struct SleepTracker<T> {
+    heap: BinaryHeap<Sleeper<T>>,
+}
+
+struct Sleeper<T> {
+    wakeup: Instant,
+    data: T,
+}
+
+impl<T> PartialEq for Sleeper<T> {
+    fn eq(&self, other: &Sleeper<T>) -> bool {
+        self.wakeup == other.wakeup
+    }
+}
+
+impl<T> PartialOrd for Sleeper<T> {
+    fn partial_cmp(&self, other: &Sleeper<T>) -> Option<Ordering> {
+        Some(other.wakeup.cmp(&self.wakeup))
+    }
+}
+
+impl<T> Eq for Sleeper<T> {}
+
+impl<T> Ord for Sleeper<T> {
+    fn cmp(&self, other: &Sleeper<T>) -> Ordering {
+        self.wakeup.cmp(&other.wakeup)
+    }
+}
+
+impl<T> SleepTracker<T> {
+    pub fn new() -> SleepTracker<T> {
+        SleepTracker {
+            heap: BinaryHeap::new(),
+        }
+    }
+
+    /// Adds a new download that should be retried in the future.
+    pub fn push(&mut self, sleep: u64, data: T) {
+        self.heap.push(Sleeper {
+            wakeup: Instant::now()
+                .checked_add(Duration::from_millis(sleep))
+                .expect("instant should not wrap"),
+            data,
+        });
+    }
+
+    pub fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    /// Returns any downloads that are ready to go now.
+    pub fn to_retry(&mut self) -> Vec<T> {
+        let now = Instant::now();
+        let mut result = Vec::new();
+        while let Some(next) = self.heap.peek() {
+            log::debug!("ERIC: now={now:?} next={:?}", next.wakeup);
+            if next.wakeup < now {
+                result.push(self.heap.pop().unwrap().data);
+            } else {
+                break;
+            }
+        }
+        result
+    }
+
+    /// Returns the time when the next download is ready to go.
+    ///
+    /// Returns None if there are no sleepers remaining.
+    pub fn time_to_next(&self) -> Option<Duration> {
+        self.heap
+            .peek()
+            .map(|s| s.wakeup.saturating_duration_since(Instant::now()))
+    }
+}
+
+#[test]
+fn returns_in_order() {
+    let mut s = SleepTracker::new();
+    s.push(3, 3);
+    s.push(1, 1);
+    s.push(6, 6);
+    s.push(5, 5);
+    s.push(2, 2);
+    s.push(10000, 10000);
+    assert_eq!(s.len(), 6);
+    std::thread::sleep(Duration::from_millis(100));
+    assert_eq!(s.to_retry(), &[1, 2, 3, 5, 6]);
+}

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -110,7 +110,7 @@ user-agent = "…"            # the user-agent header
 root = "/some/path"         # `cargo install` destination directory
 
 [net]
-retry = 2                   # network retries
+retry = 3                   # network retries
 git-fetch-with-cli = true   # use the `git` executable for git operations
 offline = true              # do not access the network
 
@@ -724,7 +724,7 @@ The `[net]` table controls networking configuration.
 
 ##### `net.retry`
 * Type: integer
-* Default: 2
+* Default: 3
 * Environment: `CARGO_NET_RETRY`
 
 Number of times to retry possibly spurious network errors.

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -327,6 +327,7 @@ fn net_err_suggests_fetch_with_cli() {
 [UPDATING] git repository `ssh://needs-proxy.invalid/git`
 warning: spurious network error[..]
 warning: spurious network error[..]
+warning: spurious network error[..]
 [ERROR] failed to get `foo` as a dependency of package `foo v0.0.0 [..]`
 
 Caused by:


### PR DESCRIPTION
This adds a delay to network retries to help guard against short-lived transient errors.

The overview of how this works is: Requests that fail are placed into a queue with a timestamp of when they should be retried. The download code then checks for any requests that need to be retried, and re-injects them back into curl.

Care must be taken in the download loops to track which requests are currently in flight *plus* which requests are waiting to be retried.

This also adds jitter to the retry times so that multiple failed requests don't all flood the server when they are retried. This is a very primitive form of jitter which suffers from clumping, but I think it should be fine.

The max number of retries is raised to 3 in order to bring the total retry time to around 10 seconds. This is intended to address Cloudfront's default negative TTL of 10 seconds. The retry schedule looks like 0.5seconds ± 1 second, then 3.5 seconds then 6.5 seconds, for a total of 10.5 to 11.5 seconds.  If the user configures additional retries, each attempt afterwards has a max delay of 10 seconds.

The retry times are currently not user-configurable. This could potentially be added in the future, but I don't think is particularly necessary for now.

There is an unfortunate amount of duplication between the crate download and HTTP index code. I think in the near future we should work on consolidating that code. That might be challenging, since their use patterns are different, but I think it is feasible.
