### PR TITLE
Documented working directory behaviour for `cargo test`, `cargo bench` and `cargo run`

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -93,6 +93,11 @@ pub fn run(
     };
     let pkg = bins[0].0;
     let mut process = compile.target_process(exe, unit.kind, pkg, *script_meta)?;
+
+    // Sets the working directory of the child process to the current working
+    // directory of the parent process.
+    // Overrides the default working directory of the `ProcessBuilder` returned
+    // by `compile.target_process` (the package's root directory)
     process.args(args).cwd(config.cwd());
 
     config.shell().status("Running", process.to_string())?;

--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -56,6 +56,14 @@ debugger.
 
 [`bench` profile]: ../reference/profiles.html#bench
 
+### Working directory of benchmarks
+
+The working directory of every benchmark is set to the root directory of the 
+package the benchmark belongs to.
+Setting the working directory of benchmarks to the package's root directory 
+makes it possible for benchmarks to reliably access the package's files using 
+relative paths, regardless from where `cargo bench` was executed from.
+
 ## OPTIONS
 
 ### Benchmark Options

--- a/src/doc/man/cargo-run.md
+++ b/src/doc/man/cargo-run.md
@@ -17,6 +17,10 @@ All the arguments following the two dashes (`--`) are passed to the binary to
 run. If you're passing arguments to both Cargo and the binary, the ones after
 `--` go to the binary, the ones before go to Cargo.
 
+Unlike {{man "cargo-test" 1}} and {{man "cargo-bench" 1}}, `cargo run` sets the 
+working directory of the binary executed to the current working directory, same 
+as if it was executed in the shell directly.
+
 ## OPTIONS
 
 {{> section-options-package }}

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -57,6 +57,14 @@ and may change in the future; beware of depending on it.
 See the [rustdoc book](https://doc.rust-lang.org/rustdoc/) for more information
 on writing doc tests.
 
+### Working directory of tests
+
+The working directory of every test is set to the root directory of the package 
+the test belongs to.
+Setting the working directory of tests to the package's root directory makes it 
+possible for tests to reliably access the package's files using relative paths,
+regardless from where `cargo test` was executed from.
+
 ## OPTIONS
 
 ### Test Options

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -49,6 +49,13 @@ DESCRIPTION
        switch to the dev profile. You can then run the debug-enabled benchmark
        within a debugger.
 
+   Working directory of benchmarks
+       The working directory of every benchmark is set to the root directory of
+       the package the benchmark belongs to. Setting the working directory of
+       benchmarks to the package’s root directory makes it possible for
+       benchmarks to reliably access the package’s files using relative
+       paths, regardless from where cargo bench was executed from.
+
 OPTIONS
    Benchmark Options
        --no-run

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -13,6 +13,10 @@ DESCRIPTION
        to run. If you’re passing arguments to both Cargo and the binary, the
        ones after -- go to the binary, the ones before go to Cargo.
 
+       Unlike cargo-test(1) and cargo-bench(1), cargo run sets the working
+       directory of the binary executed to the current working directory, same
+       as if it was executed in the shell directly.
+
 OPTIONS
    Package Selection
        By default, the package in the current working directory is selected.

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -52,6 +52,13 @@ DESCRIPTION
        See the rustdoc book <https://doc.rust-lang.org/rustdoc/> for more
        information on writing doc tests.
 
+   Working directory of tests
+       The working directory of every test is set to the root directory of the
+       package the test belongs to. Setting the working directory of tests to
+       the package’s root directory makes it possible for tests to reliably
+       access the package’s files using relative paths, regardless from where
+       cargo test was executed from.
+
 OPTIONS
    Test Options
        --no-run

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -56,6 +56,14 @@ debugger.
 
 [`bench` profile]: ../reference/profiles.html#bench
 
+### Working directory of benchmarks
+
+The working directory of every benchmark is set to the root directory of the 
+package the benchmark belongs to.
+Setting the working directory of benchmarks to the package's root directory 
+makes it possible for benchmarks to reliably access the package's files using 
+relative paths, regardless from where `cargo bench` was executed from.
+
 ## OPTIONS
 
 ### Benchmark Options

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -17,6 +17,10 @@ All the arguments following the two dashes (`--`) are passed to the binary to
 run. If you're passing arguments to both Cargo and the binary, the ones after
 `--` go to the binary, the ones before go to Cargo.
 
+Unlike [cargo-test(1)](cargo-test.html) and [cargo-bench(1)](cargo-bench.html), `cargo run` sets the 
+working directory of the binary executed to the current working directory, same 
+as if it was executed in the shell directly.
+
 ## OPTIONS
 
 ### Package Selection

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -57,6 +57,14 @@ and may change in the future; beware of depending on it.
 See the [rustdoc book](https://doc.rust-lang.org/rustdoc/) for more information
 on writing doc tests.
 
+### Working directory of tests
+
+The working directory of every test is set to the root directory of the package 
+the test belongs to.
+Setting the working directory of tests to the package's root directory makes it 
+possible for tests to reliably access the package's files using relative paths,
+regardless from where `cargo test` was executed from.
+
 ## OPTIONS
 
 ### Test Options

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -57,6 +57,12 @@ optimizations and disables debugging information. If you need to debug a
 benchmark, you can use the \fB\-\-profile=dev\fR command\-line option to switch to
 the dev profile. You can then run the debug\-enabled benchmark within a
 debugger.
+.SS "Working directory of benchmarks"
+The working directory of every benchmark is set to the root directory of the 
+package the benchmark belongs to.
+Setting the working directory of benchmarks to the package\[cq]s root directory 
+makes it possible for benchmarks to reliably access the package\[cq]s files using 
+relative paths, regardless from where \fBcargo bench\fR was executed from.
 .SH "OPTIONS"
 .SS "Benchmark Options"
 .sp

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -13,6 +13,10 @@ Run a binary or example of the local package.
 All the arguments following the two dashes (\fB\-\-\fR) are passed to the binary to
 run. If you\[cq]re passing arguments to both Cargo and the binary, the ones after
 \fB\-\-\fR go to the binary, the ones before go to Cargo.
+.sp
+Unlike \fBcargo\-test\fR(1) and \fBcargo\-bench\fR(1), \fBcargo run\fR sets the 
+working directory of the binary executed to the current working directory, same 
+as if it was executed in the shell directly.
 .SH "OPTIONS"
 .SS "Package Selection"
 By default, the package in the current working directory is selected. The \fB\-p\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -53,6 +53,12 @@ and may change in the future; beware of depending on it.
 .sp
 See the \fIrustdoc book\fR <https://doc.rust\-lang.org/rustdoc/> for more information
 on writing doc tests.
+.SS "Working directory of tests"
+The working directory of every test is set to the root directory of the package 
+the test belongs to.
+Setting the working directory of tests to the package\[cq]s root directory makes it 
+possible for tests to reliably access the package\[cq]s files using relative paths,
+regardless from where \fBcargo test\fR was executed from.
 .SH "OPTIONS"
 .SS "Test Options"
 .sp


### PR DESCRIPTION
Fixes #11852. Updated the respective man-pages of `cargo test`, `cargo bench` and `cargo run` to include the information of the working directory of the executables. Added a comment in the code of `cargo run`  where the default behaviour (the package's root directory) is overridden.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
