### PR TITLE
Include rust-version in publish request

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -57,6 +57,7 @@ pub struct NewCrate {
     pub repository: Option<String>,
     pub badges: BTreeMap<String, BTreeMap<String, String>>,
     pub links: Option<String>,
+    pub rust_version: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -110,6 +110,7 @@ pub struct ManifestMetadata {
     pub documentation: Option<String>, // URL
     pub badges: BTreeMap<String, BTreeMap<String, String>>,
     pub links: Option<String>,
+    pub rust_version: Option<String>,
 }
 
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -345,6 +345,7 @@ fn transmit(
         ref categories,
         ref badges,
         ref links,
+        ref rust_version,
     } = *manifest.metadata();
     let readme_content = readme
         .as_ref()
@@ -398,6 +399,7 @@ fn transmit(
                 license_file: license_file.clone(),
                 badges: badges.clone(),
                 links: links.clone(),
+                rust_version: rust_version.clone(),
             },
             tarball,
         )

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2433,6 +2433,11 @@ impl TomlManifest {
                 .transpose()?
                 .unwrap_or_default(),
             links: package.links.clone(),
+            rust_version: package
+                .rust_version
+                .clone()
+                .map(|mw| mw.resolve("rust-version", || inherit()?.rust_version()))
+                .transpose()?,
         };
         package.description = metadata
             .description

--- a/src/doc/src/reference/registry-index.md
+++ b/src/doc/src/reference/registry-index.md
@@ -224,9 +224,8 @@ The JSON objects should not be modified after they are added except for the
 > * The publish API includes several other fields, such as `description` and `readme`, which don't appear in the index.
 >   These are intended to make it easier for a registry to obtain the metadata about the crate to display on a website without needing to extract and parse the `.crate` file.
 >   This additional information is typically added to a database on the registry server.
-> * `rust_version` is not included.  If a registry chooses to support this
->   field, they must read it from the `Cargo.toml` contained in the `.crate`
->   file.
+> * Although `rust_version` is included here, [crates.io] will ignore this field
+>   and instead read it from the `Cargo.toml` contained in the `.crate` file.
 >
 > For [`cargo metadata`], the differences are:
 >

--- a/src/doc/src/reference/registry-web-api.md
+++ b/src/doc/src/reference/registry-web-api.md
@@ -161,7 +161,10 @@ considered as an exhaustive list of restrictions [crates.io] imposes.
     },
     // The `links` string value from the package's manifest, or null if not
     // specified. This field is optional and defaults to null.
-    "links": null
+    "links": null,
+    // The minimal supported Rust version (optional)
+    // This must be a valid version requirement without an operator (e.g. no `=`)
+    "rust_version": null
 }
 ```
 

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -366,6 +366,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
             "repository": null,
             "homepage": null,
             "documentation": null,
+            "rust_version": null,
             "vers": "0.0.1"
         }"#,
         "foo-0.0.1.crate",
@@ -515,6 +516,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
             "repository": null,
             "homepage": null,
             "documentation": null,
+            "rust_version": null,
             "vers": "0.0.1"
         }"#,
         "foo-0.0.1.crate",
@@ -607,6 +609,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
             "repository": null,
             "homepage": null,
             "documentation": null,
+            "rust_version": null,
             "vers": "0.0.1"
         }"#,
         "foo-0.0.1.crate",

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1956,6 +1956,7 @@ You may press ctrl-c [..]
           "readme": null,
           "readme_file": null,
           "repository": "foo",
+          "rust_version": null,
           "vers": "0.1.0"
         }
         "#,

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -942,6 +942,7 @@ You may press ctrl-c [..]
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.1.0"
           }
         "#,
@@ -1057,6 +1058,7 @@ You may press ctrl-c [..]
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.1.0"
           }
         "#,

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -201,6 +201,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           "readme": null,
           "readme_file": null,
           "repository": "https://github.com/example/example",
+          "rust_version": "1.60",
           "vers": "1.2.3"
           }
         "#,
@@ -376,6 +377,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.2.0"
           }
         "#,
@@ -503,6 +505,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.2.0"
           }
         "#,
@@ -734,6 +737,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           "readme": "README.md",
           "readme_file": "../README.md",
           "repository": "https://github.com/example/example",
+          "rust_version": "1.60",
           "vers": "1.2.3"
           }
         "#,
@@ -917,6 +921,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.2.0"
           }
         "#,

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -25,6 +25,7 @@ const CLEAN_FOO_JSON: &str = r#"
         "readme": null,
         "readme_file": null,
         "repository": "foo",
+        "rust_version": null,
         "vers": "0.0.1"
     }
 "#;
@@ -49,6 +50,7 @@ fn validate_upload_foo() {
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.0.1"
           }
         "#,
@@ -77,6 +79,7 @@ fn validate_upload_li() {
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": "1.69",
           "vers": "0.0.1"
           }
         "#,
@@ -1270,6 +1273,7 @@ You may press ctrl-c [..]
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.0.1"
           }
         "#,
@@ -1469,6 +1473,7 @@ You may press ctrl-c [..]
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.1.0"
           }
         "#,
@@ -1581,6 +1586,7 @@ You may press ctrl-c [..]
           "readme": null,
           "readme_file": null,
           "repository": "foo",
+          "rust_version": null,
           "vers": "0.1.0"
         }
         "#,
@@ -2049,6 +2055,7 @@ fn in_package_workspace() {
                 [package]
                 name = "li"
                 version = "0.0.1"
+                rust-version = "1.69"
                 description = "li"
                 license = "MIT"
             "#,
@@ -2151,6 +2158,7 @@ fn in_package_workspace_with_members_with_features_old() {
                 [package]
                 name = "li"
                 version = "0.0.1"
+                rust-version = "1.69"
                 description = "li"
                 license = "MIT"
             "#,
@@ -2246,6 +2254,7 @@ fn in_virtual_workspace_with_p() {
                 [package]
                 name = "li"
                 version = "0.0.1"
+                rust-version = "1.69"
                 description = "li"
                 license = "MIT"
             "#,

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -601,6 +601,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
           "readme": null,
           "readme_file": null,
           "repository": null,
+          "rust_version": null,
           "vers": "0.1.0"
           }
         "#,


### PR DESCRIPTION
crates.io reads rust-version from the tarball directly, but we can include it in the publish request for the sake of consistency for third-party registries. See [relevant Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/318791-t-crates-io/topic/rust-version.20field).

Validation for the field was already implemented in #8037.