### PR TITLE
[beta-1.70] backport add the Win32_System_Console feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ version = "0.45"
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
+  "Win32_System_Console",
   "Win32_System_IO",
   "Win32_System_Threading",
   "Win32_System_JobObjects",

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -944,7 +944,7 @@ pub fn foo<T, U>() {}
 use updated_crate::foo;
 
 fn main() {
-    foo::<u8>(); // Error: this function takes 2 generic arguments but 1 generic argument was supplied
+    foo::<u8>(); // Error: function takes 2 generic arguments but 1 generic argument was supplied
 }
 ```
 


### PR DESCRIPTION
This is a beta backport of #12016 which is required to build the cargo library on Windows.

This also includes #12011 to get CI passing.