### PR TITLE
Update git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ curl-sys = "0.4.61"
 env_logger = "0.10.0"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-git2 = "0.16.0"
-git2-curl = "0.17.0"
+git2 = "0.17.0"
+git2-curl = "0.18.0"
 gix = { version = "0.39.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
 gix-features-for-configuration-only = { version = "0.28.0", package = "gix-features", features = [ "parallel" ] }
 glob = "0.3.0"
@@ -47,9 +47,7 @@ jobserver = "0.1.26"
 lazy_static = "1.2.0"
 lazycell = "1.2.0"
 libc = "0.2"
-# Temporarily pin libgit2-sys due to some issues with SSH not working on
-# Windows.
-libgit2-sys = "=0.14.1"
+libgit2-sys = "0.15.0"
 log = "0.4.6"
 memchr = "2.1.3"
 opener = "0.5"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -14,7 +14,7 @@ cargo-util = { path = "../cargo-util" }
 crates-io = { path = "../crates-io" }
 filetime = "0.2"
 flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
-git2 = "0.16.0"
+git2 = "0.17.0"
 glob = "0.3"
 itertools = "0.10.0"
 lazy_static = "1.0"

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -567,7 +567,7 @@ where
         }
 
         // Whelp, we tried our best
-        Err(git2::Error::from_str("no authentication available"))
+        Err(git2::Error::from_str("no authentication methods succeeded"))
     });
 
     // Ok, so if it looks like we're going to be doing ssh authentication, we
@@ -612,7 +612,7 @@ where
                         return git2::Cred::ssh_key_from_agent(&s);
                     }
                 }
-                Err(git2::Error::from_str("no authentication available"))
+                Err(git2::Error::from_str("no authentication methods succeeded"))
             });
 
             // If we made two attempts then that means:

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -30,7 +30,7 @@ fn self_signed_should_fail() {
         .build();
     // I think the text here depends on the curl backend.
     let err_msg = if cfg!(target_os = "macos") {
-        "untrusted connection error; class=Ssl (16); code=Certificate (-17)"
+        "unexpected return value from ssl handshake -9806; class=Ssl (16)"
     } else if cfg!(unix) {
         "the SSL certificate is invalid; class=Ssl (16); code=Certificate (-17)"
     } else if cfg!(windows) {

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -469,11 +469,6 @@ Caused by:
   failed to authenticate when downloading repository
 
   *";
-    let err = if cfg!(windows) {
-        "error authenticating: unable to connect to agent pipe; class=Ssh (23)"
-    } else {
-        "error authenticating: failed connecting with agent; class=Ssh (23)"
-    };
     let expected = if cargo_uses_gitoxide() {
         format!(
             "{shared_stderr} attempted to find username/password via `credential.helper`, but maybe the found credentials were incorrect
@@ -496,7 +491,7 @@ Caused by:
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 
 Caused by:
-  {err}
+  no authentication methods succeeded
 "
         )
     };
@@ -546,7 +541,7 @@ Caused by:
   https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli
 
 Caused by:
-  {err}
+  no authentication methods succeeded
 "
         )
     };


### PR DESCRIPTION
This updates git2 from 0.16 to 0.17, which updates libgit2 from 1.5.0 to 1.6.3. This is quite a large update (particularly around SSH handling), so this update is fairly risky. All of the issues I'm aware of have been resolved.

Due to some changes in how libgit2 handles SSH agent errors, I tweaked the wording of the error generated by cargo when all authentications fail. Previously, libgit2 would abort the authentication when an ssh-agent connection failed.

Changelog for git2: https://github.com/rust-lang/git2-rs/blob/master/CHANGELOG.md#0170---2023-04-02
Changelog for libgit2: https://github.com/libgit2/libgit2/blob/main/docs/changelog.md#v163

Closes #11611
