### PR TITLE
doc: point to nightly cargo doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Cargo downloads your Rust project’s dependencies and compiles your project.
 
 [![CI](https://github.com/rust-lang/cargo/actions/workflows/main.yml/badge.svg?branch=auto-cargo)](https://github.com/rust-lang/cargo/actions/workflows/main.yml)
 
-Code documentation: https://docs.rs/cargo/
+Code documentation: <https://doc.rust-lang.org/nightly/nightly-rustc/cargo/>
 
 ## Installing Cargo
 


### PR DESCRIPTION
### What does this PR try to resolve?

Nightly doc contains more information and rationale for each item.
It's a better fit for those want to extend Cargo's functionality.
