### PR TITLE
fix: AIX searches dynamic libraries in `LIBPATH`.

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -55,6 +55,8 @@ pub fn dylib_path_envvar() -> &'static str {
         // penalty starting in 10.13. Cargo's testsuite ran more than twice as
         // slow with it on CI.
         "DYLD_FALLBACK_LIBRARY_PATH"
+    } else if cfg!(target_os = "aix") {
+        "LIBPATH"
     } else {
         "LD_LIBRARY_PATH"
     }

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -274,6 +274,7 @@ on the platform:
 * Windows: `PATH`
 * macOS: `DYLD_FALLBACK_LIBRARY_PATH`
 * Unix: `LD_LIBRARY_PATH`
+* AIX: `LIBPATH`
 
 The value is extended from the existing value when Cargo starts. macOS has
 special consideration where if `DYLD_FALLBACK_LIBRARY_PATH` is not already


### PR DESCRIPTION
### What does this PR try to resolve?

On IBM AIX machines people have encountered issues in `compiletest` and rustc's bootstrap builder. They haven't encountered any in cargo. This PR is made for avoiding potential failures in the future in cargo.

It's documented in <https://www.ibm.com/support/pages/libpath-environment-variables-aix-platforms>:

> The `LIBPATH` environment variable tells AIX applications where to find shared libraries when located in a different directories than those specified in the header section of the executable.

See also the counterpart in <https://github.com/rust-lang/rust/pull/109526>

### How to verify and test this in Cargo's CI?

This is indeed an issue. At IBM people are maintaining a buildbot since GitHub Action doesn't support AIX yet.