### PR TITLE
docs: Clarify that crates.io doesn't link to docs.rs right away.

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -203,13 +203,16 @@ description = "A short description of my package"
 
 The `documentation` field specifies a URL to a website hosting the crate's
 documentation. If no URL is specified in the manifest file, [crates.io] will
-automatically link your crate to the corresponding [docs.rs] page.
+automatically link your crate to the corresponding [docs.rs] page when the
+documentation has been built and is available (see [docs.rs queue]).
 
 ```toml
 [package]
 # ...
 documentation = "https://docs.rs/bitflags"
 ```
+
+[docs.rs queue]: https://docs.rs/releases/queue
 
 #### The `readme` field
 


### PR DESCRIPTION
This implements the suggestion in https://github.com/rust-lang/cargo/pull/11685#issuecomment-1544196416 to help clarify the confusion about the documentation link not appearing on crates.io.

There may be more to follow up here, perhaps with changes on crates.io or docs.rs, to help with some of the confusion. For example, #11777, or changing crates.io to always link to docs.rs, and have docs.rs provide better error pages when docs aren't available. This is just intended as a short-term fix to address some of the confusion.
