### PR TITLE
Add a success message on publish to `crates.io`

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -245,6 +245,20 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         }
     }
 
+    // Print success note on publish
+    if opts.registry.is_none() {
+        if let Some(ref registries) = pkg.publish() {
+            if registries[0] == CRATES_IO_REGISTRY {
+                if let Ok(packages) = opts.to_publish.get_packages(ws) {
+                    for package in packages {
+                        opts.config
+						.shell().note(format!("Your crate was successfully published to crates.io! You can visit it at https://crates.io/crates/{} .", package.name()))?
+                    }
+                }
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1030,7 +1030,7 @@ The registry `alternative` is not listed in the `package.publish` value in Cargo
 note: Waiting [..]
 You may press ctrl-c [..]
 [PUBLISHED] foo v0.0.1 [..]
-",
+note: Your crate was successfully published to crates.io! You can visit it at https://crates.io/crates/foo .",
         )
         .run();
 }


### PR DESCRIPTION
Fixes #11768 
Adds a success message when publishing a crate to crates.io (only crates.io).

## Why?

The current `cargo publish` output isn't very helpful or gives a lot of feedback.

It's something like:

```
$ cargo publish
    [...]
    Updating crates.io index

$
```

And that's it, it ends with a boring "Updating index" message. It could be very handy if, after a publish, Cargo printed the URL to the crates in crates.io along with a success message with some more :sparkles: **Magic** :sparkles: 

---

This PR adds a message that congratulates the user for publishing their crates, so it feels better to publish a crate!