### PR TITLE
Unpin and bump `libgit2-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,9 +47,7 @@ jobserver = "0.1.26"
 lazy_static = "1.2.0"
 lazycell = "1.2.0"
 libc = "0.2"
-# Temporarily pin libgit2-sys due to some issues with SSH not working on
-# Windows.
-libgit2-sys = "=0.14.1"
+libgit2-sys = "0.14.2"
 log = "0.4.6"
 memchr = "2.1.3"
 opener = "0.5"


### PR DESCRIPTION
This was temporarily pinned `=0.14.1` in: #11609 

However 0.14.2 addresses RUSTSEC-2023-0003 / `CVE-2023-22742` whilst this prevents any downstream bumping as well:
- https://github.com/rust-secure-code/cargo-geiger/issues/452

Since the underlying Windows issues have been resolved:
- https://github.com/libgit2/libgit2/issues/6453
- https://github.com/libgit2/libgit2/issues/6454

This would be okay to unpin and bump I would assume ?