### PR TITLE
Re-enable code_generation test on Windows

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1926,7 +1926,6 @@ fn output_separate_lines_new() {
         .run();
 }
 
-#[cfg(not(windows))] // FIXME(#867)
 #[cargo_test]
 fn code_generation() {
     let p = project()
@@ -1976,7 +1975,7 @@ fn code_generation() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] `target/debug/foo`",
+[RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("Hello, World!")
         .run();


### PR DESCRIPTION
This re-enables the `code_generation` test on Windows. It was disabled some time ago (see https://github.com/rust-lang/cargo/issues/867), but I don't think whatever issue was hitting it is relevant now. There isn't anything unusual about this test, so I think it should be fine. I was unable to get it to fail after running a few thousand times, and also testing on CI.