### PR TITLE
feat(cargo-metadata): add `workspace_default_members`

### DIFF
--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -43,6 +43,7 @@ pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> Cargo
     Ok(ExportInfo {
         packages,
         workspace_members: ws.members().map(|pkg| pkg.package_id()).collect(),
+        workspace_default_members: ws.default_members().map(|pkg| pkg.package_id()).collect(),
         resolve,
         target_directory: ws.target_dir().into_path_unlocked(),
         version: VERSION,
@@ -58,6 +59,7 @@ pub fn output_metadata(ws: &Workspace<'_>, opt: &OutputMetadataOptions) -> Cargo
 pub struct ExportInfo {
     packages: Vec<SerializedPackage>,
     workspace_members: Vec<PackageId>,
+    workspace_default_members: Vec<PackageId>,
     resolve: Option<MetadataResolve>,
     target_directory: PathBuf,
     version: u32,

--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -212,6 +212,12 @@ The output has the following format:
     "workspace_members": [
         "my-package 0.1.0 (path+file:///path/to/my-package)",
     ],
+    /* Array of default members of the workspace.
+       Each entry is the Package ID for the package.
+    */
+    "workspace_default_members": [
+        "my-package 0.1.0 (path+file:///path/to/my-package)",
+    ],
     // The resolved dependency graph for the entire workspace. The enabled
     // features are based on the enabled features for the "current" package.
     // Inactivated optional dependencies are not listed.

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -207,6 +207,12 @@ OUTPUT FORMAT
                "workspace_members": [
                    "my-package 0.1.0 (path+file:///path/to/my-package)",
                ],
+               /* Array of default members of the workspace.
+                  Each entry is the Package ID for the package.
+               */
+               "workspace_default_members": [
+                   "my-package 0.1.0 (path+file:///path/to/my-package)",
+               ],
                // The resolved dependency graph for the entire workspace. The enabled
                // features are based on the enabled features for the "current" package.
                // Inactivated optional dependencies are not listed.

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -212,6 +212,12 @@ The output has the following format:
     "workspace_members": [
         "my-package 0.1.0 (path+file:///path/to/my-package)",
     ],
+    /* Array of default members of the workspace.
+       Each entry is the Package ID for the package.
+    */
+    "workspace_default_members": [
+        "my-package 0.1.0 (path+file:///path/to/my-package)",
+    ],
     // The resolved dependency graph for the entire workspace. The enabled
     // features are based on the enabled features for the "current" package.
     // Inactivated optional dependencies are not listed.

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -209,6 +209,12 @@ The output has the following format:
     "workspace_members": [
         "my\-package 0.1.0 (path+file:///path/to/my\-package)",
     ],
+    /* Array of default members of the workspace.
+       Each entry is the Package ID for the package.
+    */
+    "workspace_default_members": [
+        "my\-package 0.1.0 (path+file:///path/to/my\-package)",
+    ],
     // The resolved dependency graph for the entire workspace. The enabled
     // features are based on the enabled features for the "current" package.
     // Inactivated optional dependencies are not listed.

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -902,6 +902,9 @@ fn alt_reg_metadata() {
                 "workspace_members": [
                     "foo 0.0.1 (path+file:[..]/foo)"
                 ],
+                "workspace_default_members": [
+                    "foo 0.0.1 (path+file:[..]/foo)"
+                ],
                 "resolve": null,
                 "target_directory": "[..]/foo/target",
                 "version": 1,
@@ -1102,6 +1105,9 @@ fn alt_reg_metadata() {
                 "workspace_members": [
                     "foo 0.0.1 (path+file:[..]/foo)"
                 ],
+                "workspace_default_members": [
+                    "foo 0.0.1 (path+file:[..]/foo)"
+                ],
                 "resolve": "{...}",
                 "target_directory": "[..]/foo/target",
                 "version": 1,
@@ -1263,6 +1269,9 @@ fn unknown_registry() {
                 }
               ],
               "workspace_members": [
+                "foo 0.0.1 (path+file://[..]/foo)"
+              ],
+              "workspace_default_members": [
                 "foo 0.0.1 (path+file://[..]/foo)"
               ],
               "resolve": "{...}",

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -609,6 +609,7 @@ fn json_exposed() {
                     }
                   ],
                   "workspace_members": "{...}",
+                  "workspace_default_members": "{...}",
                   "resolve": null,
                   "target_directory": "[..]foo/target",
                   "version": 1,

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3337,6 +3337,9 @@ fn metadata_master_consistency() {
               "workspace_members": [
                 "foo 0.1.0 [..]"
               ],
+              "workspace_default_members": [
+                "foo 0.1.0 [..]"
+              ],
               "resolve": {
                 "nodes": [
                   {

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1954,6 +1954,7 @@ const MANIFEST_OUTPUT: &str = r#"
         "documentation": null
     }],
     "workspace_members": [ "foo 0.5.0 (path+file:[..]foo)" ],
+    "workspace_default_members": [ "foo 0.5.0 (path+file:[..]foo)" ],
     "resolve": null,
     "target_directory": "[..]foo/target",
     "version": 1,
@@ -2318,6 +2319,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                 "workspace_members": [
                     "bar 0.5.0 (path+file:[..])"
                 ],
+                "workspace_default_members": [],
                 "workspace_root": "[..]",
                 "metadata": null
             }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -165,6 +165,7 @@ crate-type = ["lib", "staticlib"]
             }
         ],
         "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "workspace_default_members": ["foo 0.5.0 (path+file:[..]foo)"],
         "resolve": {
             "nodes": [
                 {
@@ -258,6 +259,7 @@ optional_feat = []
             }
         ],
         "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "workspace_default_members": ["foo 0.5.0 (path+file:[..]foo)"],
         "resolve": {
             "nodes": [
                 {
@@ -588,6 +590,9 @@ fn cargo_metadata_with_deps_and_version() {
         "workspace_members": [
             "foo 0.5.0 (path+file:[..]foo)"
         ],
+        "workspace_default_members": [
+            "foo 0.5.0 (path+file:[..]foo)"
+        ],
         "workspace_root": "[..]/foo",
         "metadata": null
     }"#,
@@ -667,6 +672,9 @@ name = "ex"
             }
         ],
         "workspace_members": [
+            "foo 0.1.0 (path+file:[..]foo)"
+        ],
+        "workspace_default_members": [
             "foo 0.1.0 (path+file:[..]foo)"
         ],
         "resolve": {
@@ -762,6 +770,9 @@ crate-type = ["rlib", "dylib"]
             }
         ],
         "workspace_members": [
+            "foo 0.1.0 (path+file:[..]foo)"
+        ],
+         "workspace_default_members": [
             "foo 0.1.0 (path+file:[..]foo)"
         ],
         "resolve": {
@@ -893,6 +904,7 @@ fn workspace_metadata() {
             }
         ],
         "workspace_members": ["bar 0.5.0 (path+file:[..]bar)", "baz 0.5.0 (path+file:[..]baz)"],
+        "workspace_default_members": ["bar 0.5.0 (path+file:[..]bar)", "baz 0.5.0 (path+file:[..]baz)"],
         "resolve": {
             "nodes": [
                 {
@@ -1120,6 +1132,11 @@ fn workspace_metadata_with_dependencies_no_deps() {
             }
         ],
         "workspace_members": [
+            "bar 0.5.0 (path+file:[..]bar)",
+            "artifact 0.5.0 (path+file:[..]/foo/artifact)",
+            "baz 0.5.0 (path+file:[..]baz)"
+        ],
+        "workspace_default_members": [
             "bar 0.5.0 (path+file:[..]bar)",
             "artifact 0.5.0 (path+file:[..]/foo/artifact)",
             "baz 0.5.0 (path+file:[..]baz)"
@@ -1756,6 +1773,12 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                 "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)",
                 "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
               ],
+              "workspace_default_members": [
+                "bar 0.5.0 (path+file://[..]/foo/bar)",
+                "artifact 0.5.0 (path+file://[..]/foo/artifact)",
+                "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)",
+                "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
+              ],
               "workspace_root": "[..]/foo"
             }
     "#,
@@ -2149,6 +2172,7 @@ fn package_metadata() {
             }
         ],
         "workspace_members": ["foo[..]"],
+        "workspace_default_members": ["foo[..]"],
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -2224,6 +2248,7 @@ fn package_publish() {
             }
         ],
         "workspace_members": ["foo[..]"],
+        "workspace_default_members": ["foo[..]"],
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -2319,7 +2344,9 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                 "workspace_members": [
                     "bar 0.5.0 (path+file:[..])"
                 ],
-                "workspace_default_members": [],
+                "workspace_default_members": [
+                    "bar 0.5.0 (path+file:[..])"
+                ],
                 "workspace_root": "[..]",
                 "metadata": null
             }
@@ -2406,6 +2433,9 @@ fn package_edition_2018() {
                 "target_directory": "[..]",
                 "version": 1,
                 "workspace_members": [
+                    "foo 0.1.0 (path+file:[..])"
+                ],
+                "workspace_default_members": [
                     "foo 0.1.0 (path+file:[..])"
                 ],
                 "workspace_root": "[..]",
@@ -2554,6 +2584,9 @@ fn target_edition_2018() {
                 "target_directory": "[..]",
                 "version": 1,
                 "workspace_members": [
+                    "foo 0.1.0 (path+file:[..])"
+                ],
+                "workspace_default_members": [
                     "foo 0.1.0 (path+file:[..])"
                 ],
                 "workspace_root": "[..]",
@@ -2792,6 +2825,9 @@ fn rename_dependency() {
     "workspace_members": [
         "foo 0.0.1[..]"
     ],
+    "workspace_default_members": [
+        "foo 0.0.1[..]"
+    ],
     "workspace_root": "[..]",
     "metadata": null
 }"#,
@@ -2892,6 +2928,9 @@ fn metadata_links() {
               "workspace_members": [
                 "foo 0.5.0 [..]"
               ],
+              "workspace_default_members": [
+                "foo 0.5.0 [..]"
+              ],
               "workspace_root": "[..]/foo",
               "metadata": null
             }
@@ -2980,6 +3019,9 @@ fn deps_with_bin_only() {
                 }
               ],
               "workspace_members": [
+                "foo 0.1.0 ([..])"
+              ],
+              "workspace_default_members": [
                 "foo 0.1.0 ([..])"
               ],
               "resolve": {
@@ -3361,6 +3403,9 @@ fn filter_platform() {
   "workspace_members": [
     "foo 0.1.0 (path+file:[..]foo)"
   ],
+  "workspace_default_members": [
+    "foo 0.1.0 (path+file:[..]foo)"
+  ],
   "resolve": {
     "nodes": [
       {
@@ -3480,6 +3525,7 @@ fn filter_platform() {
     $NORMAL_DEP
   ],
   "workspace_members": "{...}",
+  "workspace_default_members": "{...}",
   "resolve": {
     "nodes": [
       {
@@ -3561,6 +3607,7 @@ fn filter_platform() {
     $NORMAL_DEP
   ],
   "workspace_members": "{...}",
+  "workspace_default_members": "{...}",
   "resolve": {
     "nodes": [
       {
@@ -3645,6 +3692,7 @@ fn filter_platform() {
     $NORMAL_DEP
   ],
   "workspace_members": "{...}",
+  "workspace_default_members": "{...}",
   "resolve": {
     "nodes": [
       {
@@ -3759,6 +3807,7 @@ fn dep_kinds() {
             {
               "packages": "{...}",
               "workspace_members": "{...}",
+              "workspace_default_members": "{...}",
               "target_directory": "{...}",
               "version": 1,
               "workspace_root": "{...}",
@@ -3874,6 +3923,7 @@ fn dep_kinds_workspace() {
             {
               "packages": "{...}",
               "workspace_members": "{...}",
+              "workspace_default_members": "{...}",
               "target_directory": "[..]/foo/target",
               "version": 1,
               "workspace_root": "[..]/foo",
@@ -4183,6 +4233,11 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
               "target_directory": "[..]/foo/target",
               "version": 1,
               "workspace_members": [
+                "bar 0.5.0 (path+file://[..]/foo/bar)",
+                "artifact 0.5.0 (path+file://[..]/foo/artifact)",
+                "baz 0.5.0 (path+file://[..]/foo/baz)"
+              ],
+              "workspace_default_members": [
                 "bar 0.5.0 (path+file://[..]/foo/bar)",
                 "artifact 0.5.0 (path+file://[..]/foo/artifact)",
                 "baz 0.5.0 (path+file://[..]/foo/baz)"

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -65,6 +65,7 @@ fn cargo_metadata_simple() {
             }
         ],
         "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "workspace_default_members": ["foo 0.5.0 (path+file:[..]foo)"],
         "resolve": {
             "nodes": [
                 {

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -633,6 +633,9 @@ fn update_precise_first_run() {
   "workspace_members": [
     "bar 0.0.1 (path+file://[..]/foo)"
   ],
+  "workspace_default_members": [
+    "bar 0.0.1 (path+file://[..]/foo)"
+  ],
   "workspace_root": "[..]/foo",
   "metadata": null
 }"#,


### PR DESCRIPTION


### What does this PR try to resolve?

Fixes  #8033.

### How should we test and review this PR?

 I fixed one test "cargo_metadata_simple". Other tests haven't been updated, and potentially additional tests could be added to test the new functionality specifically. 

### Additional information

More tests would have to be updated. This change adds "workspace_default_members" to the ExportInfo struct which is serialized to json. I would imagine this could break existing testing infrastructure, but existing crates / apps reading this output should presumably expect that additional fields / data could be added. 
