### PR TITLE
Update windows-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "glob",
  "hex",
  "hmac",
- "home 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "home 0.5.4",
  "http-auth",
  "humantime 2.1.0",
  "ignore",
@@ -305,7 +305,7 @@ dependencies = [
  "unicode-xid",
  "url",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -342,7 +342,7 @@ name = "cargo-credential-wincred"
 version = "0.2.0"
 dependencies = [
  "cargo-credential",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -388,7 +388,7 @@ dependencies = [
  "time",
  "toml",
  "url",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -408,7 +408,7 @@ dependencies = [
  "shell-escape",
  "tempfile",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1546,7 +1546,7 @@ dependencies = [
  "bstr",
  "gix-features",
  "gix-path",
- "home 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "home 0.5.4",
  "thiserror",
  "url",
 ]
@@ -1693,17 +1693,17 @@ dependencies = [
 [[package]]
 name = "home"
 version = "0.5.4"
-dependencies = [
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "home"
-version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ openssl = { version = "0.10.50", optional = true }
 fwdansi = "1.1.0"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.45"
+version = "0.48"
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -29,4 +29,4 @@ toml = "0.7.0"
 url = "2.2.2"
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -25,4 +25,4 @@ core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 
 [target.'cfg(windows)'.dependencies]
 miow = "0.5.0"
-windows-sys = { version = "0.45.0", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Console"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Console"] }

--- a/crates/home/CHANGELOG.md
+++ b/crates/home/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## Unreleased
+- The `home` crate has migrated to the <https://github.com/rust-lang/cargo/> repository.
+  [#11359](https://github.com/rust-lang/cargo/pull/11359)
+- Replaced the winapi dependency with windows-sys.
+  [#11656](https://github.com/rust-lang/cargo/pull/11656)
 
 ## [0.5.4] - 2022-10-10
 - Add `_with_env` variants of functions to support in-process threaded tests for
@@ -38,7 +42,6 @@ Use Rust 1.36.0 as minimum Rust version.
 ### Removed
 - Remove support for `multirust` folder used in old version of `rustup`.
 
-[Unreleased]: https://github.com/brson/home/compare/v0.5.4...HEAD
 [0.5.4]: https://github.com/brson/home/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/brson/home/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/brson/home/compare/v0.5.1...v0.5.2

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home"
-version = "0.5.4" # also update `html_root_url` in `src/lib.rs`
+version = "0.5.5" # also update `html_root_url` in `src/lib.rs`
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 documentation = "https://docs.rs/home"
 edition = "2018"
@@ -17,4 +17,4 @@ repository = "https://github.com/rust-lang/cargo"
 description = "Shared definitions of home directories."
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.45.0", features = ["Win32_Foundation", "Win32_UI_Shell"] }
+windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_UI_Shell"] }

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! [discussion]: https://github.com/rust-lang/rust/pull/46799#issuecomment-361156935
 
-#![doc(html_root_url = "https://docs.rs/home/0.5.4")]
+#![doc(html_root_url = "https://docs.rs/home/0.5.5")]
 #![deny(rust_2018_idioms)]
 
 pub mod env;

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -8,4 +8,4 @@ description = "A Cargo credential process that stores tokens with Windows Creden
 
 [dependencies]
 cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
-windows-sys = { version = "0.45", features = ["Win32_Foundation", "Win32_Security_Credentials"] }
+windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_Security_Credentials"] }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -563,13 +563,13 @@ mod imp {
     use windows_sys::core::PCSTR;
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::Foundation::{GENERIC_READ, GENERIC_WRITE};
     use windows_sys::Win32::Storage::FileSystem::{
         CreateFileA, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
     };
     use windows_sys::Win32::System::Console::{
         GetConsoleScreenBufferInfo, GetStdHandle, CONSOLE_SCREEN_BUFFER_INFO, STD_ERROR_HANDLE,
     };
-    use windows_sys::Win32::System::SystemServices::{GENERIC_READ, GENERIC_WRITE};
 
     pub(super) use super::{default_err_erase_line as err_erase_line, TtyWidth};
 


### PR DESCRIPTION
This updates the windows-sys dependency from 0.45 to 0.48. This shouldn't add or remove any duplicate dependencies (since there are other dependencies still using 0.45 and 0.42). The intent is to move it along the direction towards unifying in the future (though it seems like a moving target that will be difficult to ever hit).

This also bumps the home crate version. I think it should be OK to make the migration from winapi to windows-sys a patch version, though there seems to be some issues with the way windows-sys works that could introduce some build-time problems in some situations (such as those encountered in https://github.com/rust-lang/rust/pull/108665 and https://github.com/rust-lang/rust/pull/106610). However, I don't expect too much of an issue.
