### PR TITLE
feat: Add `-Zmsrv-policy` feature flag

### DIFF
--- a/crates/cargo-test-support/src/publish.rs
+++ b/crates/cargo-test-support/src/publish.rs
@@ -165,6 +165,7 @@ pub(crate) fn create_index_line(
     features: crate::registry::FeatureMap,
     yanked: bool,
     links: Option<String>,
+    rust_version: Option<&str>,
     v: Option<u32>,
 ) -> String {
     // This emulates what crates.io does to retain backwards compatibility.
@@ -184,6 +185,9 @@ pub(crate) fn create_index_line(
     }
     if let Some(v) = v {
         json["v"] = serde_json::json!(v);
+    }
+    if let Some(rust_version) = rust_version {
+        json["rust_version"] = serde_json::json!(rust_version);
     }
 
     json.to_string()

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -1144,6 +1144,7 @@ fn save_new_crate(
         false,
         new_crate.links,
         None,
+        None,
     );
 
     write_to_index(registry_path, &new_crate.name, line, false);
@@ -1400,6 +1401,7 @@ impl Package {
             self.features.clone(),
             self.yanked,
             self.links.clone(),
+            self.rust_version.as_deref(),
             self.v,
         );
 

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -184,6 +184,7 @@ pub fn resolve_with_config_raw(
         deps,
         &BTreeMap::new(),
         None::<&String>,
+        None::<&String>,
     )
     .unwrap();
     let opts = ResolveOpts::everything();
@@ -585,6 +586,7 @@ pub fn pkg_dep<T: ToPkgId>(name: T, dep: Vec<Dependency>) -> Summary {
         dep,
         &BTreeMap::new(),
         link,
+        None::<&String>,
     )
     .unwrap()
 }
@@ -613,6 +615,7 @@ pub fn pkg_loc(name: &str, loc: &str) -> Summary {
         Vec::new(),
         &BTreeMap::new(),
         link,
+        None::<&String>,
     )
     .unwrap()
 }
@@ -627,6 +630,7 @@ pub fn remove_dep(sum: &Summary, ind: usize) -> Summary {
         deps,
         &BTreeMap::new(),
         sum.links().map(|a| a.as_str()),
+        None::<&String>,
     )
     .unwrap()
 }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -733,6 +733,7 @@ unstable_cli_options!(
     unstable_options: bool = ("Allow the usage of unstable options"),
     skip_rustdoc_fingerprint: bool = (HIDDEN),
     rustdoc_scrape_examples: bool = ("Allows Rustdoc to scrape code examples from reverse-dependencies"),
+    msrv_policy: bool = ("Enable rust-version aware policy within cargo"),
 );
 
 const STABILIZED_COMPILE_PROGRESS: &str = "The progress bar is now always \
@@ -1095,6 +1096,7 @@ impl CliUnstable {
             "timings" => stabilized_warn(k, "1.60", STABILIZED_TIMINGS),
             "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,
             "profile-rustflags" => self.profile_rustflags = parse_empty(k, v)?,
+            "msrv-policy" => self.msrv_policy = parse_empty(k, v)?,
             _ => bail!("unknown `-Z` flag specified: {}", k),
         }
 

--- a/src/cargo/core/resolver/version_prefs.rs
+++ b/src/cargo/core/resolver/version_prefs.rs
@@ -100,7 +100,15 @@ mod test {
         let pkg_id = pkgid(name, version);
         let config = Config::default().unwrap();
         let features = BTreeMap::new();
-        Summary::new(&config, pkg_id, Vec::new(), &features, None::<&String>).unwrap()
+        Summary::new(
+            &config,
+            pkg_id,
+            Vec::new(),
+            &features,
+            None::<&String>,
+            None::<&String>,
+        )
+        .unwrap()
     }
 
     fn describe(summaries: &Vec<Summary>) -> String {

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -25,6 +25,7 @@ struct Inner {
     features: Rc<FeatureMap>,
     checksum: Option<String>,
     links: Option<InternedString>,
+    rust_version: Option<InternedString>,
 }
 
 impl Summary {
@@ -34,6 +35,7 @@ impl Summary {
         dependencies: Vec<Dependency>,
         features: &BTreeMap<InternedString, Vec<InternedString>>,
         links: Option<impl Into<InternedString>>,
+        rust_version: Option<impl Into<InternedString>>,
     ) -> CargoResult<Summary> {
         // ****CAUTION**** If you change anything here that may raise a new
         // error, be sure to coordinate that change with either the index
@@ -55,6 +57,7 @@ impl Summary {
                 features: Rc::new(feature_map),
                 checksum: None,
                 links: links.map(|l| l.into()),
+                rust_version: rust_version.map(|l| l.into()),
             }),
         })
     }
