### PR TITLE
Update lock to normalize `home` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fc78f47095a0c15aea0e66103838f0748f4494bf7a9555dfe0f00425400396c"
 dependencies = [
  "bstr",
- "home 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "home 0.5.5",
  "once_cell",
  "thiserror",
 ]


### PR DESCRIPTION
I'm not sure what happened, but in #11840 `Cargo.lock` was updated in such a way that the `home` dependency had a qualified source, even though it was equivalent to crates.io. This should only happen if there is some ambiguity (like if something had a path source to the in-tree home). 

This causes the `Cargo.lock` file to be modified whenever running cargo commands locally.  This doesn't fail `--locked` because the resolve is equivalent, pointing to the the same source.

Closes #12082