### PR TITLE
Document layout SemVer compatibility.

### DIFF
--- a/crates/semver-check/src/main.rs
+++ b/crates/semver-check/src/main.rs
@@ -7,6 +7,11 @@
 //! An example with the word "MINOR" at the top is expected to successfully
 //! build against the before and after. Otherwise it should fail. A comment of
 //! "// Error:" will check that the given message appears in the error output.
+//!
+//! The code block can also include the annotations:
+//! - `run-fail`: The test should fail at runtime, not compiletime.
+//! - `dont-deny`: By default tests have a `#![deny(warnings)]`. This option
+//!   avoids this attribute. Note that `#![allow(unused)]` is always added.
 
 use std::error::Error;
 use std::fs;

--- a/crates/semver-check/src/main.rs
+++ b/crates/semver-check/src/main.rs
@@ -62,7 +62,13 @@ fn doit() -> Result<(), Box<dyn Error>> {
                     if line.trim() == "```" {
                         break;
                     }
-                    block.push(line);
+                    // Support rustdoc/mdbook hidden lines.
+                    let line = line.strip_prefix("# ").unwrap_or(line);
+                    if line == "#" {
+                        block.push("");
+                    } else {
+                        block.push(line);
+                    }
                 }
                 None => {
                     return Err(format!(

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -265,7 +265,8 @@ In some cases, types with a `repr` attribute may not have an alignment, layout, 
 In these cases, it may be safe to make changes to the types, though care should be exercised.
 For example, types with private fields that do not otherwise document their alignment, layout, or size guarantees cannot be relied upon by external crates since the public API does not fully define the alignment, layout, or size of the type.
 
-A common example where a type with *private* fields is well-defined is a type with a single private field with a generic type, using `repr(transparent)`, and which is documented as being transparent to the generic type.
+A common example where a type with *private* fields is well-defined is a type with a single private field with a generic type, using `repr(transparent)`,
+and the prose of the documentation discusses that it is transparent to the generic type.
 For example, see [`UnsafeCell`].
 
 [the default representation]: ../../reference/type-layout.html#the-default-representation

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -716,7 +716,7 @@ fn main() {
 <a id="repr-align-remove"></a>
 #### Major: Removing `repr(align)` from a struct, union, or enum
 
-It is a breaking change to remove `repr(align)` from a struct, union, or enum.
+It is a breaking change to remove `repr(align)` from a struct, union, or enum, if their layout was well-defined.
 This may change the alignment or layout that external crates are relying on.
 
 This change should be safe to make if the type is not well-defined as discussed in [type layout](#type-layout) (such as having any private fields and having an undocumented alignment).
@@ -966,7 +966,6 @@ extern "C" {
 
 fn main() {}
 ```
-
 
 ### Major: adding a private struct field when all current fields are public {#struct-add-private-field-when-public}
 

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -218,12 +218,12 @@ The compiler is free to alter the alignment, layout or size, so code should not 
 
 Some examples of changes that are not a breaking change are (assuming no other rules in this guide are violated):
 
-* Adding, removing, or changing fields of a default representation struct, union, or enum in such a way that the change follows the other rules in this guide (for example, using `non_exhaustive` to allow those changes, or changes to private fields that are already private).
+* Adding, removing, reordering, or changing fields of a default representation struct, union, or enum in such a way that the change follows the other rules in this guide (for example, using `non_exhaustive` to allow those changes, or changes to private fields that are already private).
   See [struct-add-private-field-when-public](#struct-add-private-field-when-public), [struct-add-public-field-when-no-private](#struct-add-public-field-when-no-private), [struct-private-fields-with-private](#struct-private-fields-with-private), [enum-fields-new](#enum-fields-new).
 * Adding variants to a default representation enum, if the enum uses `non_exhaustive`.
   This may change the alignment or size of the enumeration, but those are not well-defined.
   See [enum-variant-new](#enum-variant-new).
-* Adding, removing, or changing private fields of a `repr(C)` struct, union, or enum, following the other rules in this guide (for example, using `non_exhaustive`, or adding private fields when other private fields already exist).
+* Adding, removing, reordering, or changing private fields of a `repr(C)` struct, union, or enum, following the other rules in this guide (for example, using `non_exhaustive`, or adding private fields when other private fields already exist).
   See [repr-c-private-change](#repr-c-private-change).
 * Adding variants to a `repr(C)` enum, if the enum uses `non_exhastive`.
   See [repr-c-enum-variant-new](#repr-c-enum-variant-new).

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -275,8 +275,7 @@ Some examples of breaking changes are:
 [`std::mem::transmute`]: ../../std/mem/fn.transmute.html
 [`UnsafeCell`]: ../../std/cell/struct.UnsafeCell.html#memory-layout
 
-<a id="repr-c-private-change"></a>
-#### Minor: `repr(C)` add, remove, or change a private field
+#### Minor: `repr(C)` add, remove, or change a private field {#repr-c-private-change}
 
 It is usually safe to add, remove, or change a private field of a `repr(C)` struct, union, or enum, assuming it follows the other guidelines in this guide (see [struct-add-private-field-when-public](#struct-add-private-field-when-public), [struct-add-public-field-when-no-private](#struct-add-public-field-when-no-private), [struct-private-fields-with-private](#struct-private-fields-with-private), [enum-fields-new](#enum-fields-new)).
 
@@ -318,8 +317,7 @@ fn main() {
 }
 ```
 
-<a id="repr-c-enum-variant-new"></a>
-#### Minor: `repr(C)` add enum variant
+#### Minor: `repr(C)` add enum variant {#repr-c-enum-variant-new}
 
 It is usually safe to add variants to a `repr(C)` enum, if the enum uses `non_exhastive`.
 See [enum-variant-new](#enum-variant-new) for more discussion.
@@ -359,8 +357,7 @@ fn main() {
 }
 ```
 
-<a id="repr-c-add"></a>
-#### Minor: Adding `repr(C)` to a default representation
+#### Minor: Adding `repr(C)` to a default representation {#repr-c-add}
 
 It is safe to add `repr(C)` to a struct, union, or enum with [the default representation].
 This is safe because users should not make assumptions about the alignment, layout, or size of types with with the default representation.
@@ -390,8 +387,7 @@ fn main() {
 }
 ```
 
-<a id="repr-int-enum-add"></a>
-#### Minor: Adding `repr(<int>)` to an enum
+#### Minor: Adding `repr(<int>)` to an enum {#repr-int-enum-add}
 
 It is safe to add `repr(<int>)` [primitive representation] to an enum with [the default representation].
 This is safe because users should not make assumptions about the alignment, layout, or size of an enum with the default representation.
@@ -423,8 +419,7 @@ fn main() {
 }
 ```
 
-<a id="repr-transparent-add"></a>
-#### Minor: Adding `repr(transparent)` to a default representation struct or enum
+#### Minor: Adding `repr(transparent)` to a default representation struct or enum {#repr-transparent-add}
 
 It is safe to add `repr(transparent)` to a struct or enum with [the default representation].
 This is safe because users should not make assumptions about the alignment, layout, or size of a struct or enum with the default representation.
@@ -450,8 +445,7 @@ fn main() {
 }
 ```
 
-<a id="repr-packed-add"></a>
-#### Major: Adding `repr(packed)` to a struct or union
+#### Major: Adding `repr(packed)` to a struct or union {#repr-packed-add}
 
 It is a breaking change to add `repr(packed)` to a struct or union.
 Making a type `repr(packed)` makes changes that can break code, such as being invalid to take a reference to a field, or causing truncation of disjoint closure captures.
@@ -510,8 +504,7 @@ fn main() {
 }
 ```
 
-<a id="repr-align-add"></a>
-#### Major: Adding `repr(align)` to a struct, union, or enum
+#### Major: Adding `repr(align)` to a struct, union, or enum {#repr-align-add}
 
 It is a breaking change to add `repr(align)` to a struct, union, or enum.
 Making a type `repr(align)` would break any use of that type in a `repr(packed)` type because that combination is not allowed.
@@ -550,8 +543,7 @@ fn main() {
 }
 ```
 
-<a id="repr-packed-remove"></a>
-#### Major: Removing `repr(packed)` from a struct or union
+#### Major: Removing `repr(packed)` from a struct or union {#repr-packed-remove}
 
 It is a breaking change to remove `repr(packed)` from a struct or union.
 This may change the alignment or layout that extern crates are relying on.
@@ -633,8 +625,7 @@ fn main() {
 }
 ```
 
-<a id="repr-packed-n-change"></a>
-#### Major: Changing the value N of `repr(packed(N))` if that changes the alignment or layout
+#### Major: Changing the value N of `repr(packed(N))` if that changes the alignment or layout {#repr-packed-n-change}
 
 It is a breaking change to change the value of N of `repr(packed(N))` if that changes the alignment or layout.
 This may change the alignment or layout that external crates are relying on.
@@ -672,8 +663,7 @@ fn main() {
 }
 ```
 
-<a id="repr-align-n-change"></a>
-#### Major: Changing the value N of `repr(align(N))` if that changes the alignment
+#### Major: Changing the value N of `repr(align(N))` if that changes the alignment {#repr-align-n-change}
 
 It is a breaking change to change the value `N` of `repr(align(N))` if that changes the alignment.
 This may change the alignment that external crates are relying on.
@@ -713,8 +703,7 @@ fn main() {
 }
 ```
 
-<a id="repr-align-remove"></a>
-#### Major: Removing `repr(align)` from a struct, union, or enum
+#### Major: Removing `repr(align)` from a struct, union, or enum {#repr-align-remove}
 
 It is a breaking change to remove `repr(align)` from a struct, union, or enum, if their layout was well-defined.
 This may change the alignment or layout that external crates are relying on.
@@ -752,8 +741,7 @@ fn main() {
 }
 ```
 
-<a id="repr-c-shuffle"></a>
-#### Major: Changing the order of public fields of a `repr(C)` type
+#### Major: Changing the order of public fields of a `repr(C)` type {#repr-c-shuffle}
 
 It is a breaking change to change the order of public fields of a `repr(C)` type.
 External crates may be relying on the specific ordering of the fields.
@@ -807,8 +795,7 @@ fn main() {
 # }
 ```
 
-<a id="repr-c-remove"></a>
-#### Major: Removing `repr(C)` from a struct, union, or enum
+#### Major: Removing `repr(C)` from a struct, union, or enum {#repr-c-remove}
 
 It is a breaking change to remove `repr(C)` from a struct, union, or enum.
 External crates may be relying on the specific layout of the type.
@@ -862,8 +849,7 @@ fn main() {
 # }
 ```
 
-<a id="repr-int-enum-remove"></a>
-#### Major: Removing `repr(<int>)` from an enum
+#### Major: Removing `repr(<int>)` from an enum {#repr-int-enum-remove}
 
 It is a breaking change to remove `repr(<int>)` from an enum.
 External crates may be assuming that the discriminant is a specific size.
@@ -899,8 +885,7 @@ fn main() {
 }
 ```
 
-<a id="repr-int-enum-change"></a>
-#### Major: Changing the primitive representation of a `repr(<int>)` enum
+#### Major: Changing the primitive representation of a `repr(<int>)` enum {#repr-int-enum-change}
 
 It is a breaking change to change the primitive representation of a `repr(<int>)` enum.
 External crates may be assuming that the discriminant is a specific size.
@@ -936,8 +921,7 @@ fn main() {
 }
 ```
 
-<a id="repr-transparent-remove"></a>
-#### Major: Removing `repr(transparent)` from a struct or enum
+#### Major: Removing `repr(transparent)` from a struct or enum {#repr-transparent-remove}
 
 It is a breaking change to remove `repr(transparent)` from a struct or enum.
 External crates may be relying on the type having the alignment, layout, or size of the transparent field.

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -210,7 +210,7 @@ crates should be avoided.
 
 It is a breaking change to change the alignment, layout, or size of a type that was previously well-defined.
 
-In general, nominal types that use the [the default representation] do not have a well-defined alignment, layout, or size.
+In general, types that use the [the default representation] do not have a well-defined alignment, layout, or size.
 The compiler is free to alter the alignment or layout, so code should not make any assumptions about it.
 
 > **Note**: It may be possible for external crates to break if they make assumptions about the alignment, layout, or size of a type even if it is not well-defined.
@@ -218,14 +218,15 @@ The compiler is free to alter the alignment or layout, so code should not make a
 
 Some examples of changes that are not a breaking change are (assuming no other rules in this guide are violated):
 
-* Adding, removing, or changing fields of a default representation struct, union, or enum.
-* Adding variants to a default representation enum.
+* Adding, removing, or changing fields of a default representation struct, union, or enum in such a way that the change follows the other rules in this guide (for example, using `non_exhaustive` to allow those changes, or changes to private fields that are already private).
+* Adding variants to a default representation enum, if the enum uses `non_exhaustive`.
   This may change the alignment or size of the enumeration, but those are not well-defined.
 * Adding, removing, or changing private fields of a `repr(C)` struct, union, or enum.
   Note that this may be a breaking change since it may change the size and alignment of the type.
   Care should be taken in this case.
+  Adding private fields can only be done if there are already other private fields, or it is `non_exhaustive`.
   Public fields may be added if there are private fields, or it is `non_exhaustive`, and the addition does not alter the layout of the other fields.
-* Adding variants to a `repr(C)` enum.
+* Adding variants to a `repr(C)` enum, if the enum uses `non_exhastive`.
   Note that this may be a breaking change since it may change the size and alignment of the type.
   Care should be taken in this case.
 * Adding `repr(C)` to a default representation struct, union, or enum.
@@ -234,7 +235,7 @@ Some examples of changes that are not a breaking change are (assuming no other r
 
 Nominal types that use the [`repr` attribute] can be said to have an alignment and layout that is defined in some way that code may make some assumptions about that may break as a result of changing that type.
 
-Some examples of changes that are a breaking change are:
+Some examples of a breaking change are:
 
 * Adding `repr(packed)` to a struct or union.
 

--- a/src/doc/src/reference/semver.md
+++ b/src/doc/src/reference/semver.md
@@ -211,7 +211,7 @@ crates should be avoided.
 It is a breaking change to change the alignment, layout, or size of a type that was previously well-defined.
 
 In general, types that use the [the default representation] do not have a well-defined alignment, layout, or size.
-The compiler is free to alter the alignment, layout or size, so code should not make any assumptions about it.
+The compiler is free to alter the alignment, layout, or size, so code should not make any assumptions about it.
 
 > **Note**: It may be possible for external crates to break if they make assumptions about the alignment, layout, or size of a type even if it is not well-defined.
 > This is not considered a SemVer breaking change since those assumptions should not be made.
@@ -225,7 +225,7 @@ Some examples of changes that are not a breaking change are (assuming no other r
   See [enum-variant-new](#enum-variant-new).
 * Adding, removing, reordering, or changing private fields of a `repr(C)` struct, union, or enum, following the other rules in this guide (for example, using `non_exhaustive`, or adding private fields when other private fields already exist).
   See [repr-c-private-change](#repr-c-private-change).
-* Adding variants to a `repr(C)` enum, if the enum uses `non_exhastive`.
+* Adding variants to a `repr(C)` enum, if the enum uses `non_exhaustive`.
   See [repr-c-enum-variant-new](#repr-c-enum-variant-new).
 * Adding `repr(C)` to a default representation struct, union, or enum.
   See [repr-c-add](#repr-c-add).
@@ -234,9 +234,17 @@ Some examples of changes that are not a breaking change are (assuming no other r
 * Adding `repr(transparent)` to a default representation struct or enum.
   See [repr-transparent-add](#repr-transparent-add).
 
-Nominal types that use the [`repr` attribute] can be said to have an alignment and layout that is defined in some way that code may make some assumptions about that may break as a result of changing that type.
+Types that use the [`repr` attribute] can be said to have an alignment and layout that is defined in some way that code may make some assumptions about that may break as a result of changing that type.
 
-Some examples of a breaking change are:
+In some cases, types with a `repr` attribute may not have an alignment, layout, or size that is well-defined.
+In these cases, it may be safe to make changes to the types, though care should be exercised.
+For example, types with private fields that do not otherwise document their alignment, layout, or size guarantees cannot be relied upon by external crates since the public API does not fully define the alignment, layout, or size of the type.
+
+A common example where a type with *private* fields is well-defined is a type with a single private field with a generic type, using `repr(transparent)`,
+and the prose of the documentation discusses that it is transparent to the generic type.
+For example, see [`UnsafeCell`].
+
+Some examples of breaking changes are:
 
 * Adding `repr(packed)` to a struct or union.
   See [repr-packed-add](#repr-packed-add).
@@ -260,14 +268,6 @@ Some examples of a breaking change are:
   See [repr-int-enum-change](#repr-int-enum-change).
 * Removing `repr(transparent)` from a struct or enum.
   See [repr-transparent-remove](#repr-transparent-remove).
-
-In some cases, types with a `repr` attribute may not have an alignment, layout, or size that is well-defined.
-In these cases, it may be safe to make changes to the types, though care should be exercised.
-For example, types with private fields that do not otherwise document their alignment, layout, or size guarantees cannot be relied upon by external crates since the public API does not fully define the alignment, layout, or size of the type.
-
-A common example where a type with *private* fields is well-defined is a type with a single private field with a generic type, using `repr(transparent)`,
-and the prose of the documentation discusses that it is transparent to the generic type.
-For example, see [`UnsafeCell`].
 
 [the default representation]: ../../reference/type-layout.html#the-default-representation
 [primitive representation]: ../../reference/type-layout.html#primitive-representations


### PR DESCRIPTION
This adds some documentation about whether or not alignment, layout, or size changes are SemVer-compatible.

