### PR TITLE
fix(cli): Make `--help` easier to browse

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -523,7 +523,9 @@ pub fn cli() -> Command {
     Command::new("cargo")
         // Subcommands all count their args' display order independently (from 0),
         // which makes their args interspersed with global args. This puts global args last.
-        .next_display_order(1000)
+        //
+        // We also want these to come before auto-generated `--help`
+        .next_display_order(800)
         .allow_external_subcommands(true)
         // Doesn't mix well with our list of common cargo commands.  See clap-rs/clap#3108 for
         // opening clap up to allow us to style our help template
@@ -586,9 +588,21 @@ See 'cargo help <command>' for more information on a specific command.\n",
                 .value_hint(clap::ValueHint::DirPath)
                 .value_parser(clap::builder::ValueParser::path_buf()),
         )
-        .arg(flag("frozen", "Require Cargo.lock and cache are up to date").global(true))
-        .arg(flag("locked", "Require Cargo.lock is up to date").global(true))
-        .arg(flag("offline", "Run without accessing the network").global(true))
+        .arg(
+            flag("frozen", "Require Cargo.lock and cache are up to date")
+                .help_heading(heading::MANIFEST_OPTIONS)
+                .global(true),
+        )
+        .arg(
+            flag("locked", "Require Cargo.lock is up to date")
+                .help_heading(heading::MANIFEST_OPTIONS)
+                .global(true),
+        )
+        .arg(
+            flag("offline", "Run without accessing the network")
+                .help_heading(heading::MANIFEST_OPTIONS)
+                .global(true),
+        )
         .arg(multi_opt("config", "KEY=VALUE", "Override a configuration value").global(true))
         .arg(
             Arg::new("unstable-features")

--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -79,8 +79,8 @@ Example uses:
         ])
         .arg_manifest_path()
         .arg_package("Package to modify")
-        .arg_quiet()
         .arg_dry_run("Don't actually write the manifest")
