### PR TITLE
fix broken markdown in docs

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -39,7 +39,7 @@ pub struct TargetInfo {
     ///
     /// The key is the crate type name (like `cdylib`) and the value is
     /// `Some((prefix, suffix))`, for example `libcargo.so` would be
-    /// `Some(("lib", ".so")). The value is `None` if the crate type is not
+    /// `Some(("lib", ".so"))`. The value is `None` if the crate type is not
     /// supported.
     crate_types: RefCell<HashMap<CrateType, Option<(String, String)>>>,
     /// `cfg` information extracted from `rustc --print=cfg`.

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -37,7 +37,7 @@
 //! - [`core::compiler`]:
 //!   This is the code responsible for running `rustc` and `rustdoc`.
 //!   - [`core::compiler::build_context`]:
-//!     The [`BuildContext`]['core::compiler::BuildContext] is the result of the "front end" of the
+//!     The [`BuildContext`][core::compiler::BuildContext] is the result of the "front end" of the
 //!     build process. This contains the graph of work to perform and any settings necessary for
 //!     `rustc`. After this is built, the next stage of building is handled in
 //!     [`Context`][core::compiler::Context].

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -241,7 +241,7 @@ pub struct RegistryConfig {
     /// crate's sha256 checksum.
     ///
     /// For backwards compatibility, if the string does not contain any
-    /// markers (`{crate}`, `{version}`, `{prefix}`, or ``{lowerprefix}`), it
+    /// markers (`{crate}`, `{version}`, `{prefix}`, or `{lowerprefix}`), it
     /// will be extended with `/{crate}/{version}/download` to
     /// support registries like crates.io which were created before the
     /// templating setup was created.
@@ -945,7 +945,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
 }
 
 /// Get the maximum upack size that Cargo permits
-/// based on a given `size of your compressed file.
+/// based on a given `size` of your compressed file.
 ///
 /// Returns the larger one between `size * max compression ratio`
 /// and a fixed max unpacked size.


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes some broken markdown in doc comments.

### How should we test and review this PR?

1. Navigate to the online docs and observe broken markdown:
    * https://doc.rust-lang.org/nightly/nightly-rustc/cargo/index.html
    * https://doc.rust-lang.org/nightly/nightly-rustc/cargo/core/compiler/struct.TargetInfo.html#structfield.crate_types
    * https://doc.rust-lang.org/nightly/nightly-rustc/cargo/sources/registry/struct.RegistryConfig.html#structfield.dl
    * https://doc.rust-lang.org/nightly/nightly-rustc/cargo/sources/registry/fn.max_unpack_size.html
2. Run `cargo doc --document-private-items --open` and verify that the broken markdown has been fixed.

### Additional information

The broken inline code was found by a [new rustdoc lint](https://github.com/rust-lang/rust/pull/105848) and these changes will be required to deny the lint in the rust-lang/rust repository.