### PR TITLE
chore: dogfood Cargo `-Zlints` table feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
       - run: rustup component add clippy
-      # Only check cargo lib for now
-      # TODO: check every members
-      - run: cargo clippy -p cargo --lib --no-deps -- -D warnings
+      - run: cargo clippy --workspace --all-targets --no-deps -- -D warnings
 
   stale-label:
     runs-on: ubuntu-latest
@@ -110,8 +108,6 @@ jobs:
       CARGO_PROFILE_TEST_DEBUG: 1
       CARGO_INCREMENTAL: 0
       CARGO_PUBLIC_NETWORK_TESTS: 1
-      # Deny warnings on CI to avoid warnings getting into the codebase.
-      RUSTFLAGS: -D warnings
     strategy:
       matrix:
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
  "cargo-credential-libsecret",
  "cargo-credential-macos-keychain",
  "cargo-credential-wincred",
- "cargo-platform 0.1.6",
+ "cargo-platform 0.1.7",
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-1password"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cargo-credential",
  "serde",
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -353,7 +353,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "cargo-credential",
  "windows-sys",
@@ -378,7 +378,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
 ]
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "curl",
  "percent-encoding",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,20 @@ varisat = "0.2.2"
 walkdir = "2.4.0"
 windows-sys = "0.48"
 
+[workspace.lints.rust]
+rust_2018_idioms = "warn" # TODO: could this be removed?
+
+[workspace.lints.rustdoc]
+private_intra_doc_links = "allow"
+
+[workspace.lints.clippy]
+all = { level = "allow", priority = -1 }
+dbg_macro = "warn"
+disallowed_methods = "warn"
+print_stderr = "warn"
+print_stdout = "warn"
+self_named_module_files = "warn"
+
 [package]
 name = "cargo"
 version = "0.77.0"
