### PR TITLE
fix: pass `-C debuginfo` after weakening if explicitly set

### DIFF
--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -780,8 +780,12 @@ impl DebugInfo {
     }
 
     /// Reset to the lowest level: no debuginfo.
+    /// If it is explicitly set, keep it explicit.
     pub(crate) fn weaken(self) -> Self {
-        DebugInfo::None
+        match self {
+            DebugInfo::None => DebugInfo::None,
+            _ => DebugInfo::Explicit(TomlDebugInfo::None),
+        }
     }
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3885,7 +3885,7 @@ fn compiler_json_error_format() {
                 },
                 "profile": {
                     "debug_assertions": true,
-                    "debuginfo": null,
+                    "debuginfo": 0,
                     "opt_level": "0",
                     "overflow_checks": true,
                     "test": false

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -83,16 +83,16 @@ fn profile_selection_build() {
     // - bdep `panic` is not set because it thinks `build.rs` is a plugin.
     // - build_script_build is built without panic because it thinks `build.rs` is a plugin.
     // - We make sure that the build dependencies bar, bdep, and build.rs
-    //   are built without debuginfo.
+    //   are built with debuginfo=0.
     p.cargo("build -vv")
         .with_stderr_unordered("\
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -100,9 +100,6 @@ fn profile_selection_build() {
 [FINISHED] dev [unoptimized + debuginfo] [..]
 "
         )
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
         .run();
     p.cargo("build -vv")
         .with_stderr_unordered(
@@ -158,7 +155,7 @@ fn profile_selection_build_all_targets() {
     // - Benchmark dependencies are compiled in `dev` mode, which may be
     //   surprising. See issue rust-lang/cargo#4929.
     // - We make sure that the build dependencies bar, bdep, and build.rs
-    //   are built without debuginfo.
+    //   are built with debuginfo=0.
     //
     // - Dependency profiles:
     //   Pkg  Target  Profile     Reason
@@ -184,11 +181,11 @@ fn profile_selection_build_all_targets() {
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -202,9 +199,6 @@ fn profile_selection_build_all_targets() {
 [FINISHED] dev [unoptimized + debuginfo] [..]
 "
         )
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
         .run();
     p.cargo("build -vv")
         .with_stderr_unordered(


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

The weakening of debuginfo for build script shouldn't turn debuginfo
to `DebugInfo::None`. That will result in not passing `-C debuginfo=0`
to rustc, leading to build artifact cache miss.

Fixes #12163

### How should we test and review this PR?

The existing test cases should cover this change.

You can also follow the reproducer in #12163.

I don't think we need more new test cases, since #12163 is not really a new scenario. See <https://github.com/rust-lang/cargo/issues/12163#issuecomment-1556047109>.

### Additional information

Will it introduce more cache miss? The following table shows whether `-C debuginfo` is passed to rustc:

 _(before/after means before/after this pull request)_

| profile\dependency               | Before: build-deps | After: build-deps | normal-deps        |
|----------------------------------|--------------------|-------------------|--------------------|
| `dev` default                    | No flag (weakened) | `-C debuginfo=0`  | `-C debuginfo=2`   |
| `dev.debug=0`                    | No flag (weakened) | `-C debuginfo=0`  | `-C debuginfo=0`   |
| `dev.build-override.debug=0`     | `-C debuginfo=0`   | `-C debuginfo=0`  | `-C debuginfo=2`   |
| `release` default                | No flag (not set)  | No flag (not set) | No flag (not set)  |
| `release.debug=0`                | No flag (weakened) | `-C debuginfo=0`  | `-C debuginfo=0`   |
| `release.build-override.debug=0` | `-C debuginfo=0`   | `-C debuginfo=0`  | `-C debuginfo=2`   |


We can see that even with `debug=0` set explicitly, some build-deps were weakened to no flag passed at all. I am still not sure if there is any cache miss, but at least we can potentially reuse artifacts between build-deps and normal-deps when `dev.debug=0`.

(Artifacts cannot be reused for `release.debug=0` because other flags like `opt-level` may have different values)
<!-- homu-ignore:end -->
