### PR TITLE
test: loose overly matches for git cli output

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2711,7 +2711,7 @@ fn use_the_cli() {
 [UPDATING] git repository `[..]`
 [RUNNING] `git fetch [..]`
 From [..]
- * [new ref]                    -> origin/HEAD
+ * [new ref] [..] -> origin/HEAD[..]
 [CHECKING] dep1 [..]
 [RUNNING] `rustc [..]`
 [CHECKING] foo [..]


### PR DESCRIPTION
The output format should be stable I believe, but it turns out not.
This is how `git fetch` man page says [^1]:

```
<flag> <summary> <from> -> <to> [<reason>]
```

In Git 2.41 they've changed the fetch output a bit [^2].

I think let's just loose it to prevent future breakages.

[^1]: https://git-scm.com/docs/git-fetch#_output
[^2]: https://github.blog/2023-06-01-highlights-from-git-2-41/