@@ -234,3 +248,6 @@ vendored-openssl = ["openssl/vendored"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
 # This is primarily used by rust-lang/rust distributing cargo the executable.
 all-static = ['vendored-openssl', 'curl/static-curl', 'curl/force-system-lib-on-osx']
+
+[lints]
+workspace = true

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -32,3 +32,6 @@ harness = false
 [[bench]]
 name = "global_cache_tracker"
 harness = false
+
+[lints]
+workspace = true

--- a/benches/benchsuite/src/lib.rs
+++ b/benches/benchsuite/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 use cargo::Config;
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -12,3 +12,6 @@ cargo_metadata.workspace = true
 flate2.workspace = true
 tar.workspace = true
 toml.workspace = true
+
+[lints]
+workspace = true

--- a/benches/capture/src/main.rs
+++ b/benches/capture/src/main.rs
@@ -5,6 +5,7 @@
 //! The workspace will be saved in a `.tgz` file in the `../workspaces` directory.
 
 #![allow(clippy::disallowed_methods)]
+#![allow(clippy::print_stderr)]
 
 use flate2::{Compression, GzBuilder};
 use std::fs;

--- a/benches/capture/src/main.rs
+++ b/benches/capture/src/main.rs
@@ -4,6 +4,8 @@
 //! Use the `-f` flag to allow it to overwrite existing captures.
 //! The workspace will be saved in a `.tgz` file in the `../workspaces` directory.
 
+#![allow(clippy::disallowed_methods)]
+
 use flate2::{Compression, GzBuilder};
 use std::fs;
 use std::path::{Path, PathBuf};

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-platform"
-version = "0.1.6"
+version = "0.1.7"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.70.0"  # MSRV:3

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -11,3 +11,6 @@ description = "Cargo's representation of a target platform."
 
 [dependencies]
 serde.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cargo-platform/examples/matches.rs
+++ b/crates/cargo-platform/examples/matches.rs
@@ -1,6 +1,8 @@
 //! This example demonstrates how to filter a Platform based on the current
 //! host target.
 
+#![allow(clippy::print_stdout)]
+
 use cargo_platform::{Cfg, Platform};
 use std::process::Command;
 use std::str::FromStr;

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -12,3 +12,6 @@ publish = false
 
 [lib]
 proc-macro = true
+
+[lints]
+workspace = true

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -33,3 +33,6 @@ walkdir.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem"] }
+
+[lints]
+workspace = true

--- a/crates/cargo-test-support/build.rs
+++ b/crates/cargo-test-support/build.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 fn main() {
     println!(
         "cargo:rustc-env=NATIVE_ARCH={}",

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
 
+#![allow(clippy::disallowed_methods)]
+
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Write;

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -3,6 +3,8 @@
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
 
 #![allow(clippy::disallowed_methods)]
+#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
 
 use std::env;
 use std::ffi::OsStr;

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -2,8 +2,6 @@
 //!
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
 
-#![allow(clippy::all)]
-
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Write;

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -28,3 +28,6 @@ core-foundation.workspace = true
 [target.'cfg(windows)'.dependencies]
 miow.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Storage_FileSystem", "Win32_Foundation", "Win32_System_Console"] }
+
+[lints]
+workspace = true

--- a/crates/cargo-util/src/lib.rs
+++ b/crates/cargo-util/src/lib.rs
@@ -1,5 +1,7 @@
 //! Miscellaneous support code used by Cargo.
 
+#![allow(clippy::disallowed_methods)]
+
 pub use self::read2::read2;
 pub use du::du;
 pub use process_builder::ProcessBuilder;

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.39.1"
+version = "0.39.2"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -20,3 +20,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 url.workspace = true
+
+[lints]
+workspace = true

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::all)]
-
 use std::collections::BTreeMap;
 use std::fs::File;
 use std::io::prelude::*;

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -18,3 +18,6 @@ description = "Shared definitions of home directories."
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_UI_Shell"] }
+
+[lints]
+workspace = true

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home"
-version = "0.5.8"
+version = "0.5.9"
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 rust-version = "1.70.0"  # MSRV:3
 documentation = "https://docs.rs/home"

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -18,6 +18,8 @@
 //!
 //! [discussion]: https://github.com/rust-lang/rust/pull/46799#issuecomment-361156935
 
+#![allow(clippy::disallowed_methods)]
+
 pub mod env;
 
 #[cfg(target_os = "windows")]

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -18,8 +18,6 @@
 //!
 //! [discussion]: https://github.com/rust-lang/rust/pull/46799#issuecomment-361156935
 
-#![deny(rust_2018_idioms)]
-
 pub mod env;
 
 #[cfg(target_os = "windows")]

--- a/crates/mdman/Cargo.toml
+++ b/crates/mdman/Cargo.toml
@@ -17,3 +17,6 @@ url.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mdman/src/main.rs
+++ b/crates/mdman/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stderr)]
+
 use anyhow::{bail, format_err, Context, Error};
 use mdman::{Format, ManMap};
 use std::collections::HashMap;

--- a/crates/mdman/tests/compare.rs
+++ b/crates/mdman/tests/compare.rs
@@ -3,6 +3,8 @@
 //! Use the MDMAN_BLESS environment variable to automatically update the
 //! expected output.
 
+#![allow(clippy::disallowed_methods)]
+
 use mdman::{Format, ManMap};
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -10,3 +10,6 @@ cargo.workspace = true
 cargo-util.workspace = true
 proptest.workspace = true
 varisat.workspace = true
+
+[lints]
+workspace = true

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::all)]
-
 use std::cell::RefCell;
 use std::cmp::PartialEq;
 use std::cmp::{max, min};

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stderr)]
+
 use std::cell::RefCell;
 use std::cmp::PartialEq;
 use std::cmp::{max, min};

--- a/crates/semver-check/Cargo.toml
+++ b/crates/semver-check/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 
 [dependencies]
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/semver-check/src/main.rs
+++ b/crates/semver-check/src/main.rs
@@ -13,6 +13,8 @@
 //! - `dont-deny`: By default tests have a `#![deny(warnings)]`. This option
 //!   avoids this attribute. Note that `#![allow(unused)]` is always added.
 
+#![allow(clippy::print_stderr)]
+
 use std::error::Error;
 use std::fs;
 use std::path::Path;

