### PR TITLE
fix(embedded): Don't create an intermediate manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,22 +100,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
-name = "arrayref"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
 
 [[package]]
 name = "atty"
@@ -200,20 +188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729b71f35bd3fa1a4c86b85d32c8b9069ea7fe14f7a53cfabb65f62d4265b888"
-dependencies = [
- "arrayref",
- "arrayvec 0.7.3",
- "cc",
- "cfg-if",
- "constant_time_eq",
- "digest",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,7 +266,6 @@ version = "0.73.0"
 dependencies = [
  "anyhow",
  "base64",
- "blake3",
  "bytesize",
  "cargo-platform 0.1.3",
  "cargo-test-macro",
@@ -554,12 +527,6 @@ name = "const-oid"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a53c0a4d288377e7415b53dcfc3c04da5cdc2cc95c8d5ac178b58f0b861ad6"
 
 [[package]]
 name = "content_inspector"
@@ -3513,7 +3480,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
 dependencies = [
- "arrayvec 0.5.2",
+ "arrayvec",
  "utf8parse",
  "vte_generate_state_changes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ exclude = [
 [workspace.dependencies]
 anyhow = "1.0.47"
 base64 = "0.21.0"
-blake3 = "1.3.3"
 bytesize = "1.0"
 cargo = { path = "" }
 cargo-credential = { version = "0.2.0", path = "credential/cargo-credential" }
@@ -115,7 +114,6 @@ path = "src/cargo/lib.rs"
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
-blake3.workspace = true
 bytesize.workspace = true
 cargo-platform.workspace = true
 cargo-util.workspace = true

--- a/deny.toml
+++ b/deny.toml
@@ -106,7 +106,6 @@ allow = [
     "MIT-0",
     "Apache-2.0",
     "BSD-3-Clause",
-    "BSD-2-Clause",
     "MPL-2.0",
     "Unicode-DFS-2016",
     "CC0-1.0",

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use crate::command_prelude::*;
 use crate::util::restricted_names::is_glob_pattern;
 use cargo::core::Verbosity;
+use cargo::core::Workspace;
 use cargo::ops::{self, CompileFilter, Packages};
 use cargo_util::ProcessError;
 
@@ -101,8 +102,10 @@ pub fn exec_manifest_command(config: &Config, cmd: &str, args: &[OsString]) -> C
         );
     }
     let manifest_path = crate::util::try_canonicalize(manifest_path)?;
-    let script = cargo::util::toml::embedded::parse_from(&manifest_path)?;
-    let ws = cargo::util::toml::embedded::to_workspace(&script, config)?;
+    let mut ws = Workspace::new(&manifest_path, config)?;
+    if config.cli_unstable().avoid_dev_deps {
+        ws.set_require_optional_deps(false);
+    }
 
     let mut compile_opts =
         cargo::ops::CompileOptions::new(config, cargo::core::compiler::CompileMode::Build)?;

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -96,12 +96,15 @@ pub fn exec_manifest_command(config: &Config, cmd: &str, args: &[OsString]) -> C
     }
 
     let manifest_path = Path::new(cmd);
+    let manifest_path = config.cwd().join(manifest_path);
+    let manifest_path = cargo_util::paths::normalize_path(&manifest_path);
     if !manifest_path.exists() {
-        return Err(
-            anyhow::anyhow!("manifest `{}` does not exist", manifest_path.display()).into(),
-        );
+        return Err(anyhow::format_err!(
+            "manifest path `{}` does not exist",
+            manifest_path.display()
+        )
+        .into());
     }
-    let manifest_path = crate::util::try_canonicalize(manifest_path)?;
     let mut ws = Workspace::new(&manifest_path, config)?;
     if config.cli_unstable().avoid_dev_deps {
         ws.set_require_optional_deps(false);

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -64,6 +64,7 @@ pub struct Manifest {
     metabuild: Option<Vec<String>>,
     resolve_behavior: Option<ResolveBehavior>,
     lint_rustflags: Vec<String>,
+    embedded: bool,
 }
 
 /// When parsing `Cargo.toml`, some warnings should silenced
@@ -407,6 +408,7 @@ impl Manifest {
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
         lint_rustflags: Vec<String>,
+        embedded: bool,
     ) -> Manifest {
         Manifest {
             summary,
@@ -433,6 +435,7 @@ impl Manifest {
             metabuild,
             resolve_behavior,
             lint_rustflags,
+            embedded,
         }
     }
 
@@ -499,6 +502,9 @@ impl Manifest {
     }
     pub fn links(&self) -> Option<&str> {
         self.links.as_deref()
+    }
+    pub fn is_embedded(&self) -> bool {
+        self.embedded
     }
 
     pub fn workspace_config(&self) -> &WorkspaceConfig {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -726,6 +726,10 @@ impl<'cfg> Workspace<'cfg> {
         if self.members.contains(&manifest_path) {
             return Ok(());
         }
+        if is_path_dep && self.root_maybe().is_embedded() {
+            // Embedded manifests cannot have workspace members
+            return Ok(());
+        }
         if is_path_dep
             && !manifest_path.parent().unwrap().starts_with(self.root())
             && self.find_root(&manifest_path)? != self.root_manifest
@@ -1578,6 +1582,13 @@ impl MaybePackage {
         match *self {
             MaybePackage::Package(ref p) => p.manifest().workspace_config(),
             MaybePackage::Virtual(ref vm) => vm.workspace_config(),
+        }
+    }
+
+    fn is_embedded(&self) -> bool {
+        match self {
+            MaybePackage::Package(p) => p.manifest().is_embedded(),
+            MaybePackage::Virtual(_) => false,
         }
     }
 }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -393,7 +393,7 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
     let package_root = orig_pkg.root();
     let source_id = orig_pkg.package_id().source_id();
     let (manifest, _nested_paths) =
-        TomlManifest::to_real_manifest(&toml_manifest, source_id, package_root, config)?;
+        TomlManifest::to_real_manifest(&toml_manifest, false, source_id, package_root, config)?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 
     // Regenerate Cargo.lock using the old one as a guide.

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -75,12 +75,12 @@ fn write(
     let hash = hash(script).to_string();
     assert_eq!(hash.len(), 64);
 
-    let file_name = script
+    let file_stem = script
         .path
         .file_stem()
         .ok_or_else(|| anyhow::format_err!("no file name"))?
         .to_string_lossy();
-    let name = sanitize_name(file_name.as_ref());
+    let name = sanitize_name(file_stem.as_ref());
 
     let mut workspace_root = target_dir.to_owned();
     workspace_root.push("eval");
@@ -135,12 +135,12 @@ fn expand_manifest_(script: &RawScript, config: &Config) -> CargoResult<toml::Ta
             anyhow::bail!("`package.{key}` is not allowed in embedded manifests")
         }
     }
-    let file_name = script
+    let file_stem = script
         .path
         .file_stem()
         .ok_or_else(|| anyhow::format_err!("no file name"))?
         .to_string_lossy();
-    let name = sanitize_name(file_name.as_ref());
+    let name = sanitize_name(file_stem.as_ref());
     let bin_name = name.clone();
     package
         .entry("name".to_owned())

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -70,7 +70,7 @@ pub fn read_manifest(
 /// within the manifest. For virtual manifests, these paths can only
 /// come from patched or replaced dependencies. These paths are not
 /// canonicalized.
-pub fn read_manifest_from_str(
+fn read_manifest_from_str(
     contents: &str,
     manifest_file: &Path,
     source_id: SourceId,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ffi::OsStr;
 use std::fmt::{self, Display, Write};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
@@ -55,11 +56,27 @@ pub fn read_manifest(
         path.display(),
         source_id
     );
-    let contents = paths::read(path).map_err(|err| ManifestError::new(err, path.into()))?;
+    let mut contents = paths::read(path).map_err(|err| ManifestError::new(err, path.into()))?;
+    let embedded = is_embedded(path);
+    if embedded {
+        if !config.cli_unstable().script {
+            return Err(ManifestError::new(
+                anyhow::anyhow!("parsing `{}` requires `-Zscript`", path.display()),
+                path.into(),
+            ));
+        }
+        contents = embedded::expand_manifest(&contents, path, config)
+            .map_err(|err| ManifestError::new(err, path.into()))?;
+    }
 
-    read_manifest_from_str(&contents, path, source_id, config)
+    read_manifest_from_str(&contents, path, embedded, source_id, config)
         .with_context(|| format!("failed to parse manifest at `{}`", path.display()))
         .map_err(|err| ManifestError::new(err, path.into()))
+}
+
+fn is_embedded(path: &Path) -> bool {
+    let ext = path.extension();
+    ext.is_none() || ext == Some(OsStr::new("rs"))
 }
 
 /// Parse an already-loaded `Cargo.toml` as a Cargo manifest.
@@ -73,6 +90,7 @@ pub fn read_manifest(
 fn read_manifest_from_str(
     contents: &str,
     manifest_file: &Path,
+    embedded: bool,
     source_id: SourceId,
     config: &Config,
 ) -> CargoResult<(EitherManifest, Vec<PathBuf>)> {
@@ -128,7 +146,7 @@ fn read_manifest_from_str(
     }
     return if manifest.project.is_some() || manifest.package.is_some() {
         let (mut manifest, paths) =
-            TomlManifest::to_real_manifest(&manifest, source_id, package_root, config)?;
+            TomlManifest::to_real_manifest(&manifest, embedded, source_id, package_root, config)?;
         add_unused(manifest.warnings_mut());
         if manifest.targets().iter().all(|t| t.is_custom_build()) {
             bail!(
@@ -1976,6 +1994,7 @@ impl TomlManifest {
 
     pub fn to_real_manifest(
         me: &Rc<TomlManifest>,
+        embedded: bool,
         source_id: SourceId,
         package_root: &Path,
         config: &Config,
@@ -2644,6 +2663,7 @@ impl TomlManifest {
             package.metabuild.clone().map(|sov| sov.0),
             resolve_behavior,
             rustflags,
+            embedded,
         );
         if package.license_file.is_some() && package.license.is_some() {
             manifest.warnings_mut().add_warning(

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -26,16 +26,16 @@ fn basic_rs() {
     p.cargo("-Zscript echo.rs")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/echo[EXE]
 args: []
 "#,
         )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] echo v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/echo)
+[COMPILING] echo v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo[EXE]`
+[RUNNING] `[..]debug/echo[EXE]`
 ",
         )
         .run();
@@ -50,16 +50,16 @@ fn basic_path() {
     p.cargo("-Zscript ./echo")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/echo[EXE]
 args: []
 "#,
         )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] echo v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/echo)
+[COMPILING] echo v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo[EXE]`
+[RUNNING] `[..]/debug/echo[EXE]`
 ",
         )
         .run();
@@ -104,16 +104,16 @@ fn manifest_precedence_over_plugins() {
         .env("PATH", &path)
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/echo[EXE]
 args: []
 "#,
         )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] echo v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/echo)
+[COMPILING] echo v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo[EXE]`
+[RUNNING] `[..]/debug/echo[EXE]`
 ",
         )
         .run();
@@ -203,9 +203,9 @@ fn main() {
         )
         .with_stderr(
             "\
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
+[RUNNING] `[..]/debug/script[EXE]`
 ",
         )
         .run();
@@ -235,9 +235,9 @@ fn main() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
+[RUNNING] `[..]/debug/script[EXE]`
 ",
         )
         .run();
@@ -264,9 +264,9 @@ fn main() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
+[RUNNING] `[..]/debug/script[EXE]`
 ",
         )
         .run();
@@ -282,7 +282,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
+[RUNNING] `[..]/debug/script[EXE]`
 ",
         )
         .run();
@@ -298,9 +298,9 @@ fn main() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
+[RUNNING] `[..]/debug/script[EXE]`
 ",
         )
         .run();
@@ -327,9 +327,9 @@ fn main() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
+[RUNNING] `[..]/debug/script[EXE]`
 ",
         )
         .run();
@@ -345,16 +345,16 @@ fn test_escaped_hyphen_arg() {
     p.cargo("-Zscript -- script.rs -NotAnArg")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/script[EXE]
 args: ["-NotAnArg"]
 "#,
         )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] -NotAnArg`
+[RUNNING] `[..]/debug/script[EXE] -NotAnArg`
 ",
         )
         .run();
@@ -370,16 +370,16 @@ fn test_unescaped_hyphen_arg() {
     p.cargo("-Zscript script.rs -NotAnArg")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/script[EXE]
 args: ["-NotAnArg"]
 "#,
         )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] -NotAnArg`
+[RUNNING] `[..]/debug/script[EXE] -NotAnArg`
 ",
         )
         .run();
@@ -395,16 +395,16 @@ fn test_same_flags() {
     p.cargo("-Zscript script.rs --help")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/script[EXE]
 args: ["--help"]
 "#,
         )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
+[RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
         .run();
@@ -420,15 +420,15 @@ fn test_name_has_weird_chars() {
     p.cargo("-Zscript s-h.w§c!.rs")
         .masquerade_as_nightly_cargo(&["script"])
         .with_stdout(
-            r#"bin: [ROOT]/home/.cargo/eval/target/eval/[..]
+            r#"bin: [..]/debug/s-h-w-c-[EXE]
 args: []
 "#,
         )
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] s-h-w-c- v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/s-h-w-c-)
+[COMPILING] s-h-w-c- v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/s-h-w-c-/target/debug/s-h-w-c-[EXE]`
+[RUNNING] `[..]/debug/s-h-w-c-[EXE]`
 "#,
         )
         .run();
@@ -464,9 +464,9 @@ fn main() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] script v1.0.0 (registry `dummy-registry`)
 [COMPILING] script v1.0.0
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
+[RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
         .run();
@@ -501,9 +501,9 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
+[RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
         .run();
@@ -523,16 +523,12 @@ fn main() {
 
     p.cargo("-Zscript script.rs --help")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_stdout(
-            r#"Hello world!
-"#,
-        )
+        .with_status(101)
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
+[ERROR] `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
+available binaries: not-script, script
 ",
         )
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -508,3 +508,32 @@ fn main() {
         )
         .run();
 }
+
+#[cargo_test]
+fn test_no_autobins() {
+    let script = r#"#!/usr/bin/env cargo
+
+fn main() {
+    println!("Hello world!");
+}"#;
+    let p = cargo_test_support::project()
+        .file("script.rs", script)
+        .file("src/bin/not-script/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("-Zscript script.rs --help")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_stdout(
+            r#"Hello world!
+"#,
+        )
+        .with_stderr(
+            "\
+[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
+",
+        )
+        .run();
+}

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -523,12 +523,16 @@ fn main() {
 
     p.cargo("-Zscript script.rs --help")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
+        .with_stdout(
+            r#"Hello world!
+"#,
+        )
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[ERROR] `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
-available binaries: not-script, script
+[COMPILING] script v0.0.0 ([ROOT]/foo)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

More immediately, this is to unblock rust-lang/rust#112601

More generally, this gets us away from hackily writing out an out-of-line manifest from an embedded manifest.  To parse the manifest, we have to write it out so our regular manifest
loading code could handle it.  This updates the manifest parsing code to
handle it.

This doesn't mean this will work everywhere in all cases though.  For
example, ephemeral workspaces parses a manifest from the SourceId and
these won't have valid SourceIds.

As a consequence, `Cargo.lock` and `CARGO_TARGET_DIR` are changing from being next to
the temp manifest to being next to the script.  This still isn't the
desired behavior but stepping stones.

### How should we test and review this PR?

A Commit at a time

### Additional information

In production code, this does not conflict with #12255 (due to #12262) but in test code, it does.