### PR TITLE
cargo-tree: Handle -e no-proc-macro when building the graph

### DIFF
--- a/src/cargo/ops/tree/graph.rs
+++ b/src/cargo/ops/tree/graph.rs
@@ -362,6 +362,10 @@ fn add_pkg(
                 if !opts.edge_kinds.contains(&EdgeKind::Dep(dep.kind())) {
                     return false;
                 }
+                // Filter out proc-macrcos if requested.
+                if opts.no_proc_macro && graph.package_for_id(dep_id).proc_macro() {
+                    return false;
+                }
                 if dep.is_optional() {
                     // If the new feature resolver does not enable this
                     // optional dep, then don't use it.

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -267,7 +267,6 @@ fn print(
             opts.prefix,
             opts.no_dedupe,
             opts.max_display_depth,
-            opts.no_proc_macro,
             &mut visited_deps,
             &mut levels_continue,
             &mut print_stack,
@@ -288,7 +287,6 @@ fn print_node<'a>(
     prefix: Prefix,
     no_dedupe: bool,
     max_display_depth: u32,
-    no_proc_macro: bool,
     visited_deps: &mut HashSet<usize>,
     levels_continue: &mut Vec<bool>,
     print_stack: &mut Vec<usize>,
@@ -348,7 +346,6 @@ fn print_node<'a>(
             prefix,
             no_dedupe,
             max_display_depth,
-            no_proc_macro,
             visited_deps,
             levels_continue,
             print_stack,
@@ -369,7 +366,6 @@ fn print_dependencies<'a>(
     prefix: Prefix,
     no_dedupe: bool,
     max_display_depth: u32,
-    no_proc_macro: bool,
     visited_deps: &mut HashSet<usize>,
     levels_continue: &mut Vec<bool>,
     print_stack: &mut Vec<usize>,
@@ -406,19 +402,6 @@ fn print_dependencies<'a>(
     let mut it = deps
         .iter()
         .filter(|dep| {
-            // Filter out proc-macro dependencies.
-            if no_proc_macro {
-                match graph.node(**dep) {
-                    &Node::Package { package_id, .. } => {
-                        !graph.package_for_id(package_id).proc_macro()
-                    }
-                    _ => true,
-                }
-            } else {
-                true
-            }
-        })
-        .filter(|dep| {
             // Filter out packages to prune.
             match graph.node(**dep) {
                 Node::Package { package_id, .. } => {
@@ -441,7 +424,6 @@ fn print_dependencies<'a>(
             prefix,
             no_dedupe,
             max_display_depth,
-            no_proc_macro,
             visited_deps,
             levels_continue,
             print_stack,

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1134,14 +1134,7 @@ dupe-dep v2.0.0
         .run();
 
     p.cargo("tree --duplicates --edges no-proc-macro")
-        .with_stdout(
-            "\
-dupe-dep v1.0.0
-
-dupe-dep v2.0.0
-└── foo v0.1.0 ([..]/foo)
-",
-        )
+        .with_stdout("")
         .run();
 }
 
@@ -1600,8 +1593,6 @@ somedep v1.0.0
             "\
 somedep v1.0.0
 └── foo v0.1.0 ([..]/foo)
-
-somedep v1.0.0
 ",
         )
         .run();

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1086,6 +1086,66 @@ fn duplicates_with_target() {
 }
 
 #[cargo_test]
+fn duplicates_with_proc_macro() {
+    Package::new("dupe-dep", "1.0.0").publish();
+    Package::new("dupe-dep", "2.0.0").publish();
+    Package::new("proc", "1.0.0")
+        .proc_macro(true)
+        .dep("dupe-dep", "1.0")
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+
+            [dependencies]
+            proc = "1.0"
+            dupe-dep = "2.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("tree")
+        .with_stdout(
+            "\
+foo v0.1.0 ([..]/foo)
+├── dupe-dep v2.0.0
+└── proc v1.0.0 (proc-macro)
+    └── dupe-dep v1.0.0
+",
+        )
+        .run();
+
+    p.cargo("tree --duplicates")
+        .with_stdout(
+            "\
+dupe-dep v1.0.0
+└── proc v1.0.0 (proc-macro)
+    └── foo v0.1.0 ([..]/foo)
+
+dupe-dep v2.0.0
+└── foo v0.1.0 ([..]/foo)
+",
+        )
+        .run();
+
+    p.cargo("tree --duplicates --edges no-proc-macro")
+        .with_stdout(
+            "\
+dupe-dep v1.0.0
+
+dupe-dep v2.0.0
+└── foo v0.1.0 ([..]/foo)
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn charset() {
     let p = make_simple_proj();
     p.cargo("tree --charset ascii")


### PR DESCRIPTION
### What does this PR try to resolve?

Makes `-e no-proc-macro` more useful when combined with `-i` or `-d`. Fixes #12030.

### How should we test and review this PR?

The new and existing tests should cover this, I hope!

### Additional information

Pruning proc-macro crates during graph construction is closer to how the edge-based filters work (`[no-]build` etc.), so even though `no-proc-macro` isn't technically filtering on edges, it's following a well-established code path.