### PR TITLE
Warn when a dependency is available from multiple registries

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -675,7 +675,7 @@ impl<'cfg> PackageSet<'cfg> {
                 ))?;
 
                 ws.config().shell().note(&format!(
-                    r#"to handle this warning, specify the exact registry in use for the
+                    r#"you can specify the exact registry to use for the
 `{}` dependency in Cargo.toml, eg:
 
 {} = {{ version = "{}", registry = "{}" }}

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -652,7 +652,7 @@ impl<'cfg> PackageSet<'cfg> {
         // Now we have a list of multiply defined packages, we can output that
         // list, and suggest to the user how they can avoid the warning.
         for (pid, others) in multiply_defined.into_iter() {
-            let other_sources = others
+            let mut other_sources = others
                 .into_iter()
                 .map(|sid| format!("`{}`", sid.display_registry_name()))
                 .collect::<Vec<_>>();
@@ -675,8 +675,7 @@ impl<'cfg> PackageSet<'cfg> {
                 ))?;
 
                 ws.config().shell().note(&format!(
-                    r#"
-To handle this warning, specify the exact registry in use for the
+                    r#"To handle this warning, specify the exact registry in use for the
 `{}` dependency in Cargo.toml, eg:
 
 {} = {{ version = "{}", registry = "{}" }}

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -675,7 +675,7 @@ impl<'cfg> PackageSet<'cfg> {
                 ))?;
 
                 ws.config().shell().note(&format!(
-                    r#"To handle this warning, specify the exact registry in use for the
+                    r#"to handle this warning, specify the exact registry in use for the
 `{}` dependency in Cargo.toml, eg:
 
 {} = {{ version = "{}", registry = "{}" }}

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -612,6 +612,12 @@ impl<'cfg> PackageSet<'cfg> {
         target_data: &RustcTargetData<'_>,
         force_all_targets: ForceAllTargets,
     ) -> CargoResult<()> {
+        // There's no point doing this if we don't have multiple registries in
+        // the first place.
+        if self.sources().len() < 2 {
+            return Ok(());
+        }
+
         let _lock = self.config.acquire_package_cache_lock()?;
 
         let mut results = Vec::new();

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -1370,7 +1370,7 @@ mod warn_multiple {
             while !self.pending_checks.is_empty() {
                 self.pending_checks.retain(|(pid, sid)| {
                     if let Some(source) = sources.get_mut(*sid) {
-                        match source.contains(*pid) {
+                        match source.contains_package_name(&pid.name()) {
                             Poll::Ready(Ok(exists)) => {
                                 if exists {
                                     results.push(Ok((*pid, *sid)));

--- a/src/cargo/core/source/mod.rs
+++ b/src/cargo/core/source/mod.rs
@@ -94,8 +94,8 @@ pub trait Source {
         false
     }
 
-    /// Returns whether a package exists within the source.
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>>;
+    /// Returns whether a specific package is defined within the source.
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>>;
 
     /// Add a number of crates that should be whitelisted for showing up during
     /// queries, even if they are yanked. Currently only applies to registry
@@ -201,8 +201,8 @@ impl<'a, T: Source + ?Sized + 'a> Source for Box<T> {
     }
 
     /// Forwards to `Source::contains`.
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
-        (**self).contains(package)
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
+        (**self).contains_package_name(name)
     }
 
     fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {
@@ -276,8 +276,8 @@ impl<'a, T: Source + ?Sized + 'a> Source for &'a mut T {
         (**self).is_replaced()
     }
 
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
-        (**self).contains(package)
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
+        (**self).contains_package_name(name)
     }
 
     fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -224,6 +224,16 @@ pub fn resolve_ws_with_opts<'cfg>(
         force_all_targets,
     )?;
 
+    pkg_set.warn_deps_defined_in_multiple_registries(
+        ws,
+        &resolved_with_overrides,
+        &member_ids,
+        has_dev_units,
+        requested_targets,
+        target_data,
+        force_all_targets,
+    )?;
+
     Ok(WorkspaceResolve {
         pkg_set,
         workspace_resolve: resolve,

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -156,8 +156,8 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(())
     }
 
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
-        Poll::Ready(Ok(self.packages.contains_key(&package)))
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
+        Poll::Ready(Ok(self.packages.keys().any(|id| id.name() == name)))
     }
 
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {

--- a/src/cargo/sources/directory.rs
+++ b/src/cargo/sources/directory.rs
@@ -156,6 +156,10 @@ impl<'cfg> Source for DirectorySource<'cfg> {
         Ok(())
     }
 
+    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
+        Poll::Ready(Ok(self.packages.contains_key(&package)))
+    }
+
     fn download(&mut self, id: PackageId) -> CargoResult<MaybePackage> {
         self.packages
             .get(&id)

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -230,9 +230,9 @@ impl<'cfg> Source for GitSource<'cfg> {
         format!("Git repository {}", self.source_id)
     }
 
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
         match &mut self.path_source {
-            Some(path_source) => path_source.contains(package),
+            Some(path_source) => path_source.contains_package_name(name),
             None => Poll::Pending,
         }
     }

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -230,6 +230,13 @@ impl<'cfg> Source for GitSource<'cfg> {
         format!("Git repository {}", self.source_id)
     }
 
+    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
+        match &mut self.path_source {
+            Some(path_source) => path_source.contains(package),
+            None => Poll::Pending,
+        }
+    }
+
     fn add_to_yanked_whitelist(&mut self, _pkgs: &[PackageId]) {}
 
     fn is_yanked(&mut self, _pkg: PackageId) -> Poll<CargoResult<bool>> {

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -561,12 +561,12 @@ impl<'cfg> Source for PathSource<'cfg> {
         }
     }
 
-    fn contains(&mut self, pid: PackageId) -> Poll<CargoResult<bool>> {
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
         self.update()?;
         Poll::Ready(Ok(self
             .packages
             .iter()
-            .any(|package| package.package_id() == pid)))
+            .any(|package| package.name() == name)))
     }
 
     fn add_to_yanked_whitelist(&mut self, _pkgs: &[PackageId]) {}

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -561,6 +561,14 @@ impl<'cfg> Source for PathSource<'cfg> {
         }
     }
 
+    fn contains(&mut self, pid: PackageId) -> Poll<CargoResult<bool>> {
+        self.update()?;
+        Poll::Ready(Ok(self
+            .packages
+            .iter()
+            .any(|package| package.package_id() == pid)))
+    }
+
     fn add_to_yanked_whitelist(&mut self, _pkgs: &[PackageId]) {}
 
     fn is_yanked(&mut self, _pkg: PackageId) -> Poll<CargoResult<bool>> {

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -879,9 +879,9 @@ impl<'cfg> Source for RegistrySource<'cfg> {
         self.source_id.display_index()
     }
 
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
         Poll::Ready(Ok(ready!(self.index.summaries(
-            package.name(),
+            name.into(),
             &OptVersionReq::Any,
             &mut *self.ops
         ))?

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -121,6 +121,10 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         true
     }
 
+    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
+        self.inner.contains(package)
+    }
+
     fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {
         let pkgs = pkgs
             .iter()

--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -121,8 +121,8 @@ impl<'cfg> Source for ReplacedSource<'cfg> {
         true
     }
 
-    fn contains(&mut self, package: PackageId) -> Poll<CargoResult<bool>> {
-        self.inner.contains(package)
+    fn contains_package_name(&mut self, name: &str) -> Poll<CargoResult<bool>> {
+        self.inner.contains_package_name(name)
     }
 
     fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {

--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -119,6 +119,14 @@ to the name of the registry to use.
 some-crate = { version = "1.0", registry = "my-registry" }
 ```
 
+To explicitly depend on a package on [crates.io], the `registry` key can be set
+to `crates-io`.
+
+```toml
+[dependencies]
+some-crate = { version = "1.0", registry = "crates-io" }
+```
+
 > **Note**: [crates.io] does not allow packages to be published with
 > dependencies on other registries.
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -134,6 +134,7 @@ mod update;
 mod vendor;
 mod verify_project;
 mod version;
+mod warn_multiple_registries;
 mod warn_on_failure;
 mod weak_dep_features;
 mod workspaces;

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2413,7 +2413,7 @@ fn can_update_with_alt_reg() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `alternative`)
 [WARNING] package `bar v0.1.1 (registry `alternative`)` from registry `alternative` is also defined in registry `crates-io`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `bar v0.1.1 (registry `alternative`)` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.1\", registry = \"alternative\" }
@@ -2464,7 +2464,7 @@ bar = { version = \"0.1.1\", registry = \"alternative\" }
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.2 (registry `alternative`)
 [WARNING] package `bar v0.1.2 (registry `alternative`)` from registry `alternative` is also defined in registry `crates-io`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `bar v0.1.2 (registry `alternative`)` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.2\", registry = \"alternative\" }

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2412,6 +2412,12 @@ fn can_update_with_alt_reg() {
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `alternative`)
+[WARNING] package `bar v0.1.1 (registry `alternative`)` from registry `alternative` is also defined in registry `crates-io`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`bar v0.1.1 (registry `alternative`)` dependency in Cargo.toml, eg:
+
+bar = { version = \"0.1.1\", registry = \"alternative\" }
+
 [CHECKING] bar v0.1.1 (registry `alternative`)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2457,6 +2463,12 @@ fn can_update_with_alt_reg() {
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.2 (registry `alternative`)
+[WARNING] package `bar v0.1.2 (registry `alternative`)` from registry `alternative` is also defined in registry `crates-io`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`bar v0.1.2 (registry `alternative`)` dependency in Cargo.toml, eg:
+
+bar = { version = \"0.1.2\", registry = \"alternative\" }
+
 [CHECKING] bar v0.1.2 (registry `alternative`)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2413,7 +2413,7 @@ fn can_update_with_alt_reg() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `alternative`)
 [WARNING] package `bar v0.1.1 (registry `alternative`)` from registry `alternative` is also defined in registry `crates-io`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `bar v0.1.1 (registry `alternative`)` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.1\", registry = \"alternative\" }
@@ -2464,7 +2464,7 @@ bar = { version = \"0.1.1\", registry = \"alternative\" }
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.2 (registry `alternative`)
 [WARNING] package `bar v0.1.2 (registry `alternative`)` from registry `alternative` is also defined in registry `crates-io`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `bar v0.1.2 (registry `alternative`)` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.2\", registry = \"alternative\" }

--- a/tests/testsuite/warn_multiple_registries.rs
+++ b/tests/testsuite/warn_multiple_registries.rs
@@ -51,7 +51,7 @@ fn same_version_in_two_registries() {
 [DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
 [DOWNLOADED] bar v0.1.2 (registry `dummy-registry`)
 [WARNING] package `bar v0.1.2` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `bar v0.1.2` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.2\", registry = \"crates-io\" }
@@ -106,7 +106,7 @@ fn different_versions_in_two_registries() {
 [DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
 [DOWNLOADED] bar v0.1.2 (registry `dummy-registry`)
 [WARNING] package `bar v0.1.2` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `bar v0.1.2` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.2\", registry = \"crates-io\" }
@@ -333,19 +333,19 @@ fn other_dep_types() {
 [DOWNLOADED] build v0.1.3 (registry `dummy-registry`)
 [DOWNLOADED] dev v0.1.4 (registry `dummy-registry`)
 [WARNING] package `main v0.1.2` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `main v0.1.2` dependency in Cargo.toml, eg:
 
 main = { version = \"0.1.2\", registry = \"crates-io\" }
 
 [WARNING] package `build v0.1.3` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `build v0.1.3` dependency in Cargo.toml, eg:
 
 build = { version = \"0.1.3\", registry = \"crates-io\" }
 
 [WARNING] package `dev v0.1.4` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] to handle this warning, specify the exact registry in use for the
+[NOTE] you can specify the exact registry to use for the
 `dev v0.1.4` dependency in Cargo.toml, eg:
 
 dev = { version = \"0.1.4\", registry = \"crates-io\" }

--- a/tests/testsuite/warn_multiple_registries.rs
+++ b/tests/testsuite/warn_multiple_registries.rs
@@ -278,3 +278,147 @@ fn git_dep() {
         )
         .run();
 }
+
+#[cargo_test]
+fn other_dep_types() {
+    // Ensure we generate warnings on build and dev dependencies as well.
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                main = "0.1.2"
+                in-alternative = { version = "0.1.0", registry = "alternative" }
+                in-default = "0.1.1"
+
+                [build-dependencies]
+                build = "0.1.3"
+
+                [dev-dependencies]
+                dev = "0.1.4"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+
+    for (package, version) in [("main", "0.1.2"), ("build", "0.1.3"), ("dev", "0.1.4")] {
+        Package::new(package, version).alternative(true).publish();
+        Package::new(package, version).publish();
+    }
+
+    // Note one small piece of weirdness here: if a registry isn't defined in
+    // the dependency, the default is `crates-io` even if `crates-io` has been
+    // replaced by another source.
+    p.cargo("check --tests")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[DOWNLOADED] main v0.1.2 (registry `dummy-registry`)
+[DOWNLOADED] build v0.1.3 (registry `dummy-registry`)
+[DOWNLOADED] dev v0.1.4 (registry `dummy-registry`)
+[WARNING] package `main v0.1.2` from registry `crates-io` is also defined in registry `alternative`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`main v0.1.2` dependency in Cargo.toml, eg:
+
+main = { version = \"0.1.2\", registry = \"crates-io\" }
+
+[WARNING] package `build v0.1.3` from registry `crates-io` is also defined in registry `alternative`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`build v0.1.3` dependency in Cargo.toml, eg:
+
+build = { version = \"0.1.3\", registry = \"crates-io\" }
+
+[WARNING] package `dev v0.1.4` from registry `crates-io` is also defined in registry `alternative`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`dev v0.1.4` dependency in Cargo.toml, eg:
+
+dev = { version = \"0.1.4\", registry = \"crates-io\" }
+
+[CHECKING] main v0.1.2
+[CHECKING] dev v0.1.4
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn other_dep_types_explicit_registries() {
+    // Ensure we don't generate warnings on build and dev dependencies when they
+    // have explicit registries defined.
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                main = { version = "0.1.2", registry = "alternative" }
+                in-alternative = { version = "0.1.0", registry = "alternative" }
+                in-default = "0.1.1"
+
+                [build-dependencies]
+                build = { version = "0.1.3", registry = "alternative" }
+
+                [dev-dependencies]
+                dev = { version = "0.1.4", registry = "crates-io" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+
+    for (package, version) in [("main", "0.1.2"), ("build", "0.1.3"), ("dev", "0.1.4")] {
+        Package::new(package, version).alternative(true).publish();
+        Package::new(package, version).publish();
+    }
+
+    p.cargo("check --tests")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[DOWNLOADED] main v0.1.2 (registry `alternative`)
+[DOWNLOADED] build v0.1.3 (registry `alternative`)
+[DOWNLOADED] dev v0.1.4 (registry `dummy-registry`)
+[CHECKING] main v0.1.2 (registry `alternative`)
+[CHECKING] dev v0.1.4
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}

--- a/tests/testsuite/warn_multiple_registries.rs
+++ b/tests/testsuite/warn_multiple_registries.rs
@@ -51,7 +51,7 @@ fn same_version_in_two_registries() {
 [DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
 [DOWNLOADED] bar v0.1.2 (registry `dummy-registry`)
 [WARNING] package `bar v0.1.2` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `bar v0.1.2` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.2\", registry = \"crates-io\" }
@@ -106,7 +106,7 @@ fn different_versions_in_two_registries() {
 [DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
 [DOWNLOADED] bar v0.1.2 (registry `dummy-registry`)
 [WARNING] package `bar v0.1.2` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `bar v0.1.2` dependency in Cargo.toml, eg:
 
 bar = { version = \"0.1.2\", registry = \"crates-io\" }
@@ -333,19 +333,19 @@ fn other_dep_types() {
 [DOWNLOADED] build v0.1.3 (registry `dummy-registry`)
 [DOWNLOADED] dev v0.1.4 (registry `dummy-registry`)
 [WARNING] package `main v0.1.2` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `main v0.1.2` dependency in Cargo.toml, eg:
 
 main = { version = \"0.1.2\", registry = \"crates-io\" }
 
 [WARNING] package `build v0.1.3` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `build v0.1.3` dependency in Cargo.toml, eg:
 
 build = { version = \"0.1.3\", registry = \"crates-io\" }
 
 [WARNING] package `dev v0.1.4` from registry `crates-io` is also defined in registry `alternative`
-[NOTE] To handle this warning, specify the exact registry in use for the
+[NOTE] to handle this warning, specify the exact registry in use for the
 `dev v0.1.4` dependency in Cargo.toml, eg:
 
 dev = { version = \"0.1.4\", registry = \"crates-io\" }

--- a/tests/testsuite/warn_multiple_registries.rs
+++ b/tests/testsuite/warn_multiple_registries.rs
@@ -1,0 +1,280 @@
+//! Tests for the warnings issued when packages are available in multiple
+//! registries without being disambiguated.
+
+use cargo_test_support::{
+    basic_manifest, git, project,
+    registry::{self, Package},
+};
+
+#[cargo_test]
+fn same_version_in_two_registries() {
+    // The basic test: what happens if a package is available in two registries?
+    // Note that both registries have to actually be used in the dependencies
+    // for the warning to fire.
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                bar = "0.1.2"
+                in-alternative = { version = "0.1.0", registry = "alternative" }
+                in-default = "0.1.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+    Package::new("bar", "0.1.2").alternative(true).publish();
+    Package::new("bar", "0.1.2").publish();
+
+    // Note one small piece of weirdness here: if a registry isn't defined in
+    // the dependency, the default is `crates-io` even if `crates-io` has been
+    // replaced by another source.
+    p.cargo("check")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[DOWNLOADED] bar v0.1.2 (registry `dummy-registry`)
+[WARNING] package `bar v0.1.2` from registry `crates-io` is also defined in registry `alternative`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`bar v0.1.2` dependency in Cargo.toml, eg:
+
+bar = { version = \"0.1.2\", registry = \"crates-io\" }
+
+[CHECKING] bar v0.1.2
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn different_versions_in_two_registries() {
+    // Checks should take place on package names only, not versions.
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                bar = "0.1.2"
+                in-alternative = { version = "0.1.0", registry = "alternative" }
+                in-default = "0.1.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+    Package::new("bar", "1.2.3").alternative(true).publish();
+    Package::new("bar", "0.1.2").publish();
+
+    p.cargo("check")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[DOWNLOADED] bar v0.1.2 (registry `dummy-registry`)
+[WARNING] package `bar v0.1.2` from registry `crates-io` is also defined in registry `alternative`
+[NOTE] To handle this warning, specify the exact registry in use for the
+`bar v0.1.2` dependency in Cargo.toml, eg:
+
+bar = { version = \"0.1.2\", registry = \"crates-io\" }
+
+[CHECKING] bar v0.1.2
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn explicit_dep_registry() {
+    // Dependencies with explicit registries should not generate warnings.
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                bar = { version = "0.1.2", registry = "alternative" }
+                in-alternative = { version = "0.1.0", registry = "alternative" }
+                in-default = "0.1.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+    Package::new("bar", "0.1.2").alternative(true).publish();
+    Package::new("bar", "0.1.2").publish();
+
+    p.cargo("check")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[DOWNLOADED] bar v0.1.2 (registry `alternative`)
+[CHECKING] bar v0.1.2 (registry `alternative`)
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn path_dep() {
+    // Dependencies defined as path deps should never warn.
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                bar = { path = "bar" }
+                in-alternative = { version = "0.1.0", registry = "alternative" }
+                in-default = "0.1.1"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "1.1.2"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+    Package::new("bar", "0.1.2").alternative(true).publish();
+    Package::new("bar", "0.1.2").publish();
+
+    p.cargo("check")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] bar v1.1.2 ([CWD]/bar)
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn git_dep() {
+    // Dependencies defined as Git deps should never warn.
+
+    let (dep_project, _dep_repo) = git::new_repo("bar", |p| {
+        p.file("Cargo.toml", &basic_manifest("bar", "1.1.2"))
+            .file("src/lib.rs", "")
+    });
+
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+                    authors = []
+
+                    [dependencies]
+                    bar = {{ git = "{}" }}
+                    in-alternative = {{ version = "0.1.0", registry = "alternative" }}
+                    in-default = "0.1.1"
+                "#,
+                dep_project.url()
+            ),
+        )
+        .file("src/lib.rs", "")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.2"))
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    Package::new("in-alternative", "0.1.0")
+        .alternative(true)
+        .publish();
+    Package::new("in-default", "0.1.1").publish();
+    Package::new("bar", "0.1.2").alternative(true).publish();
+    Package::new("bar", "0.1.2").publish();
+
+    p.cargo("check")
+        .with_stderr_unordered(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] `alternative` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] in-default v0.1.1 (registry `dummy-registry`)
+[DOWNLOADED] in-alternative v0.1.0 (registry `alternative`)
+[UPDATING] git repository `[..]/bar`
+[CHECKING] bar v1.1.2 ([..]/bar#[..])
+[CHECKING] in-alternative v0.1.0 (registry `alternative`)
+[CHECKING] in-default v0.1.1
+[CHECKING] foo v0.0.1 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

This PR adds a warning when one or more dependencies — that aren't otherwise disambiguated by specifying a `registry` key, or being of the `path` or `git` types — are available in more than one registry source.

The underlying issue here is defined as a [dependency confusion attack](https://users.rust-lang.org/t/dependency-confusion-attack-may-be-applicable-to-alternative-registries/55389/13) in #9162: a user with multiple registries defined may believe that they are using a package from one registry, but are in fact getting it from a different registry.

Given a package that uses `rand` via `rand = "0.8.5"`, but which also sees a different `rand` package in a different registry, the output looks like this:

![image](https://user-images.githubusercontent.com/229984/228396055-76ac2f95-d8d4-4a24-98f5-e04c519543c8.png)

There is, at present, no way to disable this warning. I would be happy to explore adding a flag or environment variable check to do so if that would be useful.

Implementation wise, this takes the form of a new function alongside `PackageSet::warn_no_lib_packages_and_artifact_libs_overlapping_deps`, invoked when resolving packages. A small sub-module has been added with a minimal state machine to drive this check — originally, this was all inline in the new `PackageSet` function, but the inlined version just made me want spaghetti. :spaghetti: 

The `Source` trait has also gained a new `contains_package_name` function. Some implementations are simpler than others.

To be clear, I'm not very attached to the exact mechanics here, and since I'm essentially learning Cargo as I go here, it's likely that I've missed at least one nuance in terms of how to walk through the dependency graph and their associated sources.

This PR also updates the couple of affected tests that already existed, and adds a set of new test cases to exercise the various possibilities.

Fixes #9162.