### PR TITLE
chore: use openssl only on non-Windows platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,6 @@ libgit2-sys = "0.15.0"
 log = "0.4.6"
 memchr = "2.1.3"
 opener = "0.5"
-openssl = { version = '0.10.11', optional = true }
 os_info = "3.5.0"
 pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"
@@ -99,6 +98,9 @@ unicode-width = "0.1.5"
 unicode-xid = "0.2.0"
 url = "2.2.2"
 walkdir = "2.2"
+
+[target.'cfg(not(windows))'.dependencies]
+openssl = { version = "0.10.50", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 fwdansi = "1.1.0"


### PR DESCRIPTION
On Windows, the system-provided Schannel will be used instead.

See

- https://github.com/rust-lang/rust/pull/109133#issuecomment-1510029269
- https://github.com/rust-lang/cargo/blob/39116ccc9b420a883a98a960f0597f9cf87414b8/README.md?plain=1#L38-L49