### PR TITLE
test: set retry sleep to 1ms for all tests

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1259,6 +1259,8 @@ pub trait TestEnv: Sized {
             .env("__CARGO_TEST_CHANNEL_OVERRIDE_DO_NOT_USE_THIS", "stable")
             // Keeps cargo within its sandbox.
             .env("__CARGO_TEST_DISABLE_GLOBAL_KNOWN_HOST", "1")
+            // Set retry sleep to 1 millisecond.
+            .env("__CARGO_TEST_FIXED_RETRY_SLEEP_MS", "1")
             // Incremental generates a huge amount of data per test, which we
             // don't particularly need. Tests that specifically need to check
             // the incremental behavior should turn this back on.


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

#12188 makes me wonder, why not just give all test a short retry sleep value?
So 1ms is the new value.

### How should we test and review this PR?

Set `__CARGO_TEST_FIXED_RETRY_SLEEP_MS` to something like 10000 and you'll see its effect.

After this pull request, it should save 5s-20s for each of the following tests:

* `bad_config::fragment_in_git_url`
* `git_auth::net_err_suggests_fetch_with_cli`
* `net_config::net_retry_git_outputs_warning`
* `net_config::net_retry_loads_from_config`
* `registry::debug_header_message_dl`
* `registry::debug_header_message_index`
* `registry::dl_retry_multiple`
* `registry::dl_retry_single`
* `registry::sparse_retry_multiple`
* `registry::sparse_retry_single`

<!-- homu-ignore:end -->
