### PR TITLE
fix clippy warnings

### DIFF
--- a/crates/cargo-platform/src/cfg.rs
+++ b/crates/cargo-platform/src/cfg.rs
@@ -271,7 +271,7 @@ impl<'a> Iterator for Tokenizer<'a> {
                 Some((_, ',')) => return Some(Ok(Token::Comma)),
                 Some((_, '=')) => return Some(Ok(Token::Equals)),
                 Some((start, '"')) => {
-                    while let Some((end, ch)) = self.s.next() {
+                    for (end, ch) in &mut self.s {
                         if ch == '"' {
                             return Some(Ok(Token::String(&self.orig[start + 1..end])));
                         }

--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -176,7 +176,7 @@ fn split_rules(t: TokenStream) -> Vec<String> {
     .filter(|parts| !parts.is_empty())
     .map(|parts| {
         parts
-            .into_iter()
+            .iter()
             .map(|part| part.to_string())
             .collect::<String>()
     })
@@ -197,10 +197,10 @@ fn version() -> &'static (u32, bool) {
             .output()
             .expect("rustc should run");
         let stdout = std::str::from_utf8(&output.stdout).expect("utf8");
-        let vers = stdout.split_whitespace().skip(1).next().unwrap();
+        let vers = stdout.split_whitespace().nth(1).unwrap();
         let is_nightly = option_env!("CARGO_TEST_DISABLE_NIGHTLY").is_none()
             && (vers.contains("-nightly") || vers.contains("-dev"));
-        let minor = vers.split('.').skip(1).next().unwrap().parse().unwrap();
+        let minor = vers.split('.').nth(1).unwrap().parse().unwrap();
         unsafe { VERSION = (minor, is_nightly) }
     });
     unsafe { &VERSION }

--- a/crates/cargo-test-support/build.rs
+++ b/crates/cargo-test-support/build.rs
@@ -1,3 +1,5 @@
+// ALLOWED: testing is exempt (`std::env::var()`)
+#[allow(clippy::disallowed_methods)]
 fn main() {
     println!(
         "cargo:rustc-env=NATIVE_ARCH={}",

--- a/crates/cargo-util/src/lib.rs
+++ b/crates/cargo-util/src/lib.rs
@@ -13,6 +13,8 @@ pub mod registry;
 mod sha256;
 
 /// Whether or not this running in a Continuous Integration environment.
+// ALLOWED: testing is exempt
+#[allow(clippy::disallowed_methods)]
 pub fn is_ci() -> bool {
     std::env::var("CI").is_ok() || std::env::var("TF_BUILD").is_ok()
 }

--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -163,7 +163,13 @@ impl ProcessBuilder {
         self.env
             .get(var)
             .cloned()
-            .or_else(|| Some(env::var_os(var)))
+            .or_else(|| {
+                Some(
+                    // ALLOWED: No `Config` available.
+                    #[allow(clippy::disallowed_methods)]
+                    env::var_os(var),
+                )
+            })
             .and_then(|s| s)
     }
 
@@ -471,7 +477,7 @@ impl ProcessBuilder {
             }
             writeln!(buf, "{arg}")?;
         }
-        tmp.write_all(&mut buf)?;
+        tmp.write_all(&buf)?;
         Ok((cmd, tmp))
     }
 
@@ -541,6 +547,8 @@ impl ProcessBuilder {
 /// Forces the command to use `@path` argfile.
 ///
 /// You should set `__CARGO_TEST_FORCE_ARGFILE` to enable this.
+// ALLOWED: testing is exempt
+#[allow(clippy::disallowed_methods)]
 fn debug_force_argfile(retry_enabled: bool) -> bool {
     cfg!(debug_assertions) && env::var("__CARGO_TEST_FORCE_ARGFILE").is_ok() && retry_enabled
 }

--- a/crates/cargo-util/src/process_error.rs
+++ b/crates/cargo-util/src/process_error.rs
@@ -196,5 +196,5 @@ pub fn is_simple_exit_code(code: i32) -> bool {
     // codes are very large. This is just a rough
     // approximation of which codes are "normal" and which
     // ones are abnormal termination.
-    code >= 0 && code <= 127
+    (0..=127).contains(&code)
 }

--- a/crates/cargo-util/src/sha256.rs
+++ b/crates/cargo-util/src/sha256.rs
@@ -14,7 +14,7 @@ impl Sha256 {
     }
 
     pub fn update(&mut self, bytes: &[u8]) -> &mut Sha256 {
-        let _ = self.0.update(bytes);
+        self.0.update(bytes);
         self
     }
 

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -217,6 +217,8 @@ fn custom_test_framework() {
         .join("rustlib")
         .join(rustc_host())
         .join("bin");
+    // ALLOWED: testing is exempt (`std::env::var()`)
+    #[allow(clippy::disallowed_methods)]
     let path = env::var_os("PATH").unwrap_or_default();
     let mut paths = env::split_paths(&path).collect::<Vec<_>>();
     paths.insert(0, sysroot_bin);


### PR DESCRIPTION
I thought it would be useful to fix all warnings so those who run clippy will only see warnings of their own making.

That said, I am quite unsure outside of tests whether I have given a sensible explanation for why one wouldn't need to use `Config::get_env_var_os()` in all the cases I allowed it.