### PR TITLE
Build by PackageIdSpec, not name, to avoid ambiguity

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::{env, fs};
 
 use crate::core::compiler::{CompileKind, DefaultExecutor, Executor, UnitOutput};
-use crate::core::{Dependency, Edition, Package, PackageId, Source, SourceId, Target, Workspace};
+use crate::core::{
+    Dependency, Edition, Package, PackageId, PackageIdSpec, Source, SourceId, Target, Workspace,
+};
 use crate::ops::{common_for_install_and_uninstall::*, FilterRule};
 use crate::ops::{CompileFilter, Packages};
 use crate::sources::{GitSource, PathSource, SourceConfigMap};
@@ -173,7 +175,8 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
         // specialized compile options specific to the identified package.
         // See test `path_install_workspace_root_despite_default_members`.
         let mut opts = original_opts.clone();
-        opts.spec = Packages::Packages(vec![pkg.name().to_string()]);
+        let pkgidspec = PackageIdSpec::from_package_id(pkg.package_id());
+        opts.spec = Packages::Packages(vec![pkgidspec.to_string()]);
 
         let (ws, rustc, target) = make_ws_rustc_target(config, &opts, &source_id, pkg.clone())?;
         // If we're installing in --locked mode and there's no `Cargo.lock` published

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -193,8 +193,9 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
         // specialized compile options specific to the identified package.
         // See test `path_install_workspace_root_despite_default_members`.
         let mut opts = original_opts.clone();
-        // Unlike install source tracking (for --git, see above), use the spec url from the
-        // build workspace (hence unconditional `ws.current()` instead of `pkg` to get `package_id()`).
+        // For cargo install tracking, we retain the source git url in `pkg`, but for the build spec
+        // we need to unconditionally use `ws.current()` to correctly address the path where we
+        // locally cloned that repo.
         let pkgidspec = PackageIdSpec::from_package_id(ws.current()?.package_id());
         opts.spec = Packages::Packages(vec![pkgidspec.to_string()]);
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2365,9 +2365,9 @@ fn self_referential() {
 }
 
 #[cargo_test]
-fn ambiguous_registry_vs_local_workspace_package() {
-    // Correctly install 'foo' from a workspace, even if that workspace
-    // (somewhere) also depends on a registry package named 'foo'.
+fn ambiguous_registry_vs_local_package() {
+    // Correctly install 'foo' from a local package, even if that package also
+    // depends on a registry dependency named 'foo'.
     Package::new("foo", "0.0.1")
         .file("src/lib.rs", "fn hello() {}")
         .publish();


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #11999

I previously added this code to ensure `cargo install` will build the intended package, but it turns out to cause ambiguity in the case where a package depends on prior versions of itself.

This ambiguity can be resolved by identifying the package to build by its pkg-spec, not name.

### How should we test and review this PR?

A test case is included.

I have additionally manually tested that, with this patch, the issue in #11999 is fixed and now installs correctly.