### PR TITLE
Improve `cargo --list` output (split output into sections)

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -40,18 +40,18 @@ fn main() {
 
 /// Table for defining the aliases which come builtin in `Cargo`.
 /// The contents are structured as: `(alias, aliased_command, description)`.
-const BUILTIN_ALIASES: [(&str, &str, &str); 6] = [
-    ("b", "build", "alias: build"),
-    ("c", "check", "alias: check"),
-    ("d", "doc", "alias: doc"),
-    ("r", "run", "alias: run"),
-    ("t", "test", "alias: test"),
-    ("rm", "remove", "alias: remove"),
+const BUILTIN_ALIASES: [(&str, &str); 6] = [
+    ("b", "build"),
+    ("c", "check"),
+    ("d", "doc"),
+    ("r", "run"),
+    ("t", "test"),
+    ("rm", "remove"),
 ];
 
 /// Function which contains the list of all of the builtin aliases and it's
 /// corresponding execs represented as &str.
-fn builtin_aliases_execs(cmd: &str) -> Option<&(&str, &str, &str)> {
+fn builtin_aliases_execs(cmd: &str) -> Option<&(&str, &str)> {
     BUILTIN_ALIASES.iter().find(|alias| alias.0 == cmd)
 }
 
@@ -126,8 +126,8 @@ fn list_commands(config: &Config) -> BTreeMap<String, CommandInfo> {
     for command in &BUILTIN_ALIASES {
         commands.insert(
             command.0.to_string(),
-            CommandInfo::BuiltIn {
-                about: Some(command.2.to_string()),
+            CommandInfo::BuiltinAlias {
+                to: command.1.to_owned(),
             },
         );
     }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -796,6 +796,7 @@ pub fn ignore_unknown<T: Default>(r: Result<T, clap::parser::MatchesError>) -> T
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
 pub enum CommandInfo {
     BuiltIn { about: Option<String> },
+    BuiltinAlias { to: String },
     External { path: PathBuf },
     Alias { target: StringOrVec },
 }

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -24,13 +24,16 @@ fn path() -> Vec<PathBuf> {
 fn list_commands_with_descriptions() {
     let p = project().build();
     p.cargo("--list")
-        .with_stdout_contains(
-            "    build                Compile a local package and all of its dependencies",
-        )
         // Assert that `read-manifest` prints the right one-line description followed by another
         // command, indented.
         .with_stdout_contains(
             "    read-manifest        Print a JSON representation of a Cargo.toml manifest.",
+        )
+        .with_stdout_contains("====================\n  External commands:")
+        .with_stdout_contains("====================\n  Aliases:")
+        .with_stdout_contains("====================\n  Builtin commands:")
+        .with_stdout_contains(
+            "    build, b             Compile a local package and all of its dependencies",
         )
         .run();
 }
@@ -39,10 +42,10 @@ fn list_commands_with_descriptions() {
 fn list_builtin_aliases_with_descriptions() {
     let p = project().build();
     p.cargo("--list")
-        .with_stdout_contains("    b                    alias: build")
-        .with_stdout_contains("    c                    alias: check")
-        .with_stdout_contains("    r                    alias: run")
-        .with_stdout_contains("    t                    alias: test")
+        .with_stdout_contains("    b                    build")
+        .with_stdout_contains("    c                    check")
+        .with_stdout_contains("    r                    run")
+        .with_stdout_contains("    t                    test")
         .run();
 }
 
@@ -60,8 +63,8 @@ fn list_custom_aliases_with_descriptions() {
         .build();
 
     p.cargo("--list")
-        .with_stdout_contains("    myaliasstr           alias: foo --bar")
-        .with_stdout_contains("    myaliasvec           alias: foo --bar")
+        .with_stdout_contains("    myaliasstr           foo --bar")
+        .with_stdout_contains("    myaliasvec           foo --bar")
         .run();
 }
 
@@ -236,7 +239,7 @@ error: no such command: `biuld`
         .run();
     cargo_process("--list")
         .with_stdout_contains(
-            "    build                Compile a local package and all of its dependencies\n",
+            "    build, b             Compile a local package and all of its dependencies",
         )
         .with_stdout_contains("    biuld\n")
         .run();


### PR DESCRIPTION
(Related to #12114 , but the scope of that issue is bigger and **this PR doesn't close it.**)

### What does this PR try to resolve?

`cargo --list`'s output is really bad. It mixes aliases, builtin commands and external commands.
It would look something like this:

```
$ cargo --list
Installed Commands:
    add                  Add dependencies to a Cargo.toml manifest file
    b                    alias: build
    bench                Execute all benchmarks of a local package
    build                Compile a local package and all of its dependencies
    build-man            alias: run --package xtask-build-man --
    bump
    c                    alias: check
    check                Check a local package and all of its dependencies for errors
    checktests
    clean                Remove artifacts that cargo has generated in the past
    clippy               Checks a package to catch common mistakes and improve your Rust code.
    config               Inspect configuration values
    d                    alias: doc
    doc                  Build a package's documentation
    examples
    expand
    fetch                Fetch dependencies of a package from the network
    fix                  Automatically fix lint warnings reported by rustc
    flowistry
    fmt                  Formats all bin and lib files of the current crate using rustfmt.
    generate
    generate-lockfile    Generate the lockfile for a package
    git-checkout         This command has been removed
    help                 Displays help for a cargo subcommand
    init                 Create a new cargo package in an existing directory
    install              Install a Rust binary. Default location is $HOME/.cargo/bin
    is-tested
    locate-project       Print a JSON representation of a Cargo.toml file's location
    login                Save an api token from the registry locally. If token is not specified, it will be read from stdin.
    logout               Remove an API token from the registry locally
    metadata             Output the resolved dependencies of a package, the concrete used versions including overrides, in machine-readable format
    miri
    new                  Create a new cargo package at <path>
    owner                Manage the owners of a crate on the registry
    package              Assemble the local package into a distributable tarball
    pkgid                Print a fully qualified package specification
    publish              Upload a package to the registry
    r                    alias: run
    rdme
    read-manifest        Print a JSON representation of a Cargo.toml manifest.
    remove               Remove dependencies from a Cargo.toml manifest file
    report               Generate and display various kinds of reports
    rm                   alias: remove
    run                  Run a binary or example of the local package
    rustc                Compile a package, and pass extra options to the compiler
    rustdoc              Build a package's documentation, using specified custom flags.
    search               Search packages in crates.io
    set-version
    stale-label          alias: run --package xtask-stale-label --
    t                    alias: test
    test                 Execute all unit and integration tests and build examples of a local package
    tree                 Display a tree visualization of a dependency graph
    udeps
    uninstall            Remove a Rust binary
    unpublished          alias: run --package xtask-unpublished --
    update               Update dependencies as recorded in the local lock file
    upgrade
    vendor               Vendor all dependencies for a project locally
    verify-project       Check correctness of crate manifest
    version              Show version information
    watch
    yank                 Remove a pushed crate from the index
```

Finding a command is very hard in this list. That's why this PR aims to fix this list.
It groups builtin commands, external and aliases in three different sections. It also groups builtin commands with its builtin aliases.

```
    build, b             Compile a local package and all of its dependencies
```

The final output looks like this

```
$ cargo run -- --list
Installed Commands:
====================
  Builtin commands:
    add                  Add dependencies to a Cargo.toml manifest file
    bench                Execute all benchmarks of a local package
    build, b             Compile a local package and all of its dependencies
    check, c             Check a local package and all of its dependencies for errors
    clean                Remove artifacts that cargo has generated in the past
    config               Inspect configuration values
    doc, d               Build a package's documentation
    fetch                Fetch dependencies of a package from the network
    fix                  Automatically fix lint warnings reported by rustc
    generate-lockfile    Generate the lockfile for a package
    git-checkout         This command has been removed
    help                 Displays help for a cargo subcommand
    init                 Create a new cargo package in an existing directory
    install              Install a Rust binary. Default location is $HOME/.cargo/bin
    locate-project       Print a JSON representation of a Cargo.toml file's location
    login                Save an api token from the registry locally. If token is not specified, it will be read from stdin.
    logout               Remove an API token from the registry locally
    metadata             Output the resolved dependencies of a package, the concrete used versions including overrides, in machine-readable format
    new                  Create a new cargo package at <path>
    owner                Manage the owners of a crate on the registry
    package              Assemble the local package into a distributable tarball
    pkgid                Print a fully qualified package specification
    publish              Upload a package to the registry
    read-manifest        Print a JSON representation of a Cargo.toml manifest.
    remove, rm           Remove dependencies from a Cargo.toml manifest file
    report               Generate and display various kinds of reports
    run, r               Run a binary or example of the local package
    rustc                Compile a package, and pass extra options to the compiler
    rustdoc              Build a package's documentation, using specified custom flags.
    search               Search packages in crates.io
    test, t              Execute all unit and integration tests and build examples of a local package
    tree                 Display a tree visualization of a dependency graph
    uninstall            Remove a Rust binary
    update               Update dependencies as recorded in the local lock file
    vendor               Vendor all dependencies for a project locally
    verify-project       Check correctness of crate manifest
    version              Show version information
    yank                 Remove a pushed crate from the index
====================
  External commands:
    bump
    checktests
    clippy               Checks a package to catch common mistakes and improve your Rust code.
    examples
    expand
    flowistry
    fmt                  Formats all bin and lib files of the current crate using rustfmt.
    generate
    is-tested
    miri
    mommy
    rdme
    set-version
    udeps
    upgrade
    watch
====================
  Aliases:
    b                    build
    build-man            run --package xtask-build-man --
    c                    check
    d                    doc
    r                    run
    rm                   remove
    stale-label          run --package xtask-stale-label --
    t                    test
    unpublished          run --package xtask-unpublished --
```

### How should we test and review this PR?

Execute `cargo run -- --list` (in the Cargo repository) and check that the output is better than before.
