### PR TITLE
[beta 1.69] Backport #11936 - Don't query permutations of the path prefix

### DIFF
--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -360,15 +360,15 @@ impl<'cfg> RegistryIndex<'cfg> {
             .chars()
             .flat_map(|c| c.to_lowercase())
             .collect::<String>();
-        let raw_path = make_dep_path(&fs_name, false);
 
         let mut any_pending = false;
         // Attempt to handle misspellings by searching for a chain of related
-        // names to the original `raw_path` name. Only return summaries
+        // names to the original `fs_name` name. Only return summaries
         // associated with the first hit, however. The resolver will later
         // reject any candidates that have the wrong name, and with this it'll
         // along the way produce helpful "did you mean?" suggestions.
-        for (i, path) in UncanonicalizedIter::new(&raw_path).take(1024).enumerate() {
+        for (i, name_permutation) in UncanonicalizedIter::new(&fs_name).take(1024).enumerate() {
+            let path = make_dep_path(&name_permutation, false);
             let summaries = Summaries::parse(
                 root,
                 &cache_root,

--- a/tests/testsuite/cargo_add/invalid_arg/stderr.log
+++ b/tests/testsuite/cargo_add/invalid_arg/stderr.log
@@ -1,6 +1,6 @@
 error: unexpected argument '--flag' found
 
-  note: argument '--tag' exists
+  tip: a similar argument exists: '--tag'
 
 Usage: cargo add [OPTIONS] <DEP>[@<VERSION>] ...
        cargo add [OPTIONS] --path <PATH> ...

--- a/tests/testsuite/cargo_remove/invalid_arg/stderr.log
+++ b/tests/testsuite/cargo_remove/invalid_arg/stderr.log
@@ -1,6 +1,6 @@
 error: unexpected argument '--flag' found
 
-  note: to pass '--flag' as a value, use '-- --flag'
+  tip: to pass '--flag' as a value, use '-- --flag'
 
 Usage: cargo[EXE] remove <DEP_ID>...
 

--- a/tests/testsuite/init/unknown_flags/stderr.log
+++ b/tests/testsuite/init/unknown_flags/stderr.log
@@ -1,6 +1,6 @@
 error: unexpected argument '--flag' found
 
-  note: to pass '--flag' as a value, use '-- --flag'
+  tip: to pass '--flag' as a value, use '-- --flag'
 
 Usage: cargo[EXE] init <path>
 

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -592,7 +592,7 @@ fn run_bins() {
             "\
 error: unexpected argument '--bins' found
 
-  note: argument '--bin' exists",
+  tip: a similar argument exists: '--bin'",
         )
         .run();
 }


### PR DESCRIPTION
Backport of #11936 to beta to reduce the number of 404 requests hitting index.crates.io before sparse default hits stable.