### PR TITLE
misc: Use 'and' joined summary for install/uninstall

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -9,7 +9,7 @@ use crate::ops::{common_for_install_and_uninstall::*, FilterRule};
 use crate::ops::{CompileFilter, Packages};
 use crate::sources::{GitSource, PathSource, SourceConfigMap};
 use crate::util::errors::CargoResult;
-use crate::util::{Config, Filesystem, Rustc, ToSemver, VersionReqExt};
+use crate::util::{and_joined_words, Config, Filesystem, Rustc, ToSemver, VersionReqExt};
 use crate::{drop_println, ops};
 
 use anyhow::{bail, format_err, Context as _};
@@ -686,12 +686,15 @@ pub fn install(
 
         let mut summary = vec![];
         if !succeeded.is_empty() {
-            summary.push(format!("Successfully installed {}!", succeeded.join(", ")));
+            summary.push(format!(
+                "Successfully installed {}!",
+                and_joined_words(&succeeded)
+            ));
         }
         if !failed.is_empty() {
             summary.push(format!(
                 "Failed to install {} (see error(s) above).",
-                failed.join(", ")
+                and_joined_words(&failed)
             ));
         }
         if !succeeded.is_empty() || !failed.is_empty() {

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -3,8 +3,8 @@ use crate::core::{PackageIdSpec, SourceId};
 use crate::ops::common_for_install_and_uninstall::*;
 use crate::sources::PathSource;
 use crate::util::errors::CargoResult;
-use crate::util::Config;
 use crate::util::Filesystem;
+use crate::util::{and_joined_words, Config};
 use anyhow::bail;
 use cargo_util::paths;
 use std::collections::BTreeSet;
@@ -45,13 +45,13 @@ pub fn uninstall(
         if !succeeded.is_empty() {
             summary.push(format!(
                 "Successfully uninstalled {}!",
-                succeeded.join(", ")
+                and_joined_words(&succeeded)
             ));
         }
         if !failed.is_empty() {
             summary.push(format!(
                 "Failed to uninstall {} (see error(s) above).",
-                failed.join(", ")
+                and_joined_words(&failed)
             ));
         }
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -133,6 +133,20 @@ pub fn truncate_with_ellipsis(s: &str, max_width: usize) -> String {
     prefix
 }
 
+/// Formats a slice of strings by joining them together using comma, "and" word
+/// or both, depending on the number of words.
+pub fn and_joined_words(words: &[&str]) -> String {
+    match words.len() {
+        0 => String::default(),
+        1 => words.first().map(|w| w.to_string()).unwrap(),
+        2 => words.join(" and "),
+        len => {
+            let (left, right) = words.split_at(len - 2);
+            format!("{}, {}", left.join(", "), right.join(" and "))
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -164,5 +178,23 @@ mod test {
             (1., "EiB")
         );
         assert_eq!(human_readable_bytes(u64::MAX), (16., "EiB"));
+    }
+
+    #[test]
+    fn test_and_joined_words() {
+        assert_eq!(and_joined_words(&[]), String::from(""));
+        assert_eq!(and_joined_words(&["foo"]), String::from("foo"));
+        assert_eq!(
+            and_joined_words(&["foo", "bar"]),
+            String::from("foo and bar")
+        );
+        assert_eq!(
+            and_joined_words(&["foo", "bar", "baz"]),
+            String::from("foo, bar and baz")
+        );
+        assert_eq!(
+            and_joined_words(&["foo", "bar", "baz", "qux"]),
+            String::from("foo, bar, baz and qux")
+        );
     }
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -189,7 +189,7 @@ fn multiple_pkgs() {
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/bar[EXE]
 [INSTALLED] package `bar v0.0.2` (executable `bar[EXE]`)
-[SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
+[SUMMARY] Successfully installed foo and bar! Failed to install baz (see error(s) above).
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
 [ERROR] some crates failed to install
 ",
@@ -203,7 +203,7 @@ fn multiple_pkgs() {
             "\
 [REMOVING] [CWD]/home/.cargo/bin/foo[EXE]
 [REMOVING] [CWD]/home/.cargo/bin/bar[EXE]
-[SUMMARY] Successfully uninstalled foo, bar!
+[SUMMARY] Successfully uninstalled foo and bar!
 ",
         )
         .run();
@@ -249,7 +249,7 @@ fn multiple_pkgs_path_set() {
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/bar[EXE]
 [INSTALLED] package `bar v0.0.2` (executable `bar[EXE]`)
-[SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
+[SUMMARY] Successfully installed foo and bar! Failed to install baz (see error(s) above).
 [ERROR] some crates failed to install
 ",
         )
@@ -262,7 +262,7 @@ fn multiple_pkgs_path_set() {
             "\
 [REMOVING] [CWD]/home/.cargo/bin/foo[EXE]
 [REMOVING] [CWD]/home/.cargo/bin/bar[EXE]
-[SUMMARY] Successfully uninstalled foo, bar!
+[SUMMARY] Successfully uninstalled foo and bar!
 ",
         )
         .run();

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -616,7 +616,7 @@ fn multiple_report() {
 [INSTALLING] [..]/.cargo/bin/x[EXE]
 [INSTALLING] [..]/.cargo/bin/y[EXE]
 [INSTALLED] package `three v1.0.0` (executables `three[EXE]`, `x[EXE]`, `y[EXE]`)
-[SUMMARY] Successfully installed one, two, three!
+[SUMMARY] Successfully installed one, two and three!
 [WARNING] be sure to add `[..]/.cargo/bin` to your PATH [..]
 ",
         )
@@ -639,7 +639,7 @@ fn multiple_report() {
 [REPLACING] [..]/.cargo/bin/x[EXE]
 [REPLACING] [..]/.cargo/bin/y[EXE]
 [REPLACED] package `three v1.0.0` with `three v1.0.1` (executables `three[EXE]`, `x[EXE]`, `y[EXE]`)
-[SUMMARY] Successfully installed one, two, three!
+[SUMMARY] Successfully installed one, two and three!
 [WARNING] be sure to add `[..]/.cargo/bin` to your PATH [..]
 ",
         )
@@ -854,7 +854,7 @@ fn partially_already_installed_does_one_update() {
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/baz[EXE]
 [INSTALLED] package `baz v1.0.0` (executable `baz[EXE]`)
-[SUMMARY] Successfully installed foo, bar, baz!
+[SUMMARY] Successfully installed foo, bar and baz!
 [WARNING] be sure to add [..]
 ",
         )


### PR DESCRIPTION
It's a cosmetic change, that modifies how installed/uninstalled crates are listed. When precisely two are installed, it just reads oddly right now IMO. 

Note that https://crates.io/crates/and crate is reserved, so there will never be `something and and`.

```
A: Summary Successfully installed tauri-cli, trunk!
B: Summary Successfully installed tauri-cli and trunk!
```

```
A: Summary Successfully installed tauri, tauri-cli, trunk!
B: Summary Successfully installed tauri, tauri-cli and trunk!
```
