### PR TITLE
Remove disabled optional weak dependencies from Cargo.lock

### DIFF
--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -11,7 +11,7 @@ use std::task::Poll;
 use std::time::Instant;
 
 use cargo::core::dependency::DepKind;
-use cargo::core::resolver::{self, ResolveOpts, VersionPreferences};
+use cargo::core::resolver::{self, ResolveOpts, ResolveVersion, VersionPreferences};
 use cargo::core::source::{GitReference, QueryKind, SourceId};
 use cargo::core::Resolve;
 use cargo::core::{Dependency, PackageId, Registry, Summary};
@@ -196,6 +196,7 @@ pub fn resolve_with_config_raw(
         &VersionPreferences::default(),
         Some(config),
         true,
+        ResolveVersion::default(),
     );
 
     // The largest test in our suite takes less then 30 sec.

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -490,7 +490,7 @@ impl Requirements<'_> {
     }
 
     fn require_dependency(&mut self, pkg: InternedString) {
-        self.deps.entry(pkg).or_default();
+        self.deps.entry(pkg).or_default().0 = false;
     }
 
     fn require_feature(&mut self, feat: InternedString) -> Result<(), RequirementError> {

--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -158,6 +158,7 @@ impl EncodableResolve {
         let mut checksums = HashMap::new();
 
         let mut version = match self.version {
+            Some(4) => ResolveVersion::V4,
             Some(3) => ResolveVersion::V3,
             Some(n) => bail!(
                 "lock file version `{}` was found, but this version of Cargo \
@@ -612,6 +613,7 @@ impl ser::Serialize for Resolve {
             metadata,
             patch,
             version: match self.version() {
+                ResolveVersion::V4 => Some(4),
                 ResolveVersion::V3 => Some(3),
                 ResolveVersion::V2 | ResolveVersion::V1 => None,
             },

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -138,6 +138,7 @@ pub fn resolve(
     version_prefs: &VersionPreferences,
     config: Option<&Config>,
     check_public_visible_dependencies: bool,
+    version: ResolveVersion,
 ) -> CargoResult<Resolve> {
     let _p = profile::start("resolving");
     let minimal_versions = match config {
@@ -158,6 +159,7 @@ pub fn resolve(
             summaries,
             direct_minimal_versions,
             config,
+            version,
         )?;
         if registry.reset_pending() {
             break cx;
@@ -190,7 +192,7 @@ pub fn resolve(
         cksums,
         BTreeMap::new(),
         Vec::new(),
-        ResolveVersion::default(),
+        version,
         summaries,
     );
 
@@ -212,6 +214,7 @@ fn activate_deps_loop(
     summaries: &[(Summary, ResolveOpts)],
     direct_minimal_versions: bool,
     config: Option<&Config>,
+    version: ResolveVersion,
 ) -> CargoResult<Context> {
     let mut backtrack_stack = Vec::new();
     let mut remaining_deps = RemainingDeps::new();
@@ -230,6 +233,7 @@ fn activate_deps_loop(
             summary.clone(),
             direct_minimal_versions,
             opts,
+            version,
         );
         match res {
             Ok(Some((frame, _))) => remaining_deps.push(frame),
@@ -436,6 +440,7 @@ fn activate_deps_loop(
                 candidate,
                 direct_minimal_version,
                 &opts,
+                version,
             );
 
             let successfully_activated = match res {
@@ -650,6 +655,7 @@ fn activate(
     candidate: Summary,
     first_minimal_version: bool,
     opts: &ResolveOpts,
+    version: ResolveVersion,
 ) -> ActivateResult<Option<(DepsFrame, Duration)>> {
     let candidate_pid = candidate.package_id();
     cx.age += 1;
@@ -706,6 +712,7 @@ fn activate(
         &candidate,
         opts,
         first_minimal_version,
+        version,
     )?;
 
     // Record what list of features is active for this package.

--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -80,6 +80,8 @@ pub enum ResolveVersion {
     /// V3 by default staring in 1.53.
     #[default]
     V3,
+    /// Weak dependency features are not treated as non-weak.
+    V4,
 }
 
 impl Resolve {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -495,6 +495,8 @@ pub fn resolve_with_previous<'cfg>(
         None => root_replace.to_vec(),
     };
 
+    let version = previous.map(|p| p.version()).unwrap_or_default();
+
     ws.preload(registry);
     let mut resolved = resolver::resolve(
         &summaries,
@@ -505,6 +507,7 @@ pub fn resolve_with_previous<'cfg>(
         ws.unstable_features()
             .require(Feature::public_dependency())
             .is_ok(),
+        version,
     )?;
     let patches: Vec<_> = registry
         .patches()


### PR DESCRIPTION
In #10801, it was noted that Cargo treats weak dependencies just like strong ones in Cargo.lock, as in, includes them unconditionally. Cargo does not build these dependencies though, only uses them during resolution.

Cargo [has two resolvers](https://github.com/rust-lang/cargo/blob/7bf43f028ba5eb1f4d70d271c2546c38512c9875/src/cargo/core/resolver/mod.rs#L40):

* one that performs aggressive unification and is used to generate Cargo.lock files
* one that takes the enabled features on the command line into account, as well as the target platform

The implementation in #8818 only changed the latter resolver, which implemented weak dependency support for most important workflows, like determining which crates are actually built. The former resolver still keeps a list of enabled and disabled features for each crate, and the way more aggressive unification it performs isn't an issue for weak dependency support, so fundamentally one can add weak dependency support to it, too. This PR does that precisely:

* it changes the parts of the resolver that generate Cargo.lock to not include weak dependencies.
* it adds a new Cargo.lock `ResolveVersion::V4` variant, which isn't emitted by default. The idea is though that at some point in the future cargo switches to the new version by default. I'm open to feedback for different suggestions how to phase in the change, maybe via `resolver = 3`, or maybe additionally by having an unstable flag so that we can iterate before version 4 is stabilized.

Fixes #10801