### PR TITLE
[beta-1.70] backport #12165

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -59,8 +59,8 @@ pub fn panic_error(what: &str, err: impl Into<anyhow::Error>) -> ! {
     fn pe(what: &str, err: anyhow::Error) -> ! {
         let mut result = format!("{}\nerror: {}", what, err);
         for cause in err.chain().skip(1) {
-            drop(writeln!(result, "\nCaused by:"));
-            drop(write!(result, "{}", cause));
+            let _ = writeln!(result, "\nCaused by:");
+            let _ = write!(result, "{}", cause);
         }
         panic!("\n{}", result);
     }

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1045,10 +1045,10 @@ impl<'cfg> DrainState<'cfg> {
                     if fixable > 1 {
                         suggestions.push_str("s")
                     }
-                    drop(write!(
+                    let _ = write!(
                         message,
                         " (run `{command} --{args}` to apply {suggestions})"
-                    ))
+                    );
                 }
             }
         }

--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -149,7 +149,7 @@ pub fn build_unit_dependencies<'a, 'cfg>(
 
 /// Compute all the dependencies for the standard library.
 fn calc_deps_of_std(
-    mut state: &mut State<'_, '_>,
+    state: &mut State<'_, '_>,
     std_roots: &HashMap<CompileKind, Vec<Unit>>,
 ) -> CargoResult<Option<UnitGraph>> {
     if std_roots.is_empty() {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -585,19 +585,19 @@ impl Features {
                     feature_name, feature.version
                 );
                 if self.is_local {
-                    drop(writeln!(
+                    let _ = writeln!(
                         msg,
                         "Remove the feature from Cargo.toml to remove this error."
-                    ));
+                    );
                 } else {
-                    drop(writeln!(
+                    let _ = writeln!(
                         msg,
                         "This package cannot be used with this version of Cargo, \
                          as the unstable feature `{}` is no longer supported.",
                         feature_name
-                    ));
+                    );
                 }
-                drop(writeln!(msg, "{}", see_docs()));
+                let _ = writeln!(msg, "{}", see_docs());
                 bail!(msg);
             }
         }
@@ -629,32 +629,29 @@ impl Features {
 
         if self.nightly_features_allowed {
             if self.is_local {
-                drop(writeln!(
+                let _ = writeln!(
                     msg,
                     "Consider adding `cargo-features = [\"{}\"]` \
                      to the top of Cargo.toml (above the [package] table) \
                      to tell Cargo you are opting in to use this unstable feature.",
                     feature_name
-                ));
+                );
             } else {
-                drop(writeln!(
-                    msg,
-                    "Consider trying a more recent nightly release."
-                ));
+                let _ = writeln!(msg, "Consider trying a more recent nightly release.");
             }
         } else {
-            drop(writeln!(
+            let _ = writeln!(
                 msg,
                 "Consider trying a newer version of Cargo \
                  (this may require the nightly release)."
-            ));
+            );
         }
-        drop(writeln!(
+        let _ = writeln!(
             msg,
             "See https://doc.rust-lang.org/nightly/cargo/{} for more information \
              about the status of this feature.",
             feature.docs
-        ));
+        );
 
         bail!("{}", msg);
     }

--- a/src/cargo/core/profiles.rs
+++ b/src/cargo/core/profiles.rs
@@ -784,8 +784,12 @@ impl DebugInfo {
     }
 
     /// Reset to the lowest level: no debuginfo.
+    /// If it is explicitly set, keep it explicit.
     pub(crate) fn weaken(self) -> Self {
-        DebugInfo::None
+        match self {
+            DebugInfo::None => DebugInfo::None,
+            _ => DebugInfo::Explicit(0),
+        }
     }
 }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -3885,7 +3885,7 @@ fn compiler_json_error_format() {
                 },
                 "profile": {
                     "debug_assertions": true,
-                    "debuginfo": null,
+                    "debuginfo": 0,
                     "opt_level": "0",
                     "overflow_checks": true,
                     "test": false

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -83,16 +83,16 @@ fn profile_selection_build() {
     // - bdep `panic` is not set because it thinks `build.rs` is a plugin.
     // - build_script_build is built without panic because it thinks `build.rs` is a plugin.
     // - We make sure that the build dependencies bar, bdep, and build.rs
-    //   are built without debuginfo.
+    //   are built with debuginfo=0.
     p.cargo("build -vv")
         .with_stderr_unordered("\
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -100,9 +100,6 @@ fn profile_selection_build() {
 [FINISHED] dev [unoptimized + debuginfo] [..]
 "
         )
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
         .run();
     p.cargo("build -vv")
         .with_stderr_unordered(
@@ -158,7 +155,7 @@ fn profile_selection_build_all_targets() {
     // - Benchmark dependencies are compiled in `dev` mode, which may be
     //   surprising. See issue rust-lang/cargo#4929.
     // - We make sure that the build dependencies bar, bdep, and build.rs
-    //   are built without debuginfo.
+    //   are built with debuginfo=0.
     //
     // - Dependency profiles:
     //   Pkg  Target  Profile     Reason
@@ -184,11 +181,11 @@ fn profile_selection_build_all_targets() {
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] bdep [..]
-[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [COMPILING] foo [..]
-[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 [..]
+[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=5 -C debuginfo=0[..]
 [RUNNING] `[..]/target/debug/build/foo-[..]/build-script-build`
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
@@ -202,9 +199,6 @@ fn profile_selection_build_all_targets() {
 [FINISHED] dev [unoptimized + debuginfo] [..]
 "
         )
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bar bar/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name bdep bdep/src/lib.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
-        .with_stderr_line_without(&["[RUNNING] `[..] rustc --crate-name build_script_build build.rs [..]-C codegen-units=5 [..]"], &["-C debuginfo"])
         .run();
     p.cargo("build -vv")
         .with_stderr_unordered(


### PR DESCRIPTION
Beta backports:

- https://github.com/rust-lang/cargo/pull/12165
  - Adjusted a bit since `TomlDebugInfo::None` was not there in 1.70.0. It was a simple u32 `0`.

In order to make CI pass, the following PRs are also cherry-picked:

- https://github.com/rust-lang/cargo/pull/12065
- https://github.com/rust-lang/cargo/pull/12136