### PR TITLE
Drop derive feature from serde in cargo-platform

### DIFF
--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -9,4 +9,4 @@ documentation = "https://docs.rs/cargo-platform"
 description = "Cargo's representation of a target platform."
 
 [dependencies]
-serde = { version = "1.0.82", features = ['derive'] }
+serde = "1.0.82"


### PR DESCRIPTION
<!-- homu-ignore:start -->### What does this PR try to resolve?

`cargo-platform` introduces a depdency to `serde_derive` via the `derive` feature of `serde`, yet the crate does not use it.

### Additional information

~~This slightly hurts compile times for rust-analyzer due to the dependencyh between `serde` and `serde_derive` this constructs, see https://github.com/rust-lang/rust-analyzer/pull/14450~~ not relevant anymore, so if this is too much churn feel free to close

<!-- homu-ignore:end -->
