### PR TITLE
Remove useless drop of copy type

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -59,8 +59,8 @@ pub fn panic_error(what: &str, err: impl Into<anyhow::Error>) -> ! {
     fn pe(what: &str, err: anyhow::Error) -> ! {
         let mut result = format!("{}\nerror: {}", what, err);
         for cause in err.chain().skip(1) {
-            drop(writeln!(result, "\nCaused by:"));
-            drop(write!(result, "{}", cause));
+            let _ = writeln!(result, "\nCaused by:");
+            let _ = write!(result, "{}", cause);
         }
         panic!("\n{}", result);
     }

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1045,10 +1045,10 @@ impl<'cfg> DrainState<'cfg> {
                     if fixable > 1 {
                         suggestions.push_str("s")
                     }
-                    drop(write!(
+                    let _ = write!(
                         message,
                         " (run `{command} --{args}` to apply {suggestions})"
-                    ))
+                    );
                 }
             }
         }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -585,19 +585,19 @@ impl Features {
                     feature_name, feature.version
                 );
                 if self.is_local {
-                    drop(writeln!(
+                    let _ = writeln!(
                         msg,
                         "Remove the feature from Cargo.toml to remove this error."
-                    ));
+                    );
                 } else {
-                    drop(writeln!(
+                    let _ = writeln!(
                         msg,
                         "This package cannot be used with this version of Cargo, \
                          as the unstable feature `{}` is no longer supported.",
                         feature_name
-                    ));
+                    );
                 }
-                drop(writeln!(msg, "{}", see_docs()));
+                let _ = writeln!(msg, "{}", see_docs());
                 bail!(msg);
             }
         }
@@ -629,32 +629,29 @@ impl Features {
 
         if self.nightly_features_allowed {
             if self.is_local {
-                drop(writeln!(
+                let _ = writeln!(
                     msg,
                     "Consider adding `cargo-features = [\"{}\"]` \
                      to the top of Cargo.toml (above the [package] table) \
                      to tell Cargo you are opting in to use this unstable feature.",
                     feature_name
-                ));
+                );
             } else {
-                drop(writeln!(
-                    msg,
-                    "Consider trying a more recent nightly release."
-                ));
+                let _ = writeln!(msg, "Consider trying a more recent nightly release.");
             }
         } else {
-            drop(writeln!(
+            let _ = writeln!(
                 msg,
                 "Consider trying a newer version of Cargo \
                  (this may require the nightly release)."
-            ));
+            );
         }
-        drop(writeln!(
+        let _ = writeln!(
             msg,
             "See https://doc.rust-lang.org/nightly/cargo/{} for more information \
              about the status of this feature.",
             feature.docs
-        ));
+        );
 
         bail!("{}", msg);
     }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR aims to remove useless drop of copy type to clear warnings that reported after rust-lang/rust#109732

```
warning: calls to `std::mem::drop` with a value that implements `Copy` does nothing
    --> src/cargo/core/compiler/job_queue/mod.rs:1048:21
     |
1048 |                        drop(write!(
     |  ______________________^____-
     | | _____________________|
     | ||
1049 | ||                         message,
1050 | ||                         " (run `{command} --{args}` to apply {suggestions})"
1051 | ||                     ))
     | ||_____________________-^
     | |______________________|
     |                        argument has type `Result<(), std::fmt::Error>`
     |
     = note: use `let _ = ...` to ignore the expression or result
     = note: `#[warn(drop_copy)]` on by default
```

### How should we test and review this PR?

```bash
cargo build && cargo test # without any warnings
```

### Additional information

None
