### PR TITLE
xtask-unpublished: output a markdown table

### DIFF
--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Tool for capturing a real-world workspace for benchmarking."
+publish = false
 
 [dependencies]
 cargo_metadata.workspace = true

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://github.com/rust-lang/cargo"
 description = "Helper proc-macro for Cargo's testsuite."
+publish = false
 
 [lib]
 proc-macro = true

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -3,6 +3,7 @@ name = "cargo-test-support"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
+publish = false
 
 [lib]
 doctest = false


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Part of #12033

~~The purpose of these changes is to make sure that every subcrate gets a version bump if their source files change.~~ 

This turns out to be adding a table output for xtask-unpublished. Will address CI issue later on.

### How should we test and review this PR?

This extends `xtask-unpublished` to

- respects `--package` flag
- outputs a markdown table of crate publish statuses

This also marks `capture` `cargo-test-support`, and `cargo-test-marco` crates as `publish = false`.

To review, you may want to

- Review it by commits.
- Run `cargo unpublished` and check the output correctness.

### Additional information

Initially, I was going to run `gh pr comment --body <comment>` to write a comment on the pull request. I had [a basic example here][exp]. However, it seems to have some safety concerns [^1] — we may grant too many permissions to a malicious PR author to mess up our pull requests.

I stopped to provide this new CI job only. No any new GitHub Action permission required.

If you got a good idea to post a comment without sacrificing CI security and complexity, I am happy to know!

[exp]: https://github.com/weihanglo/cargo/pull/27#issuecomment-1535378898
[^1]: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
<!-- homu-ignore:end -->
