### PR TITLE
Fix Cargo warning about unused sparse configuration key

### DIFF
--- a/src/cargo/util/auth.rs
+++ b/src/cargo/util/auth.rs
@@ -133,6 +133,8 @@ pub fn registry_credential_config(
         secret_key_subject: Option<String>,
         #[serde(rename = "default")]
         _default: Option<String>,
+        #[serde(rename = "protocol")]
+        _protocol: Option<String>,
     }
 
     log::trace!("loading credential config for {}", sid);

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -438,6 +438,33 @@ or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
 }
 
 #[cargo_test]
+fn cargo_registries_crates_io_protocol() {
+    let _ = RegistryBuilder::new()
+        .no_configure_token()
+        .alternative()
+        .build();
+    // Should not produce a warning due to the registries.crates-io.protocol = 'sparse' configuration
+    let p = project()
+        .file("src/lib.rs", "")
+        .file(
+            ".cargo/config.toml",
+            "[registries.crates-io]
+            protocol = 'sparse'",
+        )
+        .build();
+
+    p.cargo("publish --registry alternative")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] `alternative` index
+error: no token found for `alternative`, please run `cargo login --registry alternative`
+or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn publish_to_alt_registry() {
     let _reg = RegistryBuilder::new()
         .http_api()


### PR DESCRIPTION
When doing a credential lookup, Cargo deserializes the registry configuration and detects the `registries.crates-io.protocol` key as unused and issues a warning:
```
warning: unused config key `registries.crates-io.protocol` in [..]
```

This fixes the issue by adding the field to the `RegistryConfig` struct.
