### PR TITLE
fix: Allow win/mac credential managers to build on all platforms

### DIFF
--- a/crates/credential/cargo-credential-macos-keychain/src/main.rs
+++ b/crates/credential/cargo-credential-macos-keychain/src/main.rs
@@ -1,5 +1,6 @@
 //! Cargo registry macos keychain credential process.
 
+#[cfg(target_os = "macos")]
 mod macos {
     use cargo_credential::{Credential, Error};
     use security_framework::os::macos::keychain::SecKeychain;
@@ -47,6 +48,11 @@ mod macos {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+use cargo_credential::UnsupportedCredential as MacKeychain;
+#[cfg(target_os = "macos")]
+use macos::MacKeychain;
+
 fn main() {
-    cargo_credential::main(macos::MacKeychain);
+    cargo_credential::main(MacKeychain);
 }

--- a/crates/credential/cargo-credential-macos-keychain/src/main.rs
+++ b/crates/credential/cargo-credential-macos-keychain/src/main.rs
@@ -1,50 +1,52 @@
 //! Cargo registry macos keychain credential process.
 
-use cargo_credential::{Credential, Error};
-use security_framework::os::macos::keychain::SecKeychain;
+mod macos {
+    use cargo_credential::{Credential, Error};
+    use security_framework::os::macos::keychain::SecKeychain;
 
-struct MacKeychain;
+    pub(crate) struct MacKeychain;
 
-/// The account name is not used.
-const ACCOUNT: &'static str = "";
+    /// The account name is not used.
+    const ACCOUNT: &'static str = "";
 
-fn registry(registry_name: &str) -> String {
-    format!("cargo-registry:{}", registry_name)
-}
-
-impl Credential for MacKeychain {
-    fn name(&self) -> &'static str {
-        env!("CARGO_PKG_NAME")
+    fn registry(registry_name: &str) -> String {
+        format!("cargo-registry:{}", registry_name)
     }
 
-    fn get(&self, index_url: &str) -> Result<String, Error> {
-        let keychain = SecKeychain::default().unwrap();
-        let service_name = registry(index_url);
-        let (pass, _item) = keychain.find_generic_password(&service_name, ACCOUNT)?;
-        String::from_utf8(pass.as_ref().to_vec())
-            .map_err(|_| "failed to convert token to UTF8".into())
-    }
-
-    fn store(&self, index_url: &str, token: &str, name: Option<&str>) -> Result<(), Error> {
-        let keychain = SecKeychain::default().unwrap();
-        let service_name = registry(name.unwrap_or(index_url));
-        if let Ok((_pass, mut item)) = keychain.find_generic_password(&service_name, ACCOUNT) {
-            item.set_password(token.as_bytes())?;
-        } else {
-            keychain.add_generic_password(&service_name, ACCOUNT, token.as_bytes())?;
+    impl Credential for MacKeychain {
+        fn name(&self) -> &'static str {
+            env!("CARGO_PKG_NAME")
         }
-        Ok(())
-    }
 
-    fn erase(&self, index_url: &str) -> Result<(), Error> {
-        let keychain = SecKeychain::default().unwrap();
-        let service_name = registry(index_url);
-        let (_pass, item) = keychain.find_generic_password(&service_name, ACCOUNT)?;
-        item.delete();
-        Ok(())
+        fn get(&self, index_url: &str) -> Result<String, Error> {
+            let keychain = SecKeychain::default().unwrap();
+            let service_name = registry(index_url);
+            let (pass, _item) = keychain.find_generic_password(&service_name, ACCOUNT)?;
+            String::from_utf8(pass.as_ref().to_vec())
+                .map_err(|_| "failed to convert token to UTF8".into())
+        }
+
+        fn store(&self, index_url: &str, token: &str, name: Option<&str>) -> Result<(), Error> {
+            let keychain = SecKeychain::default().unwrap();
+            let service_name = registry(name.unwrap_or(index_url));
+            if let Ok((_pass, mut item)) = keychain.find_generic_password(&service_name, ACCOUNT) {
+                item.set_password(token.as_bytes())?;
+            } else {
+                keychain.add_generic_password(&service_name, ACCOUNT, token.as_bytes())?;
+            }
+            Ok(())
+        }
+
+        fn erase(&self, index_url: &str) -> Result<(), Error> {
+            let keychain = SecKeychain::default().unwrap();
+            let service_name = registry(index_url);
+            let (_pass, item) = keychain.find_generic_password(&service_name, ACCOUNT)?;
+            item.delete();
+            Ok(())
+        }
     }
 }
 
 fn main() {
-    cargo_credential::main(MacKeychain);
+    cargo_credential::main(macos::MacKeychain);
 }

--- a/crates/credential/cargo-credential-wincred/src/main.rs
+++ b/crates/credential/cargo-credential-wincred/src/main.rs
@@ -1,111 +1,116 @@
 //! Cargo registry windows credential process.
 
-use cargo_credential::{Credential, Error};
-use std::ffi::OsStr;
-use std::os::windows::ffi::OsStrExt;
+mod win {
+    use cargo_credential::{Credential, Error};
+    use std::ffi::OsStr;
+    use std::os::windows::ffi::OsStrExt;
 
-use windows_sys::core::PWSTR;
-use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
-use windows_sys::Win32::Foundation::FILETIME;
-use windows_sys::Win32::Foundation::TRUE;
-use windows_sys::Win32::Security::Credentials::CredDeleteW;
-use windows_sys::Win32::Security::Credentials::CredReadW;
-use windows_sys::Win32::Security::Credentials::CredWriteW;
-use windows_sys::Win32::Security::Credentials::CREDENTIALW;
-use windows_sys::Win32::Security::Credentials::CRED_PERSIST_LOCAL_MACHINE;
-use windows_sys::Win32::Security::Credentials::CRED_TYPE_GENERIC;
+    use windows_sys::core::PWSTR;
+    use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
+    use windows_sys::Win32::Foundation::FILETIME;
+    use windows_sys::Win32::Foundation::TRUE;
+    use windows_sys::Win32::Security::Credentials::CredDeleteW;
+    use windows_sys::Win32::Security::Credentials::CredReadW;
+    use windows_sys::Win32::Security::Credentials::CredWriteW;
+    use windows_sys::Win32::Security::Credentials::CREDENTIALW;
+    use windows_sys::Win32::Security::Credentials::CRED_PERSIST_LOCAL_MACHINE;
+    use windows_sys::Win32::Security::Credentials::CRED_TYPE_GENERIC;
 
-struct WindowsCredential;
+    pub(crate) struct WindowsCredential;
 
-/// Converts a string to a nul-terminated wide UTF-16 byte sequence.
-fn wstr(s: &str) -> Vec<u16> {
-    let mut wide: Vec<u16> = OsStr::new(s).encode_wide().collect();
-    if wide.iter().any(|b| *b == 0) {
-        panic!("nul byte in wide string");
-    }
-    wide.push(0);
-    wide
-}
-
-fn target_name(registry_name: &str) -> Vec<u16> {
-    wstr(&format!("cargo-registry:{}", registry_name))
-}
-
-impl Credential for WindowsCredential {
-    fn name(&self) -> &'static str {
-        env!("CARGO_PKG_NAME")
+    /// Converts a string to a nul-terminated wide UTF-16 byte sequence.
+    fn wstr(s: &str) -> Vec<u16> {
+        let mut wide: Vec<u16> = OsStr::new(s).encode_wide().collect();
+        if wide.iter().any(|b| *b == 0) {
+            panic!("nul byte in wide string");
+        }
+        wide.push(0);
+        wide
     }
 
-    fn get(&self, index_url: &str) -> Result<String, Error> {
-        let target_name = target_name(index_url);
-        let p_credential: *mut CREDENTIALW = std::ptr::null_mut() as *mut _;
-        unsafe {
-            if CredReadW(
-                target_name.as_ptr(),
-                CRED_TYPE_GENERIC,
-                0,
-                p_credential as *mut _ as *mut _,
-            ) != TRUE
-            {
-                return Err(
-                    format!("failed to fetch token: {}", std::io::Error::last_os_error()).into(),
+    fn target_name(registry_name: &str) -> Vec<u16> {
+        wstr(&format!("cargo-registry:{}", registry_name))
+    }
+
+    impl Credential for WindowsCredential {
+        fn name(&self) -> &'static str {
+            env!("CARGO_PKG_NAME")
+        }
+
+        fn get(&self, index_url: &str) -> Result<String, Error> {
+            let target_name = target_name(index_url);
+            let p_credential: *mut CREDENTIALW = std::ptr::null_mut() as *mut _;
+            unsafe {
+                if CredReadW(
+                    target_name.as_ptr(),
+                    CRED_TYPE_GENERIC,
+                    0,
+                    p_credential as *mut _ as *mut _,
+                ) != TRUE
+                {
+                    return Err(format!(
+                        "failed to fetch token: {}",
+                        std::io::Error::last_os_error()
+                    )
+                    .into());
+                }
+                let bytes = std::slice::from_raw_parts(
+                    (*p_credential).CredentialBlob,
+                    (*p_credential).CredentialBlobSize as usize,
                 );
+                String::from_utf8(bytes.to_vec())
+                    .map_err(|_| "failed to convert token to UTF8".into())
             }
-            let bytes = std::slice::from_raw_parts(
-                (*p_credential).CredentialBlob,
-                (*p_credential).CredentialBlobSize as usize,
-            );
-            String::from_utf8(bytes.to_vec()).map_err(|_| "failed to convert token to UTF8".into())
         }
-    }
 
-    fn store(&self, index_url: &str, token: &str, name: Option<&str>) -> Result<(), Error> {
-        let token = token.as_bytes();
-        let target_name = target_name(index_url);
-        let comment = match name {
-            Some(name) => wstr(&format!("Cargo registry token for {}", name)),
-            None => wstr("Cargo registry token"),
-        };
-        let mut credential = CREDENTIALW {
-            Flags: 0,
-            Type: CRED_TYPE_GENERIC,
-            TargetName: target_name.as_ptr() as PWSTR,
-            Comment: comment.as_ptr() as PWSTR,
-            LastWritten: FILETIME {
-                dwLowDateTime: 0,
-                dwHighDateTime: 0,
-            },
-            CredentialBlobSize: token.len() as u32,
-            CredentialBlob: token.as_ptr() as *mut u8,
-            Persist: CRED_PERSIST_LOCAL_MACHINE,
-            AttributeCount: 0,
-            Attributes: std::ptr::null_mut(),
-            TargetAlias: std::ptr::null_mut(),
-            UserName: std::ptr::null_mut(),
-        };
-        let result = unsafe { CredWriteW(&mut credential, 0) };
-        if result != TRUE {
-            let err = std::io::Error::last_os_error();
-            return Err(format!("failed to store token: {}", err).into());
-        }
-        Ok(())
-    }
-
-    fn erase(&self, index_url: &str) -> Result<(), Error> {
-        let target_name = target_name(index_url);
-        let result = unsafe { CredDeleteW(target_name.as_ptr(), CRED_TYPE_GENERIC, 0) };
-        if result != TRUE {
-            let err = std::io::Error::last_os_error();
-            if err.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
-                eprintln!("not currently logged in to `{}`", index_url);
-                return Ok(());
+        fn store(&self, index_url: &str, token: &str, name: Option<&str>) -> Result<(), Error> {
+            let token = token.as_bytes();
+            let target_name = target_name(index_url);
+            let comment = match name {
+                Some(name) => wstr(&format!("Cargo registry token for {}", name)),
+                None => wstr("Cargo registry token"),
+            };
+            let mut credential = CREDENTIALW {
+                Flags: 0,
+                Type: CRED_TYPE_GENERIC,
+                TargetName: target_name.as_ptr() as PWSTR,
+                Comment: comment.as_ptr() as PWSTR,
+                LastWritten: FILETIME {
+                    dwLowDateTime: 0,
+                    dwHighDateTime: 0,
+                },
+                CredentialBlobSize: token.len() as u32,
+                CredentialBlob: token.as_ptr() as *mut u8,
+                Persist: CRED_PERSIST_LOCAL_MACHINE,
+                AttributeCount: 0,
+                Attributes: std::ptr::null_mut(),
+                TargetAlias: std::ptr::null_mut(),
+                UserName: std::ptr::null_mut(),
+            };
+            let result = unsafe { CredWriteW(&mut credential, 0) };
+            if result != TRUE {
+                let err = std::io::Error::last_os_error();
+                return Err(format!("failed to store token: {}", err).into());
             }
-            return Err(format!("failed to remove token: {}", err).into());
+            Ok(())
         }
-        Ok(())
+
+        fn erase(&self, index_url: &str) -> Result<(), Error> {
+            let target_name = target_name(index_url);
+            let result = unsafe { CredDeleteW(target_name.as_ptr(), CRED_TYPE_GENERIC, 0) };
+            if result != TRUE {
+                let err = std::io::Error::last_os_error();
+                if err.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
+                    eprintln!("not currently logged in to `{}`", index_url);
+                    return Ok(());
+                }
+                return Err(format!("failed to remove token: {}", err).into());
+            }
+            Ok(())
+        }
     }
 }
 
 fn main() {
-    cargo_credential::main(WindowsCredential);
+    cargo_credential::main(win::WindowsCredential);
 }

--- a/crates/credential/cargo-credential-wincred/src/main.rs
+++ b/crates/credential/cargo-credential-wincred/src/main.rs
@@ -1,5 +1,6 @@
 //! Cargo registry windows credential process.
 
+#[cfg(windows)]
 mod win {
     use cargo_credential::{Credential, Error};
     use std::ffi::OsStr;
@@ -111,6 +112,11 @@ mod win {
     }
 }
 
+#[cfg(not(windows))]
+use cargo_credential::UnsupportedCredential as WindowsCredential;
+#[cfg(windows)]
+use win::WindowsCredential;
+
 fn main() {
-    cargo_credential::main(win::WindowsCredential);
+    cargo_credential::main(WindowsCredential);
 }

--- a/crates/credential/cargo-credential/src/lib.rs
+++ b/crates/credential/cargo-credential/src/lib.rs
@@ -34,6 +34,26 @@ pub trait Credential {
     fn erase(&self, index_url: &str) -> Result<(), Error>;
 }
 
+pub struct UnsupportedCredential;
+
+impl Credential for UnsupportedCredential {
+    fn name(&self) -> &'static str {
+        "unsupported"
+    }
+
+    fn get(&self, _index_url: &str) -> Result<String, Error> {
+        Err("unsupported".into())
+    }
+
+    fn store(&self, _index_url: &str, _token: &str, _name: Option<&str>) -> Result<(), Error> {
+        Err("unsupported".into())
+    }
+
+    fn erase(&self, _index_url: &str) -> Result<(), Error> {
+        Err("unsupported".into())
+    }
+}
+
 /// Runs the credential interaction by processing the command-line and
 /// environment variables.
 pub fn main(credential: impl Credential) {


### PR DESCRIPTION
### What does this PR try to resolve?

This is a step towards #11987 by making two of the platform-specific credential managers build on all platforms using `cfg`.

I haven't done `gnome-secret` yet because that is more of an oddball in that it isn't just platforms-specific but dependent on what is installed on that platform.

### How should we test and review this PR?

```console
$ cargo check --workspace --exclude cargo-credential-gnome-secret
```

Note that the commits are broken down so you can view the movements of code separate from the functionality being changed.

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
