### PR TITLE
Update linux-raw-sys to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1953,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
 
 [[package]]
 name = "lock_api"


### PR DESCRIPTION
Adds support for LoongArch.
