### PR TITLE
Show a better error when container tests fail.

### DIFF
--- a/crates/cargo-test-support/src/containers.rs
+++ b/crates/cargo-test-support/src/containers.rs
@@ -94,7 +94,9 @@ impl Container {
 
         let image_base = self.build_context.file_name().unwrap();
         let image_name = format!("cargo-test-{}", image_base.to_str().unwrap());
-        let _lock = BUILD_LOCK.lock().unwrap();
+        let _lock = BUILD_LOCK
+            .lock()
+            .map_err(|_| panic!("previous docker build failed, unable to run test"));
         ProcessBuilder::new("docker")
             .args(&["build", "--tag", image_name.as_str()])
             .arg(&self.build_context)


### PR DESCRIPTION
This adds a better error message when a container test fails to build a container.

Previously the output would look something like:

```
---- ssh::ssh_key_in_config stdout ----
SSH_AGENT_PID=69284
thread 'ssh::ssh_key_in_config' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', crates/cargo-test-support/src/containers.rs:97:39
```

Now it looks like:

```
---- ssh::ssh_key_in_config stdout ----
SSH_AGENT_PID=44281
thread 'ssh::ssh_key_in_config' panicked at 'previous docker build failed, unable to run test', crates/cargo-test-support/src/containers.rs:97:51
```