### PR TITLE
chore(ci): remove temporary fix for rustup 1.24.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,10 +108,6 @@ jobs:
     - uses: actions/checkout@v3
     - name: Dump Environment
       run: ci/dump-environment.sh
-    - name: Update Rustup (temporary workaround)
-      run: rustup self update
-      shell: bash
-      if: startsWith(matrix.os, 'windows')
     - run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - run: rustup target add ${{ matrix.other }}
     - run: rustup component add rustc-dev llvm-tools-preview rust-docs


### PR DESCRIPTION
rust-lang/rustup#2759 was fixed in 1.24.2 and now GitHub ships 1.26.0 [^1]. The temporary workaround is not needed anymore. Let's see if everything goes well!

[^1]: https://github.com/actions/runner-images/blob/156ad8a318284c617f76cef1077cd0d64aeb758e/images/linux/Ubuntu2204-Readme.md?plain=1#L151