--- a/crates/xtask-build-man/Cargo.toml
+++ b/crates/xtask-build-man/Cargo.toml
@@ -6,3 +6,6 @@ edition.workspace = true
 publish = false
 
 [dependencies]
+
+[lints]
+workspace = true

--- a/crates/xtask-build-man/src/main.rs
+++ b/crates/xtask-build-man/src/main.rs
@@ -10,6 +10,8 @@
 //!         For more, read their doc comments.
 //! ```
 
+#![allow(clippy::print_stderr)]
+
 use std::fs;
 use std::io;
 use std::path::PathBuf;

--- a/crates/xtask-bump-check/Cargo.toml
+++ b/crates/xtask-bump-check/Cargo.toml
@@ -14,3 +14,6 @@ git2.workspace = true
 semver.workspace = true
 tracing-subscriber.workspace = true
 tracing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/xtask-stale-label/Cargo.toml
+++ b/crates/xtask-stale-label/Cargo.toml
@@ -7,3 +7,6 @@ publish = false
 
 [dependencies]
 toml_edit.workspace = true
+
+[lints]
+workspace = true

--- a/crates/xtask-stale-label/src/main.rs
+++ b/crates/xtask-stale-label/src/main.rs
@@ -10,6 +10,8 @@
 //!         Probably autofix them in the future.
 //! ```
 
+#![allow(clippy::print_stderr)]
+
 use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::process;

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -11,3 +11,6 @@ description = "A Cargo credential process that stores tokens in a 1password vaul
 cargo-credential.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-1password"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.70.0"  # MSRV:3

--- a/credential/cargo-credential-1password/src/main.rs
+++ b/credential/cargo-credential-1password/src/main.rs
@@ -1,5 +1,7 @@
 //! Cargo registry 1password credential process.
 
+#![allow(clippy::disallowed_methods)]
+
 use cargo_credential::{
     Action, CacheControl, Credential, CredentialResponse, Error, RegistryInfo, Secret,
 };

--- a/credential/cargo-credential-1password/src/main.rs
+++ b/credential/cargo-credential-1password/src/main.rs
@@ -1,6 +1,7 @@
 //! Cargo registry 1password credential process.
 
 #![allow(clippy::disallowed_methods)]
