### PR TITLE
fix: disable multiplexing on macOS for some versions of curl

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -293,10 +293,6 @@ fn init_git(config: &Config) {
 /// configured to use libcurl instead of the built-in networking support so
 /// that those configuration settings can be used.
 fn init_git_transports(config: &Config) {
-    // Only use a custom transport if any HTTP options are specified,
-    // such as proxies or custom certificate authorities. The custom
-    // transport, however, is not as well battle-tested.
-
     match cargo::ops::needs_custom_http_transport(config) {
         Ok(true) => {}
         _ => return,

--- a/src/cargo/ops/registry.rs
+++ b/src/cargo/ops/registry.rs
@@ -35,6 +35,7 @@ use crate::util::auth::{
 use crate::util::config::{Config, JobsConfig, SslVersionConfig, SslVersionConfigRange};
 use crate::util::errors::CargoResult;
 use crate::util::important_paths::find_root_manifest_for_wd;
+use crate::util::network;
 use crate::util::{truncate_with_ellipsis, IntoUrl};
 use crate::util::{Progress, ProgressStyle};
 use crate::{drop_print, drop_println, version};
@@ -611,16 +612,22 @@ pub fn http_handle_and_timeout(config: &Config) -> CargoResult<(Easy, HttpTimeou
     Ok((handle, timeout))
 }
 
+// Only use a custom transport if any HTTP options are specified,
+// such as proxies or custom certificate authorities.
+//
+// The custom transport, however, is not as well battle-tested.
 pub fn needs_custom_http_transport(config: &Config) -> CargoResult<bool> {
-    Ok(http_proxy_exists(config)?
-        || *config.http_config()? != Default::default()
-        || config.get_env_os("HTTP_TIMEOUT").is_some())
+    Ok(
+        network::proxy::http_proxy_exists(config.http_config()?, config)
+            || *config.http_config()? != Default::default()
+            || config.get_env_os("HTTP_TIMEOUT").is_some(),
+    )
 }
 
 /// Configure a libcurl http handle with the defaults options for Cargo
 pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<HttpTimeout> {
     let http = config.http_config()?;
-    if let Some(proxy) = http_proxy(config)? {
+    if let Some(proxy) = network::proxy::http_proxy(http) {
         handle.proxy(&proxy)?;
     }
     if let Some(cainfo) = &http.cainfo {
@@ -770,43 +777,6 @@ impl HttpTimeout {
         handle.low_speed_time(self.dur)?;
         handle.low_speed_limit(self.low_speed_limit)?;
         Ok(())
-    }
-}
-
-/// Finds an explicit HTTP proxy if one is available.
-///
-/// Favor cargo's `http.proxy`, then git's `http.proxy`. Proxies specified
-/// via environment variables are picked up by libcurl.
-fn http_proxy(config: &Config) -> CargoResult<Option<String>> {
-    let http = config.http_config()?;
-    if let Some(s) = &http.proxy {
-        return Ok(Some(s.clone()));
-    }
-    if let Ok(cfg) = git2::Config::open_default() {
-        if let Ok(s) = cfg.get_string("http.proxy") {
-            return Ok(Some(s));
-        }
-    }
-    Ok(None)
-}
-
-/// Determine if an http proxy exists.
-///
-/// Checks the following for existence, in order:
-///
-/// * cargo's `http.proxy`
-/// * git's `http.proxy`
-/// * `http_proxy` env var
-/// * `HTTP_PROXY` env var
-/// * `https_proxy` env var
-/// * `HTTPS_PROXY` env var
-fn http_proxy_exists(config: &Config) -> CargoResult<bool> {
-    if http_proxy(config)?.is_some() {
-        Ok(true)
-    } else {
-        Ok(["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"]
-            .iter()
-            .any(|v| config.get_env(v).is_ok()))
     }
 }
 

--- a/src/cargo/util/network/mod.rs
+++ b/src/cargo/util/network/mod.rs
@@ -2,6 +2,7 @@
 
 use std::task::Poll;
 
+pub mod proxy;
 pub mod retry;
 pub mod sleep;
 

--- a/src/cargo/util/network/proxy.rs
+++ b/src/cargo/util/network/proxy.rs
@@ -1,0 +1,42 @@
+//! Utilities for network proxies.
+
+use crate::util::config::CargoHttpConfig;
+use crate::util::config::Config;
+
+/// Proxy environment variables that are picked up by libcurl.
+const LIBCURL_HTTP_PROXY_ENVS: [&str; 4] =
+    ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"];
+
+/// Finds an explicit HTTP proxy if one is available.
+///
+/// Favor [Cargo's `http.proxy`], then [Git's `http.proxy`].
+/// Proxies specified via environment variables are picked up by libcurl.
+/// See [`LIBCURL_HTTP_PROXY_ENVS`].
+///
+/// [Cargo's `http.proxy`]: https://doc.rust-lang.org/nightly/cargo/reference/config.html#httpproxy
+/// [Git's `http.proxy`]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpproxy
+pub fn http_proxy(http: &CargoHttpConfig) -> Option<String> {
+    if let Some(s) = &http.proxy {
+        return Some(s.into());
+    }
+    git2::Config::open_default()
+        .and_then(|cfg| cfg.get_string("http.proxy"))
+        .ok()
+}
+
+/// Determine if an http proxy exists.
+///
+/// Checks the following for existence, in order:
+///
+/// * Cargo's `http.proxy`
+/// * Git's `http.proxy`
+/// * `http_proxy` env var
+/// * `HTTP_PROXY` env var
+/// * `https_proxy` env var
+/// * `HTTPS_PROXY` env var
+pub fn http_proxy_exists(http: &CargoHttpConfig, config: &Config) -> bool {
+    http_proxy(http).is_some()
+        || LIBCURL_HTTP_PROXY_ENVS
+            .iter()
+            .any(|v| config.get_env(v).is_ok())
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #12202.
[Zulip topic](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/curl.20error.20.60send.3A.20no.20filter.20connected.60).

In certain versions of libcurl when proxy is in use with HTTP/2
multiplexing, connections will continue stacking up. This was
fixed in libcurl 8.0.0 in curl/curl@821f6e2a89de8aec1c7da3c0f381b92b2b801efc

However, Cargo can still link against old system libcurl if it is from a
custom built one or on macOS. For those cases, multiplexing needs to be
disabled when those versions are detected.

### How should we test and review this PR?

The first commit refactors how Cargo gets `http.proxy` config, so that
wecan have the detection inside `Config`. Please call it out if you
feel uncomfortable to this.

The second one did the trick, and a unit test is added.

### Manual test the behavior

To manually test the behavior, you need to build cargo with
the `all-static` feature, which despite its name links libcurl
dynamically on macOS. It is a feature used by rustup distributions.

```
cargo b -F all-static
```

I don't really understand curl internals so had no luck to figure
out the relationship between proxies and HTTP/2 multiplexing.
I use [`hinata/nginx-forward-proxy`] to spin up a proxy to test curl's behavior.
It turns out that if there are fewer dependencies to download,
or we set `MAX_CONCURRENT_STREAMS` to a lower value in curl,
it largely affects the happening of the error `no filter connected`.

That implies multiplexing and http proxy are really influencing
each other in some way.

<details><summary>My patch to curl and curl-sys</summary>
<p>

```patch
diff --git a/Cargo.toml b/Cargo.toml
index ec9f878b3..3a687c309 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,3 +205,7 @@ vendored-libgit2 = ["libgit2-sys/vendored"]
 pretty-env-logger = ["pretty_env_logger"]
 # This is primarily used by rust-lang/rust distributing cargo the executable.
 all-static = ['vendored-openssl', 'curl/static-curl', 'curl/force-system-lib-on-osx']
+
+[patch.crates-io]
+curl = { git = "https://github.com/weihanglo/curl-rust", branch = "curlmopt" }
+curl-sys = { git = "https://github.com/weihanglo/curl-rust", branch = "curlmopt" }
diff --git a/src/cargo/sources/registry/http_remote.rs b/src/cargo/sources/registry/http_remote.rs
index 7e1f2a587..21ae3ca10 100644
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -246,6 +246,8 @@ impl<'cfg> HttpRegistry<'cfg> {
                 .status("Updating", self.source_id.display_index())?;
         }
 
+        self.multi.set_max_concurrent_streams(10)?;
+
         Ok(())
     }
```

</p>
</details> 

[`hinata/nginx-forward-proxy`]: https://hub.docker.com/r/hinata/nginx-forward-proxy
<!-- homu-ignore:end -->
