### PR TITLE
Use registry.default for login/logout

### DIFF
--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -34,10 +34,11 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
+    let registry = args.registry(config)?;
     ops::registry_login(
         config,
         args.get_one::<String>("token").map(|s| s.as_str().into()),
-        args.get_one("registry").map(String::as_str),
+        registry.as_deref(),
         args.flag("generate-keypair"),
         args.flag("secret-key"),
         args.get_one("key-subject").map(String::as_str),

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -15,9 +15,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             .cli_unstable()
             .fail_if_stable_command(config, "logout", 8933)?;
     }
-    ops::registry_logout(
-        config,
-        args.get_one::<String>("registry").map(String::as_str),
-    )?;
+    let registry = args.registry(config)?;
+    ops::registry_logout(config, registry.as_deref())?;
     Ok(())
 }

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -373,16 +373,13 @@ fn login_with_generate_asymmetric_token() {
 fn default_registry_configured() {
     // When registry.default is set, login should use that one when
     // --registry is not used.
+    let _alternative = RegistryBuilder::new().alternative().build();
     let cargo_home = paths::home().join(".cargo");
-    cargo_home.mkdir_p();
-    cargo_util::paths::write(
-        &cargo_home.join("config.toml"),
-        r#"
+    cargo_util::paths::append(
+        &cargo_home.join("config"),
+        br#"
             [registry]
-            default = "dummy-registry"
-
-            [registries.dummy-registry]
-            index = "https://127.0.0.1/index"
+            default = "alternative"
         "#,
     )
     .unwrap();
@@ -391,12 +388,12 @@ fn default_registry_configured() {
         .arg("a-new-token")
         .with_stderr(
             "\
-[UPDATING] crates.io index
-[LOGIN] token for `crates.io` saved
+[UPDATING] `alternative` index
+[LOGIN] token for `alternative` saved
 ",
         )
         .run();
 
-    check_token(Some("a-new-token"), None);
-    check_token(None, Some("alternative"));
+    check_token(None, None);
+    check_token(Some("a-new-token"), Some("alternative"));
 }

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -27,14 +27,15 @@ fn setup_new_credentials_at(config: PathBuf) {
     ));
 }
 
-fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
+/// Asserts whether or not the token is set to the given value for the given registry.
+pub fn check_token(expected_token: Option<&str>, registry: Option<&str>) {
     let credentials = credentials_toml();
     assert!(credentials.is_file());
 
     let contents = fs::read_to_string(&credentials).unwrap();
     let toml: toml::Table = contents.parse().unwrap();
 
-    let token = match registry {
+    let actual_token = match registry {
         // A registry has been provided, so check that the token exists in a
         // table for the registry.
         Some(registry) => toml
@@ -54,10 +55,15 @@ fn check_token(expected_token: &str, registry: Option<&str>) -> bool {
             }),
     };
 
-    if let Some(token_val) = token {
-        token_val == expected_token
-    } else {
-        false
+    match (actual_token, expected_token) {
+        (None, None) => {}
+        (Some(actual), Some(expected)) => assert_eq!(actual, expected),
+        (None, Some(expected)) => {
+            panic!("expected `{registry:?}` to be `{expected}`, but was not set")
+        }
+        (Some(actual), None) => {
+            panic!("expected `{registry:?}` to be unset, but was set to `{actual}`")
+        }
     }
 }
 
@@ -75,10 +81,10 @@ fn registry_credentials() {
     cargo_process("login --registry").arg(reg).arg(TOKEN).run();
 
     // Ensure that we have not updated the default token
-    assert!(check_token(ORIGINAL_TOKEN, None));
+    check_token(Some(ORIGINAL_TOKEN), None);
 
     // Also ensure that we get the new token for the registry
-    assert!(check_token(TOKEN, Some(reg)));
+    check_token(Some(TOKEN), Some(reg));
 
     let reg2 = "alternative2";
     cargo_process("login --registry")
@@ -88,9 +94,9 @@ fn registry_credentials() {
 
     // Ensure not overwriting 1st alternate registry token with
     // 2nd alternate registry token (see rust-lang/cargo#7701).
-    assert!(check_token(ORIGINAL_TOKEN, None));
-    assert!(check_token(TOKEN, Some(reg)));
-    assert!(check_token(TOKEN2, Some(reg2)));
+    check_token(Some(ORIGINAL_TOKEN), None);
+    check_token(Some(TOKEN), Some(reg));
+    check_token(Some(TOKEN2), Some(reg2));
 }
 
 #[cargo_test]

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -1,9 +1,8 @@
 //! Tests for the `cargo logout` command.
 
-use cargo_test_support::install::cargo_home;
+use super::login::check_token;
 use cargo_test_support::registry::TestRegistry;
 use cargo_test_support::{cargo_process, registry};
-use std::fs;
 
 #[cargo_test]
 fn gated() {
@@ -21,32 +20,9 @@ the `cargo logout` command.
         .run();
 }
 
-/// Checks whether or not the token is set for the given token.
-fn check_config_token(registry: Option<&str>, should_be_set: bool) {
-    let credentials = cargo_home().join("credentials.toml");
-    let contents = fs::read_to_string(&credentials).unwrap();
-    let toml: toml::Table = contents.parse().unwrap();
-    if let Some(registry) = registry {
-        assert_eq!(
-            toml.get("registries")
-                .and_then(|registries| registries.get(registry))
-                .and_then(|registry| registry.get("token"))
-                .is_some(),
-            should_be_set
-        );
-    } else {
-        assert_eq!(
-            toml.get("registry")
-                .and_then(|registry| registry.get("token"))
-                .is_some(),
-            should_be_set
-        );
-    }
-}
-
 fn simple_logout_test(registry: &TestRegistry, reg: Option<&str>, flag: &str, note: &str) {
     let msg = reg.unwrap_or("crates-io");
-    check_config_token(reg, true);
+    check_token(Some(registry.token()), reg);
     let mut cargo = cargo_process(&format!("logout -Z unstable-options {}", flag));
     if reg.is_none() {
         cargo.replace_crates_io(registry.index_url());
@@ -61,7 +37,7 @@ If you need to revoke the token, visit {note} and follow the instructions there.
 "
         ))
         .run();
-    check_config_token(reg, false);
+    check_token(None, reg);
 
     let mut cargo = cargo_process(&format!("logout -Z unstable-options {}", flag));
     if reg.is_none() {
@@ -71,7 +47,7 @@ If you need to revoke the token, visit {note} and follow the instructions there.
         .masquerade_as_nightly_cargo(&["cargo-logout"])
         .with_stderr(&format!("[LOGOUT] not currently logged in to `{msg}`"))
         .run();
-    check_config_token(reg, false);
+    check_token(None, reg);
 }
 
 #[cargo_test]
@@ -89,4 +65,6 @@ fn other_registry() {
         "--registry alternative",
         "the `alternative` website",
     );
+    // It should not touch crates.io.
+    check_token(Some("sekrit"), None);
 }

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -105,18 +105,18 @@ fn default_registry_configured() {
         .masquerade_as_nightly_cargo(&["cargo-logout"])
         .with_stderr(
             "\
-[LOGOUT] token for `crates-io` has been removed from local storage
+[LOGOUT] token for `dummy-registry` has been removed from local storage
 [NOTE] This does not revoke the token on the registry server.
-    If you need to revoke the token, visit <https://crates.io/me> \
+    If you need to revoke the token, visit the `dummy-registry` website \
     and follow the instructions there.
 ",
         )
         .run();
-    check_token(Some("dummy-token"), Some("dummy-registry"));
-    check_token(None, None);
+    check_token(None, Some("dummy-registry"));
+    check_token(Some("crates-io-token"), None);
 
     cargo_process("logout -Zunstable-options")
         .masquerade_as_nightly_cargo(&["cargo-logout"])
-        .with_stderr("[LOGOUT] not currently logged in to `crates-io`")
+        .with_stderr("[LOGOUT] not currently logged in to `dummy-registry`")
         .run();
 }


### PR DESCRIPTION
This changes `cargo login` and `cargo logout` to use the registry configured at `registry.default` as the registry instead of crates.io. For `cargo login`, this was an unintentional regression from #6466. The documentation has always stated that it will use the default registry.

This makes the command more in line with other registry-involving commands. There are still some inconsistencies.

These commands use the default if not specified:

* `cargo init`
* `cargo new`
* `cargo owner`
* `cargo search`
* `cargo yank`
* `cargo publish` uses the default, but will also look at the `publish` field `Cargo.toml` and use that if the registry is not specified.

These commands would always use crates.io if `--registry` is not specified:

* `cargo login`
* `cargo logout`
* `cargo install`

I'm a bit uncertain how to proceed, since this is technically a breaking change particularly if someone has scripted it. I suspect that the number of users that use `registry.default` is very small, and those that script `cargo login` are even smaller, and thus the intersection is probably small or nonexistent. However, there is some risk here.
