### PR TITLE
CI: use `-p` to specify workspace members instead of `--manifest-path`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,6 @@ jobs:
     - run: rustup update stable && rustup default stable
     - run: rustup component add rustfmt
     - run: cargo fmt --all --check
-    - run: cargo fmt --all --check --manifest-path crates/resolver-tests/Cargo.toml
 
   # Ensure there are no clippy warnings
   clippy:
@@ -152,7 +151,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: rustup update stable && rustup default stable
-    - run: cargo test --manifest-path crates/resolver-tests/Cargo.toml
+    - run: cargo test -p resolver-tests
 
   test_gitoxide:
     runs-on: ubuntu-latest

--- a/src/doc/build-man.sh
+++ b/src/doc/build-man.sh
@@ -18,14 +18,14 @@ OPTIONS="--url https://doc.rust-lang.org/cargo/commands/ \
     --man rustc:1=https://doc.rust-lang.org/rustc/index.html \
     --man rustdoc:1=https://doc.rust-lang.org/rustdoc/index.html"
 
-cargo run --manifest-path=../../crates/mdman/Cargo.toml -- \
+cargo run -p mdman -- \
     -t md -o src/commands man/cargo*.md \
     $OPTIONS
 
-cargo run --manifest-path=../../crates/mdman/Cargo.toml -- \
+cargo run -p mdman -- \
     -t txt -o man/generated_txt man/cargo*.md \
     $OPTIONS
 
-cargo run --manifest-path=../../crates/mdman/Cargo.toml -- \
+cargo run -p mdman -- \
     -t man -o ../etc/man man/cargo*.md \
     $OPTIONS


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Use `-p` to specify workspace members instead of `--manifest-path`.


### How should we test and review this PR?

Run `./src/doc/build-man.sh` to see if it's still runnable. For other parts just wait for CI green.
<!-- homu-ignore:end -->
