### PR TITLE
Change overly threatening error message when depending on cdylib or staticlib crates

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1314,7 +1314,7 @@ fn build_deps_args(
                 "The package `{}` \
                  provides no linkable target. The compiler might raise an error while compiling \
                  `{}`. Consider adding 'dylib' or 'rlib' to key `crate-type` in `{}`'s \
-                 Cargo.toml. This warning might turn into a hard error in the future.",
+                 Cargo.toml if this was not intentional.",
                 dep.unit.target.crate_name(),
                 unit.target.crate_name(),
                 dep.unit.target.crate_name()


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #12155. As explained in the issue, there are legitimate reasons to depend
on a staticlib or cdylib crate, and this error message threatening to become a
hard error may dissuade users from those reasons.

### How should we test and review this PR?

You can test this PR by running:

```
cargo new --lib /tmp/test-lib
echo -e '[lib]\ncrate-type = ["staticlib"]' >> /tmp/test-lib/Cargo.toml
cargo new --bin /tmp/test-bin
cargo add --manifest-path /tmp/test-bin/Cargo.toml --path /tmp/test-lib/
cargo build --manifest-path /tmp/test-bin/Cargo.toml
```

You should see the new error message.

### Additional information

This error messagaging was mentioned in #4797, and maintainers assumed
staticlib crate types are a mistake. Generally, staticlib crates (at least for
the purpose I use them for -- fuzzing targets) would not be published on
crates.io, but would be used internally or privately. Rarity of this type of
crate on crates.io isn't a good reason to threaten users with an error for what
they are doing unless it is truly an error.
