### PR TITLE
Better error message when getting an empty dep table

### DIFF
--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -279,7 +279,13 @@ impl Dependency {
                     let src = WorkspaceSource::new();
                     src.into()
                 } else {
-                    anyhow::bail!("Unrecognized dependency source for `{key}`");
+                    let mut msg = format!("Unrecognized dependency source for `{key}`");
+                    if table.is_empty() {
+                        msg.push_str(
+                        ", expected a table with a `version`, `git`, `path`, or `workspace` key",
+                    );
+                    }
+                    anyhow::bail!(msg);
                 };
             let registry = if let Some(value) = table.get("registry") {
                 Some(


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?
close https://github.com/rust-lang/cargo/issues/11781

Give more details when getting an empty dep table.

### How should we test and review this PR?

See the unit test.

### Additional information
None
<!-- homu-ignore:end -->
