### PR TITLE
Bump libc to 0.2.142

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,9 +1892,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libgit2-sys"


### PR DESCRIPTION
libc 0.2.141 cannot build successfully on AIX. (CI on AIX is not available yet)

Upgrade libc to 0.2.142 to make cargo build on AIX.