### PR TITLE
Fix semver checks for 1.69

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -944,7 +944,7 @@ pub fn foo<T, U>() {}
 use updated_crate::foo;
 
 fn main() {
-    foo::<u8>(); // Error: this function takes 2 generic arguments but 1 generic argument was supplied
+    foo::<u8>(); // Error: function takes 2 generic arguments but 1 generic argument was supplied
 }
 ```
 


### PR DESCRIPTION
There is a small wording change in the 1.69 release that was causing this test to fail.