### PR TITLE
Add a note to `cargo logout` that it does not revoke the token.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -954,6 +954,20 @@ pub fn registry_logout(config: &Config, reg: Option<&str>) -> CargoResult<()> {
             reg_name
         ),
     )?;
+    let location = if source_ids.original.is_crates_io() {
+        "<https://crates.io/me>".to_string()
+    } else {
+        // The URL for the source requires network access to load the config.
+        // That could be a fairly heavy operation to perform just to provide a
+        // help message, so for now this just provides some generic text.
+        // Perhaps in the future this could have an API to fetch the config if
+        // it is cached, but avoid network access otherwise?
+        format!("the `{reg_name}` website")
+    };
+    config.shell().note(format!(
+        "This does not revoke the token on the registry server.\n    \
+        If you need to revoke the token, visit {location} and follow the instructions there."
+    ))?;
     Ok(())
 }
 

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -383,6 +383,9 @@ fn logout() {
             "\
 token for `crates-io` has been erased!
 [LOGOUT] token for `crates-io` has been removed from local storage
+[NOTE] This does not revoke the token on the registry server.
+    If you need to revoke the token, visit <https://crates.io/me> \
+    and follow the instructions there.
 ",
         )
         .run();


### PR DESCRIPTION
This adds a note to help emphasize that `cargo logout` does not "log out of the server", and suggests what to do if that is what you want.

Unfortunately getting the URL for a registry is not a simple operation, so for now it just gives a generic message for the non-crates.io case.
