### PR TITLE
test(z-flags): Verify `-Z` flags list is sorted

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -687,6 +687,26 @@ macro_rules! unstable_cli_options {
                 fields
             }
         }
+
+        #[cfg(test)]
+        mod test {
+            #[test]
+            fn ensure_sorted() {
+                // This will be printed out if the fields are not sorted.
+                let location = std::panic::Location::caller();
+                println!(
+                    "\nTo fix this test, sort the features inside the macro at {}:{}\n",
+                    location.file(),
+                    location.line()
+                );
+                let mut expected = vec![$(stringify!($element)),*];
+                expected[2..].sort();
+                snapbox::assert_eq(
+                    format!("{:#?}", expected),
+                    format!("{:#?}", vec![$(stringify!($element)),*])
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
#12182 made it so that `unstable_cli_options!` was sorted, but had no way to make sure it would stay sorted in the future. 

In [this thread](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Sorting.20features!.20and.20ensuring.20it.20stays.20sorted), I proposed that a test should be added that would fail if the list is not sorted, this PR adds that test.

If the list is not sorted the test output looks like this:
![Screenshot from 2023-06-02 10-17-08](https://github.com/rust-lang/cargo/assets/23045215/f22cf5f3-4411-44ec-ac5a-991165d5e0a1)
