### PR TITLE
ci: check if any version bump needed for member crates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,18 @@ jobs:
       - run: rustup update stable && rustup default stable
       - run: cargo update -p cargo --locked
 
+  check-version-bump:
+    runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # make `git diff` work
+      - run: rustup update stable && rustup default stable
+      - run: ci/validate-version-bump.sh
+
   test:
     runs-on: ${{ matrix.os }}
     env:

--- a/ci/validate-version-bump.sh
+++ b/ci/validate-version-bump.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This script checks if a crate needs a version bump.
+#
+# At the time of writing, it doesn't check what kind of bump is required.
+# In the future, we could take SemVer compatibliity into account, like
+# integrating `cargo-semver-checks` of else
+#
+# Inputs:
+#     BASE_SHA    The commit SHA of the branch where the PR wants to merge into.
+#     HEAD_SHA    The commit SHA that triggered the workflow.
+
+set -euo pipefail
+
+# When `BASE_SHA` is missing, we assume it is from bors merge commit,
+# so hope `HEAD~` to find the previous commit on master branch.
+base_sha=$(git rev-parse "${BASE_SHA:-HEAD~1}")
+head_sha=$(git rev-parse "${HEAD_SHA:-HEAD}")
+
+echo "Base branch  is $base_sha"
+echo "Current head is $head_sha"
+
+# Gets crate names of members that has been changed from $bash_sha to $head_sha.
+changed_crates=$(
+    git diff --name-only "$base_sha" "$head_sha" -- crates/ credential/ benches/ \
+    | cut  -d'/' -f2 \
+    | sort -u
+)
+
+if  [ -z "$changed_crates" ]
+then
+    echo "No file changed in member crates."
+    exit 0
+fi
+
+# Checks publish status for only crates with code changes.
+publish_status_table=$(
+    echo "$changed_crates" \
+    | xargs printf -- '--package %s\n' \
+    | xargs cargo unpublished
+)
+
+# "yes" -> code changed but no version difference -> need a bump
+# Prints 2nd column (sep by space), which is the name of the crate.
+crates_need_bump=$(
+    echo "$publish_status_table" \
+    | { grep '| yes ' || true; } \
+    | awk '{print $2}'
+)
+
+if  [ -z "$crates_need_bump" ]
+then
+    echo "No version bump needed for member crates."
+    exit 0
+fi
+
+echo "Detected changes in these crates but no version bump found:"
+echo "$crates_need_bump"
+echo
+echo "Please bump at least one patch version for each corresponding Cargo.toml:"
+echo 'Run "cargo unpublished" to read the publish status table for details.'
+exit 1

--- a/crates/xtask-unpublished/src/xtask.rs
+++ b/crates/xtask-unpublished/src/xtask.rs
@@ -1,3 +1,9 @@
+//! `xtask-unpublished` outputs a table with publish status --- a local version
+//! and a version on crates.io for comparisons.
+//!
+//! This aims to help developers check if there is any crate required a new
+//! publish, as well as detect if a version bump is needed in CI pipeline.
+
 use std::collections::HashSet;
 
 use cargo::core::registry::PackageRegistry;


### PR DESCRIPTION
### What does this PR try to resolve?

Check if a crate requires a version bump in CI.

Part of #12033

### How should we test and review this PR?

Demo action result: <https://github.com/weihanglo/cargo/actions/runs/4941952784/jobs/8835049007>

### Additional information

This doesn't devalue #12089. I love the changelog detection, saving maintainers' times a lot ( I am the one writing changelogs for each release for now). However, the amount of code there is too excessive to me. I think someday when we are going to integrate [cargo-release](https://crates.io/crates/cargo-release) and/or [ehuss/cargo-new-release](https://github.com/ehuss/cargo-new-release), we can remove this script perhaps entirely :)

I tried to document the script a bit hard. Hope it won't get worse over time.