+        .arg_quiet()
         .next_help_heading("Source")
         .args([
             clap::Arg::new("path")

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -4,7 +4,7 @@ use cargo::ops::{self, TestOptions};
 pub fn cli() -> Command {
     subcommand("bench")
         .about("Execute all benchmarks of a local package")
-        .arg_quiet()
+        .next_display_order(0)
         .arg(
             Arg::new("BENCHNAME")
                 .action(ArgAction::Set)
@@ -15,6 +15,19 @@ pub fn cli() -> Command {
                 .help("Arguments for the bench binary")
                 .num_args(0..)
                 .last(true),
+        )
+        .arg(flag("no-run", "Compile, but don't run benchmarks"))
+        .arg(flag(
+            "no-fail-fast",
+            "Run all benchmarks regardless of failure",
+        ))
+        .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
+        .arg_package_spec(
+            "Package to run benchmarks for",
+            "Benchmark all packages in the workspace",
+            "Exclude packages from the benchmark",
         )
         .arg_targets_all(
             "Benchmark only this package's library",
@@ -28,26 +41,14 @@ pub fn cli() -> Command {
             "Benchmark all benches",
             "Benchmark all targets",
         )
-        .arg(flag("no-run", "Compile, but don't run benchmarks"))
-        .arg_package_spec(
-            "Package to run benchmarks for",
-            "Benchmark all packages in the workspace",
-            "Exclude packages from the benchmark",
-        )
+        .arg_features()
         .arg_jobs()
         .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
-        .arg_manifest_path()
-        .arg_ignore_rust_version()
-        .arg_message_format()
-        .arg(flag(
-            "no-fail-fast",
-            "Run all benchmarks regardless of failure",
-        ))
         .arg_unit_graph()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help bench` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -7,13 +7,15 @@ pub fn cli() -> Command {
         // subcommand aliases are handled in aliased_command()
         // .alias("b")
         .about("Compile a local package and all of its dependencies")
+        .arg_ignore_rust_version()
+        .arg_future_incompat_report()
+        .arg_message_format()
         .arg_quiet()
         .arg_package_spec(
             "Package to build (see `cargo help pkgid`)",
             "Build all packages in the workspace",
             "Exclude packages from the build",
         )
-        .arg_jobs()
         .arg_targets_all(
             "Build only this package's library",
             "Build only the specified binary",
@@ -26,9 +28,10 @@ pub fn cli() -> Command {
             "Build all benches",
             "Build all targets",
         )
+        .arg_features()
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
+        .arg_jobs()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg(
@@ -36,15 +39,13 @@ pub fn cli() -> Command {
                 "out-dir",
                 "Copy final artifacts to this directory (unstable)",
             )
-            .value_name("PATH"),
+            .value_name("PATH")
+            .help_heading(heading::COMPILATION_OPTIONS),
         )
-        .arg_manifest_path()
-        .arg_ignore_rust_version()
-        .arg_message_format()
         .arg_build_plan()
         .arg_unit_graph()
-        .arg_future_incompat_report()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help build` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -7,13 +7,15 @@ pub fn cli() -> Command {
         // subcommand aliases are handled in aliased_command()
         // .alias("c")
         .about("Check a local package and all of its dependencies for errors")
+        .arg_ignore_rust_version()
+        .arg_future_incompat_report()
+        .arg_message_format()
         .arg_quiet()
         .arg_package_spec(
             "Package(s) to check",
             "Check all packages in the workspace",
             "Exclude packages from the check",
         )
-        .arg_jobs()
         .arg_targets_all(
             "Check only this package's library",
             "Check only the specified binary",
@@ -26,17 +28,15 @@ pub fn cli() -> Command {
             "Check all benches",
             "Check all targets",
         )
+        .arg_features()
+        .arg_jobs()
         .arg_release("Check artifacts in release mode, with optimizations")
         .arg_profile("Check artifacts with the specified profile")
-        .arg_features()
         .arg_target_triple("Check for the target triple")
         .arg_target_dir()
-        .arg_manifest_path()
-        .arg_ignore_rust_version()
-        .arg_message_format()
         .arg_unit_graph()
-        .arg_future_incompat_report()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help check` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -6,14 +6,14 @@ use cargo::util::print_available_packages;
 pub fn cli() -> Command {
     subcommand("clean")
         .about("Remove artifacts that cargo has generated in the past")
+        .arg_doc("Whether or not to clean just the documentation directory")
         .arg_quiet()
         .arg_package_spec_simple("Package to clean artifacts for")
-        .arg_manifest_path()
-        .arg_target_triple("Target triple to clean output for")
-        .arg_target_dir()
         .arg_release("Whether or not to clean release artifacts")
         .arg_profile("Clean artifacts of the specified profile")
-        .arg_doc("Whether or not to clean just the documentation directory")
+        .arg_target_triple("Target triple to clean output for")
+        .arg_target_dir()
+        .arg_manifest_path()
         .after_help("Run `cargo help clean` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -7,22 +7,24 @@ pub fn cli() -> Command {
         // subcommand aliases are handled in aliased_command()
         // .alias("d")
         .about("Build a package's documentation")
-        .arg_quiet()
         .arg(flag(
             "open",
             "Opens the docs in a browser after the operation",
         ))
-        .arg_package_spec(
-            "Package to document",
-            "Document all packages in the workspace",
-            "Exclude packages from the build",
-        )
         .arg(flag(
             "no-deps",
             "Don't build documentation for dependencies",
         ))
         .arg(flag("document-private-items", "Document private items"))
-        .arg_jobs()
+        .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
+        .arg_package_spec(
+            "Package to document",
+            "Document all packages in the workspace",
+            "Exclude packages from the build",
+        )
+        .arg_features()
         .arg_targets_lib_bin_example(
             "Document only this package's library",
             "Document only the specified binary",
@@ -30,16 +32,14 @@ pub fn cli() -> Command {
             "Document only the specified example",
             "Document all examples",
         )
+        .arg_jobs()
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
-        .arg_manifest_path()
-        .arg_message_format()
-        .arg_ignore_rust_version()
         .arg_unit_graph()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help doc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/fetch.rs
+++ b/src/bin/cargo/commands/fetch.rs
@@ -7,8 +7,8 @@ pub fn cli() -> Command {
     subcommand("fetch")
         .about("Fetch dependencies of a package from the network")
         .arg_quiet()
-        .arg_manifest_path()
         .arg_target_triple("Fetch dependencies for the target triple")
+        .arg_manifest_path()
         .after_help("Run `cargo help fetch` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -5,40 +5,14 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("fix")
         .about("Automatically fix lint warnings reported by rustc")
-        .arg_quiet()
-        .arg_package_spec(
-            "Package(s) to fix",
-            "Fix all packages in the workspace",
-            "Exclude packages from the fixes",
-        )
-        .arg_jobs()
-        .arg_targets_all(
-            "Fix only this package's library",
-            "Fix only the specified binary",
-            "Fix all binaries",
-            "Fix only the specified example",
-            "Fix all examples",
-            "Fix only the specified test target",
-            "Fix all tests",
-            "Fix only the specified bench target",
-            "Fix all benches",
-            "Fix all targets (default)",
-        )
-        .arg_release("Fix artifacts in release mode, with optimizations")
-        .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
-        .arg_target_triple("Fix for the target triple")
-        .arg_target_dir()
-        .arg_manifest_path()
-        .arg_message_format()
-        .arg(flag(
-            "broken-code",
-            "Fix code even if it already has compiler errors",
-        ))
         .arg(flag("edition", "Fix in preparation for the next edition"))
         .arg(flag(
             "edition-idioms",
             "Fix warnings to migrate to the idioms of an edition",
+        ))
+        .arg(flag(
+            "broken-code",
+            "Fix code even if it already has compiler errors",
         ))
         .arg(flag(
             "allow-no-vcs",
@@ -53,7 +27,33 @@ pub fn cli() -> Command {
             "Fix code even if the working directory has staged changes",
         ))
         .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
+        .arg_package_spec(
+            "Package(s) to fix",
+            "Fix all packages in the workspace",
+            "Exclude packages from the fixes",
+        )
+        .arg_targets_all(
+            "Fix only this package's library",
+            "Fix only the specified binary",
+            "Fix all binaries",
+            "Fix only the specified example",
+            "Fix all examples",
+            "Fix only the specified test target",
+            "Fix all tests",
+            "Fix only the specified bench target",
+            "Fix all benches",
+            "Fix all targets (default)",
+        )
+        .arg_features()
+        .arg_jobs()
+        .arg_release("Fix artifacts in release mode, with optimizations")
+        .arg_profile("Build artifacts with the specified profile")
+        .arg_target_triple("Fix for the target triple")
+        .arg_target_dir()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help fix` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -5,10 +5,10 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("init")
         .about("Create a new cargo package in an existing directory")
-        .arg_quiet()
         .arg(Arg::new("path").action(ArgAction::Set).default_value("."))
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
         .arg_new_opts()
+        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_quiet()
         .after_help("Run `cargo help init` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -10,7 +10,6 @@ use cargo_util::paths;
 pub fn cli() -> Command {
     subcommand("install")
         .about("Install a Rust binary. Default location is $HOME/.cargo/bin")
-        .arg_quiet()
         .arg(
             Arg::new("crate")
                 .value_parser(clap::builder::NonEmptyStringValueParser::new())
@@ -21,6 +20,18 @@ pub fn cli() -> Command {
                 .alias("vers")
                 .value_name("VERSION")
                 .requires("crate"),
+        )
+        .arg(
+            opt("index", "Registry index to install from")
+                .value_name("INDEX")
+                .requires("crate")
+                .conflicts_with_all(&["git", "path", "registry"]),
+        )
+        .arg(
+            opt("registry", "Registry to use")
+                .value_name("REGISTRY")
+                .requires("crate")
+                .conflicts_with_all(&["git", "path", "index"]),
         )
         .arg(
             opt("git", "Git URL to install the specified crate from")
@@ -47,42 +58,31 @@ pub fn cli() -> Command {
                 .value_name("PATH")
                 .conflicts_with_all(&["git", "index", "registry"]),
         )
+        .arg(opt("root", "Directory to install packages into").value_name("DIR"))
+        .arg(flag("force", "Force overwriting existing crates or binaries").short('f'))
+        .arg(flag("no-track", "Do not save tracking information"))
         .arg(flag(
             "list",
             "list all installed packages and their versions",
         ))
-        .arg_jobs()
-        .arg(flag("force", "Force overwriting existing crates or binaries").short('f'))
-        .arg(flag("no-track", "Do not save tracking information"))
-        .arg_features()
-        .arg_profile("Install artifacts with the specified profile")
-        .arg(flag(
-            "debug",
-            "Build in debug mode (with the 'dev' profile) instead of release mode",
-        ))
+        .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
         .arg_targets_bins_examples(
             "Install only the specified binary",
             "Install all binaries",
             "Install only the specified example",
             "Install all examples",
         )
+        .arg_features()
+        .arg_jobs()
+        .arg(flag(
+            "debug",
+            "Build in debug mode (with the 'dev' profile) instead of release mode",
+        ))
+        .arg_profile("Install artifacts with the specified profile")
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
-        .arg(opt("root", "Directory to install packages into").value_name("DIR"))
-        .arg(
-            opt("index", "Registry index to install from")
-                .value_name("INDEX")
-                .requires("crate")
-                .conflicts_with_all(&["git", "path", "registry"]),
-        )
-        .arg(
-            opt("registry", "Registry to use")
-                .value_name("REGISTRY")
-                .requires("crate")
-                .conflicts_with_all(&["git", "path", "index"]),
-        )
-        .arg_ignore_rust_version()
-        .arg_message_format()
         .arg_timings()
         .after_help("Run `cargo help install` for more detailed information.\n")
 }

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -6,8 +6,7 @@ use serde::Serialize;
 pub fn cli() -> Command {
     subcommand("locate-project")
         .about("Print a JSON representation of a Cargo.toml file's location")
-        .arg_quiet()
-        .arg_manifest_path()
+        .arg(flag("workspace", "Locate Cargo.toml of the workspace root"))
         .arg(
             opt(
                 "message-format",
@@ -15,7 +14,8 @@ pub fn cli() -> Command {
             )
             .value_name("FMT"),
         )
-        .arg(flag("workspace", "Locate Cargo.toml of the workspace root"))
+        .arg_quiet()
+        .arg_manifest_path()
         .after_help("Run `cargo help locate-project` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -5,9 +5,9 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("login")
         .about("Log in to a registry.")
-        .arg_quiet()
         .arg(Arg::new("token").action(ArgAction::Set))
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_quiet()
         .after_help("Run `cargo help login` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -4,8 +4,8 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("logout")
         .about("Remove an API token from the registry locally")
-        .arg_quiet()
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_quiet()
         .after_help("Run `cargo help logout` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -8,8 +8,6 @@ pub fn cli() -> Command {
              the concrete used versions including overrides, \
              in machine-readable format",
         )
-        .arg_quiet()
-        .arg_features()
         .arg(multi_opt(
             "filter-platform",
             "TRIPLE",
@@ -20,12 +18,14 @@ pub fn cli() -> Command {
             "Output information only about the workspace members \
              and don't fetch dependencies",
         ))
-        .arg_manifest_path()
         .arg(
             opt("format-version", "Format version")
                 .value_name("VERSION")
                 .value_parser(["1"]),
         )
+        .arg_quiet()
+        .arg_features()
+        .arg_manifest_path()
         .after_help("Run `cargo help metadata` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -5,10 +5,10 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("new")
         .about("Create a new cargo package at <path>")
-        .arg_quiet()
         .arg(Arg::new("path").action(ArgAction::Set).required(true))
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
         .arg_new_opts()
+        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_quiet()
         .after_help("Run `cargo help new` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -6,7 +6,6 @@ use cargo_credential::Secret;
 pub fn cli() -> Command {
     subcommand("owner")
         .about("Manage the owners of a crate on the registry")
-        .arg_quiet()
         .arg(Arg::new("crate").action(ArgAction::Set))
         .arg(
             multi_opt(
@@ -28,6 +27,7 @@ pub fn cli() -> Command {
         .arg(opt("index", "Registry index to modify owners for").value_name("INDEX"))
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_quiet()
         .after_help("Run `cargo help owner` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -5,7 +5,6 @@ use cargo::ops::{self, PackageOpts};
 pub fn cli() -> Command {
     subcommand("package")
         .about("Assemble the local package into a distributable tarball")
-        .arg_quiet()
         .arg(
             flag(
                 "list",
@@ -25,16 +24,17 @@ pub fn cli() -> Command {
             "allow-dirty",
             "Allow dirty working directories to be packaged",
         ))
-        .arg_target_triple("Build for the target triple")
-        .arg_target_dir()
-        .arg_features()
+        .arg_quiet()
         .arg_package_spec_no_all(
             "Package(s) to assemble",
             "Assemble all packages in the workspace",
             "Don't assemble specified packages",
         )
-        .arg_manifest_path()
+        .arg_features()
+        .arg_target_triple("Build for the target triple")
+        .arg_target_dir()
         .arg_jobs()
+        .arg_manifest_path()
         .after_help("Run `cargo help package` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/pkgid.rs
+++ b/src/bin/cargo/commands/pkgid.rs
@@ -6,8 +6,8 @@ use cargo::util::print_available_packages;
 pub fn cli() -> Command {
     subcommand("pkgid")
         .about("Print a fully qualified package specification")
-        .arg_quiet()
         .arg(Arg::new("spec").action(ArgAction::Set))
+        .arg_quiet()
         .arg_package("Argument to get the package ID specifier for")
         .arg_manifest_path()
         .after_help("Run `cargo help pkgid` for more detailed information.\n")

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -5,8 +5,9 @@ use cargo::ops::{self, PublishOpts};
 pub fn cli() -> Command {
     subcommand("publish")
         .about("Upload a package to the registry")
-        .arg_quiet()
+        .arg_dry_run("Perform all checks without uploading")
         .arg_index()
+        .arg(opt("registry", "Registry to publish to").value_name("REGISTRY"))
         .arg(opt("token", "Token to use when uploading").value_name("TOKEN"))
         .arg(flag(
             "no-verify",
@@ -16,14 +17,13 @@ pub fn cli() -> Command {
             "allow-dirty",
             "Allow dirty working directories to be packaged",
         ))
-        .arg_target_triple("Build for the target triple")
-        .arg_target_dir()
+        .arg_quiet()
         .arg_package("Package to publish")
-        .arg_manifest_path()
         .arg_features()
         .arg_jobs()
-        .arg_dry_run("Perform all checks without uploading")
-        .arg(opt("registry", "Registry to publish to").value_name("REGISTRY"))
+        .arg_target_triple("Build for the target triple")
+        .arg_target_dir()
+        .arg_manifest_path()
         .after_help("Run `cargo help publish` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -24,10 +24,8 @@ pub fn cli() -> clap::Command {
             .num_args(1..)
             .value_name("DEP_ID")
             .help("Dependencies to be removed")])
-        .arg_package("Package to remove from")
-        .arg_manifest_path()
-        .arg_quiet()
         .arg_dry_run("Don't actually write the manifest")
+        .arg_quiet()
         .next_help_heading("Section")
         .args([
             clap::Arg::new("dev")
@@ -49,6 +47,8 @@ pub fn cli() -> clap::Command {
                 .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .help("Remove as dependency from the given target platform"),
         ])
+        .arg_package("Package to remove from")
+        .arg_manifest_path()
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -14,7 +14,6 @@ pub fn cli() -> Command {
         // subcommand aliases are handled in aliased_command()
         // .alias("r")
         .about("Run a binary or example of the local package")
-        .arg_quiet()
         .arg(
             Arg::new("args")
                 .help("Arguments for the binary or example to run")
@@ -22,21 +21,22 @@ pub fn cli() -> Command {
                 .num_args(0..)
                 .trailing_var_arg(true),
         )
+        .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
+        .arg_package("Package with the target to run")
         .arg_targets_bin_example(
             "Name of the bin target to run",
             "Name of the example target to run",
         )
-        .arg_package("Package with the target to run")
+        .arg_features()
         .arg_jobs()
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
         .arg_manifest_path()
-        .arg_message_format()
         .arg_unit_graph()
-        .arg_ignore_rust_version()
         .arg_timings()
         .after_help("Run `cargo help run` for more detailed information.\n")
 }

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -8,31 +8,12 @@ const CRATE_TYPE_ARG_NAME: &str = "crate-type";
 pub fn cli() -> Command {
     subcommand("rustc")
         .about("Compile a package, and pass extra options to the compiler")
-        .arg_quiet()
         .arg(
             Arg::new("args")
                 .num_args(0..)
                 .help("Extra rustc flags")
                 .trailing_var_arg(true),
         )
-        .arg_package("Package to build")
-        .arg_jobs()
-        .arg_targets_all(
-            "Build only this package's library",
-            "Build only the specified binary",
-            "Build all binaries",
-            "Build only the specified example",
-            "Build all examples",
-            "Build only the specified test target",
-            "Build all tests",
-            "Build only the specified bench target",
-            "Build all benches",
-            "Build all targets",
-        )
-        .arg_release("Build artifacts in release mode, with optimizations")
-        .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
-        .arg_target_triple("Target triple which compiles will be for")
         .arg(
             opt(
                 PRINT_ARG_NAME,
@@ -45,13 +26,32 @@ pub fn cli() -> Command {
             "CRATE-TYPE",
             "Comma separated list of types of crates for the compiler to emit",
         ))
-        .arg_target_dir()
-        .arg_manifest_path()
-        .arg_message_format()
-        .arg_unit_graph()
-        .arg_ignore_rust_version()
         .arg_future_incompat_report()
+        .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
+        .arg_package("Package to build")
+        .arg_targets_all(
+            "Build only this package's library",
+            "Build only the specified binary",
+            "Build all binaries",
+            "Build only the specified example",
+            "Build all examples",
+            "Build only the specified test target",
+            "Build all tests",
+            "Build only the specified bench target",
+            "Build all benches",
+            "Build all targets",
+        )
+        .arg_features()
+        .arg_jobs()
+        .arg_release("Build artifacts in release mode, with optimizations")
+        .arg_profile("Build artifacts with the specified profile")
+        .arg_target_triple("Target triple which compiles will be for")
+        .arg_target_dir()
+        .arg_unit_graph()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help rustc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -5,7 +5,6 @@ use crate::command_prelude::*;
 pub fn cli() -> Command {
     subcommand("rustdoc")
         .about("Build a package's documentation, using specified custom flags.")
-        .arg_quiet()
         .arg(
             Arg::new("args")
                 .help("Extra rustdoc flags")
@@ -16,8 +15,10 @@ pub fn cli() -> Command {
             "open",
             "Opens the docs in a browser after the operation",
         ))
+        .arg_ignore_rust_version()
+        .arg_message_format()
+        .arg_quiet()
         .arg_package("Package to document")
-        .arg_jobs()
         .arg_targets_all(
             "Build only this package's library",
             "Build only the specified binary",
@@ -30,16 +31,15 @@ pub fn cli() -> Command {
             "Build all benches",
             "Build all targets",
         )
+        .arg_features()
+        .arg_jobs()
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
-        .arg_manifest_path()
-        .arg_message_format()
         .arg_unit_graph()
-        .arg_ignore_rust_version()
         .arg_timings()
+        .arg_manifest_path()
         .after_help("Run `cargo help rustdoc` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -7,9 +7,7 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("search")
         .about("Search packages in crates.io")
-        .arg_quiet()
         .arg(Arg::new("query").num_args(0..))
-        .arg_index()
         .arg(
             opt(
                 "limit",
@@ -17,7 +15,9 @@ pub fn cli() -> Command {
             )
             .value_name("LIMIT"),
         )
+        .arg_index()
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_quiet()
         .after_help("Run `cargo help search` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -17,12 +17,23 @@ pub fn cli() -> Command {
                 .num_args(0..)
                 .last(true),
         )
+        .arg(flag("doc", "Test only this library's documentation"))
+        .arg(flag("no-run", "Compile, but don't run tests"))
+        .arg(flag("no-fail-fast", "Run all tests regardless of failure"))
+        .arg_ignore_rust_version()
+        .arg_future_incompat_report()
+        .arg_message_format()
         .arg(
             flag(
                 "quiet",
                 "Display one character per test instead of one line",
             )
             .short('q'),
+        )
+        .arg_package_spec(
+            "Package to run tests for",
+            "Test all packages in the workspace",
+            "Exclude packages from the test",
         )
         .arg_targets_all(
             "Test only this package's library unit tests",
@@ -36,26 +47,15 @@ pub fn cli() -> Command {
             "Test all benches",
             "Test all targets (does not include doctests)",
         )
-        .arg(flag("doc", "Test only this library's documentation"))
-        .arg(flag("no-run", "Compile, but don't run tests"))
-        .arg(flag("no-fail-fast", "Run all tests regardless of failure"))
-        .arg_package_spec(
-            "Package to run tests for",
-            "Test all packages in the workspace",
-            "Exclude packages from the test",
-        )
+        .arg_features()
         .arg_jobs()
         .arg_release("Build artifacts in release mode, with optimizations")
         .arg_profile("Build artifacts with the specified profile")
-        .arg_features()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
-        .arg_manifest_path()
-        .arg_ignore_rust_version()
-        .arg_message_format()
         .arg_unit_graph()
-        .arg_future_incompat_report()
         .arg_timings()
+        .arg_manifest_path()
         .after_help(
             "Run `cargo help test` for more detailed information.\n\
              Run `cargo test -- --help` for test binary options.\n",

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -12,24 +12,12 @@ use std::str::FromStr;
 pub fn cli() -> Command {
     subcommand("tree")
         .about("Display a tree visualization of a dependency graph")
-        .arg_quiet()
-        .arg_manifest_path()
-        .arg_package_spec_no_all(
-            "Package to be used as the root of the tree",
-            "Display the tree for all packages in the workspace",
-            "Exclude specific workspace members",
-        )
         .arg(
             flag("all", "Deprecated, use --no-dedupe instead")
                 .short('a')
                 .hide(true),
         )
-        .arg(flag("all-targets", "Deprecated, use --target=all instead").hide(true))
-        .arg_features()
-        .arg_target_triple(
-            "Filter dependencies matching the given target-triple (default host platform). \
-            Pass `all` to include all targets.",
-        )
+        .arg_quiet()
         .arg(flag("no-dev-dependencies", "Deprecated, use -e=no-dev instead").hide(true))
         .arg(
             multi_opt(
@@ -96,6 +84,18 @@ pub fn cli() -> Command {
                 .short('V')
                 .hide(true),
         )
+        .arg_package_spec_no_all(
+            "Package to be used as the root of the tree",
+            "Display the tree for all packages in the workspace",
+            "Exclude specific workspace members",
+        )
+        .arg_features()
+        .arg(flag("all-targets", "Deprecated, use --target=all instead").hide(true))
+        .arg_target_triple(
+            "Filter dependencies matching the given target-triple (default host platform). \
+            Pass `all` to include all targets.",
+        )
+        .arg_manifest_path()
         .after_help("Run `cargo help tree` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/uninstall.rs
+++ b/src/bin/cargo/commands/uninstall.rs
@@ -5,11 +5,14 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("uninstall")
         .about("Remove a Rust binary")
-        .arg_quiet()
         .arg(Arg::new("spec").num_args(0..))
-        .arg_package_spec_simple("Package to uninstall")
-        .arg(multi_opt("bin", "NAME", "Only uninstall the binary NAME"))
         .arg(opt("root", "Directory to uninstall packages from").value_name("DIR"))
+        .arg_quiet()
+        .arg_package_spec_simple("Package to uninstall")
+        .arg(
+            multi_opt("bin", "NAME", "Only uninstall the binary NAME")
+                .help_heading(heading::TARGET_SELECTION),
+        )
         .after_help("Run `cargo help uninstall` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -6,9 +6,7 @@ use cargo::util::print_available_packages;
 pub fn cli() -> Command {
     subcommand("update")
         .about("Update dependencies as recorded in the local lock file")
-        .arg_quiet()
-        .arg(flag("workspace", "Only update the workspace packages").short('w'))
-        .arg_package_spec_simple("Package to update")
+        .arg_dry_run("Don't actually write the lockfile")
         .arg(
             flag(
                 "aggressive",
@@ -24,8 +22,14 @@ pub fn cli() -> Command {
             .value_name("PRECISE")
             .requires("package"),
         )
+        .arg_quiet()
+        .arg(
+            flag("workspace", "Only update the workspace packages")
+                .short('w')
+                .help_heading(heading::PACKAGE_SELECTION),
+        )
+        .arg_package_spec_simple("Package to update")
         .arg_manifest_path()
-        .arg_dry_run("Don't actually write the lockfile")
         .after_help("Run `cargo help update` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -5,8 +5,6 @@ use std::path::PathBuf;
 pub fn cli() -> Command {
     subcommand("vendor")
         .about("Vendor all dependencies for a project locally")
-        .arg_quiet()
-        .arg_manifest_path()
         .arg(
             Arg::new("path")
                 .action(ArgAction::Set)
@@ -38,6 +36,8 @@ pub fn cli() -> Command {
         .arg(flag("relative-path", "Not supported").hide(true))
         .arg(flag("only-git-deps", "Not supported").hide(true))
         .arg(flag("disallow-duplicates", "Not supported").hide(true))
+        .arg_quiet()
+        .arg_manifest_path()
         .after_help("Run `cargo help vendor` for more detailed information.\n")
 }
 

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -6,7 +6,6 @@ use cargo_credential::Secret;
 pub fn cli() -> Command {
     subcommand("yank")
         .about("Remove a pushed crate from the index")
-        .arg_quiet()
         .arg(Arg::new("crate").action(ArgAction::Set))
         .arg(
             opt("version", "The version to yank or un-yank")
@@ -18,8 +17,9 @@ pub fn cli() -> Command {
             "Undo a yank, putting a version back into the index",
         ))
         .arg(opt("index", "Registry index to yank from").value_name("INDEX"))
-        .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
+        .arg_quiet()
         .after_help("Run `cargo help yank` for more detailed information.\n")
 }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -26,6 +26,14 @@ pub use clap::Command;
 
 use super::config::JobsConfig;
 
+pub mod heading {
+    pub const PACKAGE_SELECTION: &str = "Package Selection";
+    pub const TARGET_SELECTION: &str = "Target Selection";
+    pub const FEATURE_SELECTION: &str = "Feature Selection";
+    pub const COMPILATION_OPTIONS: &str = "Compilation Options";
+    pub const MANIFEST_OPTIONS: &str = "Manifest Options";
+}
+
 pub trait CommandExt: Sized {
     fn _arg(self, arg: Arg) -> Self;
 
@@ -37,8 +45,10 @@ pub trait CommandExt: Sized {
         all: &'static str,
         exclude: &'static str,
     ) -> Self {
-        self.arg_package_spec_no_all(package, all, exclude)
-            ._arg(flag("all", "Alias for --workspace (deprecated)"))
+        self.arg_package_spec_no_all(package, all, exclude)._arg(
+            flag("all", "Alias for --workspace (deprecated)")
+                .help_heading(heading::PACKAGE_SELECTION),
+        )
     }
 
     /// Variant of arg_package_spec that does not include the `--all` flag
@@ -51,19 +61,24 @@ pub trait CommandExt: Sized {
         exclude: &'static str,
     ) -> Self {
         self.arg_package_spec_simple(package)
-            ._arg(flag("workspace", all))
-            ._arg(multi_opt("exclude", "SPEC", exclude))
+            ._arg(flag("workspace", all).help_heading(heading::PACKAGE_SELECTION))
+            ._arg(multi_opt("exclude", "SPEC", exclude).help_heading(heading::PACKAGE_SELECTION))
     }
 
     fn arg_package_spec_simple(self, package: &'static str) -> Self {
-        self._arg(optional_multi_opt("package", "SPEC", package).short('p'))
+        self._arg(
+            optional_multi_opt("package", "SPEC", package)
+                .short('p')
+                .help_heading(heading::PACKAGE_SELECTION),
+        )
     }
 
     fn arg_package(self, package: &'static str) -> Self {
         self._arg(
             optional_opt("package", package)
                 .short('p')
-                .value_name("SPEC"),
+                .value_name("SPEC")
+                .help_heading(heading::PACKAGE_SELECTION),
         )
     }
 
@@ -72,12 +87,16 @@ pub trait CommandExt: Sized {
             opt("jobs", "Number of parallel jobs, defaults to # of CPUs.")
                 .short('j')
                 .value_name("N")
-                .allow_hyphen_values(true),
+                .allow_hyphen_values(true)
+                .help_heading(heading::COMPILATION_OPTIONS),
         )
-        ._arg(flag(
-            "keep-going",
-            "Do not abort the build as soon as there is an error (unstable)",
-        ))
+        ._arg(
+            flag(
+                "keep-going",
+                "Do not abort the build as soon as there is an error (unstable)",
+            )
+            .help_heading(heading::COMPILATION_OPTIONS),
+        )
     }
 
     fn arg_targets_all(
@@ -94,11 +113,13 @@ pub trait CommandExt: Sized {
         all: &'static str,
     ) -> Self {
         self.arg_targets_lib_bin_example(lib, bin, bins, example, examples)
-            ._arg(flag("tests", tests))
-            ._arg(optional_multi_opt("test", "NAME", test))
-            ._arg(flag("benches", benches))
-            ._arg(optional_multi_opt("bench", "NAME", bench))
-            ._arg(flag("all-targets", all))
+            ._arg(flag("tests", tests).help_heading(heading::TARGET_SELECTION))
+            ._arg(optional_multi_opt("test", "NAME", test).help_heading(heading::TARGET_SELECTION))
+            ._arg(flag("benches", benches).help_heading(heading::TARGET_SELECTION))
+            ._arg(
+                optional_multi_opt("bench", "NAME", bench).help_heading(heading::TARGET_SELECTION),
+            )
+            ._arg(flag("all-targets", all).help_heading(heading::TARGET_SELECTION))
     }
 
     fn arg_targets_lib_bin_example(
@@ -109,11 +130,14 @@ pub trait CommandExt: Sized {
         example: &'static str,
         examples: &'static str,
     ) -> Self {
-        self._arg(flag("lib", lib))
-            ._arg(flag("bins", bins))
-            ._arg(optional_multi_opt("bin", "NAME", bin))
-            ._arg(flag("examples", examples))
-            ._arg(optional_multi_opt("example", "NAME", example))
+        self._arg(flag("lib", lib).help_heading(heading::TARGET_SELECTION))
+            ._arg(flag("bins", bins).help_heading(heading::TARGET_SELECTION))
+            ._arg(optional_multi_opt("bin", "NAME", bin).help_heading(heading::TARGET_SELECTION))
+            ._arg(flag("examples", examples).help_heading(heading::TARGET_SELECTION))
+            ._arg(
+                optional_multi_opt("example", "NAME", example)
+                    .help_heading(heading::TARGET_SELECTION),
+            )
     }
 
     fn arg_targets_bins_examples(
@@ -123,15 +147,21 @@ pub trait CommandExt: Sized {
         example: &'static str,
         examples: &'static str,
     ) -> Self {
-        self._arg(optional_multi_opt("bin", "NAME", bin))
-            ._arg(flag("bins", bins))
-            ._arg(optional_multi_opt("example", "NAME", example))
-            ._arg(flag("examples", examples))
+        self._arg(optional_multi_opt("bin", "NAME", bin).help_heading(heading::TARGET_SELECTION))
+            ._arg(flag("bins", bins).help_heading(heading::TARGET_SELECTION))
+            ._arg(
+                optional_multi_opt("example", "NAME", example)
+                    .help_heading(heading::TARGET_SELECTION),
+            )
+            ._arg(flag("examples", examples).help_heading(heading::TARGET_SELECTION))
     }
 
     fn arg_targets_bin_example(self, bin: &'static str, example: &'static str) -> Self {
-        self._arg(optional_multi_opt("bin", "NAME", bin))
-            ._arg(optional_multi_opt("example", "NAME", example))
+        self._arg(optional_multi_opt("bin", "NAME", bin).help_heading(heading::TARGET_SELECTION))
+            ._arg(
+                optional_multi_opt("example", "NAME", example)
+                    .help_heading(heading::TARGET_SELECTION),
+            )
     }
 
     fn arg_features(self) -> Self {
@@ -141,21 +171,36 @@ pub trait CommandExt: Sized {
                 "FEATURES",
                 "Space or comma separated list of features to activate",
             )
-            .short('F'),
+            .short('F')
+            .help_heading(heading::FEATURE_SELECTION),
         )
-        ._arg(flag("all-features", "Activate all available features"))
-        ._arg(flag(
-            "no-default-features",
-            "Do not activate the `default` feature",
-        ))
+        ._arg(
+            flag("all-features", "Activate all available features")
+                .help_heading(heading::FEATURE_SELECTION),
+        )
+        ._arg(
+            flag(
+                "no-default-features",
+                "Do not activate the `default` feature",
+            )
+            .help_heading(heading::FEATURE_SELECTION),
+        )
     }
 
     fn arg_release(self, release: &'static str) -> Self {
-        self._arg(flag("release", release).short('r'))
+        self._arg(
+            flag("release", release)
+                .short('r')
+                .help_heading(heading::COMPILATION_OPTIONS),
+        )
     }
 
     fn arg_profile(self, profile: &'static str) -> Self {
-        self._arg(opt("profile", profile).value_name("PROFILE-NAME"))
+        self._arg(
+            opt("profile", profile)
+                .value_name("PROFILE-NAME")
+                .help_heading(heading::COMPILATION_OPTIONS),
+        )
     }
 
     fn arg_doc(self, doc: &'static str) -> Self {
@@ -163,17 +208,23 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_target_triple(self, target: &'static str) -> Self {
-        self._arg(multi_opt("target", "TRIPLE", target))
+        self._arg(multi_opt("target", "TRIPLE", target).help_heading(heading::COMPILATION_OPTIONS))
     }
 
     fn arg_target_dir(self) -> Self {
         self._arg(
-            opt("target-dir", "Directory for all generated artifacts").value_name("DIRECTORY"),
+            opt("target-dir", "Directory for all generated artifacts")
+                .value_name("DIRECTORY")
+                .help_heading(heading::COMPILATION_OPTIONS),
         )
     }
 
     fn arg_manifest_path(self) -> Self {
-        self._arg(opt("manifest-path", "Path to Cargo.toml").value_name("PATH"))
+        self._arg(
+            opt("manifest-path", "Path to Cargo.toml")
+                .value_name("PATH")
+                .help_heading(heading::MANIFEST_OPTIONS),
+        )
     }
 
     fn arg_message_format(self) -> Self {
@@ -181,14 +232,17 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_build_plan(self) -> Self {
-        self._arg(flag(
-            "build-plan",
-            "Output the build plan in JSON (unstable)",
-        ))
+        self._arg(
+            flag("build-plan", "Output the build plan in JSON (unstable)")
+                .help_heading(heading::COMPILATION_OPTIONS),
+        )
     }
 
     fn arg_unit_graph(self) -> Self {
-        self._arg(flag("unit-graph", "Output build graph in JSON (unstable)"))
+        self._arg(
+            flag("unit-graph", "Output build graph in JSON (unstable)")
+                .help_heading(heading::COMPILATION_OPTIONS),
+        )
     }
 
     fn arg_new_opts(self) -> Self {
@@ -252,7 +306,8 @@ pub trait CommandExt: Sized {
                 "Timing output formats (unstable) (comma separated): html, json",
             )
             .value_name("FMTS")
-            .require_equals(true),
+            .require_equals(true)
+            .help_heading(heading::COMPILATION_OPTIONS),
         )
     }
 }

--- a/tests/testsuite/cargo/help/stdout.log
+++ b/tests/testsuite/cargo/help/stdout.log
@@ -4,7 +4,6 @@ Usage: cargo [..][OPTIONS] [COMMAND]
        cargo [..][OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
 
 Options:
-  -h, --help                Print help
   -V, --version             Print version info and exit
       --list                List installed commands
       --explain <CODE>      Run `rustc --explain CODE`
@@ -17,6 +16,7 @@ Options:
       --offline             Run without accessing the network
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
 
 Some common cargo commands are (see all commands with --list):
     build, b    Compile the current package

--- a/tests/testsuite/cargo_add/help/stdout.log
+++ b/tests/testsuite/cargo_add/help/stdout.log
@@ -42,26 +42,30 @@ Options:
       --ignore-rust-version
           Ignore `rust-version` specification in packages (unstable)
 
-      --manifest-path <PATH>
-          Path to Cargo.toml
-
-  -p, --package [<SPEC>]
-          Package to modify
-
-  -q, --quiet
-          Do not print cargo log messages
-
       --dry-run
           Don't actually write the manifest
 
-  -h, --help
-          Print help (see a summary with '-h')
+  -q, --quiet
+          Do not print cargo log messages
 
   -v, --verbose...
           Use verbose output (-vv very verbose/build.rs output)
 
       --color <WHEN>
           Coloring: auto, always, never
+
+      --config <KEY=VALUE>
+          Override a configuration value
+
+  -Z <FLAG>
+          Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Manifest Options:
+      --manifest-path <PATH>
+          Path to Cargo.toml
 
       --frozen
           Require Cargo.lock and cache are up to date
@@ -72,11 +76,9 @@ Options:
       --offline
           Run without accessing the network
 
-      --config <KEY=VALUE>
-          Override a configuration value
-
-  -Z <FLAG>
-          Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+Package Selection:
+  -p, --package [<SPEC>]
+          Package to modify
 
 Source:
       --path <PATH>

--- a/tests/testsuite/cargo_bench/help/stdout.log
+++ b/tests/testsuite/cargo_bench/help/stdout.log
@@ -7,44 +7,54 @@ Arguments:
   [args]...    Arguments for the bench binary
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-      --lib                     Benchmark only this package's library
-      --bins                    Benchmark all binaries
-      --bin [<NAME>]            Benchmark only the specified binary
-      --examples                Benchmark all examples
-      --example [<NAME>]        Benchmark only the specified example
-      --tests                   Benchmark all tests
-      --test [<NAME>]           Benchmark only the specified test target
-      --benches                 Benchmark all benches
-      --bench [<NAME>]          Benchmark only the specified bench target
-      --all-targets             Benchmark all targets
-      --no-run                  Compile, but don't run benchmarks
-  -p, --package [<SPEC>]        Package to run benchmarks for
-      --workspace               Benchmark all packages in the workspace
-      --exclude <SPEC>          Exclude packages from the benchmark
-      --all                     Alias for --workspace (deprecated)
+      --no-run                Compile, but don't run benchmarks
+      --no-fail-fast          Run all benchmarks regardless of failure
+      --ignore-rust-version   Ignore `rust-version` specification in packages
+      --message-format <FMT>  Error format
+  -q, --quiet                 Do not print cargo log messages
+  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>          Coloring: auto, always, never
+      --config <KEY=VALUE>    Override a configuration value
+  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                              details
+  -h, --help                  Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to run benchmarks for
+      --workspace         Benchmark all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the benchmark
+      --all               Alias for --workspace (deprecated)
+
+Target Selection:
+      --lib               Benchmark only this package's library
+      --bins              Benchmark all binaries
+      --bin [<NAME>]      Benchmark only the specified binary
+      --examples          Benchmark all examples
+      --example [<NAME>]  Benchmark only the specified example
+      --tests             Benchmark all tests
+      --test [<NAME>]     Benchmark only the specified test target
+      --benches           Benchmark all benches
+      --bench [<NAME>]    Benchmark only the specified bench target
+      --all-targets       Benchmark all targets
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
       --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
       --target <TRIPLE>         Build for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
-      --ignore-rust-version     Ignore `rust-version` specification in packages
-      --message-format <FMT>    Error format
-      --no-fail-fast            Run all benchmarks regardless of failure
       --unit-graph              Output build graph in JSON (unstable)
       --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help bench` for more detailed information.

--- a/tests/testsuite/cargo_build/help/stdout.log
+++ b/tests/testsuite/cargo_build/help/stdout.log
@@ -3,46 +3,56 @@ Compile a local package and all of its dependencies
 Usage: cargo[EXE] build [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-  -p, --package [<SPEC>]        Package to build (see `cargo help pkgid`)
-      --workspace               Build all packages in the workspace
-      --exclude <SPEC>          Exclude packages from the build
-      --all                     Alias for --workspace (deprecated)
-  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
-      --keep-going              Do not abort the build as soon as there is an error (unstable)
-      --lib                     Build only this package's library
-      --bins                    Build all binaries
-      --bin [<NAME>]            Build only the specified binary
-      --examples                Build all examples
-      --example [<NAME>]        Build only the specified example
-      --tests                   Build all tests
-      --test [<NAME>]           Build only the specified test target
-      --benches                 Build all benches
-      --bench [<NAME>]          Build only the specified bench target
-      --all-targets             Build all targets
-  -r, --release                 Build artifacts in release mode, with optimizations
-      --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
-      --target <TRIPLE>         Build for the target triple
-      --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --out-dir <PATH>          Copy final artifacts to this directory (unstable)
-      --manifest-path <PATH>    Path to Cargo.toml
       --ignore-rust-version     Ignore `rust-version` specification in packages
-      --message-format <FMT>    Error format
-      --build-plan              Output the build plan in JSON (unstable)
-      --unit-graph              Output build graph in JSON (unstable)
       --future-incompat-report  Outputs a future incompatibility report at the end of the build
-      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
+      --message-format <FMT>    Error format
+  -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details
+  -h, --help                    Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to build (see `cargo help pkgid`)
+      --workspace         Build all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the build
+      --all               Alias for --workspace (deprecated)
+
+Target Selection:
+      --lib               Build only this package's library
+      --bins              Build all binaries
+      --bin [<NAME>]      Build only the specified binary
+      --examples          Build all examples
+      --example [<NAME>]  Build only the specified example
+      --tests             Build all tests
+      --test [<NAME>]     Build only the specified test target
+      --benches           Build all benches
+      --bench [<NAME>]    Build only the specified bench target
+      --all-targets       Build all targets
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
+  -r, --release                 Build artifacts in release mode, with optimizations
+      --profile <PROFILE-NAME>  Build artifacts with the specified profile
+  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
+      --keep-going              Do not abort the build as soon as there is an error (unstable)
+      --target <TRIPLE>         Build for the target triple
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --out-dir <PATH>          Copy final artifacts to this directory (unstable)
+      --build-plan              Output the build plan in JSON (unstable)
+      --unit-graph              Output build graph in JSON (unstable)
+      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help build` for more detailed information.

--- a/tests/testsuite/cargo_check/help/stdout.log
+++ b/tests/testsuite/cargo_check/help/stdout.log
@@ -3,44 +3,54 @@ Check a local package and all of its dependencies for errors
 Usage: cargo[EXE] check [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-  -p, --package [<SPEC>]        Package(s) to check
-      --workspace               Check all packages in the workspace
-      --exclude <SPEC>          Exclude packages from the check
-      --all                     Alias for --workspace (deprecated)
-  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
-      --keep-going              Do not abort the build as soon as there is an error (unstable)
-      --lib                     Check only this package's library
-      --bins                    Check all binaries
-      --bin [<NAME>]            Check only the specified binary
-      --examples                Check all examples
-      --example [<NAME>]        Check only the specified example
-      --tests                   Check all tests
-      --test [<NAME>]           Check only the specified test target
-      --benches                 Check all benches
-      --bench [<NAME>]          Check only the specified bench target
-      --all-targets             Check all targets
-  -r, --release                 Check artifacts in release mode, with optimizations
-      --profile <PROFILE-NAME>  Check artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
-      --target <TRIPLE>         Check for the target triple
-      --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
       --ignore-rust-version     Ignore `rust-version` specification in packages
-      --message-format <FMT>    Error format
-      --unit-graph              Output build graph in JSON (unstable)
       --future-incompat-report  Outputs a future incompatibility report at the end of the build
-      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
+      --message-format <FMT>    Error format
+  -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details
+  -h, --help                    Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package(s) to check
+      --workspace         Check all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the check
+      --all               Alias for --workspace (deprecated)
+
+Target Selection:
+      --lib               Check only this package's library
+      --bins              Check all binaries
+      --bin [<NAME>]      Check only the specified binary
+      --examples          Check all examples
+      --example [<NAME>]  Check only the specified example
+      --tests             Check all tests
+      --test [<NAME>]     Check only the specified test target
+      --benches           Check all benches
+      --bench [<NAME>]    Check only the specified bench target
+      --all-targets       Check all targets
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
+  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
+      --keep-going              Do not abort the build as soon as there is an error (unstable)
+  -r, --release                 Check artifacts in release mode, with optimizations
+      --profile <PROFILE-NAME>  Check artifacts with the specified profile
+      --target <TRIPLE>         Check for the target triple
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --unit-graph              Output build graph in JSON (unstable)
+      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help check` for more detailed information.

--- a/tests/testsuite/cargo_clean/help/stdout.log
+++ b/tests/testsuite/cargo_clean/help/stdout.log
@@ -3,22 +3,27 @@ Remove artifacts that cargo has generated in the past
 Usage: cargo[EXE] clean [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-  -p, --package [<SPEC>]        Package to clean artifacts for
-      --manifest-path <PATH>    Path to Cargo.toml
-      --target <TRIPLE>         Target triple to clean output for
-      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --doc                 Whether or not to clean just the documentation directory
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to clean artifacts for
+
+Compilation Options:
   -r, --release                 Whether or not to clean release artifacts
       --profile <PROFILE-NAME>  Clean artifacts of the specified profile
-      --doc                     Whether or not to clean just the documentation directory
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+      --target <TRIPLE>         Target triple to clean output for
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help clean` for more detailed information.

--- a/tests/testsuite/cargo_config/help/stdout.log
+++ b/tests/testsuite/cargo_config/help/stdout.log
@@ -6,11 +6,13 @@ Commands:
   get  
 
 Options:
-  -h, --help                Print help
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>        Coloring: auto, always, never
-      --frozen              Require Cargo.lock and cache are up to date
-      --locked              Require Cargo.lock is up to date
-      --offline             Run without accessing the network
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network

--- a/tests/testsuite/cargo_doc/help/stdout.log
+++ b/tests/testsuite/cargo_doc/help/stdout.log
@@ -3,41 +3,51 @@ Build a package's documentation
 Usage: cargo[EXE] doc [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
       --open                    Opens the docs in a browser after the operation
-  -p, --package [<SPEC>]        Package to document
-      --workspace               Document all packages in the workspace
-      --exclude <SPEC>          Exclude packages from the build
-      --all                     Alias for --workspace (deprecated)
       --no-deps                 Don't build documentation for dependencies
       --document-private-items  Document private items
-  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
-      --keep-going              Do not abort the build as soon as there is an error (unstable)
-      --lib                     Document only this package's library
-      --bins                    Document all binaries
-      --bin [<NAME>]            Document only the specified binary
-      --examples                Document all examples
-      --example [<NAME>]        Document only the specified example
-  -r, --release                 Build artifacts in release mode, with optimizations
-      --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
-      --target <TRIPLE>         Build for the target triple
-      --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
-      --message-format <FMT>    Error format
       --ignore-rust-version     Ignore `rust-version` specification in packages
-      --unit-graph              Output build graph in JSON (unstable)
-      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
+      --message-format <FMT>    Error format
+  -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details
+  -h, --help                    Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to document
+      --workspace         Document all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the build
+      --all               Alias for --workspace (deprecated)
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Target Selection:
+      --lib               Document only this package's library
+      --bins              Document all binaries
+      --bin [<NAME>]      Document only the specified binary
+      --examples          Document all examples
+      --example [<NAME>]  Document only the specified example
+
+Compilation Options:
+  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
+      --keep-going              Do not abort the build as soon as there is an error (unstable)
+  -r, --release                 Build artifacts in release mode, with optimizations
+      --profile <PROFILE-NAME>  Build artifacts with the specified profile
+      --target <TRIPLE>         Build for the target triple
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --unit-graph              Output build graph in JSON (unstable)
+      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help doc` for more detailed information.

--- a/tests/testsuite/cargo_fetch/help/stdout.log
+++ b/tests/testsuite/cargo_fetch/help/stdout.log
@@ -3,17 +3,20 @@ Fetch dependencies of a package from the network
 Usage: cargo[EXE] fetch [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Compilation Options:
+      --target <TRIPLE>  Fetch dependencies for the target triple
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-      --target <TRIPLE>       Fetch dependencies for the target triple
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
 
 Run `cargo help fetch` for more detailed information.

--- a/tests/testsuite/cargo_fix/help/stdout.log
+++ b/tests/testsuite/cargo_fix/help/stdout.log
@@ -3,48 +3,58 @@ Automatically fix lint warnings reported by rustc
 Usage: cargo[EXE] fix [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-  -p, --package [<SPEC>]        Package(s) to fix
-      --workspace               Fix all packages in the workspace
-      --exclude <SPEC>          Exclude packages from the fixes
-      --all                     Alias for --workspace (deprecated)
+      --edition               Fix in preparation for the next edition
+      --edition-idioms        Fix warnings to migrate to the idioms of an edition
+      --broken-code           Fix code even if it already has compiler errors
+      --allow-no-vcs          Fix code even if a VCS was not detected
+      --allow-dirty           Fix code even if the working directory is dirty
+      --allow-staged          Fix code even if the working directory has staged changes
+      --ignore-rust-version   Ignore `rust-version` specification in packages
+      --message-format <FMT>  Error format
+  -q, --quiet                 Do not print cargo log messages
+  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>          Coloring: auto, always, never
+      --config <KEY=VALUE>    Override a configuration value
+  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                              details
+  -h, --help                  Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package(s) to fix
+      --workspace         Fix all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the fixes
+      --all               Alias for --workspace (deprecated)
+
+Target Selection:
+      --lib               Fix only this package's library
+      --bins              Fix all binaries
+      --bin [<NAME>]      Fix only the specified binary
+      --examples          Fix all examples
+      --example [<NAME>]  Fix only the specified example
+      --tests             Fix all tests
+      --test [<NAME>]     Fix only the specified test target
+      --benches           Fix all benches
+      --bench [<NAME>]    Fix only the specified bench target
+      --all-targets       Fix all targets (default)
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
-      --lib                     Fix only this package's library
-      --bins                    Fix all binaries
-      --bin [<NAME>]            Fix only the specified binary
-      --examples                Fix all examples
-      --example [<NAME>]        Fix only the specified example
-      --tests                   Fix all tests
-      --test [<NAME>]           Fix only the specified test target
-      --benches                 Fix all benches
-      --bench [<NAME>]          Fix only the specified bench target
-      --all-targets             Fix all targets (default)
   -r, --release                 Fix artifacts in release mode, with optimizations
       --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
       --target <TRIPLE>         Fix for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
-      --message-format <FMT>    Error format
-      --broken-code             Fix code even if it already has compiler errors
-      --edition                 Fix in preparation for the next edition
-      --edition-idioms          Fix warnings to migrate to the idioms of an edition
-      --allow-no-vcs            Fix code even if a VCS was not detected
-      --allow-dirty             Fix code even if the working directory is dirty
-      --allow-staged            Fix code even if the working directory has staged changes
-      --ignore-rust-version     Ignore `rust-version` specification in packages
       --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help fix` for more detailed information.

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.log
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.log
@@ -3,16 +3,17 @@ Generate the lockfile for a package
 Usage: cargo[EXE] generate-lockfile [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
 
 Run `cargo help generate-lockfile` for more detailed information.

--- a/tests/testsuite/cargo_help/help/stdout.log
+++ b/tests/testsuite/cargo_help/help/stdout.log
@@ -6,11 +6,13 @@ Arguments:
   [COMMAND]  
 
 Options:
-  -h, --help                Print help
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>        Coloring: auto, always, never
-      --frozen              Require Cargo.lock and cache are up to date
-      --locked              Require Cargo.lock is up to date
-      --offline             Run without accessing the network
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network

--- a/tests/testsuite/cargo_init/help/stdout.log
+++ b/tests/testsuite/cargo_init/help/stdout.log
@@ -6,8 +6,6 @@ Arguments:
   [path]  [default: .]
 
 Options:
-  -q, --quiet                Do not print cargo log messages
-      --registry <REGISTRY>  Registry to use
       --vcs <VCS>            Initialize a new repository for the given version control system (git,
                              hg, pijul, or fossil) or do not initialize any version control at all
                              (none), overriding a global configuration. [possible values: git, hg,
@@ -17,13 +15,17 @@ Options:
       --edition <YEAR>       Edition to set for the crate generated [possible values: 2015, 2018,
                              2021]
       --name <NAME>          Set the resulting package name, defaults to the directory name
-  -h, --help                 Print help
+      --registry <REGISTRY>  Registry to use
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help init` for more detailed information.

--- a/tests/testsuite/cargo_install/help/stdout.log
+++ b/tests/testsuite/cargo_install/help/stdout.log
@@ -6,43 +6,51 @@ Arguments:
   [crate]...  
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-      --version <VERSION>       Specify a version to install
-      --git <URL>               Git URL to install the specified crate from
-      --branch <BRANCH>         Branch to use when installing from git
-      --tag <TAG>               Tag to use when installing from git
-      --rev <SHA>               Specific commit to use when installing from git
-      --path <PATH>             Filesystem path to local crate to install
-      --list                    list all installed packages and their versions
+      --version <VERSION>     Specify a version to install
+      --index <INDEX>         Registry index to install from
+      --registry <REGISTRY>   Registry to use
+      --git <URL>             Git URL to install the specified crate from
+      --branch <BRANCH>       Branch to use when installing from git
+      --tag <TAG>             Tag to use when installing from git
+      --rev <SHA>             Specific commit to use when installing from git
+      --path <PATH>           Filesystem path to local crate to install
+      --root <DIR>            Directory to install packages into
+  -f, --force                 Force overwriting existing crates or binaries
+      --no-track              Do not save tracking information
+      --list                  list all installed packages and their versions
+      --ignore-rust-version   Ignore `rust-version` specification in packages
+      --message-format <FMT>  Error format
+  -q, --quiet                 Do not print cargo log messages
+      --debug                 Build in debug mode (with the 'dev' profile) instead of release mode
+  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>          Coloring: auto, always, never
+      --config <KEY=VALUE>    Override a configuration value
+  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                              details
+  -h, --help                  Print help
+
+Target Selection:
+      --bin [<NAME>]      Install only the specified binary
+      --bins              Install all binaries
+      --example [<NAME>]  Install only the specified example
+      --examples          Install all examples
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
-  -f, --force                   Force overwriting existing crates or binaries
-      --no-track                Do not save tracking information
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
       --profile <PROFILE-NAME>  Install artifacts with the specified profile
-      --debug                   Build in debug mode (with the 'dev' profile) instead of release mode
-      --bin [<NAME>]            Install only the specified binary
-      --bins                    Install all binaries
-      --example [<NAME>]        Install only the specified example
-      --examples                Install all examples
       --target <TRIPLE>         Build for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --root <DIR>              Directory to install packages into
-      --index <INDEX>           Registry index to install from
-      --registry <REGISTRY>     Registry to use
-      --ignore-rust-version     Ignore `rust-version` specification in packages
-      --message-format <FMT>    Error format
       --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help install` for more detailed information.

--- a/tests/testsuite/cargo_locate_project/help/stdout.log
+++ b/tests/testsuite/cargo_locate_project/help/stdout.log
@@ -3,18 +3,20 @@ Print a JSON representation of a Cargo.toml file's location
 Usage: cargo[EXE] locate-project [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
-      --manifest-path <PATH>  Path to Cargo.toml
-      --message-format <FMT>  Output representation [possible values: json, plain]
       --workspace             Locate Cargo.toml of the workspace root
-  -h, --help                  Print help
+      --message-format <FMT>  Output representation [possible values: json, plain]
+  -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
-      --frozen                Require Cargo.lock and cache are up to date
-      --locked                Require Cargo.lock is up to date
-      --offline               Run without accessing the network
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details
+  -h, --help                  Print help
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help locate-project` for more detailed information.

--- a/tests/testsuite/cargo_login/help/stdout.log
+++ b/tests/testsuite/cargo_login/help/stdout.log
@@ -6,15 +6,17 @@ Arguments:
   [token]  
 
 Options:
-  -q, --quiet                Do not print cargo log messages
       --registry <REGISTRY>  Registry to use
-  -h, --help                 Print help
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help login` for more detailed information.

--- a/tests/testsuite/cargo_logout/help/stdout.log
+++ b/tests/testsuite/cargo_logout/help/stdout.log
@@ -3,15 +3,17 @@ Remove an API token from the registry locally
 Usage: cargo[EXE] logout [OPTIONS]
 
 Options:
-  -q, --quiet                Do not print cargo log messages
       --registry <REGISTRY>  Registry to use
-  -h, --help                 Print help
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help logout` for more detailed information.

--- a/tests/testsuite/cargo_metadata/help/stdout.log
+++ b/tests/testsuite/cargo_metadata/help/stdout.log
@@ -4,23 +4,27 @@ machine-readable format
 Usage: cargo[EXE] metadata [OPTIONS]
 
 Options:
-  -q, --quiet                     Do not print cargo log messages
-  -F, --features <FEATURES>       Space or comma separated list of features to activate
-      --all-features              Activate all available features
-      --no-default-features       Do not activate the `default` feature
       --filter-platform <TRIPLE>  Only include resolve dependencies matching the given target-triple
       --no-deps                   Output information only about the workspace members and don't
                                   fetch dependencies
-      --manifest-path <PATH>      Path to Cargo.toml
       --format-version <VERSION>  Format version [possible values: 1]
-  -h, --help                      Print help
+  -q, --quiet                     Do not print cargo log messages
   -v, --verbose...                Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>              Coloring: auto, always, never
-      --frozen                    Require Cargo.lock and cache are up to date
-      --locked                    Require Cargo.lock is up to date
-      --offline                   Run without accessing the network
       --config <KEY=VALUE>        Override a configuration value
   -Z <FLAG>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details
+  -h, --help                      Print help
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help metadata` for more detailed information.

--- a/tests/testsuite/cargo_new/help/stdout.log
+++ b/tests/testsuite/cargo_new/help/stdout.log
@@ -6,8 +6,6 @@ Arguments:
   <path>  
 
 Options:
-  -q, --quiet                Do not print cargo log messages
-      --registry <REGISTRY>  Registry to use
       --vcs <VCS>            Initialize a new repository for the given version control system (git,
                              hg, pijul, or fossil) or do not initialize any version control at all
                              (none), overriding a global configuration. [possible values: git, hg,
@@ -17,13 +15,17 @@ Options:
       --edition <YEAR>       Edition to set for the crate generated [possible values: 2015, 2018,
                              2021]
       --name <NAME>          Set the resulting package name, defaults to the directory name
-  -h, --help                 Print help
+      --registry <REGISTRY>  Registry to use
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help new` for more detailed information.

--- a/tests/testsuite/cargo_owner/help/stdout.log
+++ b/tests/testsuite/cargo_owner/help/stdout.log
@@ -6,20 +6,22 @@ Arguments:
   [crate]  
 
 Options:
-  -q, --quiet                Do not print cargo log messages
   -a, --add <LOGIN>          Name of a user or team to invite as an owner
   -r, --remove <LOGIN>       Name of a user or team to remove as an owner
   -l, --list                 List owners of a crate
       --index <INDEX>        Registry index to modify owners for
       --token <TOKEN>        API token to use when authenticating
       --registry <REGISTRY>  Registry to use
-  -h, --help                 Print help
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help owner` for more detailed information.

--- a/tests/testsuite/cargo_package/help/stdout.log
+++ b/tests/testsuite/cargo_package/help/stdout.log
@@ -3,30 +3,37 @@ Assemble the local package into a distributable tarball
 Usage: cargo[EXE] package [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-  -l, --list                    Print files included in a package without making one
-      --no-verify               Don't verify the contents by building them
-      --no-metadata             Ignore warnings about a lack of human-usable metadata
-      --allow-dirty             Allow dirty working directories to be packaged
+  -l, --list                Print files included in a package without making one
+      --no-verify           Don't verify the contents by building them
+      --no-metadata         Ignore warnings about a lack of human-usable metadata
+      --allow-dirty         Allow dirty working directories to be packaged
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package(s) to assemble
+      --workspace         Assemble all packages in the workspace
+      --exclude <SPEC>    Don't assemble specified packages
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
       --target <TRIPLE>         Build for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
-  -p, --package [<SPEC>]        Package(s) to assemble
-      --workspace               Assemble all packages in the workspace
-      --exclude <SPEC>          Don't assemble specified packages
-      --manifest-path <PATH>    Path to Cargo.toml
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help package` for more detailed information.

--- a/tests/testsuite/cargo_pkgid/help/stdout.log
+++ b/tests/testsuite/cargo_pkgid/help/stdout.log
@@ -6,17 +6,20 @@ Arguments:
   [spec]  
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
-  -p, --package [<SPEC>]      Argument to get the package ID specifier for
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Argument to get the package ID specifier for
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
 
 Run `cargo help pkgid` for more detailed information.

--- a/tests/testsuite/cargo_publish/help/stdout.log
+++ b/tests/testsuite/cargo_publish/help/stdout.log
@@ -3,30 +3,37 @@ Upload a package to the registry
 Usage: cargo[EXE] publish [OPTIONS]
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-      --index <INDEX>           Registry index URL to upload the package to
-      --token <TOKEN>           Token to use when uploading
-      --no-verify               Don't verify the contents by building them
-      --allow-dirty             Allow dirty working directories to be packaged
-      --target <TRIPLE>         Build for the target triple
-      --target-dir <DIRECTORY>  Directory for all generated artifacts
-  -p, --package [<SPEC>]        Package to publish
-      --manifest-path <PATH>    Path to Cargo.toml
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
+      --dry-run              Perform all checks without uploading
+      --index <INDEX>        Registry index URL to upload the package to
+      --registry <REGISTRY>  Registry to publish to
+      --token <TOKEN>        Token to use when uploading
+      --no-verify            Don't verify the contents by building them
+      --allow-dirty          Allow dirty working directories to be packaged
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to publish
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
-      --dry-run                 Perform all checks without uploading
-      --registry <REGISTRY>     Registry to publish to
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+      --target <TRIPLE>         Build for the target triple
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help publish` for more detailed information.

--- a/tests/testsuite/cargo_read_manifest/help/stdout.log
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.log
@@ -5,14 +5,15 @@ Deprecated, use `cargo metadata --no-deps` instead.
 Usage: cargo[EXE] read-manifest [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details

--- a/tests/testsuite/cargo_remove/help/stdout.log
+++ b/tests/testsuite/cargo_remove/help/stdout.log
@@ -6,21 +6,24 @@ Arguments:
   <DEP_ID>...  Dependencies to be removed
 
 Options:
-  -p, --package [<SPEC>]      Package to remove from
-      --manifest-path <PATH>  Path to Cargo.toml
-  -q, --quiet                 Do not print cargo log messages
-      --dry-run               Don't actually write the manifest
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
-      --frozen                Require Cargo.lock and cache are up to date
-      --locked                Require Cargo.lock is up to date
-      --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
+      --dry-run             Don't actually write the manifest
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
 
 Section:
       --dev              Remove as development dependency
       --build            Remove as build dependency
       --target <TARGET>  Remove as dependency from the given target platform
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to remove from
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network

--- a/tests/testsuite/cargo_report/help/stdout.log
+++ b/tests/testsuite/cargo_report/help/stdout.log
@@ -6,13 +6,15 @@ Commands:
   future-incompatibilities  Reports any crates which will eventually stop compiling
 
 Options:
-  -h, --help                Print help
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>        Coloring: auto, always, never
-      --frozen              Require Cargo.lock and cache are up to date
-      --locked              Require Cargo.lock is up to date
-      --offline             Run without accessing the network
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help report` for more detailed information.

--- a/tests/testsuite/cargo_run/help/stdout.log
+++ b/tests/testsuite/cargo_run/help/stdout.log
@@ -6,32 +6,42 @@ Arguments:
   [args]...  Arguments for the binary or example to run
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-      --bin [<NAME>]            Name of the bin target to run
-      --example [<NAME>]        Name of the example target to run
-  -p, --package [<SPEC>]        Package with the target to run
+      --ignore-rust-version   Ignore `rust-version` specification in packages
+      --message-format <FMT>  Error format
+  -q, --quiet                 Do not print cargo log messages
+  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>          Coloring: auto, always, never
+      --config <KEY=VALUE>    Override a configuration value
+  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                              details
+  -h, --help                  Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package with the target to run
+
+Target Selection:
+      --bin [<NAME>]      Name of the bin target to run
+      --example [<NAME>]  Name of the example target to run
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
   -r, --release                 Build artifacts in release mode, with optimizations
       --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
       --target <TRIPLE>         Build for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
-      --message-format <FMT>    Error format
       --unit-graph              Output build graph in JSON (unstable)
-      --ignore-rust-version     Ignore `rust-version` specification in packages
       --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help run` for more detailed information.

--- a/tests/testsuite/cargo_rustc/help/stdout.log
+++ b/tests/testsuite/cargo_rustc/help/stdout.log
@@ -6,43 +6,53 @@ Arguments:
   [args]...  Extra rustc flags
 
 Options:
-  -q, --quiet                    Do not print cargo log messages
-  -p, --package [<SPEC>]         Package to build
-  -j, --jobs <N>                 Number of parallel jobs, defaults to # of CPUs.
-      --keep-going               Do not abort the build as soon as there is an error (unstable)
-      --lib                      Build only this package's library
-      --bins                     Build all binaries
-      --bin [<NAME>]             Build only the specified binary
-      --examples                 Build all examples
-      --example [<NAME>]         Build only the specified example
-      --tests                    Build all tests
-      --test [<NAME>]            Build only the specified test target
-      --benches                  Build all benches
-      --bench [<NAME>]           Build only the specified bench target
-      --all-targets              Build all targets
-  -r, --release                  Build artifacts in release mode, with optimizations
-      --profile <PROFILE-NAME>   Build artifacts with the specified profile
-  -F, --features <FEATURES>      Space or comma separated list of features to activate
-      --all-features             Activate all available features
-      --no-default-features      Do not activate the `default` feature
-      --target <TRIPLE>          Target triple which compiles will be for
       --print <INFO>             Output compiler information without compiling
       --crate-type <CRATE-TYPE>  Comma separated list of types of crates for the compiler to emit
-      --target-dir <DIRECTORY>   Directory for all generated artifacts
-      --manifest-path <PATH>     Path to Cargo.toml
-      --message-format <FMT>     Error format
-      --unit-graph               Output build graph in JSON (unstable)
-      --ignore-rust-version      Ignore `rust-version` specification in packages
       --future-incompat-report   Outputs a future incompatibility report at the end of the build
-      --timings[=<FMTS>]         Timing output formats (unstable) (comma separated): html, json
-  -h, --help                     Print help
+      --ignore-rust-version      Ignore `rust-version` specification in packages
+      --message-format <FMT>     Error format
+  -q, --quiet                    Do not print cargo log messages
   -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>             Coloring: auto, always, never
-      --frozen                   Require Cargo.lock and cache are up to date
-      --locked                   Require Cargo.lock is up to date
-      --offline                  Run without accessing the network
       --config <KEY=VALUE>       Override a configuration value
   -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                  details
+  -h, --help                     Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to build
+
+Target Selection:
+      --lib               Build only this package's library
+      --bins              Build all binaries
+      --bin [<NAME>]      Build only the specified binary
+      --examples          Build all examples
+      --example [<NAME>]  Build only the specified example
+      --tests             Build all tests
+      --test [<NAME>]     Build only the specified test target
+      --benches           Build all benches
+      --bench [<NAME>]    Build only the specified bench target
+      --all-targets       Build all targets
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
+  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
+      --keep-going              Do not abort the build as soon as there is an error (unstable)
+  -r, --release                 Build artifacts in release mode, with optimizations
+      --profile <PROFILE-NAME>  Build artifacts with the specified profile
+      --target <TRIPLE>         Target triple which compiles will be for
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --unit-graph              Output build graph in JSON (unstable)
+      --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help rustc` for more detailed information.

--- a/tests/testsuite/cargo_rustdoc/help/stdout.log
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.log
@@ -6,41 +6,51 @@ Arguments:
   [args]...  Extra rustdoc flags
 
 Options:
-  -q, --quiet                   Do not print cargo log messages
-      --open                    Opens the docs in a browser after the operation
-  -p, --package [<SPEC>]        Package to document
+      --open                  Opens the docs in a browser after the operation
+      --ignore-rust-version   Ignore `rust-version` specification in packages
+      --message-format <FMT>  Error format
+  -q, --quiet                 Do not print cargo log messages
+  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>          Coloring: auto, always, never
+      --config <KEY=VALUE>    Override a configuration value
+  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                              details
+  -h, --help                  Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to document
+
+Target Selection:
+      --lib               Build only this package's library
+      --bins              Build all binaries
+      --bin [<NAME>]      Build only the specified binary
+      --examples          Build all examples
+      --example [<NAME>]  Build only the specified example
+      --tests             Build all tests
+      --test [<NAME>]     Build only the specified test target
+      --benches           Build all benches
+      --bench [<NAME>]    Build only the specified bench target
+      --all-targets       Build all targets
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
-      --lib                     Build only this package's library
-      --bins                    Build all binaries
-      --bin [<NAME>]            Build only the specified binary
-      --examples                Build all examples
-      --example [<NAME>]        Build only the specified example
-      --tests                   Build all tests
-      --test [<NAME>]           Build only the specified test target
-      --benches                 Build all benches
-      --bench [<NAME>]          Build only the specified bench target
-      --all-targets             Build all targets
   -r, --release                 Build artifacts in release mode, with optimizations
       --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
       --target <TRIPLE>         Build for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
-      --message-format <FMT>    Error format
       --unit-graph              Output build graph in JSON (unstable)
-      --ignore-rust-version     Ignore `rust-version` specification in packages
       --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help rustdoc` for more detailed information.

--- a/tests/testsuite/cargo_search/help/stdout.log
+++ b/tests/testsuite/cargo_search/help/stdout.log
@@ -6,17 +6,19 @@ Arguments:
   [query]...  
 
 Options:
-  -q, --quiet                Do not print cargo log messages
-      --index <INDEX>        Registry index URL to upload the package to
       --limit <LIMIT>        Limit the number of results (default: 10, max: 100)
+      --index <INDEX>        Registry index URL to upload the package to
       --registry <REGISTRY>  Registry to use
-  -h, --help                 Print help
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help search` for more detailed information.

--- a/tests/testsuite/cargo_test/help/stdout.log
+++ b/tests/testsuite/cargo_test/help/stdout.log
@@ -7,48 +7,58 @@ Arguments:
   [args]...   Arguments for the test binary
 
 Options:
-  -q, --quiet                   Display one character per test instead of one line
-      --lib                     Test only this package's library unit tests
-      --bins                    Test all binaries
-      --bin [<NAME>]            Test only the specified binary
-      --examples                Test all examples
-      --example [<NAME>]        Test only the specified example
-      --tests                   Test all tests
-      --test [<NAME>]           Test only the specified test target
-      --benches                 Test all benches
-      --bench [<NAME>]          Test only the specified bench target
-      --all-targets             Test all targets (does not include doctests)
       --doc                     Test only this library's documentation
       --no-run                  Compile, but don't run tests
       --no-fail-fast            Run all tests regardless of failure
-  -p, --package [<SPEC>]        Package to run tests for
-      --workspace               Test all packages in the workspace
-      --exclude <SPEC>          Exclude packages from the test
-      --all                     Alias for --workspace (deprecated)
+      --ignore-rust-version     Ignore `rust-version` specification in packages
+      --future-incompat-report  Outputs a future incompatibility report at the end of the build
+      --message-format <FMT>    Error format
+  -q, --quiet                   Display one character per test instead of one line
+  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>            Coloring: auto, always, never
+      --config <KEY=VALUE>      Override a configuration value
+  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                                details
+  -h, --help                    Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to run tests for
+      --workspace         Test all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the test
+      --all               Alias for --workspace (deprecated)
+
+Target Selection:
+      --lib               Test only this package's library unit tests
+      --bins              Test all binaries
+      --bin [<NAME>]      Test only the specified binary
+      --examples          Test all examples
+      --example [<NAME>]  Test only the specified example
+      --tests             Test all tests
+      --test [<NAME>]     Test only the specified test target
+      --benches           Test all benches
+      --bench [<NAME>]    Test only the specified bench target
+      --all-targets       Test all targets (does not include doctests)
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
   -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
       --keep-going              Do not abort the build as soon as there is an error (unstable)
   -r, --release                 Build artifacts in release mode, with optimizations
       --profile <PROFILE-NAME>  Build artifacts with the specified profile
-  -F, --features <FEATURES>     Space or comma separated list of features to activate
-      --all-features            Activate all available features
-      --no-default-features     Do not activate the `default` feature
       --target <TRIPLE>         Build for the target triple
       --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --manifest-path <PATH>    Path to Cargo.toml
-      --ignore-rust-version     Ignore `rust-version` specification in packages
-      --message-format <FMT>    Error format
       --unit-graph              Output build graph in JSON (unstable)
-      --future-incompat-report  Outputs a future incompatibility report at the end of the build
       --timings[=<FMTS>]        Timing output formats (unstable) (comma separated): html, json
-  -h, --help                    Print help
-  -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>            Coloring: auto, always, never
-      --frozen                  Require Cargo.lock and cache are up to date
-      --locked                  Require Cargo.lock is up to date
-      --offline                 Run without accessing the network
-      --config <KEY=VALUE>      Override a configuration value
-  -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                                details
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help test` for more detailed information.
 Run `cargo test -- --help` for test binary options.

--- a/tests/testsuite/cargo_tree/help/stdout.log
+++ b/tests/testsuite/cargo_tree/help/stdout.log
@@ -3,36 +3,43 @@ Display a tree visualization of a dependency graph
 Usage: cargo[EXE] tree [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
+  -q, --quiet               Do not print cargo log messages
+  -e, --edges <KINDS>       The kinds of dependencies to display (features, normal, build, dev, all,
+                            no-normal, no-build, no-dev, no-proc-macro)
+  -i, --invert [<SPEC>]     Invert the tree direction and focus on the given package
+      --prune <SPEC>        Prune the given package from the display of the dependency tree
+      --depth <DEPTH>       Maximum display depth of the dependency tree
+      --prefix <PREFIX>     Change the prefix (indentation) of how each entry is displayed [default:
+                            indent] [possible values: depth, indent, none]
+      --no-dedupe           Do not de-duplicate (repeats all shared dependencies)
+  -d, --duplicates          Show only dependencies which come in multiple versions (implies -i)
+      --charset <CHARSET>   Character set to use in output [default: utf8] [possible values: utf8,
+                            ascii]
+  -f, --format <FORMAT>     Format string used for printing dependencies [default: {p}]
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to be used as the root of the tree
+      --workspace         Display the tree for all packages in the workspace
+      --exclude <SPEC>    Exclude specific workspace members
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
+      --target <TRIPLE>  Filter dependencies matching the given target-triple (default host
+                         platform). Pass `all` to include all targets.
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-  -p, --package [<SPEC>]      Package to be used as the root of the tree
-      --workspace             Display the tree for all packages in the workspace
-      --exclude <SPEC>        Exclude specific workspace members
-  -F, --features <FEATURES>   Space or comma separated list of features to activate
-      --all-features          Activate all available features
-      --no-default-features   Do not activate the `default` feature
-      --target <TRIPLE>       Filter dependencies matching the given target-triple (default host
-                              platform). Pass `all` to include all targets.
-  -e, --edges <KINDS>         The kinds of dependencies to display (features, normal, build, dev,
-                              all, no-normal, no-build, no-dev, no-proc-macro)
-  -i, --invert [<SPEC>]       Invert the tree direction and focus on the given package
-      --prune <SPEC>          Prune the given package from the display of the dependency tree
-      --depth <DEPTH>         Maximum display depth of the dependency tree
-      --prefix <PREFIX>       Change the prefix (indentation) of how each entry is displayed
-                              [default: indent] [possible values: depth, indent, none]
-      --no-dedupe             Do not de-duplicate (repeats all shared dependencies)
-  -d, --duplicates            Show only dependencies which come in multiple versions (implies -i)
-      --charset <CHARSET>     Character set to use in output [default: utf8] [possible values: utf8,
-                              ascii]
-  -f, --format <FORMAT>       Format string used for printing dependencies [default: {p}]
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
 
 Run `cargo help tree` for more detailed information.

--- a/tests/testsuite/cargo_uninstall/help/stdout.log
+++ b/tests/testsuite/cargo_uninstall/help/stdout.log
@@ -6,17 +6,23 @@ Arguments:
   [spec]...  
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -p, --package [<SPEC>]    Package to uninstall
-      --bin <NAME>          Only uninstall the binary NAME
       --root <DIR>          Directory to uninstall packages from
-  -h, --help                Print help
+  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>        Coloring: auto, always, never
-      --frozen              Require Cargo.lock and cache are up to date
-      --locked              Require Cargo.lock is up to date
-      --offline             Run without accessing the network
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to uninstall
+
+Target Selection:
+      --bin <NAME>  Only uninstall the binary NAME
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help uninstall` for more detailed information.

--- a/tests/testsuite/cargo_update/help/stdout.log
+++ b/tests/testsuite/cargo_update/help/stdout.log
@@ -3,21 +3,24 @@ Update dependencies as recorded in the local lock file
 Usage: cargo[EXE] update [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
-  -w, --workspace             Only update the workspace packages
-  -p, --package [<SPEC>]      Package to update
-      --aggressive            Force updating all dependencies of SPEC as well when used with -p
-      --precise <PRECISE>     Update a single dependency to exactly PRECISE when used with -p
+      --dry-run             Don't actually write the lockfile
+      --aggressive          Force updating all dependencies of SPEC as well when used with -p
+      --precise <PRECISE>   Update a single dependency to exactly PRECISE when used with -p
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Package Selection:
+  -w, --workspace         Only update the workspace packages
+  -p, --package [<SPEC>]  Package to update
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-      --dry-run               Don't actually write the lockfile
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
 
 Run `cargo help update` for more detailed information.

--- a/tests/testsuite/cargo_vendor/help/stdout.log
+++ b/tests/testsuite/cargo_vendor/help/stdout.log
@@ -6,20 +6,22 @@ Arguments:
   [path]  Where to vendor crates (`vendor` by default)
 
 Options:
-  -q, --quiet                  Do not print cargo log messages
-      --manifest-path <PATH>   Path to Cargo.toml
       --no-delete              Don't delete older crates in the vendor directory
   -s, --sync <TOML>            Additional `Cargo.toml` to sync and vendor
       --respect-source-config  Respect `[source]` config in `.cargo/config`
       --versioned-dirs         Always include version in subdir name
-  -h, --help                   Print help
+  -q, --quiet                  Do not print cargo log messages
   -v, --verbose...             Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>           Coloring: auto, always, never
-      --frozen                 Require Cargo.lock and cache are up to date
-      --locked                 Require Cargo.lock is up to date
-      --offline                Run without accessing the network
       --config <KEY=VALUE>     Override a configuration value
   -Z <FLAG>                    Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                details
+  -h, --help                   Print help
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --frozen                Require Cargo.lock and cache are up to date
+      --locked                Require Cargo.lock is up to date
+      --offline               Run without accessing the network
 
 Run `cargo help vendor` for more detailed information.

--- a/tests/testsuite/cargo_verify_project/help/stdout.log
+++ b/tests/testsuite/cargo_verify_project/help/stdout.log
@@ -3,16 +3,17 @@ Check correctness of crate manifest
 Usage: cargo[EXE] verify-project [OPTIONS]
 
 Options:
-  -q, --quiet                 Do not print cargo log messages
+  -q, --quiet               Do not print cargo log messages
+  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>        Coloring: auto, always, never
+      --config <KEY=VALUE>  Override a configuration value
+  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml
-  -h, --help                  Print help
-  -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>          Coloring: auto, always, never
       --frozen                Require Cargo.lock and cache are up to date
       --locked                Require Cargo.lock is up to date
       --offline               Run without accessing the network
-      --config <KEY=VALUE>    Override a configuration value
-  -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
-                              details
 
 Run `cargo help verify-project` for more detailed information.

--- a/tests/testsuite/cargo_version/help/stdout.log
+++ b/tests/testsuite/cargo_version/help/stdout.log
@@ -4,13 +4,15 @@ Usage: cargo[EXE] version [OPTIONS]
 
 Options:
   -q, --quiet               Do not print cargo log messages
-  -h, --help                Print help
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>        Coloring: auto, always, never
-      --frozen              Require Cargo.lock and cache are up to date
-      --locked              Require Cargo.lock is up to date
-      --offline             Run without accessing the network
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help version` for more detailed information.

--- a/tests/testsuite/cargo_yank/help/stdout.log
+++ b/tests/testsuite/cargo_yank/help/stdout.log
@@ -6,19 +6,21 @@ Arguments:
   [crate]  
 
 Options:
-  -q, --quiet                Do not print cargo log messages
       --version <VERSION>    The version to yank or un-yank
       --undo                 Undo a yank, putting a version back into the index
       --index <INDEX>        Registry index to yank from
-      --token <TOKEN>        API token to use when authenticating
       --registry <REGISTRY>  Registry to use
-  -h, --help                 Print help
+      --token <TOKEN>        API token to use when authenticating
+  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
-      --frozen               Require Cargo.lock and cache are up to date
-      --locked               Require Cargo.lock is up to date
-      --offline              Run without accessing the network
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
+
+Manifest Options:
+      --frozen   Require Cargo.lock and cache are up to date
+      --locked   Require Cargo.lock is up to date
+      --offline  Run without accessing the network
 
 Run `cargo help yank` for more detailed information.


### PR DESCRIPTION
This mirrors some of the categories from `cargo help` (the man pages) using [`clap::Arg::help_heading`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.help_heading).
There are fewer categories to avoid extra vertical space.  Instead, they
are left int the `Options` category but put first.

The goal is to try to make it easier to scan `--help` output as the list of flags can get quite long and its easy to miss what features are there.