### PR TITLE
Bump versions of local crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytesize",
- "cargo-platform 0.1.2",
+ "cargo-platform 0.1.3",
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
@@ -348,15 +348,15 @@ dependencies = [
 [[package]]
 name = "cargo-platform"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+version = "0.1.3"
 dependencies = [
  "serde",
 ]
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
- "cargo-platform 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo-platform 0.1.2",
  "semver",
  "serde",
  "serde_json",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "anyhow",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ path = "src/cargo/lib.rs"
 anyhow = "1.0.47"
 base64 = "0.21.0"
 bytesize = "1.0"
-cargo-platform = { path = "crates/cargo-platform", version = "0.1.2" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.3" }
 cargo-util = { path = "crates/cargo-util", version = "0.2.4" }
 clap = { version = "4.2.0", features = ["wrap_help"] }
-crates-io = { path = "crates/crates-io", version = "0.36.0" }
+crates-io = { path = "crates/crates-io", version = "0.36.1" }
 curl = { version = "0.4.44", features = ["http2"] }
 curl-sys = "0.4.61"
 env_logger = "0.10.0"

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.36.0"
+version = "0.36.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"


### PR DESCRIPTION
These crates have had the following changes since their last version bump:

- `cargo-platform`
    - https://github.com/rust-lang/cargo/pull/11915 — Drop derive feature from serde in cargo-platform
- `crates-io`
    - https://github.com/rust-lang/cargo/pull/11951 — Fix credential token format validation.
    - https://github.com/rust-lang/cargo/pull/11952 — Validate token on publish.

    
AFAICT, none of these seem to warrant a semver breaking change.
