### PR TITLE
Add S-triage auto-label.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Create a report to help us improve
-labels: ["C-bug"]
+labels: ["C-bug", "S-triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest an idea for enhancing Cargo
-labels: ["C-feature-request"]
+labels: ["C-feature-request", "S-triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
This automatically adds the https://github.com/rust-lang/cargo/labels/S-triage label to new issues using the template.

This is intended to help make it clear that issues have not been triaged, and need some decision on the next state they should go to.

cc #11788