### PR TITLE
Automatically inherit workspace lints when running cargo new/init

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -820,6 +820,18 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
                     workspace_package_keys,
                 )
             }
+
+            // Try to inherit the workspace lints key if it exists.
+            if config.cli_unstable().lints
+                && workspace_document
+                    .get("workspace")
+                    .and_then(|workspace| workspace.get("lints"))
+                    .is_some()
+            {
+                let mut table = toml_edit::Table::new();
+                table["workspace"] = toml_edit::value(true);
+                manifest["lints"] = toml_edit::Item::Table(table);
+            }
         }
     }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/in/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/in/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.lints.rust]
+unsafe_code = "forbid"

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/in/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/in/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/mod.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/mod.rs
@@ -1,0 +1,24 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::curr_dir;
+use cargo_test_support::CargoCommand;
+use cargo_test_support::ChannelChanger;
+use cargo_test_support::Project;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("new")
+        .args(["crates/foo", "-Zlints"])
+        .current_dir(cwd)
+        .masquerade_as_nightly_cargo(&["lints"])
+        .assert()
+        .success()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.lints.rust]
+unsafe_code = "forbid"

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/src/main.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.log
@@ -1,0 +1,1 @@
+     Created binary (application) `crates/foo` package

--- a/tests/testsuite/cargo_new/mod.rs
+++ b/tests/testsuite/cargo_new/mod.rs
@@ -1,3 +1,4 @@
+mod inherit_workspace_lints;
 mod inherit_workspace_package_table;
 mod inherit_workspace_package_table_with_edition;
 mod inherit_workspace_package_table_with_registry;


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Follow up https://github.com/rust-lang/cargo/pull/12069.

See more at: https://github.com/rust-lang/cargo/pull/12069#discussion_r1201093239
<!-- homu-ignore:end -->
