### PR TITLE
Fix warning with unused mut

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -149,7 +149,7 @@ pub fn build_unit_dependencies<'a, 'cfg>(
 
 /// Compute all the dependencies for the standard library.
 fn calc_deps_of_std(
-    mut state: &mut State<'_, '_>,
+    state: &mut State<'_, '_>,
     std_roots: &HashMap<CompileKind, Vec<Unit>>,
 ) -> CargoResult<Option<UnitGraph>> {
     if std_roots.is_empty() {


### PR DESCRIPTION
### What does this PR try to resolve?

```
warning: variable does not need to be mutable
   --> src/cargo/core/compiler/unit_dependencies.rs:152:5
    |
152 |     mut state: &mut State<'_, '_>,
    |     ----^^^^^
    |     |
    |     help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: `cargo` (lib) generated 1 warning (run `cargo fix --lib -p cargo` to apply 1 suggestion)
```

This is caused by https://github.com/rust-lang/rust/pull/110960

### How should we test and review this PR?

Running the mainline rust toolchain and `cargo build` without any wanrning messages would look like the above.

### Additional information

None
