### PR TITLE
ci: requires `test_gitoxide` and `lockfile` for both bors success and failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -206,7 +206,14 @@ jobs:
     permissions:
       contents: none
     name: bors build finished
-    needs: [docs, rustfmt, test, resolver, build_std, test_gitoxide]
+    needs:
+    - build_std
+    - docs
+    - lockfile
+    - resolver
+    - rustfmt
+    - test
+    - test_gitoxide
     runs-on: ubuntu-latest
     if: "success() && github.event_name == 'push' && github.ref == 'refs/heads/auto-cargo'"
     steps:
@@ -215,7 +222,14 @@ jobs:
     permissions:
       contents: none
     name: bors build finished
-    needs: [docs, rustfmt, test, resolver, build_std]
+    needs:
+    - build_std
+    - docs
+    - lockfile
+    - resolver
+    - rustfmt
+    - test
+    - test_gitoxide
     runs-on: ubuntu-latest
     if: "!success() && github.event_name == 'push' && github.ref == 'refs/heads/auto-cargo'"
     steps:


### PR DESCRIPTION
### What does this PR try to resolve?

* Both bors success and failure jobs should share the same group of dependent jobs.
* `lockfile` job should be able to fail the CI pipeline.

<!-- homu-ignore:start -->
### How should we test and review this PR?

Wait for all CI jobs green.

Correct me if I am wrong on my bors understanding.
<!-- homu-ignore:end -->
