### PR TITLE
`--help` output use line wrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "bitflags",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -3071,6 +3072,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ base64 = "0.21.0"
 bytesize = "1.0"
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.4" }
-clap = "4.2.0"
+clap = { version = "4.2.0", features = ["wrap_help"] }
 crates-io = { path = "crates/crates-io", version = "0.36.0" }
 curl = { version = "0.4.44", features = ["http2"] }
 curl-sys = "0.4.61"


### PR DESCRIPTION
### What does this PR try to resolve?

Enable the `wrap_help` feature to help the output of `--help` wrap, making it easier to read.

Fixes #11895