### PR TITLE
Update outdated crates.io URLs in publishing guide

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -12,10 +12,10 @@ limit to the number of versions which can be published, however.
 
 First things first, you’ll need an account on [crates.io] to acquire
 an API token. To do so, [visit the home page][crates.io] and log in via a GitHub
-account (required for now). You will also need to verify your email address on the
-[Account Settings](https://crates.io/me) page. Once that is done create an API token,
-make sure you copy it. Once you leave the page you will not be able to see it
-again.
+account (required for now). You will also need to provide and verify your email
+address on the [Account Settings](https://crates.io/settings/profile) page. Once
+that is done [create an API token](https://crates.io/settings/tokens), make sure
+you copy it. Once you leave the page you will not be able to see it again.
 
 Then run the [`cargo login`] command.
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Apparently crates.io was redesigned some time ago to have separate subpages for the account settings (https://github.com/rust-lang/crates.io/pull/4309). And later on the `/me` path was redirected to the API token creation page (https://github.com/rust-lang/crates.io/pull/4311). Therefore the current publishing documentation is outdated.

### How should we test and review this PR?

Open https://crates.io/settings/profile and click through the settings pages to see their URLs.

Also open https://crates.io/me to see where it redirects to.

### Additional information

There are still multiple references to https://crates.io/me in the code; though if I saw that correctly all the other ones refer to API token creation, so keeping these references should be fine for now.

<!-- homu-ignore:end -->
