### PR TITLE
Improve error message for empty dep

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2908,8 +2908,8 @@ impl<P: ResolveToPath + Clone> DetailedTomlDependency<P> {
         if self.version.is_none() && self.path.is_none() && self.git.is_none() {
             let msg = format!(
                 "dependency ({}) specified without \
-                 providing a local path, Git repository, or \
-                 version to use. This will be considered an \
+                 providing a local path, Git repository, version, or \
+                 workspace dependency to use. This will be considered an \
                  error in future versions",
                 name_in_toml
             );

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -780,8 +780,8 @@ fn empty_dependencies() {
     p.cargo("check")
         .with_stderr_contains(
             "\
-warning: dependency (bar) specified without providing a local path, Git repository, or version \
-to use. This will be considered an error in future versions
+warning: dependency (bar) specified without providing a local path, Git repository, version, \
+or workspace dependency to use. This will be considered an error in future versions
 ",
         )
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1269,7 +1269,9 @@ fn error_workspace_dependency_looked_for_workspace_itself() {
         .with_stderr(
             "\
 [WARNING] [CWD]/Cargo.toml: unused manifest key: workspace.dependencies.dep.workspace
-[WARNING] [CWD]/Cargo.toml: dependency (dep) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
+[WARNING] [CWD]/Cargo.toml: dependency (dep) specified without providing a local path, Git repository, version, \
+or workspace dependency to use. \
+This will be considered an error in future versions
 [UPDATING] `dummy-registry` index
 [ERROR] no matching package named `dep` found
 location searched: registry `crates-io`
@@ -1589,7 +1591,9 @@ fn cannot_inherit_in_patch() {
         .with_stderr(
             "\
 [WARNING] [CWD]/Cargo.toml: unused manifest key: patch.crates-io.bar.workspace
-[WARNING] [CWD]/Cargo.toml: dependency (bar) specified without providing a local path, Git repository, or version to use. This will be considered an error in future versions
+[WARNING] [CWD]/Cargo.toml: dependency (bar) specified without providing a local path, Git repository, version, \
+or workspace dependency to use. \
+This will be considered an error in future versions
 [UPDATING] `dummy-registry` index
 [ERROR] failed to resolve patches for `https://github.com/rust-lang/crates.io-index`
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Improve error message for empty dep. Now we can specify a workspace dep in the table.

### How should we test and review this PR?

See the unit tests.

### Additional information

Should we make it an error? Because this warning exists for a long time.

<!-- homu-ignore:end -->
