### PR TITLE
Fix flaky not_found_permutations test.

### DIFF
--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3183,13 +3183,14 @@ required by package `foo v0.0.1 ([ROOT]/foo)`
 ",
         )
         .run();
-    let misses = misses.lock().unwrap();
+    let mut misses = misses.lock().unwrap();
+    misses.sort();
     assert_eq!(
         &*misses,
         &[
             "/index/a-/b-/a-b-c",
-            "/index/a_/b-/a_b-c",
             "/index/a-/b_/a-b_c",
+            "/index/a_/b-/a_b-c",
             "/index/a_/b_/a_b_c"
         ]
     );


### PR DESCRIPTION
This fixes the `registry::not_found_permutations` test which would randomly fail since the order of http requests was not deterministic. The resolver can issue queries in parallel which can process requests out-of-order.

Fixes #11975