### PR TITLE
Fix broken links in contributor guide.

### DIFF
--- a/src/doc/contrib/src/implementation/console.md
+++ b/src/doc/contrib/src/implementation/console.md
@@ -19,7 +19,7 @@ the [`JobQueue`] as it processes each message.
 [`Shell`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/shell.rs
 [`Config`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/util/config/mod.rs
 [`drop_print`]: https://github.com/rust-lang/cargo/blob/e4b65bdc80f2a293447f2f6a808fa7c84bf9a357/src/cargo/util/config/mod.rs#L1820-L1848
-[`JobQueue`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/job_queue.rs
+[`JobQueue`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/job_queue/mod.rs
 
 ## Errors
 

--- a/src/doc/contrib/src/implementation/filesystem.md
+++ b/src/doc/contrib/src/implementation/filesystem.md
@@ -17,5 +17,5 @@ its best to handle them. Some examples of issues to deal with:
   fractional part of the time stamp.
 * Symlinks are not always supported, particularly on Windows.
 
-[`fingerprint`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/fingerprint.rs
+[`fingerprint`]: https://github.com/rust-lang/cargo/blob/master/src/cargo/core/compiler/fingerprint/mod.rs
 [`fs::canonicalize`]: https://doc.rust-lang.org/std/fs/fn.canonicalize.html


### PR DESCRIPTION
These modules were recently moved to a new location.