### PR TITLE
Update home repo URL

### DIFF
--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "home"
 version = "0.5.4" # also update `html_root_url` in `src/lib.rs`
-authors = [ "Brian Anderson <andersrb@gmail.com>" ]
+authors = ["Brian Anderson <andersrb@gmail.com>"]
 documentation = "https://docs.rs/home"
 edition = "2018"
 include = [
@@ -13,8 +13,8 @@ include = [
 ]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/brson/home"
-description = "Shared definitions of home directories"
+repository = "https://github.com/rust-lang/cargo"
+description = "Shared definitions of home directories."
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_UI_Shell"] }


### PR DESCRIPTION
According to the Readme in https://github.com/brson/home this is the new location of the home repository.