+#![allow(clippy::print_stderr)]
 
 use cargo_credential::{
     Action, CacheControl, Credential, CredentialResponse, Error, RegistryInfo, Secret,

--- a/credential/cargo-credential-libsecret/Cargo.toml
+++ b/credential/cargo-credential-libsecret/Cargo.toml
@@ -11,3 +11,6 @@ description = "A Cargo credential process that stores tokens with GNOME libsecre
 anyhow.workspace = true
 cargo-credential.workspace = true
 libloading.workspace = true
+
+[lints]
+workspace = true

--- a/credential/cargo-credential-libsecret/Cargo.toml
+++ b/credential/cargo-credential-libsecret/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-libsecret"
-version = "0.3.3"
+version = "0.3.4"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-macos-keychain"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -12,3 +12,6 @@ cargo-credential.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework.workspace = true
+
+[lints]
+workspace = true

--- a/credential/cargo-credential-macos-keychain/src/lib.rs
+++ b/credential/cargo-credential-macos-keychain/src/lib.rs
@@ -1,5 +1,7 @@
 //! Cargo registry macos keychain credential process.
 
+#![allow(clippy::print_stderr)]
+
 #[cfg(target_os = "macos")]
 mod macos {
     use cargo_credential::{

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -13,3 +13,6 @@ cargo-credential.workspace = true
 [target.'cfg(windows)'.dependencies.windows-sys]
 features = ["Win32_Foundation", "Win32_Security_Credentials"]
 workspace = true
+
+[lints]
+workspace = true

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-wincred"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.70.0"  # MSRV:3

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -20,3 +20,6 @@ windows-sys = { workspace = true, features = ["Win32_System_Console", "Win32_Fou
 
 [dev-dependencies]
 snapbox = { workspace = true, features = ["examples"] }
+
+[lints]
+workspace = true

--- a/credential/cargo-credential/examples/stdout-redirected.rs
+++ b/credential/cargo-credential/examples/stdout-redirected.rs
@@ -1,5 +1,8 @@
 //! Provider used for testing redirection of stdout.
 
+#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
+
 use cargo_credential::{Action, Credential, CredentialResponse, Error, RegistryInfo};
 
 struct MyCredential;

--- a/credential/cargo-credential/src/lib.rs
+++ b/credential/cargo-credential/src/lib.rs
@@ -37,6 +37,9 @@
 #![doc = include_str!("../examples/file-provider.rs")]
 //! ```
 
+#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
+
 use serde::{Deserialize, Serialize};
 use std::{fmt::Display, io};
 use time::OffsetDateTime;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,7 +1,3 @@
-#![warn(rust_2018_idioms)] // while we're getting used to 2018
-#![allow(clippy::all)]
-#![warn(clippy::disallowed_methods)]
-
 use cargo::util::network::http::http_handle;
 use cargo::util::network::http::needs_custom_http_transport;
 use cargo::util::toml::schema::StringOrVec;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::self_named_module_files)] // false positive in `commands/build.rs`
+
 use cargo::util::network::http::http_handle;
 use cargo::util::network::http::needs_custom_http_transport;
 use cargo::util::toml::schema::StringOrVec;

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -129,20 +129,6 @@
 //! [The Cargo Book]: https://doc.rust-lang.org/cargo/
 //! [Cargo Contributor Guide]: https://doc.crates.io/contrib/
 
-// TODO: consider removing these lint attributes when `-Zlints` hits stable.
-// For various reasons, some idioms are still allow'ed, but we would like to
-// test and enforce them.
-#![warn(rust_2018_idioms)]
-// Due to some of the default clippy lints being somewhat subjective and not
-// necessarily an improvement, we prefer to not use them at this time.
-#![allow(clippy::all)]
-#![warn(clippy::disallowed_methods)]
-#![warn(clippy::self_named_module_files)]
-#![warn(clippy::print_stdout)]
-#![warn(clippy::print_stderr)]
-#![warn(clippy::dbg_macro)]
-#![allow(rustdoc::private_intra_doc_links)]
-
 use crate::core::shell::Verbosity::Verbose;
 use crate::core::Shell;
 use anyhow::Error;

--- a/src/cargo/util/errors.rs
+++ b/src/cargo/util/errors.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints)]
-
 use anyhow::Error;
 use curl::easy::Easy;
 use std::fmt::{self, Write};

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -18,6 +18,8 @@
 //! `CARGO_RUN_BUILD_STD_TESTS` env var to be set to actually run these tests.
 //! Otherwise the tests are skipped.
 
+#![allow(clippy::disallowed_methods)]
+
 use cargo_test_support::*;
 use std::env;
 use std::path::Path;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,7 +1,3 @@
-// See src/cargo/lib.rs for notes on these lint settings.
-#![warn(rust_2018_idioms)]
-#![allow(clippy::all)]
-
 #[macro_use]
 extern crate cargo_test_macro;
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::disallowed_methods)]
+#![allow(clippy::print_stderr)]
+#![allow(clippy::print_stdout)]
 
 #[macro_use]
 extern crate cargo_test_macro;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 #[macro_use]
 extern crate cargo_test_macro;
 


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

[`-Zlints`] unstable feature just landed on `nightly-2023-05-25` (rustc 1.71.0-nightly). It would be awesome if Cargo starts dogfooding itself.

[`-Zlints`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#lints

### How should we test and review this PR?

A shell script is added to check lint rules on nightly channel. This is expected to fail at this time. We probably want to fix lint errors in this PR or in follow-ups, depending on the review.

This does nothing on stable channel, which Cargo sticks to. Merely that `cargo build` becomes noisy because `-Zlints` triggers lots of `unused manifest key: lints` warnings, and has no way to turn them off. If people feel unease about this, we can wait.

### Additional information

<!-- homu-ignore:end -->
