### PR TITLE
chore: make credential dependencies platform-specific

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,12 +128,10 @@ jobs:
     - run: cargo test -p home
     - run: cargo test -p mdman
     - run: cargo build -p cargo-credential-1password
+    - run: cargo build -p cargo-credential-macos-keychain
+    - run: cargo build -p cargo-credential-wincred
     - run: cargo build -p cargo-credential-gnome-secret
       if: matrix.os == 'ubuntu-latest'
-    - run: cargo build -p cargo-credential-macos-keychain
-      if: matrix.os == 'macos-latest'
-    - run: cargo build -p cargo-credential-wincred
-      if: matrix.os == 'windows-latest'
     - name: Check benchmarks
       run: |
         # This only tests one benchmark since it can take over 10 minutes to

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -8,4 +8,6 @@ description = "A Cargo credential process that stores tokens in a macOS keychain
 
 [dependencies]
 cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
+
+[target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2.0.0"

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -8,4 +8,10 @@ description = "A Cargo credential process that stores tokens with Windows Creden
 
 [dependencies]
 cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
-windows-sys = { version = "0.48", features = ["Win32_Foundation", "Win32_Security_Credentials"] }
+
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.48"
+features = [
+  "Win32_Foundation",
+  "Win32_Security_Credentials"
+]


### PR DESCRIPTION

### What does this PR try to resolve?

Starting from #11993, we made `cargo-credential-macos-keychain` and `cargo-credential-wincred` able to build on all platforms. However, some of their dependencies are not. This PR turns them into platform specific dependencies to circumvent the situation.

### How should we test and review this PR?

Run the following commands on all platforms Cargo supports.

```
cargo check --workspace --exclude cargo-credential-gnome-secret
```
