### PR TITLE
Semver: Note that it is not a breaking change to make an unsafe function safe

### DIFF
--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -88,7 +88,7 @@ considered incompatible.
         * [Possibly-breaking: introducing a new function type parameter](#fn-generic-new)
         * [Minor: generalizing a function to use generics (supporting original type)](#fn-generalize-compatible)
         * [Major: generalizing a function to use generics with type mismatch](#fn-generalize-mismatch)
-        * [Possibly-breaking: making an `unsafe` function safe](#fn-unsafe-safe)
+        * [Minor: making an `unsafe` function safe](#fn-unsafe-safe)
     * Attributes
         * [Major: switching from `no_std` support to requiring `std`](#attr-no-std-to-std)
         * [Major: adding `non_exhaustive` to an existing enum, variant, or struct with no private fields](#attr-adding-non-exhaustive)
@@ -1082,12 +1082,14 @@ fn main() {
 ```
 
 <a id="fn-unsafe-safe"></a>
-### Possibly-breaking: making an `unsafe` function safe
+### Minor: making an `unsafe` function safe
 
-A previously `unsafe` function can be made safe without breaking code. Note
-however that it will likely cause the [`unused_unsafe`][unused_unsafe] lint
-to trigger as in the example below, which will cause local crates that have
-specified `#![deny(warnings)]` to stop compiling.
+A previously `unsafe` function can be made safe without breaking code.
+
+Note however that it may cause the [`unused_unsafe`][unused_unsafe] lint to
+trigger as in the example below, which will cause local crates that have
+specified `#![deny(warnings)]` to stop compiling. Per [introducing new
+lints](#new-lints), it is allowed for updates to introduce new warnings.
 
 Going the other way (making a safe function `unsafe`) is a breaking change.
 
@@ -1118,33 +1120,7 @@ fn main() {
 
 Making a previously `unsafe` associated function or method on structs / enums
 safe is also a minor change, while the same is not true for associated
-function on traits:
-
-```rust,ignore
-// MAJOR CHANGE
-
-///////////////////////////////////////////////////////////
-// Before
-pub trait Foo {
-    unsafe fn foo();
-}
-
-///////////////////////////////////////////////////////////
-// After
-pub trait Foo {
-    fn foo();
-}
-
-///////////////////////////////////////////////////////////
-// Example usage that will break.
-use updated_crate::Foo;
-
-struct Bar;
-
-impl Foo for Bar {
-    unsafe fn foo() {} // Error: method `foo` has an incompatible type for trait
-}
-```
+function on traits (see [any change to trait item signatures](#trait-item-signature)).
 
 <a id="attr-no-std-to-std"></a>
 ### Major: switching from `no_std` support to requiring `std`

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -1116,8 +1116,8 @@ fn main() {
 }
 ```
 
-Making an a previously `unsafe` associated function or method on structs /
-enums safe is also a minor change, while the same is not true for associated
+Making a previously `unsafe` associated function or method on structs / enums
+safe is also a minor change, while the same is not true for associated
 function on traits:
 
 ```rust,ignore

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -88,7 +88,7 @@ considered incompatible.
         * [Possibly-breaking: introducing a new function type parameter](#fn-generic-new)
         * [Minor: generalizing a function to use generics (supporting original type)](#fn-generalize-compatible)
         * [Major: generalizing a function to use generics with type mismatch](#fn-generalize-mismatch)
-        * [Minor: making an `unsafe` function safe](#fn-unsafe-safe)
+        * [Possibly-breaking: making an `unsafe` function safe](#fn-unsafe-safe)
     * Attributes
         * [Major: switching from `no_std` support to requiring `std`](#attr-no-std-to-std)
         * [Major: adding `non_exhaustive` to an existing enum, variant, or struct with no private fields](#attr-adding-non-exhaustive)
@@ -1082,10 +1082,12 @@ fn main() {
 ```
 
 <a id="fn-unsafe-safe"></a>
-### Minor: making an `unsafe` function safe
+### Possibly-breaking: making an `unsafe` function safe
 
-It is not a breaking change to make a previously `unsafe` function safe, as in
-the example below.
+A previously `unsafe` function can be made safe without breaking code. Note
+however that it will likely cause the [`unused_unsafe`][unused_unsafe] lint
+to trigger as in the example below, which will cause local crates that have
+specified `#![deny(warnings)]` to stop compiling.
 
 Going the other way (making a safe function `unsafe`) is a breaking change.
 
@@ -1101,7 +1103,7 @@ pub unsafe fn foo() {}
 pub fn foo() {}
 
 ///////////////////////////////////////////////////////////
-// Example use of the library that will safely work.
+// Example use of the library that will trigger a lint.
 use updated_crate::foo;
 
 unsafe fn bar(f: unsafe fn()) {
@@ -1143,10 +1145,6 @@ impl Foo for Bar {
     unsafe fn foo() {} // Error: method `foo` has an incompatible type for trait
 }
 ```
-
-Note that local crates that have specified `#![deny(warnings)]` (which is an
-[anti-pattern][deny warnings]) will break, since they've explicitly opted out
-of Rust's stability guarantees.
 
 <a id="attr-no-std-to-std"></a>
 ### Major: switching from `no_std` support to requiring `std`
@@ -1555,4 +1553,4 @@ document what your commitments are.
 [SemVer]: https://semver.org/
 [struct literal]: ../../reference/expressions/struct-expr.html
 [wildcard patterns]: ../../reference/patterns.html#wildcard-pattern
-[deny warnings]: https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html
+[unused_unsafe]: ../../rustc/lints/listing/warn-by-default.html#unused-unsafe


### PR DESCRIPTION
This is a repost of #11200 with some requested edits made. This makes it clear that it is a minor change due to our policy that triggering new lints is not a breaking change. I also simplified it by not repeating what constitutes a breaking change for a trait definition, and instead link to the rule that specifies no signature changes are allowed.
