### PR TITLE
Publish docs: Clarify requirements about the state of the index after publish.

### DIFF
--- a/src/doc/src/reference/registry-web-api.md
+++ b/src/doc/src/reference/registry-web-api.md
@@ -57,6 +57,10 @@ The publish endpoint is used to publish a new version of a crate. The server
 should validate the crate, make it available for download, and add it to the
 index.
 
+It is not required for the index to be updated before the successful response is sent.
+After a successful response, Cargo will poll the index for a short period of time to identify that the new crate has been added.
+If the crate does not appear in the index after a short period of time, then Cargo will display a warning letting the user know that the new crate is not yet available.
+
 The body of the data sent by Cargo is:
 
 - 32-bit unsigned little-endian integer of the length of JSON data.


### PR DESCRIPTION
The current Publish API docs don't mention anything about the requirements of updating the index asynchronously, so this adds some information about how cargo handles that.