### PR TITLE
fix: apply `[env]` to target info discovery rustc

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -7,6 +7,7 @@
 //! * [`RustcTargetData::info`] to get a [`TargetInfo`] for an in-depth query.
 //! * [`TargetInfo::rustc_outputs`] to get a list of supported file types.
 
+use crate::core::compiler::apply_env_config;
 use crate::core::compiler::{
     BuildOutput, CompileKind, CompileMode, CompileTarget, Context, CrateType,
 };
@@ -175,6 +176,7 @@ impl TargetInfo {
             //
             // Search `--print` to see what we query so far.
             let mut process = rustc.workspace_process();
+            apply_env_config(config, &mut process)?;
             process
                 .arg("-")
                 .arg("--crate-name")

--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -7,7 +7,8 @@ use std::path::PathBuf;
 use cargo_platform::CfgExpr;
 use cargo_util::{paths, ProcessBuilder};
 
-use super::BuildContext;
+use crate::core::compiler::apply_env_config;
+use crate::core::compiler::BuildContext;
 use crate::core::compiler::{CompileKind, Metadata, Unit};
 use crate::core::Package;
 use crate::util::{config, CargoResult, Config};
@@ -349,17 +350,7 @@ impl<'cfg> Compilation<'cfg> {
             )
             .cwd(pkg.root());
 
-        // Apply any environment variables from the config
-        for (key, value) in self.config.env_config()?.iter() {
-            // never override a value that has already been set by cargo
-            if cmd.get_envs().contains_key(key) {
-                continue;
-            }
-
-            if value.is_force() || self.config.get_env_os(key).is_none() {
-                cmd.env(key, value.resolve(self.config));
-            }
-        }
+        apply_env_config(self.config, &mut cmd)?;
 
         Ok(cmd)
     }

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1805,3 +1805,18 @@ fn descriptive_pkg_name(name: &str, target: &Target, mode: &CompileMode) -> Stri
     };
     format!("`{name}` ({desc_name}{mode})")
 }
+
+/// Applies environment variables from config `[env]` to [`ProcessBuilder`].
+fn apply_env_config(config: &crate::Config, cmd: &mut ProcessBuilder) -> CargoResult<()> {
+    for (key, value) in config.env_config()?.iter() {
+        // never override a value that has already been set by cargo
+        if cmd.get_envs().contains_key(key) {
+            continue;
+        }
+
+        if value.is_force() || config.get_env_os(key).is_none() {
+            cmd.env(key, value.resolve(config));
+        }
+    }
+    Ok(())
+}

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -224,11 +224,8 @@ fn env_applied_to_target_info_discovery_rustc() {
 
     p.cargo("run")
         .env("RUSTC_WORKSPACE_WRAPPER", wrapper)
-        .with_stderr_contains("error: failed to run `rustc` to learn about target-specific information")
-        .with_stderr_contains("[..]thread '[..]' panicked at [..]unwrap[..]") // env::var().unwrap()
-        .with_stderr_does_not_contain("WRAPPER ENV_TEST:from-config")
-        .with_stderr_does_not_contain("MAIN ENV_TEST:from-config")
-        .with_status(101)
+        .with_stderr_contains("WRAPPER ENV_TEST:from-config")
+        .with_stderr_contains("MAIN ENV_TEST:from-config")
         .run();
 
     // Ensure wrapper also maintains the same overridden priority for envs.

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -1,5 +1,6 @@
 //! Tests for `[env]` config.
 
+use cargo_test_support::basic_manifest;
 use cargo_test_support::{basic_bin_manifest, project};
 
 #[cargo_test]
@@ -177,5 +178,65 @@ fn env_no_override() {
 
     p.cargo("run")
         .with_stdout_contains("CARGO_PKG_NAME:unchanged")
+        .run();
+}
+
+#[cargo_test]
+fn env_applied_to_target_info_discovery_rustc() {
+    let wrapper = project()
+        .at("wrapper")
+        .file("Cargo.toml", &basic_manifest("wrapper", "1.0.0"))
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {
+                let mut args = std::env::args().skip(1);
+                let env_test = std::env::var("ENV_TEST").unwrap();
+                eprintln!("WRAPPER ENV_TEST:{env_test}");
+                let status = std::process::Command::new(&args.next().unwrap())
+                    .args(args).status().unwrap();
+                std::process::exit(status.code().unwrap_or(1));
+            }
+            "#,
+        )
+        .build();
+    wrapper.cargo("build").run();
+    let wrapper = &wrapper.bin("wrapper");
+
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file(
+            "src/main.rs",
+            r#"
+            fn main() {
+                eprintln!( "MAIN ENV_TEST:{}", std::env!("ENV_TEST") );
+            }
+            "#,
+        )
+        .file(
+            ".cargo/config",
+            r#"
+                [env]
+                ENV_TEST = "from-config"
+            "#,
+        )
+        .build();
+
+    p.cargo("run")
+        .env("RUSTC_WORKSPACE_WRAPPER", wrapper)
+        .with_stderr_contains("error: failed to run `rustc` to learn about target-specific information")
+        .with_stderr_contains("[..]thread '[..]' panicked at [..]unwrap[..]") // env::var().unwrap()
+        .with_stderr_does_not_contain("WRAPPER ENV_TEST:from-config")
+        .with_stderr_does_not_contain("MAIN ENV_TEST:from-config")
+        .with_status(101)
+        .run();
+
+    // Ensure wrapper also maintains the same overridden priority for envs.
+    p.cargo("clean").run();
+    p.cargo("run")
+        .env("ENV_TEST", "from-env")
+        .env("RUSTC_WORKSPACE_WRAPPER", wrapper)
+        .with_stderr_contains("WRAPPER ENV_TEST:from-env")
+        .with_stderr_contains("MAIN ENV_TEST:from-env")
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

The first rustc invoked by Cargo is for learning target specific info.
However, Cargo didn't apply `[env]` to that rustc invocation.
This was an oversight when implementing `[env]` configuration.

<!-- homu-ignore:start -->
### How should we test and review this PR?

The first commit asserts the broken behavior. 
The second contains the fix, reusing part of `fill_env()` that handles `[env]`.

Fixes #12028. 
<!-- homu-ignore:end -->
