### PR TITLE
Fix version requirement example in Dependency Resolution, SemVer compatibility section

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -50,7 +50,7 @@ Tilde | `~1.2` | <code>>=1.2.0,&nbsp;<1.3.0</code> | Minimum version, with restr
 Wildcard | `1.*` | <code>>=1.0.0,&nbsp;<2.0.0</code> | Any version in the `*` position.
 Equals | `=1.2.3` | <code>=1.2.3</code> | Exactly the specified version only.
 Comparison | `>1.1` | <code>>=1.2.0</code> | Naive numeric comparison of specified digits.
-Compound | <code>>=1.2,&nbsp;<1.5</code> | <code>>1.2.0,&nbsp;<1.5.0</code> | Multiple requirements that must be simultaneously satisfied.
+Compound | <code>>=1.2,&nbsp;<1.5</code> | <code>>=1.2.0,&nbsp;<1.5.0</code> | Multiple requirements that must be simultaneously satisfied.
 
 When multiple packages specify a dependency for a common package, the resolver
 attempts to ensure that they use the same version of that common package, as


### PR DESCRIPTION
I additionally verified with `dtolnay/semver` crate (which it seems cargo itself uses) that version `1.2.0` really matches `>=1.2, <1.5` version requirement.