### PR TITLE
src/doc/src/reference/build-scripts.md: a{n =>} benchmark target

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -206,7 +206,7 @@ target.
 #### `cargo:rustc-link-arg-benches=FLAG`
 
 The `rustc-link-arg-benches` instruction tells Cargo to pass the [`-C
-link-arg=FLAG` option][link-arg] to the compiler, but only when building an benchmark
+link-arg=FLAG` option][link-arg] to the compiler, but only when building a benchmark
 target.
 
 <a id="rustc-link-search"></a>


### PR DESCRIPTION
### What does this PR try to resolve?

"an benchmark target"

### How should we test and review this PR?

idk, reading it is a good start, maybe compare to [the original](https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#cargorustc-link-arg-benchesflag). it may help to vocalise out loud that *b* is not a vowel, too