### PR TITLE
Update the semver-check script to be able to run in any directory.

### DIFF
--- a/crates/semver-check/src/main.rs
+++ b/crates/semver-check/src/main.rs
@@ -23,9 +23,13 @@ fn main() {
 const SEPARATOR: &str = "///////////////////////////////////////////////////////////";
 
 fn doit() -> Result<(), Box<dyn Error>> {
-    let filename = std::env::args()
-        .nth(1)
-        .unwrap_or_else(|| "src/doc/src/reference/semver.md".to_string());
+    let filename = std::env::args().nth(1).unwrap_or_else(|| {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../src/doc/src/reference/semver.md")
+            .to_str()
+            .unwrap()
+            .to_string()
+    });
     let contents = fs::read_to_string(filename)?;
     let mut lines = contents.lines().enumerate();
 

--- a/src/doc/README.md
+++ b/src/doc/README.md
@@ -55,8 +55,12 @@ To rebuild the man pages, run `cargo build-man` inside the workspace.
 ### SemVer chapter tests
 
 There is a script to verify that the examples in the SemVer chapter work as
-intended. To run the tests, go into the `semver-check` directory and run
-`cargo run`.
+intended. To run the tests, run `cargo +stable run -p semver-check`.
+
+Note that these tests run on the most recent stable release because they
+validate the output of the compiler diagnostics. The output can change between
+releases, so we pin to a specific release to avoid frequent and unexpected
+breakage.
 
 ## Contributing
 


### PR DESCRIPTION
When semver-check was moved into the workspace, that changed how semver-check is expected to be run. This updates the script so that it can more easily be run from any directory. This also updates the documentation for the correct way to run it, along with some clarification on why it uses the stable release.
