### PR TITLE
deps: remove unused features from windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,11 +183,8 @@ features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",
   "Win32_System_Console",
-  "Win32_System_IO",
   "Win32_System_Threading",
   "Win32_System_JobObjects",
-  "Win32_Security",
-  "Win32_System_SystemServices"
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
Drops unused features from `windows-sys` crate.