### PR TITLE
Update git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89511277159354bea13ae1e53e0c9ab85ba1b20d7e91618fa30e6bc5566857fb"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
@@ -1936,9 +1936,9 @@ checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.15.0+1.6.3"
+version = "0.15.1+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "032e537ae4dd4e50c877f258dc55fcd0657b5021f454094a425bb6bcc9edea4c"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ env_logger = "0.10.0"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }
 fwdansi = "1.1.0"
-git2 = "0.17.0"
+git2 = "0.17.1"
 git2-curl = "0.18.0"
 gix = { version = "0.44.1", default-features = false, features = ["blocking-http-transport-curl", "progress-tree"] }
 gix-features-for-configuration-only = { version = "0.29.0", package = "gix-features", features = [ "parallel" ] }
@@ -51,7 +51,7 @@ jobserver = "0.1.26"
 lazy_static = "1.3.0"
 lazycell = "1.2.0"
 libc = "0.2.88"
-libgit2-sys = "0.15.0"
+libgit2-sys = "0.15.1"
 log = "0.4.17"
 memchr = "2.1.3"
 miow = "0.5.0"


### PR DESCRIPTION
This is a very minor update to libgit2 which fixes an issue when the ProgramData folder is missing on Windows.

git2 changelog: https://github.com/rust-lang/git2-rs/blob/master/CHANGELOG.md#0171---2023-04-13
libgit2-sys changelog: https://github.com/rust-lang/git2-rs/blob/master/libgit2-sys/CHANGELOG.md#0151164---2023-04-13
libgit2 changelog: https://github.com/libgit2/libgit2/releases/tag/v1.6.4