### PR TITLE
Add the Win32_System_Console feature since it is used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ version = "0.45"
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
+  "Win32_System_Console",
   "Win32_System_IO",
   "Win32_System_Threading",
   "Win32_System_JobObjects",


### PR DESCRIPTION
In `src/cargo/core/shell.rs` `windows_sys::Win32::System::Console` is used but the feature is not present in Cargo.toml.

I found it while updating `cargo-c`.