### PR TITLE
chore: Use `[workspace.dependencies]`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,89 @@ exclude = [
   "target/", # exclude bench testing
 ]
 
+[workspace.dependencies]
+anyhow = "1.0.47"
+base64 = "0.21.0"
+bytesize = "1.0"
+cargo = { path = "" }
+cargo-credential = { version = "0.2.0", path = "credential/cargo-credential" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.3" }
+cargo-test-macro = { path = "crates/cargo-test-macro" }
+cargo-test-support = { path = "crates/cargo-test-support" }
+cargo-util = { version = "0.2.4", path = "crates/cargo-util" }
+cargo_metadata = "0.14.0"
+clap = "4.2.0"
+core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
+crates-io = { version = "0.36.1", path = "crates/crates-io" }
+criterion = { version = "0.3.5", features = ["html_reports"] }
+curl = "0.4.44"
+curl-sys = "0.4.61"
+env_logger = "0.10.0"
+filetime = "0.2.9"
+flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
+fwdansi = "1.1.0"
+git2 = "0.17.0"
+git2-curl = "0.18.0"
+gix = { version = "0.44.1", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
+gix-features-for-configuration-only = { version = "0.29.0", package = "gix-features", features = [ "parallel" ] }
+glob = "0.3.0"
+handlebars = { version = "3.2.1", features = ["dir_source"] }
+hex = "0.4.2"
+hmac = "0.12.1"
+home = "0.5.5"
+http-auth = { version = "0.1.6", default-features = false }
+humantime = "2.0.0"
+ignore = "0.4.7"
+im-rc = "15.0.0"
+indexmap = "1"
+is-terminal = "0.4.4"
+itertools = "0.10.0"
+jobserver = "0.1.26"
+lazy_static = "1.3.0"
+lazycell = "1.2.0"
+libc = "0.2.88"
+libgit2-sys = "0.15.0"
+log = "0.4.17"
+memchr = "2.1.3"
+miow = "0.5.0"
+opener = "0.5"
+openssl ="0.10.50"
+os_info = "3.5.0"
+pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
+pathdiff = "0.2"
+percent-encoding = "2.0"
+pkg-config = "0.3.19"
+pretty_assertions = "1.3.0"
+pretty_env_logger = "0.4"
+proptest = "1.1.0"
+pulldown-cmark = { version = "0.9.2", default-features = false }
+rand = "0.8.5"
+rustfix = "0.6.0"
+same-file = "1.0.6"
+security-framework = "2.0.0"
+semver = { version = "1.0.3", features = ["serde"] }
+serde = "1.0.123"
+serde-value = "0.7.0"
+serde_ignored = "0.1.0"
+serde_json = "1.0.59"
+sha1 = "0.10.5"
+sha2 = "0.10.6"
+shell-escape = "0.1.4"
+snapbox = { version = "0.4.0", features = ["diff", "path"] }
+strip-ansi-escapes = "0.1.0"
+tar = { version = "0.4.38", default-features = false }
+tempfile = "3.1.0"
+termcolor = "1.1.2"
+time = { version = "0.3", features = ["parsing", "formatting"] }
+toml = "0.7.0"
+toml_edit = "0.19.0"
+unicode-width = "0.1.5"
+unicode-xid = "0.2.0"
+url = "2.2.2"
+varisat = "0.2.1"
+walkdir = "2.3.1"
+windows-sys = "0.48"
+
 [package]
 name = "cargo"
 version = "0.72.0"
@@ -28,74 +111,74 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
-anyhow = "1.0.47"
-base64 = "0.21.0"
-bytesize = "1.0"
-cargo-platform = { path = "crates/cargo-platform", version = "0.1.3" }
-cargo-util = { path = "crates/cargo-util", version = "0.2.4" }
-clap = { version = "4.2.0", features = ["wrap_help"] }
-crates-io = { path = "crates/crates-io", version = "0.36.1" }
-curl = { version = "0.4.44", features = ["http2"] }
-curl-sys = "0.4.61"
-env_logger = "0.10.0"
-filetime = "0.2.9"
-flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-git2 = "0.17.0"
-git2-curl = "0.18.0"
-gix = { version = "0.44.1", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
-gix-features-for-configuration-only = { version = "0.29.0", package = "gix-features", features = [ "parallel" ] }
-glob = "0.3.0"
-hex = "0.4"
-hmac = "0.12.1"
-home = "0.5.5"
-http-auth = { version = "0.1.6", default-features = false }
-humantime = "2.0.0"
-ignore = "0.4.7"
-im-rc = "15.0.0"
-indexmap = "1"
-is-terminal = "0.4.4"
-itertools = "0.10.0"
-jobserver = "0.1.26"
-lazy_static = "1.2.0"
-lazycell = "1.2.0"
-libc = "0.2"
-libgit2-sys = "0.15.0"
-log = "0.4.6"
-memchr = "2.1.3"
-opener = "0.5"
-os_info = "3.5.0"
-pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
-pathdiff = "0.2"
-pretty_env_logger = { version = "0.4", optional = true }
-rand = "0.8.5"
-rustfix = "0.6.0"
-semver = { version = "1.0.3", features = ["serde"] }
-serde = { version = "1.0.123", features = ["derive"] }
-serde-value = "0.7.0"
-serde_ignored = "0.1.0"
-serde_json = { version = "1.0.30", features = ["raw_value"] }
-sha1 = "0.10.5"
-shell-escape = "0.1.4"
-strip-ansi-escapes = "0.1.0"
-tar = { version = "0.4.38", default-features = false }
-tempfile = "3.0"
-termcolor = "1.1"
-time = { version = "0.3", features = ["parsing", "formatting"]}
-toml = "0.7.0"
-toml_edit = "0.19.0"
-unicode-width = "0.1.5"
-unicode-xid = "0.2.0"
-url = "2.2.2"
-walkdir = "2.2"
+anyhow.workspace = true
+base64.workspace = true
+bytesize.workspace = true
+cargo-platform.workspace = true
+cargo-util.workspace = true
+clap = { workspace = true, features = ["wrap_help"] }
+crates-io.workspace = true
+curl = { workspace = true, features = ["http2"] }
+curl-sys.workspace = true
+env_logger.workspace = true
+filetime.workspace = true
+flate2.workspace = true
+git2.workspace = true
+git2-curl.workspace = true
+gix.workspace = true
+gix-features-for-configuration-only.workspace = true
+glob.workspace = true
+hex.workspace = true
+hmac.workspace = true
+home.workspace = true
+http-auth.workspace = true
+humantime.workspace = true
+ignore.workspace = true
+im-rc.workspace = true
+indexmap.workspace = true
+is-terminal.workspace = true
+itertools.workspace = true
+jobserver.workspace = true
+lazy_static.workspace = true
+lazycell.workspace = true
+libc.workspace = true
+libgit2-sys.workspace = true
+log.workspace = true
+memchr.workspace = true
+opener.workspace = true
+os_info.workspace = true
+pasetors.workspace = true
+pathdiff.workspace = true
+pretty_env_logger = { workspace = true, optional = true }
+rand.workspace = true
+rustfix.workspace = true
+semver.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde-value.workspace = true
+serde_ignored.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
+sha1.workspace = true
+shell-escape.workspace = true
+strip-ansi-escapes.workspace = true
+tar.workspace = true
+tempfile.workspace = true
+termcolor.workspace = true
+time.workspace = true
+toml.workspace = true
+toml_edit.workspace = true
+unicode-width.workspace = true
+unicode-xid.workspace = true
+url.workspace = true
+walkdir.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
-openssl = { version = "0.10.50", optional = true }
+openssl = { workspace = true, optional = true }
 
 [target.'cfg(windows)'.dependencies]
-fwdansi = "1.1.0"
+fwdansi.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+workspace = true
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
@@ -108,14 +191,14 @@ features = [
 ]
 
 [dev-dependencies]
-cargo-test-macro = { path = "crates/cargo-test-macro" }
-cargo-test-support = { path = "crates/cargo-test-support" }
-same-file = "1.0.6"
-snapbox = { version = "0.4.0", features = ["diff", "path"] }
+cargo-test-macro.workspace = true
+cargo-test-support.workspace = true
+same-file.workspace = true
+snapbox.workspace = true
 
 [build-dependencies]
-flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-tar = { version = "0.4.38", default-features = false }
+flate2.workspace = true
+tar.workspace = true
 
 [[bin]]
 name = "cargo"

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -9,12 +9,11 @@ description = "Benchmarking suite for Cargo."
 publish = false
 
 [dependencies]
-cargo = { path = "../.." }
-# Consider removing html_reports in 0.4 and switching to `cargo criterion`.
-criterion = { version = "0.3.5", features = ["html_reports"] }
-flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-tar = { version = "0.4.38", default-features = false }
-url = "2.2.2"
+cargo.workspace = true
+criterion.workspace = true
+flate2.workspace = true
+tar.workspace = true
+url.workspace = true
 
 [lib]
 bench = false

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 description = "Tool for capturing a real-world workspace for benchmarking."
 
 [dependencies]
-cargo_metadata = "0.14.0"
-flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
-tar = { version = "0.4.38", default-features = false }
-toml = "0.7.0"
+cargo_metadata.workspace = true
+flate2.workspace = true
+tar.workspace = true
+toml.workspace = true

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -9,4 +9,4 @@ documentation = "https://docs.rs/cargo-platform"
 description = "Cargo's representation of a target platform."
 
 [dependencies]
-serde = "1.0.82"
+serde.workspace = true

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -8,25 +8,25 @@ edition = "2021"
 doctest = false
 
 [dependencies]
-anyhow = "1.0.34"
-cargo-test-macro = { path = "../cargo-test-macro" }
-cargo-util = { path = "../cargo-util" }
-crates-io = { path = "../crates-io" }
-filetime = "0.2"
-flate2 = { version = "1.0", default-features = false, features = ["zlib"] }
-git2 = "0.17.0"
-glob = "0.3"
-itertools = "0.10.0"
-lazy_static = "1.0"
-pasetors = { version = "0.6.4", features = ["v3", "paserk", "std", "serde"] }
-serde = { version = "1.0.123", features = ["derive"] }
-serde_json = "1.0"
-snapbox = { version = "0.4.0", features = ["diff", "path"] }
-tar = { version = "0.4.38", default-features = false }
-termcolor = "1.1.2"
-time = { version = "0.3", features = ["parsing", "formatting"]}
-toml = "0.7.0"
-url = "2.2.2"
+anyhow.workspace = true
+cargo-test-macro.workspace = true
+cargo-util.workspace = true
+crates-io.workspace = true
+filetime.workspace = true
+flate2.workspace = true
+git2.workspace = true
+glob.workspace = true
+itertools.workspace = true
+lazy_static.workspace = true
+pasetors.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+snapbox.workspace = true
+tar.workspace = true
+termcolor.workspace = true
+time.workspace = true
+toml.workspace = true
+url.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem"] }
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -8,21 +8,21 @@ repository = "https://github.com/rust-lang/cargo"
 description = "Miscellaneous support code used by Cargo."
 
 [dependencies]
-anyhow = "1.0.34"
-sha2 = "0.10.6"
-filetime = "0.2.9"
-hex = "0.4.2"
-jobserver = "0.1.26"
-libc = "0.2.88"
-log = "0.4.6"
-same-file = "1.0.6"
-shell-escape = "0.1.4"
-tempfile = "3.1.0"
-walkdir = "2.3.1"
+anyhow.workspace = true
+sha2.workspace = true
+filetime.workspace = true
+hex.workspace = true
+jobserver.workspace = true
+libc.workspace = true
+log.workspace = true
+same-file.workspace = true
+shell-escape.workspace = true
+tempfile.workspace = true
+walkdir.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
+core-foundation.workspace = true
 
 [target.'cfg(windows)'.dependencies]
-miow = "0.5.0"
-windows-sys = { version = "0.48.0", features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Console"] }
+miow.workspace = true
+windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Console"] }

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -13,9 +13,9 @@ name = "crates_io"
 path = "lib.rs"
 
 [dependencies]
-anyhow = "1.0.34"
-curl = "0.4"
-percent-encoding = "2.0"
-serde = { version = "1.0", features = ['derive'] }
-serde_json = "1.0"
-url = "2.0"
+anyhow.workspace = true
+curl.workspace = true
+percent-encoding.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+url.workspace = true

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -17,4 +17,4 @@ repository = "https://github.com/rust-lang/cargo"
 description = "Shared definitions of home directories."
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.48.0", features = ["Win32_Foundation", "Win32_UI_Shell"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_UI_Shell"] }

--- a/crates/mdman/Cargo.toml
+++ b/crates/mdman/Cargo.toml
@@ -7,12 +7,12 @@ description = "Creates a man page page from markdown."
 publish = false
 
 [dependencies]
-anyhow = "1.0.31"
-handlebars = { version = "3.2.1", features = ["dir_source"] }
-pulldown-cmark = { version = "0.9.2", default-features = false }
-same-file = "1.0.6"
-serde_json = "1.0.56"
-url = "2.2.2"
+anyhow.workspace = true
+handlebars.workspace = true
+pulldown-cmark.workspace = true
+same-file.workspace = true
+serde_json.workspace = true
+url.workspace = true
 
 [dev-dependencies]
-pretty_assertions = "1.3.0"
+pretty_assertions.workspace = true

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2018"
 publish = false
 
 [dependencies]
-cargo = { path = "../.." }
-cargo-util = { path = "../cargo-util" }
-is-terminal = "0.4.0"
-lazy_static = "1.3.0"
-proptest = "1.1.0"
-varisat = "0.2.1"
+cargo.workspace = true
+cargo-util.workspace = true
+is-terminal.workspace = true
+lazy_static.workspace = true
+proptest.workspace = true
+varisat.workspace = true

--- a/crates/semver-check/Cargo.toml
+++ b/crates/semver-check/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tempfile = "3.1.0"
+tempfile.workspace = true

--- a/crates/xtask-stale-label/Cargo.toml
+++ b/crates/xtask-stale-label/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-toml_edit = "0.19"
+toml_edit.workspace = true

--- a/crates/xtask-unpublished/Cargo.toml
+++ b/crates/xtask-unpublished/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-anyhow = "1.0.47"
-cargo = { path = "../.." }
-clap = "4.2.0"
-env_logger = "0.10.0"
-log = "0.4.17"
+anyhow.workspace = true
+cargo.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+log.workspace = true

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -7,6 +7,6 @@ repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a 1password vault."
 
 [dependencies]
-cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
-serde = { version = "1.0.117", features = ["derive"] }
-serde_json = "1.0.59"
+cargo-credential.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true

--- a/credential/cargo-credential-gnome-secret/Cargo.toml
+++ b/credential/cargo-credential-gnome-secret/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with GNOME libsecret."
 
 [dependencies]
-cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
+cargo-credential.workspace = true
 
 [build-dependencies]
-pkg-config = "0.3.19"
+pkg-config.workspace = true

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a macOS keychain."
 
 [dependencies]
-cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
+cargo-credential.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-security-framework = "2.0.0"
+security-framework.workspace = true

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -7,11 +7,8 @@ repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with Windows Credential Manager."
 
 [dependencies]
-cargo-credential = { version = "0.2.0", path = "../cargo-credential" }
+cargo-credential.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
-features = [
-  "Win32_Foundation",
-  "Win32_Security_Credentials"
-]
+features = ["Win32_Foundation", "Win32_Security_Credentials"]
+workspace = true


### PR DESCRIPTION
### What does this PR try to resolve?
Keeping shared dependencies in sync. It does this by utilizing workspace inheritance and adding `[workspace.dependencies]`.

### Additional information
The ability to use workspace inheritance was added in #11851, as that PR added a workspace for `cargo`.

The changes were made by a tool I wrote to assist in finding duplicate dependencies.