@@ -83,6 +86,10 @@ impl Summary {
     }
     pub fn links(&self) -> Option<InternedString> {
         self.inner.links
+    }
+
+    pub fn rust_version(&self) -> Option<InternedString> {
+        self.inner.rust_version
     }
 
     pub fn override_id(mut self, id: PackageId) -> Summary {

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -814,6 +814,7 @@ impl IndexSummary {
             features2,
             yanked,
             links,
+            rust_version: _,
             v,
         } = serde_json::from_slice(line)?;
         let v = v.unwrap_or(1);

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -814,7 +814,7 @@ impl IndexSummary {
             features2,
             yanked,
             links,
-            rust_version: _,
+            rust_version,
             v,
         } = serde_json::from_slice(line)?;
         let v = v.unwrap_or(1);
@@ -829,7 +829,7 @@ impl IndexSummary {
                 features.entry(name).or_default().extend(values);
             }
         }
-        let mut summary = Summary::new(config, pkgid, deps, &features, links)?;
+        let mut summary = Summary::new(config, pkgid, deps, &features, links, rust_version)?;
         summary.set_checksum(cksum);
         Ok(IndexSummary {
             summary,

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -293,7 +293,6 @@ pub struct RegistryPackage<'a> {
     ///
     /// Added in 2023 (see <https://github.com/rust-lang/crates.io/pull/6267>),
     /// can be `None` if published before then or if not set in the manifest.
-    #[allow(dead_code)]
     rust_version: Option<InternedString>,
     /// The schema version for this entry.
     ///

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -287,6 +287,14 @@ pub struct RegistryPackage<'a> {
     /// Added early 2018 (see <https://github.com/rust-lang/cargo/pull/4978>),
     /// can be `None` if published before then.
     links: Option<InternedString>,
+    /// Required version of rust
+    ///
+    /// Corresponds to `package.rust-version`.
+    ///
+    /// Added in 2023 (see <https://github.com/rust-lang/crates.io/pull/6267>),
+    /// can be `None` if published before then or if not set in the manifest.
+    #[allow(dead_code)]
+    rust_version: Option<InternedString>,
     /// The schema version for this entry.
     ///
     /// If this is None, it defaults to version 1. Entries with unknown

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2367,6 +2367,7 @@ impl TomlManifest {
             deps,
             me.features.as_ref().unwrap_or(&empty_features),
             package.links.as_deref(),
+            rust_version.as_deref().map(InternedString::new),
         )?;
 
         let metadata = ManifestMetadata {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -69,6 +69,7 @@ Each new feature described below should explain how to use it.
     * [minimal-versions](#minimal-versions) --- Forces the resolver to use the lowest compatible version instead of the highest.
     * [direct-minimal-versions](#direct-minimal-versions) — Forces the resolver to use the lowest compatible version instead of the highest.
     * [public-dependency](#public-dependency) --- Allows dependencies to be classified as either public or private.
+    * [msrv-policy](#msrv-policy) --- MSRV-aware resolver and version selection
 * Output behavior
     * [out-dir](#out-dir) --- Adds a directory where artifacts are copied to.
     * [Different binary name](#different-binary-name) --- Assign a name to the built binary that is separate from the crate name.
@@ -299,6 +300,14 @@ cargo-features = ["public-dependency"]
 my_dep = { version = "1.2.3", public = true }
 private_dep = "2.0.0" # Will be 'private' by default
 ```
+
+### msrv-policy
+- [#9930](https://github.com/rust-lang/cargo/issues/9930) (MSRV-aware resolver)
+- [#10653](https://github.com/rust-lang/cargo/issues/10653) (MSRV-aware cargo-add)
+- [#10903](https://github.com/rust-lang/cargo/issues/10903) (MSRV-aware cargo-install)
+
+The `msrv-policy` feature enables experiments in MSRV-aware policy for cargo in
+preparation for an upcoming RFC.
 
 ### build-std
 * Tracking Repository: <https://github.com/rust-lang/wg-cargo-std-aware>


### PR DESCRIPTION
### What does this PR try to resolve?

Nothing noticeable....

The intent is to unblock experiments with different compatible MSRV policies like
- #9930
- #10653
- #10903

While I normally don't like PRs that do nothing on their own, this at least allows any one of those efforts to move forward with different people without juggling these base commits for whoever is first to include in their PR

While there isn't an RFC for this yet, this is intended to allow us to experiment to get a better idea of what we should put in an RFC.  In some cases, we first do an eRFC for this but I assumed this wouldn't be needed in this case as this builds on rust-lang/rfcs#2495 and, I'm assuming, will be more surgical in nature

### How should we test and review this PR?

The `Summary` changes are largely untested as they will be mostly tested through the future work that builds on this PR.  However, I wasn't too concerned about that because the code is relatively trivial.

### Additional information

I chose the name `msrv-policy` to distinguish this unstable feature from `rust-version`.  Though those appear in different places (`Cargo.toml` vs `-Z`), I can see them being confusing which was especially apparent when editing `unstable.md` which has an anchor for `rust-version`.