### PR TITLE
Allow named debuginfo options in Cargo.toml

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -762,7 +762,7 @@ impl DebugInfo {
         }
     }
 
-    /// Returns true if the debuginfo level is high enough (at least 1). Helper
+    /// Returns true if any debuginfo will be generated. Helper
     /// for a common operation on the usual `Option` representation.
     pub(crate) fn is_turned_on(&self) -> bool {
         !matches!(self.to_option(), None | Some(TomlDebugInfo::None))

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -55,10 +55,18 @@ impl<'a> Message for Artifact<'a> {
 #[derive(Serialize)]
 pub struct ArtifactProfile {
     pub opt_level: &'static str,
-    pub debuginfo: Option<u32>,
+    pub debuginfo: Option<ArtifactDebuginfo>,
     pub debug_assertions: bool,
     pub overflow_checks: bool,
     pub test: bool,
+}
+
+/// Internally this is an enum with different variants, but keep using 0/1/2 as integers for compatibility.
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum ArtifactDebuginfo {
+    Int(u32),
+    Named(&'static str),
 }
 
 #[derive(Serialize)]

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -477,8 +477,9 @@ impl<'de> de::Deserialize<'de> for TomlDebugInfo {
             type Value = TomlDebugInfo;
 
             fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter
-                    .write_str("a boolean, 0-2, \"line-tables-only\", or \"line-directives-only\"")
+                formatter.write_str(
+                    "a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"",
+                )
             }
 
             fn visit_i64<E>(self, value: i64) -> Result<TomlDebugInfo, E>

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -510,6 +510,9 @@ impl<'de> de::Deserialize<'de> for TomlDebugInfo {
                 E: de::Error,
             {
                 let debuginfo = match value {
+                    "none" => TomlDebugInfo::None,
+                    "limited" => TomlDebugInfo::Limited,
+                    "full" => TomlDebugInfo::Full,
                     "line-directives-only" => TomlDebugInfo::LineDirectivesOnly,
                     "line-tables-only" => TomlDebugInfo::LineTablesOnly,
                     _ => return Err(de::Error::invalid_value(Unexpected::Str(value), &self)),

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -67,9 +67,11 @@ amount of debug information included in the compiled binary.
 
 The valid options are:
 
-* `0` or `false`: no debug info at all
-* `1`: line tables only
-* `2` or `true`: full debug info
+* `0`, `false`, or `"none"`: no debug info at all
+* `"line-directives-only"`: line info directives only. For the nvptx* targets this enables [profiling](https://reviews.llvm.org/D46061). For other use cases, `line-tables-only` is the better, more compatible choice.
+* `"line-tables-only"`: line tables only. Generates the minimal amount of debug info for backtraces with filename/line number info, but not anything else, i.e. no variable or function parameter info.
+* `1` or `"limited"`: debug info without type or variable-level information. Generates more detailed module-level info than `line-tables-only`.
+* `2`, `true`, or `"full"`: full debug info
 
 You may wish to also configure the [`split-debuginfo`](#split-debuginfo) option
 depending on your needs as well.

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -67,16 +67,20 @@ amount of debug information included in the compiled binary.
 
 The valid options are:
 
-* `0`, `false`, or `"none"`: no debug info at all
-* `"line-directives-only"`: line info directives only. For the nvptx* targets this enables [profiling](https://reviews.llvm.org/D46061). For other use cases, `line-tables-only` is the better, more compatible choice.
+* `0`, `false`, or `"none"`: no debug info at all, default for [`release`](#release)
+* `"line-directives-only"`: line info directives only. For the nvptx* targets this enables [profiling]. For other use cases, `line-tables-only` is the better, more compatible choice.
 * `"line-tables-only"`: line tables only. Generates the minimal amount of debug info for backtraces with filename/line number info, but not anything else, i.e. no variable or function parameter info.
 * `1` or `"limited"`: debug info without type or variable-level information. Generates more detailed module-level info than `line-tables-only`.
-* `2`, `true`, or `"full"`: full debug info
+* `2`, `true`, or `"full"`: full debug info, default for [`dev`](#dev)
+
+For more information on what each option does see `rustc`'s docs on [debuginfo].
 
 You may wish to also configure the [`split-debuginfo`](#split-debuginfo) option
 depending on your needs as well.
 
 [`-C debuginfo` flag]: ../../rustc/codegen-options/index.html#debuginfo
+[debuginfo]: ../../rustc/codegen-options/index.html#debuginfo
+[profiling]: https://reviews.llvm.org/D46061
 
 #### split-debuginfo
 

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1320,7 +1320,7 @@ fn bad_debuginfo() {
 error: failed to parse manifest [..]
 
 Caused by:
-  invalid value: string \"a\", expected a boolean, 0-2, \"line-tables-only\", or \"line-directives-only\"
+  invalid value: string \"a\", expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
   in `profile.dev.debug`
 ",
         )
@@ -1352,7 +1352,7 @@ fn bad_debuginfo2() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: floating point `3.6`, expected a boolean, 0-2, \"line-tables-only\", or \"line-directives-only\"
+  invalid type: floating point `3.6`, expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
   in `profile.dev.debug`
 ",
         )

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1317,10 +1317,42 @@ fn bad_debuginfo() {
         .with_status(101)
         .with_stderr(
             "\
+error: failed to parse manifest [..]
+
+Caused by:
+  invalid value: string \"a\", expected a boolean, 0-2, \"line-tables-only\", or \"line-directives-only\"
+  in `profile.dev.debug`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bad_debuginfo2() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+
+                [profile.dev]
+                debug = 3.6
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
 error: failed to parse manifest at `[..]`
 
 Caused by:
-  expected a boolean or an integer
+  invalid type: floating point `3.6`, expected a boolean, 0-2, \"line-tables-only\", or \"line-directives-only\"
   in `profile.dev.debug`
 ",
         )

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -401,7 +401,7 @@ lto = false
             opt_level: Some(cargo_toml::TomlOptLevel("s".to_string())),
             lto: Some(cargo_toml::StringOrBool::Bool(true)),
             codegen_units: Some(5),
-            debug: Some(cargo_toml::U32OrBool::Bool(true)),
+            debug: Some(cargo_toml::TomlDebugInfo::Full),
             debug_assertions: Some(true),
             rpath: Some(true),
             panic: Some("abort".to_string()),
@@ -444,7 +444,7 @@ fn profile_env_var_prefix() {
         .build();
     let p: cargo_toml::TomlProfile = config.get("profile.dev").unwrap();
     assert_eq!(p.debug_assertions, None);
-    assert_eq!(p.debug, Some(cargo_toml::U32OrBool::U32(1)));
+    assert_eq!(p.debug, Some(cargo_toml::TomlDebugInfo::Limited));
 
     let config = ConfigBuilder::new()
         .env("CARGO_PROFILE_DEV_DEBUG_ASSERTIONS", "false")
@@ -452,7 +452,7 @@ fn profile_env_var_prefix() {
         .build();
     let p: cargo_toml::TomlProfile = config.get("profile.dev").unwrap();
     assert_eq!(p.debug_assertions, Some(false));
-    assert_eq!(p.debug, Some(cargo_toml::U32OrBool::U32(1)));
+    assert_eq!(p.debug, Some(cargo_toml::TomlDebugInfo::Limited));
 }
 
 #[cargo_test]
@@ -1511,7 +1511,7 @@ fn all_profile_options() {
         lto: Some(cargo_toml::StringOrBool::String("thin".to_string())),
         codegen_backend: Some(InternedString::new("example")),
         codegen_units: Some(123),
-        debug: Some(cargo_toml::U32OrBool::U32(1)),
+        debug: Some(cargo_toml::TomlDebugInfo::Limited),
         split_debuginfo: Some("packed".to_string()),
         debug_assertions: Some(true),
         rpath: Some(true),

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -1,5 +1,6 @@
 //! Tests for profiles defined in config files.
 
+use cargo::util::toml::TomlDebugInfo;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, paths, project};
@@ -436,7 +437,7 @@ fn named_config_profile() {
     assert_eq!(p.name, "foo");
     assert_eq!(p.codegen_units, Some(2)); // "foo" from config
     assert_eq!(p.opt_level, "1"); // "middle" from manifest
-    assert_eq!(p.debuginfo.to_option(), Some(1)); // "bar" from config
+    assert_eq!(p.debuginfo.to_option(), Some(TomlDebugInfo::Limited)); // "bar" from config
     assert_eq!(p.debug_assertions, true); // "dev" built-in (ignore build-override)
     assert_eq!(p.overflow_checks, true); // "dev" built-in (ignore package override)
 
@@ -445,7 +446,7 @@ fn named_config_profile() {
     assert_eq!(bo.name, "foo");
     assert_eq!(bo.codegen_units, Some(6)); // "foo" build override from config
     assert_eq!(bo.opt_level, "0"); // default to zero
-    assert_eq!(bo.debuginfo.to_option(), Some(1)); // SAME as normal
+    assert_eq!(bo.debuginfo.to_option(), Some(TomlDebugInfo::Limited)); // SAME as normal
     assert_eq!(bo.debug_assertions, false); // "foo" build override from manifest
     assert_eq!(bo.overflow_checks, true); // SAME as normal
 
@@ -454,7 +455,7 @@ fn named_config_profile() {
     assert_eq!(po.name, "foo");
     assert_eq!(po.codegen_units, Some(7)); // "foo" package override from config
     assert_eq!(po.opt_level, "1"); // SAME as normal
-    assert_eq!(po.debuginfo.to_option(), Some(1)); // SAME as normal
+    assert_eq!(po.debuginfo.to_option(), Some(TomlDebugInfo::Limited)); // SAME as normal
     assert_eq!(po.debug_assertions, true); // SAME as normal
     assert_eq!(po.overflow_checks, false); // "middle" package override from manifest
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

-->

### What does this PR try to resolve?

Rustc supports these since rust-lang/rust#109808. It's technically possible to set a named debuginfo level through `RUSTFLAGS`, but in practice cargo always passes its own opinion of what the debuginfo level is, so allow it to be configured through cargo too so the options don't conflict.

Note that this also adds support for `"none"`, `"limited"`, and `"full"` as aliases for 0, 1, and 2 respectively. The motivation is not just to match rustc, but also to make it easier for us to change the default for `1` over an edition to mean `"line-tables-only"` instead of `"limited"`. If we allow `limited` as an alias for `1`, people will be able to use it before and after the change in defaults  to mean the same thing; if we disallow it and only allow it in the new edition, it will be impossible to have the same code work with both new and old versions of cargo.

### How should we test and review this PR?

All modified tests are normal tests that can be run with `cargo test`. You can also build cargo from source and verify that `CARGO_PROFILE_DEV_DEBUG=line-tables-only cargo build` on a hello world project correctly passes `-C debuginfo=line-tables-only` through to rustc.

I recommend viewing this with whitespace changes hidden.

### Additional information

Enabling these flags in cargo is required before bootstrap can start passing them through to rustc (which I'd like to do so we can reduce the size of the generated artifacts: https://github.com/rust-lang/rust/pull/104968#issuecomment-1474884018).

<!-- homu-ignore:end -->
