### PR TITLE
Update home dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
  "glob",
  "hex",
  "hmac",
- "home 0.5.4",
+ "home 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-auth",
  "humantime 2.1.0",
  "ignore",
@@ -1546,7 +1546,7 @@ dependencies = [
  "bstr",
  "gix-features",
  "gix-path",
- "home 0.5.4",
+ "home 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
  "url",
 ]
@@ -1692,16 +1692,16 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+version = "0.5.5"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "home"
 version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ gix-features-for-configuration-only = { version = "0.28.0", package = "gix-featu
 glob = "0.3.0"
 hex = "0.4"
 hmac = "0.12.1"
-home = "0.5"
+home = "0.5.5"
 http-auth = { version = "0.1.6", default-features = false }
 humantime = "2.0.0"
 ignore = "0.4.7"

--- a/crates/home/CHANGELOG.md
+++ b/crates/home/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.5.5 - 2023-04-25
 - The `home` crate has migrated to the <https://github.com/rust-lang/cargo/> repository.
   [#11359](https://github.com/rust-lang/cargo/pull/11359)
 - Replaced the winapi dependency with windows-sys.


### PR DESCRIPTION
This updates the `home` dependency to 0.5.5 (published today). The only notable difference is the switch from winapi to windows-sys.
