### PR TITLE
Compute the right output filenames for rustdoc invocations that request the JSON format

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1761,9 +1761,7 @@ fn doc_json_artifacts() {
 
 #[cargo_test(nightly, reason = "rustdoc-json")]
 fn doc_json_artifacts_are_cached_correctly() {
-    let p = project()
-        .file("src/lib.rs", "")
-        .build();
+    let p = project().file("src/lib.rs", "").build();
 
     // The first run should emit the unit as dirty ("fresh": false), while showing
     // the correct output filenames.
@@ -1799,7 +1797,8 @@ fn doc_json_artifacts_are_cached_correctly() {
 
     // We then run it again and check that the unit is now marked as fresh.
     p.cargo("rustdoc --lib --message-format=json -- -Zunstable-options --output-format=json")
-        .with_json_contains_unordered(r#"
+        .with_json_contains_unordered(
+            r#"
 {
     "reason": "compiler-artifact",
     "package_id": "foo 0.0.1 [..]",
@@ -1823,7 +1822,8 @@ fn doc_json_artifacts_are_cached_correctly() {
 }
 
 {"reason":"build-finished","success":true}
-        "#)
+        "#,
+        )
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo` currently assumes that all invocations of `cargo rustdoc` produce HTML files as outputs.  
This assumption breaks down for invocations of `cargo rustdoc` that instruct `rustdoc` to produce documentation in a different format (i.e. JSON).

As a consequence, running the very same command multiple times (`cargo +nightly rustdoc --lib -p <NAME> -- -Zunstable-options -wjson`) recomputes the documentation every single time, instead of detecting that the pre-existing file is still fresh.

![immagine](https://user-images.githubusercontent.com/20745048/236691604-51554597-c216-44a1-aaf4-c9788ab95925.png)

This PR fixes the logic in `cargo` to correctly detect the output filename when the JSON format is required.

### How should we test and review this PR?

I've added a test to confirm that:

- The output filename is what we expect (i.e. `<crate name>.json`);
- The unit is marked as fresh the second time the same command is invoked.

### Additional information

An alternative implementation strategy could see us adding `--output-format` as a `cargo rustdoc` option, rather than trying to parse the extra arguments being passed to `rustdoc`.
