### PR TITLE
Add message on reusing previous temporary path on failed cargo installs

### DIFF
--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -320,7 +320,9 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
 
             format!(
                 "failed to compile `{}`, intermediate artifacts can be \
-                 found at `{}`",
+                 found at `{}`, to reuse those artifacts with a future \
+                 compilation, set the environment variable \
+                 `CARGO_TARGET_DIR` to that path.",
                 self.pkg,
                 self.ws.target_dir().display()
             )

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -188,7 +188,9 @@ fn simple_install_fail() {
         .with_status(101)
         .with_stderr(
             "  Installing bar v0.1.0
-error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`
+error: failed to compile `bar v0.1.0`, intermediate artifacts can be found at `[..]`, \
+to reuse those artifacts with a future compilation, set the environment variable \
+`CARGO_TARGET_DIR` to that path.
 
 Caused by:
   no matching package found

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -978,7 +978,8 @@ fn compile_failure() {
             "\
 [ERROR] could not compile `foo` (bin \"foo\") due to previous error
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be \
-    found at `[..]target`
+    found at `[..]target`, to reuse those artifacts with a future compilation, \
+    set the environment variable `CARGO_TARGET_DIR` to that path.
 ",
         )
         .run();
@@ -2264,7 +2265,9 @@ fn failed_install_retains_temp_directory() {
     )
     .unwrap();
     compare::match_contains(
-        "error: failed to compile `foo v0.0.1`, intermediate artifacts can be found at `[..]`",
+        "error: failed to compile `foo v0.0.1`, intermediate artifacts can be found at \
+        `[..]`, to reuse those artifacts with a future compilation, set the environment \
+        variable `CARGO_TARGET_DIR` to that path.",
         &stderr,
         None,
     )
@@ -2272,7 +2275,7 @@ fn failed_install_retains_temp_directory() {
 
     // Find the path in the output.
     let start = stderr.find("found at `").unwrap() + 10;
-    let end = stderr[start..].find('\n').unwrap() - 1;
+    let end = stderr[start..].find(',').unwrap() - 1;
     let path = Path::new(&stderr[start..(end + start)]);
     assert!(path.exists());
     assert!(path.join("release/deps").exists());

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -658,7 +658,8 @@ Consider enabling some of the needed features by passing, e.g., `--features=\"a\
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be found at \
-    `[..]target`
+    `[..]target`, to reuse those artifacts with a future compilation, set the environment \
+    variable `CARGO_TARGET_DIR` to that path.
 
 Caused by:
   target `foo` in package `foo` requires the features: `a`
@@ -678,7 +679,8 @@ Caused by:
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be found at \
-    `[..]target`
+    `[..]target`, to reuse those artifacts with a future compilation, set the environment \
+    variable `CARGO_TARGET_DIR` to that path.
 
 Caused by:
   target `foo` in package `foo` requires the features: `a`


### PR DESCRIPTION
### What does this PR try to resolve?
Fixes https://github.com/rust-lang/cargo/issues/4890 by extending the error message.

### How should we test and review this PR?
It was well-tested, a total of 4 tests started failing by changing the error message, which is really good for a first issue, a lot less scary and I got to see the code that tests that the preconditions for this actually works (ie the temp-dir is indeed created).