### PR TITLE
Pass the --config settings to external subcommands with CARGO_CONFIG env

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -206,7 +206,10 @@ fn execute_subcommand(config: &Config, cmd_path: Option<&PathBuf>, args: &[&OsSt
         Some(cmd_path) => ProcessBuilder::new(cmd_path),
         None => ProcessBuilder::new(&cargo_exe),
     };
-    cmd.env(cargo::CARGO_ENV, cargo_exe).args(args);
+    let cargo_config = config.cli_config().map(|s| s.join("\n"));
+    cmd.env(cargo::CARGO_ENV, cargo_exe)
+        .env("CARGO_CONFIG", cargo_config.unwrap_or_default())
+        .args(args);
     if let Some(client) = config.jobserver_from_env() {
         cmd.inherit_jobserver(client);
     }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1276,6 +1276,11 @@ impl Config {
         Ok(includes)
     }
 
+    /// Returns the CLI config items.
+    pub fn cli_config(&self) -> Option<&Vec<String>> {
+        self.cli_config.as_ref()
+    }
+
     /// Parses the CLI config args and returns them as a table.
     pub(crate) fn cli_args_as_table(&self) -> CargoResult<ConfigValue> {
         let mut loaded_args = CV::Table(HashMap::new(), Definition::Cli(None));


### PR DESCRIPTION
### What does this PR try to resolve?

This PR makes cargo pass the --config settings to external subcommands with CARGO_CONFIG env.

if the user use --config to change the configurations, but the external subcommands does not know about it.

So we pass the settings by CARGO_CONFIG env to tell external subcommands load the correct configurations same as cargo.
