### PR TITLE
Don't query permutations of the path prefix.

### DIFF
--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -360,15 +360,15 @@ impl<'cfg> RegistryIndex<'cfg> {
             .chars()
             .flat_map(|c| c.to_lowercase())
             .collect::<String>();
-        let raw_path = make_dep_path(&fs_name, false);
 
         let mut any_pending = false;
         // Attempt to handle misspellings by searching for a chain of related
-        // names to the original `raw_path` name. Only return summaries
+        // names to the original `fs_name` name. Only return summaries
         // associated with the first hit, however. The resolver will later
         // reject any candidates that have the wrong name, and with this it'll
         // along the way produce helpful "did you mean?" suggestions.
-        for (i, path) in UncanonicalizedIter::new(&raw_path).take(1024).enumerate() {
+        for (i, name_permutation) in UncanonicalizedIter::new(&fs_name).take(1024).enumerate() {
+            let path = make_dep_path(&name_permutation, false);
             let summaries = Summaries::parse(
                 root,
                 &cache_root,

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -4,7 +4,7 @@ use cargo::core::SourceId;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::{
-    self, registry_path, Dependency, Package, RegistryBuilder, TestRegistry,
+    self, registry_path, Dependency, Package, RegistryBuilder, Response, TestRegistry,
 };
 use cargo_test_support::{basic_manifest, project};
 use cargo_test_support::{git, install::cargo_home, t};
@@ -3134,4 +3134,61 @@ fn corrupted_ok_overwritten() {
     assert_eq!(fs::read_to_string(&ok).unwrap(), "");
     p.cargo("fetch").with_stderr("").run();
     assert_eq!(fs::read_to_string(&ok).unwrap(), "ok");
+}
+
+#[cargo_test]
+fn not_found_permutations() {
+    // Test for querying permutations for a missing dependency.
+    let misses = Arc::new(Mutex::new(Vec::new()));
+    let misses2 = misses.clone();
+    let _registry = RegistryBuilder::new()
+        .http_index()
+        .not_found_handler(move |req, _server| {
+            let mut misses = misses2.lock().unwrap();
+            misses.push(req.url.path().to_string());
+            Response {
+                code: 404,
+                headers: vec![],
+                body: b"not found".to_vec(),
+            }
+        })
+        .build();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                a-b-c = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+error: no matching package named `a-b-c` found
+location searched: registry `crates-io`
+required by package `foo v0.0.1 ([ROOT]/foo)`
+",
+        )
+        .run();
+    let misses = misses.lock().unwrap();
+    assert_eq!(
+        &*misses,
+        &[
+            "/index/a-/b-/a-b-c",
+            "/index/a_/b-/a_b-c",
+            "/index/a-/b_/a-b_c",
+            "/index/a_/b_/a_b_c"
+        ]
+    );
 }


### PR DESCRIPTION
This fixes the use of the `UncanonicalizedIter` to not create permutations that are not valid paths if the crate has a dash or underscore in the first four characters of the name.

Previously it was permuting the path in the prefix, creating invalid paths. For example, `my-tool` would create a path like `my/_t/my-tool` which isn't valid since the filename doesn't match the prefix directories.

This fixes it so that it permutes just the name, and then generates the index path *after* permuting it.

The test included here goes from 16 queries to just 4 queries.

Fixes #11935