### PR TITLE
Emit error when users try to use a toolchain via the `add` or `install` command

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -242,7 +242,20 @@ fn parse_dependencies(config: &Config, matches: &ArgMatches) -> CargoResult<Vec<
         .flatten()
         .map(|c| (Some(c.clone()), None))
         .collect::<IndexMap<_, _>>();
+
     let mut infer_crate_name = false;
+
+    for (crate_name, _) in crates.iter() {
+        let crate_name = crate_name.as_ref().unwrap();
+
+        if let Some(toolchain) = crate_name.strip_prefix("+") {
+            anyhow::bail!(
+                "invalid character `+` in dependency name: `+{toolchain}`
+    Use `cargo +{toolchain} add` if you meant to use the `{toolchain}` toolchain."
+            );
+        }
+    }
+
     if crates.is_empty() {
         if path.is_some() || git.is_some() {
             crates.insert(None, None);

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -1,5 +1,6 @@
 use crate::command_prelude::*;
 
+use anyhow::anyhow;
 use cargo::core::{GitReference, SourceId, Workspace};
 use cargo::ops;
 use cargo::util::IntoUrl;
@@ -107,6 +108,16 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         .unwrap_or_default()
         .map(|k| resolve_crate(k, version))
         .collect::<crate::CargoResult<Vec<_>>>()?;
+
+    for (crate_name, _) in krates.iter() {
+        if let Some(toolchain) = crate_name.strip_prefix("+") {
+            return Err(anyhow!(
+                "invalid character `+` in package name: `+{toolchain}`
+    Use `cargo +{toolchain} install` if you meant to use the `{toolchain}` toolchain."
+            )
+            .into());
+        }
+    }
 
     let mut from_cwd = false;
 

--- a/tests/testsuite/cargo_add/add_toolchain/in
+++ b/tests/testsuite/cargo_add/add_toolchain/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/add_toolchain/mod.rs
+++ b/tests/testsuite/cargo_add/add_toolchain/mod.rs
@@ -1,0 +1,23 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::Project;
+
+use cargo_test_support::curr_dir;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .arg_line("+nightly")
+        .current_dir(cwd)
+        .assert()
+        .failure()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/add_toolchain/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/add_toolchain/out/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"

--- a/tests/testsuite/cargo_add/add_toolchain/stderr.log
+++ b/tests/testsuite/cargo_add/add_toolchain/stderr.log
@@ -1,0 +1,2 @@
+error: invalid character `+` in dependency name: `+nightly`
+    Use `cargo +nightly add` if you meant to use the `nightly` toolchain.

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -1,6 +1,7 @@
 mod add_basic;
 mod add_multiple;
 mod add_normalized_name_external;
+mod add_toolchain;
 mod build;
 mod build_prefer_existing_version;
 mod change_rename_target;

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -58,6 +58,20 @@ fn simple() {
 }
 
 #[cargo_test]
+fn toolchain() {
+    pkg("foo", "0.0.1");
+
+    cargo_process("install +nightly")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] invalid character `+` in package name: `+nightly`
+    Use `cargo +nightly install` if you meant to use the `nightly` toolchain.",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn simple_with_message_format() {
     pkg("foo", "0.0.1");
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Running `cargo install +nightly` or `cargo add +nightly` does not actually use the nightly toolchain, but the user won't know until the compilation fails. With this PR, an error is emitted if the `install` and `add` command is given a crate name
that starts with a `+` as we assume the user's intention was to use a certain toolchain instead of installing/adding a crate.

Example:
<img width="758" alt="image" src="https://github.com/rust-lang/cargo/assets/45989466/16e59436-32ee-49ee-9933-8b68b176c09d">

Fixes #10362 