### PR TITLE
ci: check if Cargo.lock is up-to-date

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,14 @@ jobs:
       # TODO: check every members
       - run: cargo clippy -p cargo --lib --no-deps -- -D warnings
 
+  # Ensure Cargo.lock is up-to-date
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update stable && rustup default stable
+      - run: cargo update -p cargo --locked
+
   test:
     runs-on: ${{ matrix.os }}
     env:

--- a/ci/validate-man.sh
+++ b/ci/validate-man.sh
@@ -5,7 +5,7 @@ set -e
 
 cd src/doc
 
-changes=$(git status --porcelain)
+changes=$(git status --porcelain -- .)
 if [ -n "$changes" ]
 then
     echo "git directory must be clean before running this script."
@@ -14,10 +14,10 @@ fi
 
 ./build-man.sh
 
-changes=$(git status --porcelain)
+changes=$(git status --porcelain -- .)
 if [ -n "$changes" ]
 then
-    echo "Detected changes in man pages:"
+    echo "Detected changes of man pages in src/doc:"
     echo "$changes"
     echo
     echo "Please run './build-man.sh' in the src/doc directory to rebuild the"


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #11992. I believe there is no need to check git status here.

85dc569ac132d8fa369a9a6678542f4dc63f45ed from #11840 is also cherry-picked, since it doesn't need to check changes for the entire git repository.

<!-- homu-ignore:end -->
