### PR TITLE
Fix self_signed_should_fail for macOS.

### DIFF
--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -30,7 +30,7 @@ fn self_signed_should_fail() {
         .build();
     // I think the text here depends on the curl backend.
     let err_msg = if cfg!(target_os = "macos") {
-        "unexpected return value from ssl handshake -9806; class=Ssl (16)"
+        "untrusted connection error; class=Ssl (16); code=Certificate (-17)"
     } else if cfg!(unix) {
         "the SSL certificate is invalid; class=Ssl (16); code=Certificate (-17)"
     } else if cfg!(windows) {


### PR DESCRIPTION
I'm not sure what exactly happened in #11928, but that PR changed this error text in what I think is an incorrect way. At least, I cannot reproduce what happened. The original text seems to be correct and this PR restores it to the original text which works correctly on my systems.
