### PR TITLE
Switch benchsuite to the index archive.

### DIFF
--- a/benches/benchsuite/src/lib.rs
+++ b/benches/benchsuite/src/lib.rs
@@ -120,7 +120,7 @@ impl Fixtures {
         } else {
             fs::create_dir_all(&index).unwrap();
             git("init --bare");
-            git("remote add origin https://github.com/rust-lang/crates.io-index");
+            git("remote add origin https://github.com/rust-lang/crates.io-index-archive");
         }
         git(&format!("fetch origin {}", CRATES_IO_COMMIT));
         git("branch -f master FETCH_HEAD");


### PR DESCRIPTION
Due to the index squash this morning, the commit of the index that the benchsuite was using is no longer available. This switches to the archive which contains the complete history of the index and shouldn't have issues with commits going away.
