### PR TITLE
fix: hack around `libsysroot` instead of `libtest`

### DIFF
--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -92,7 +92,7 @@ pub fn resolve_std<'cfg>(
         String::from("library/std"),
         String::from("library/core"),
         String::from("library/alloc"),
-        String::from("library/test"),
+        String::from("library/sysroot"),
     ];
     let ws_config = crate::core::WorkspaceConfig::Root(crate::core::WorkspaceRootConfig::new(
         &src_path,
@@ -114,13 +114,13 @@ pub fn resolve_std<'cfg>(
     let config = ws.config();
     // This is a delicate hack. In order for features to resolve correctly,
     // the resolver needs to run a specific "current" member of the workspace.
-    // Thus, in order to set the features for `std`, we need to set `libtest`
-    // to be the "current" member. `libtest` is the root, and all other
+    // Thus, in order to set the features for `std`, we need to set `sysroot`
+    // to be the "current" member. `sysroot` is the root, and all other
     // standard library crates are dependencies from there. Since none of the
     // other crates need to alter their features, this should be fine, for
     // now. Perhaps in the future features will be decoupled from the resolver
     // and it will be easier to control feature selection.
-    let current_manifest = src_path.join("library/test/Cargo.toml");
+    let current_manifest = src_path.join("library/sysroot/Cargo.toml");
     // TODO: Consider doing something to enforce --locked? Or to prevent the
     // lock file from being written, such as setting ephemeral.
     let mut std_ws = Workspace::new_virtual(src_path, current_manifest, virtual_manifest, config)?;
@@ -128,10 +128,10 @@ pub fn resolve_std<'cfg>(
     // `[dev-dependencies]`. No need for us to generate a `Resolve` which has
     // those included because we'll never use them anyway.
     std_ws.set_require_optional_deps(false);
-    // `test` is not in the default set because it is optional, but it needs
-    // to be part of the resolve in case we do need it.
+    // `sysroot` is not in the default set because it is optional, but it needs
+    // to be part of the resolve in case we do need it or `libtest`.
     let mut spec_pkgs = Vec::from(crates);
-    spec_pkgs.push("test".to_string());
+    spec_pkgs.push("sysroot".to_string());
     let spec = Packages::Packages(spec_pkgs);
     let specs = spec.to_package_id_specs(&std_ws)?;
     let features = match &config.cli_unstable().build_std_features {

--- a/tests/testsuite/mock-std/library/sysroot/Cargo.toml
+++ b/tests/testsuite/mock-std/library/sysroot/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sysroot"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+proc_macro = { path = "../proc_macro" }
+std = { path = "../std" }
+test = { path = "../test" }
+
+[features]
+panic-unwind = []
+backtrace = []
+feature1 = ["std/feature1"]
+default = []

--- a/tests/testsuite/mock-std/library/sysroot/src/lib.rs
+++ b/tests/testsuite/mock-std/library/sysroot/src/lib.rs
@@ -1,0 +1,1 @@
+// Intentionally left blank.

--- a/tests/testsuite/mock-std/library/test/Cargo.toml
+++ b/tests/testsuite/mock-std/library/test/Cargo.toml
@@ -5,14 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
-proc_macro = { path = "../proc_macro" }
 std = { path = "../std" }
 panic_unwind = { path = "../panic_unwind" }
 compiler_builtins = { path = "../compiler_builtins" }
 registry-dep-using-std = { version = "*", features = ['mockbuild'] }
-
-[features]
-panic-unwind = []
-backtrace = []
-feature1 = ["std/feature1"]
-default = []


### PR DESCRIPTION
### What does this PR try to resolve?

This is a fix in response to rust-lang/rust#108865.

Cargo `-Zbuild-std` now use `sysroot` crate to resolve cargo features instead
of the old hack around `libtest`. `sysroot` is just a dummy crate depending on
other standard library crates.