### PR TITLE
CI: ensure intra links for all members are checked

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,14 +187,15 @@ jobs:
     # This requires rustfmt, use stable.
     - name: Run semver-check
       run: cargo +stable run -p semver-check
-    - run: |
+    - name: Ensure intradoc links are valid
+      run: cargo doc --workspace --document-private-items --no-deps
+      env:
+        RUSTDOCFLAGS: -D warnings
+    - name: Install mdbook
+      run: |
         mkdir mdbook
         curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.27/mdbook-v0.4.27-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
         echo `pwd`/mdbook >> $GITHUB_PATH
-    # TODO: should check all workspace members
-    - run: cargo doc -p cargo --document-private-items --no-deps
-      env:
-        RUSTDOCFLAGS: -D warnings
     - run: cd src/doc && mdbook build --dest-dir ../../target/doc
     - name: Run linkchecker.sh
       run: |


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

We are making sure that intra links are checked for all workspace members.
However, some system dependencies of `cargo-credential-gnome-secret` are not available on all platforms so we test it only on Ubuntu.

### How should we test and review this PR?

Wait for all CI job green.
<!-- homu-ignore:end -->
