### PR TITLE
Remove wrong url in benchsuite manifest.

### DIFF
--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
-documentation = "https://docs.rs/cargo-platform"
 description = "Benchmarking suite for Cargo."
 
 [dependencies]


### PR DESCRIPTION
This was a copy-paste error when it was added. The documentation field isn't too important here since this is never published.