### PR TITLE
Update proptest

### DIFF
--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -8,5 +8,5 @@ cargo = { path = "../.." }
 cargo-util = { path = "../cargo-util" }
 is-terminal = "0.4.0"
 lazy_static = "1.3.0"
-proptest = "0.9.1"
+proptest = "1.1.0"
 varisat = "0.2.1"


### PR DESCRIPTION
This updates proptest from 0.9.1 to 1.1.0. This helps drop some old, unsupported dependencies like `fuchsia-cprng` from an old version of `rand`.

Changelog: https://github.com/proptest-rs/proptest/blob/master/proptest/CHANGELOG.md

I don't see any particularly relevant breaking changes for our use.
