### PR TITLE
Warn instead of error in `cargo package` on empty `readme` or `license-file` in manifest

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1775,6 +1775,142 @@ fn exclude_dot_files_and_directories_by_default() {
 }
 
 #[cargo_test]
+fn empty_readme_path() {
+    // Warn but don't fail if `readme` is empty.
+    // Issue #11522.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.0.0"
+            readme = ""
+            license = "MIT"
+            description = "foo"
+            homepage = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("package --no-verify")
+        .with_stderr(
+            "\
+[WARNING] readme `` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
+This may become a hard error in the future.
+[PACKAGING] foo v1.0.0 ([..]/foo)
+[PACKAGED] [..] files, [..] ([..] compressed)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn invalid_readme_path() {
+    // Warn but don't fail if `readme` path is invalid.
+    // Issue #11522.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.0.0"
+            readme = "DOES-NOT-EXIST"
+            license = "MIT"
+            description = "foo"
+            homepage = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("package --no-verify")
+        .with_stderr(
+            "\
+[WARNING] readme `DOES-NOT-EXIST` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
+This may become a hard error in the future.
+[PACKAGING] foo v1.0.0 ([..]/foo)
+[PACKAGED] [..] files, [..] ([..] compressed)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn readme_or_license_file_is_dir() {
+    // Test warning when `readme` or `license-file` is a directory, not a file.
+    // Issue #11522.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.0.0"
+            readme = "./src"
+            license-file = "./src"
+            description = "foo"
+            homepage = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("package --no-verify")
+        .with_stderr(
+            "\
+[WARNING] license-file `./src` does not appear to exist (relative to `[..]/foo`).
+Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`
+This may become a hard error in the future.
+[WARNING] readme `./src` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
+This may become a hard error in the future.
+[PACKAGING] foo v1.0.0 ([..]/foo)
+[PACKAGED] [..] files, [..] ([..] compressed)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn empty_license_file_path() {
+    // Warn but don't fail if license-file is empty.
+    // Issue #11522.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "1.0.0"
+            license-file = ""
+            description = "foo"
+            homepage = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("package --no-verify")
+        .with_stderr(
+            "\
+[WARNING] manifest has no license or license-file.
+See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
+[WARNING] license-file `` does not appear to exist (relative to `[..]/foo`).
+Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`
+This may become a hard error in the future.
+[PACKAGING] foo v1.0.0 ([..]/foo)
+[PACKAGED] [..] files, [..] ([..] compressed)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn invalid_license_file_path() {
     // Test warning when license-file points to a non-existent file.
     let p = project()

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1756,6 +1756,9 @@ fn publish_with_missing_readme() {
         .with_stderr(&format!(
             "\
 [UPDATING] [..]
+[WARNING] readme `foo.md` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
+This may become a hard error in the future.
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.1.0 [..]


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #11522. The cause of the problem is that `cargo package` and `cargo publish` fail if `readme = ""` or `license-file = ""` in the manifest.

This PR changes the `build_ar_list` function to check that the `readme` and `license-file` paths point to a file (instead of checking if the paths simply exist), and emits a warning if not. This should also catch the related failure case when either value is a valid path to a directory (e.g., `readme = "./src"`).

Changes to warnings:
- `license-file`: extends the existing warning when `license-file` points to a non-existent path to also cover the case where it points to a directory
- `readme`: new warning when `readme` is not a path to a file

### How should we test and review this PR?

Please see the new integration tests in `testsuite/package.rs`. Thanks!