### PR TITLE
Fix redacting tokens in http debug.

### DIFF
--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -704,12 +704,17 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
                 InfoType::SslDataIn | InfoType::SslDataOut => return,
                 _ => return,
             };
+            let starts_with_ignore_case = |line: &str, text: &str| -> bool {
+                line[..line.len().min(text.len())].eq_ignore_ascii_case(text)
+            };
             match str::from_utf8(data) {
                 Ok(s) => {
                     for mut line in s.lines() {
-                        if line.starts_with("Authorization:") {
+                        if starts_with_ignore_case(line, "authorization:") {
                             line = "Authorization: [REDACTED]";
-                        } else if line[..line.len().min(10)].eq_ignore_ascii_case("set-cookie") {
+                        } else if starts_with_ignore_case(line, "h2h3 [authorization:") {
+                            line = "h2h3 [Authorization: [REDACTED]]";
+                        } else if starts_with_ignore_case(line, "set-cookie") {
                             line = "set-cookie: [REDACTED]";
                         }
                         log!(level, "http-debug: {} {}", prefix, line);


### PR DESCRIPTION
Unfortunately it seems like #8222 didn't properly redact tokens when connecting to an http2 server. There were multiple problems:

* For some reason, curl changes the authorization header to be lowercase when using http2.
* Curl also logs the h2h3 lines separately with a different syntax.

This fixes it by checking for these additional cases.

This also adds a test, but it doesn't actually detect this problem because we don't have an http2 server handy. You can test this yourself by running `CARGO_LOG=trace CARGO_HTTP_DEBUG=true cargo publish --token a-unique-token --allow-dirty --no-verify`, and verifying the output does not contain the given token text. 

