### PR TITLE
Enable `doctest-in-workspace` by default

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -730,7 +730,6 @@ unstable_cli_options!(
     config_include: bool = ("Enable the `include` key in config files"),
     credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
     direct_minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum (direct dependencies only)"),
-    doctest_in_workspace: bool = ("Compile doctests with paths relative to the workspace root"),
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
     features: Option<Vec<String>>  = (HIDDEN),
@@ -799,6 +798,9 @@ const STABILIZED_PATCH_IN_CONFIG: &str = "The patch-in-config feature is now alw
 const STABILIZED_NAMED_PROFILES: &str = "The named-profiles feature is now always enabled.\n\
     See https://doc.rust-lang.org/nightly/cargo/reference/profiles.html#custom-profiles \
     for more information";
+
+const STABILIZED_DOCTEST_IN_WORKSPACE: &str =
+    "The doctest-in-workspace feature is now always enabled.";
 
 const STABILIZED_FUTURE_INCOMPAT_REPORT: &str =
     "The future-incompat-report feature is now always enabled.";
@@ -1080,6 +1082,7 @@ impl CliUnstable {
             "multitarget" => stabilized_warn(k, "1.64", STABILISED_MULTITARGET),
             "sparse-registry" => stabilized_warn(k, "1.68", STABILISED_SPARSE_REGISTRY),
             "terminal-width" => stabilized_warn(k, "1.68", STABILIZED_TERMINAL_WIDTH),
+            "doctest-in-workspace" => stabilized_warn(k, "1.72", STABILIZED_DOCTEST_IN_WORKSPACE),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1098,7 +1101,6 @@ impl CliUnstable {
             "config-include" => self.config_include = parse_empty(k, v)?,
             "credential-process" => self.credential_process = parse_empty(k, v)?,
             "direct-minimal-versions" => self.direct_minimal_versions = parse_empty(k, v)?,
-            "doctest-in-workspace" => self.doctest_in_workspace = parse_empty(k, v)?,
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
             "gitoxide" => {

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -172,7 +172,6 @@ fn run_doc_tests(
     let config = ws.config();
     let mut errors = Vec::new();
     let doctest_xcompile = config.cli_unstable().doctest_xcompile;
-    let doctest_in_workspace = config.cli_unstable().doctest_in_workspace;
 
     for doctest_info in &compilation.to_doc_test {
         let Doctest {
@@ -215,13 +214,9 @@ fn run_doc_tests(
         p.arg("--crate-name").arg(&unit.target.crate_name());
         p.arg("--test");
 
-        if doctest_in_workspace {
-            add_path_args(ws, unit, &mut p);
-            p.arg("--test-run-directory")
-                .arg(unit.pkg.root().to_path_buf());
-        } else {
-            p.arg(unit.target.src_path().path().unwrap());
-        }
+        add_path_args(ws, unit, &mut p);
+        p.arg("--test-run-directory")
+            .arg(unit.pkg.root().to_path_buf());
 
         if let CompileKind::Target(target) = unit.kind {
             // use `rustc_target()` to properly handle JSON target paths

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -65,6 +65,13 @@ Setting the working directory of tests to the package's root directory makes it
 possible for tests to reliably access the package's files using relative paths,
 regardless from where `cargo test` was executed from.
 
+For documentation tests, the working directory when invoking `rustdoc` is set to
+the workspace root directory, and is also the directory `rustdoc` uses as the
+compilation directory of each documentation test.
+The working directory when running each documentation test is set to the root
+directory of the package the test belongs to, and is controlled via `rustdoc`s
+`--test-run-directory` option.
+
 ## OPTIONS
 
 ### Test Options

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -59,6 +59,13 @@ DESCRIPTION
        access the package’s files using relative paths, regardless from where
        cargo test was executed from.
 
+       For documentation tests, the working directory when invoking rustdoc is
+       set to the workspace root directory, and is also the directory rustdoc
+       uses as the compilation directory of each documentation test. The
+       working directory when running each documentation test is set to the
+       root directory of the package the test belongs to, and is controlled via
+       rustdocs --test-run-directory option.
+
 OPTIONS
    Test Options
        --no-run

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -65,6 +65,13 @@ Setting the working directory of tests to the package's root directory makes it
 possible for tests to reliably access the package's files using relative paths,
 regardless from where `cargo test` was executed from.
 
+For documentation tests, the working directory when invoking `rustdoc` is set to
+the workspace root directory, and is also the directory `rustdoc` uses as the
+compilation directory of each documentation test.
+The working directory when running each documentation test is set to the root
+directory of the package the test belongs to, and is controlled via `rustdoc`s
+`--test-run-directory` option.
+
 ## OPTIONS
 
 ### Test Options

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -85,7 +85,6 @@ Each new feature described below should explain how to use it.
     * [host-config](#host-config) --- Allows setting `[target]`-like configuration settings for host build targets.
     * [target-applies-to-host](#target-applies-to-host) --- Alters whether certain flags will be passed to host build targets.
 * rustdoc
-    * [`doctest-in-workspace`](#doctest-in-workspace) --- Fixes workspace-relative paths when running doctests.
     * [rustdoc-map](#rustdoc-map) --- Provides mappings for documentation to link to external sites like [docs.rs](https://docs.rs/).
     * [scrape-examples](#scrape-examples) --- Shows examples within documentation.
 * `Cargo.toml` extensions
@@ -1793,3 +1792,11 @@ See [Registry Protocols](registries.md#registry-protocols) for more information.
 The [`cargo logout`] command has been stabilized in the 1.70 release.
 
 [target triple]: ../appendix/glossary.md#target '"target" (glossary)'
+
+
+### `doctest-in-workspace`
+
+The `-Z doctest-in-workspace` option for `cargo test` has been stabilized and
+enabled by default in the 1.72 release. See the
+[`cargo test` documentation](../commands/cargo-test.md#working-directory-of-tests)
+for more information about the working directory for compiling and running tests.

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -59,6 +59,13 @@ the test belongs to.
 Setting the working directory of tests to the package\[cq]s root directory makes it 
 possible for tests to reliably access the package\[cq]s files using relative paths,
 regardless from where \fBcargo test\fR was executed from.
+.sp
+For documentation tests, the working directory when invoking \fBrustdoc\fR is set to
+the workspace root directory, and is also the directory \fBrustdoc\fR uses as the
+compilation directory of each documentation test.
+The working directory when running each documentation test is set to the root
+directory of the package the test belongs to, and is controlled via \fBrustdoc\fRs
+\fB\-\-test\-run\-directory\fR option.
 .SH "OPTIONS"
 .SS "Test Options"
 .sp

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -5107,7 +5107,7 @@ fn duplicate_script_with_extra_env() {
         p.cargo("test --workspace -Z doctest-xcompile --doc --target")
             .arg(&target)
             .masquerade_as_nightly_cargo(&["doctest-xcompile"])
-            .with_stdout_contains("test src/lib.rs - (line 2) ... ok")
+            .with_stdout_contains("test foo/src/lib.rs - (line 2) ... ok")
             .run();
     }
 }


### PR DESCRIPTION
This stabilizes and enables the `-Z doctest-in-workspace` flag by default.

Also adds another testcase to make sure that the `include!()` and `file!()` macros interact well together.


fixes #9427
fixes https://github.com/rust-lang/rust/issues/46372