### PR TITLE
fix: fetch nested git submodules

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -444,26 +444,25 @@ impl<'a> GitCheckout<'a> {
             // See [`git submodule add`] documentation.
             //
             // [`git submodule add`]: https://git-scm.com/docs/git-submodule
-            let child_remote_url = if child_url_str.starts_with("./")
-                || child_url_str.starts_with("../")
-            {
-                let mut new_parent_remote_url = parent_remote_url.clone();
+            let child_remote_url =
+                if child_url_str.starts_with("./") || child_url_str.starts_with("../") {
+                    let mut new_parent_remote_url = parent_remote_url.clone();
 
-                let mut new_path = Cow::from(parent_remote_url.path());
-                if !new_path.ends_with('/') {
-                    new_path.to_mut().push('/');
-                }
-                new_parent_remote_url.set_path(&new_path);
+                    let mut new_path = Cow::from(parent_remote_url.path());
+                    if !new_path.ends_with('/') {
+                        new_path.to_mut().push('/');
+                    }
+                    new_parent_remote_url.set_path(&new_path);
 
-                new_parent_remote_url.join(child_url_str).with_context(|| {
-                    format!(
-                        "failed to parse relative child submodule url `{}` using parent base url `{}`",
-                        child_url_str, new_parent_remote_url
-                    )
-                })?
-            } else {
-                Url::parse(child_url_str)?
-            };
+                    new_parent_remote_url.join(child_url_str).with_context(|| {
+                        format!(
+                            "failed to parse relative child submodule url `{child_url_str}` \
+                        using parent base url `{new_parent_remote_url}`"
+                        )
+                    })?
+                } else {
+                    Url::parse(child_url_str)?
+                };
 
             // A submodule which is listed in .gitmodules but not actually
             // checked out will not have a head id, so we should ignore it.

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -444,7 +444,9 @@ impl<'a> GitCheckout<'a> {
             // See [`git submodule add`] documentation.
             //
             // [`git submodule add`]: https://git-scm.com/docs/git-submodule
-            let child_remote_url = if child_url_str.starts_with("./") || child_url_str.starts_with("../") {
+            let child_remote_url = if child_url_str.starts_with("./")
+                || child_url_str.starts_with("../")
+            {
                 let mut new_parent_remote_url = parent_remote_url.clone();
 
                 let mut new_path = Cow::from(parent_remote_url.path());
@@ -453,15 +455,12 @@ impl<'a> GitCheckout<'a> {
                 }
                 new_parent_remote_url.set_path(&new_path);
 
-                match new_parent_remote_url.join(child_url_str) {
-                    Ok(x) => x,
-                    Err(err) => Err(err).with_context(|| {
-                        format!(
-                            "failed to parse relative child submodule url `{}` using parent base url `{}`",
-                            child_url_str, new_parent_remote_url
-                        )
-                    })?,
-                }
+                new_parent_remote_url.join(child_url_str).with_context(|| {
+                    format!(
+                        "failed to parse relative child submodule url `{}` using parent base url `{}`",
+                        child_url_str, new_parent_remote_url
+                    )
+                })?
             } else {
                 Url::parse(child_url_str)?
             };

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -444,25 +444,31 @@ impl<'a> GitCheckout<'a> {
             // See [`git submodule add`] documentation.
             //
             // [`git submodule add`]: https://git-scm.com/docs/git-submodule
-            let child_remote_url =
-                if child_url_str.starts_with("./") || child_url_str.starts_with("../") {
-                    let mut new_parent_remote_url = parent_remote_url.clone();
+            let child_remote_url = if child_url_str.starts_with("./")
+                || child_url_str.starts_with("../")
+            {
+                let mut new_parent_remote_url = parent_remote_url.clone();
 
-                    let mut new_path = Cow::from(parent_remote_url.path());
-                    if !new_path.ends_with('/') {
-                        new_path.to_mut().push('/');
-                    }
-                    new_parent_remote_url.set_path(&new_path);
+                let mut new_path = Cow::from(parent_remote_url.path());
+                if !new_path.ends_with('/') {
+                    new_path.to_mut().push('/');
+                }
+                new_parent_remote_url.set_path(&new_path);
 
-                    new_parent_remote_url.join(child_url_str).with_context(|| {
-                        format!(
-                            "failed to parse relative child submodule url `{child_url_str}` \
+                new_parent_remote_url.join(child_url_str).with_context(|| {
+                    format!(
+                        "failed to parse relative child submodule url `{child_url_str}` \
                         using parent base url `{new_parent_remote_url}`"
+                    )
+                })?
+            } else {
+                Url::parse(child_url_str).with_context(|| {
+                        let child_module_name = child.name().unwrap_or("");
+                        format!(
+                            "failed to parse url for submodule `{child_module_name}`: `{child_url_str}`"
                         )
                     })?
-                } else {
-                    Url::parse(child_url_str)?
-                };
+            };
 
             // A submodule which is listed in .gitmodules but not actually
             // checked out will not have a head id, so we should ignore it.

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -444,7 +444,7 @@ impl<'a> GitCheckout<'a> {
             // See [`git submodule add`] documentation.
             //
             // [`git submodule add`]: https://git-scm.com/docs/git-submodule
-            let url = if child_url_str.starts_with("./") || child_url_str.starts_with("../") {
+            let child_remote_url = if child_url_str.starts_with("./") || child_url_str.starts_with("../") {
                 let mut new_parent_remote_url = parent_remote_url.clone();
 
                 let mut new_path = Cow::from(parent_remote_url.path());
@@ -498,10 +498,10 @@ impl<'a> GitCheckout<'a> {
             let reference = GitReference::Rev(head.to_string());
             cargo_config
                 .shell()
-                .status("Updating", format!("git submodule `{}`", url))?;
+                .status("Updating", format!("git submodule `{}`", child_remote_url))?;
             fetch(
                 &mut repo,
-                &url,
+                &child_remote_url,
                 &reference,
                 cargo_config,
                 RemoteKind::GitDependency,
@@ -510,7 +510,7 @@ impl<'a> GitCheckout<'a> {
                 format!(
                     "failed to fetch submodule `{}` from {}",
                     child.name().unwrap_or(""),
-                    url
+                    child_remote_url
                 )
             })?;
 

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3670,12 +3670,14 @@ fn different_user_relative_submodules() {
     project
         .cargo("build")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`\n\
-             [UPDATING] git submodule `{}`\n\
-             [UPDATING] git submodule `{}`\n\
-             [COMPILING] dep1 v0.5.0 ({}#[..])\n\
-             [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+            "\
+[UPDATING] git repository `{}`
+[UPDATING] git submodule `{}`
+[UPDATING] git submodule `{}`
+[COMPILING] dep1 v0.5.0 ({}#[..])
+[COMPILING] foo v0.5.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
             path2url(&user1_git_project.root()),
             path2url(&user2_git_project.root()),
             path2url(&user2_git_project2.root()),


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #12151.

When recursing submodules, the url of the parent remote was being passed to `update_submodules` instead of the child remote url. This caused Cargo to try to add the wrong submodule. 

### How should we test and review this PR?

A test case is added in the first commit. The second one renames the `url` variable as suggested in the issue. The third includes the changes to fix the issue. The last one includes a minor refactor where a redundant `match` expr is removed.
