### PR TITLE
fix(embedded): Don't append hash to bin names

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -142,8 +142,7 @@ fn expand_manifest_(script: &RawScript, config: &Config) -> CargoResult<toml::Ta
         .to_string_lossy();
     let separator = '_';
     let name = sanitize_package_name(file_name.as_ref(), separator);
-    let hash = hash(script);
-    let bin_name = format!("{name}{separator}{hash}");
+    let bin_name = name.clone();
     package
         .entry("name".to_owned())
         .or_insert(toml::Value::String(name));
@@ -449,7 +448,7 @@ mod test_expand {
     fn test_default() {
         snapbox::assert_eq(
             r#"[[bin]]
-name = "test_a472c7a31645d310613df407eab80844346938a3b8fe4f392cae059cb181aa85"
+name = "test"
 path = "/home/me/test.rs"
 
 [package]
@@ -471,7 +470,7 @@ strip = true
     fn test_dependencies() {
         snapbox::assert_eq(
             r#"[[bin]]
-name = "test_3a1fa07700654ea2e893f70bb422efa7884eb1021ccacabc5466efe545da8a0b"
+name = "test"
 path = "/home/me/test.rs"
 
 [dependencies]

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -35,7 +35,7 @@ args: []
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/echo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo[EXE]`
 ",
         )
         .run();
@@ -59,7 +59,7 @@ args: []
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/echo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo[EXE]`
 ",
         )
         .run();
@@ -113,7 +113,7 @@ args: []
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/echo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/echo/target/debug/echo[EXE]`
 ",
         )
         .run();
@@ -205,7 +205,7 @@ fn main() {
             "\
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
 ",
         )
         .run();
@@ -237,7 +237,7 @@ fn main() {
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
 ",
         )
         .run();
@@ -266,7 +266,7 @@ fn main() {
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
 ",
         )
         .run();
@@ -282,7 +282,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
 ",
         )
         .run();
@@ -300,7 +300,7 @@ fn main() {
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
 ",
         )
         .run();
@@ -329,7 +329,7 @@ fn main() {
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE]`
 ",
         )
         .run();
@@ -354,7 +354,7 @@ args: ["-NotAnArg"]
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..] -NotAnArg`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] -NotAnArg`
 ",
         )
         .run();
@@ -379,7 +379,7 @@ args: ["-NotAnArg"]
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..] -NotAnArg`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] -NotAnArg`
 ",
         )
         .run();
@@ -404,7 +404,7 @@ args: ["--help"]
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..] --help`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
 ",
         )
         .run();
@@ -427,14 +427,8 @@ args: []
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] s-h_w_c_ v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/s-h_w_c_)
-[WARNING] crate `s_h_w_c__[..]` should have a snake case name
-  |
-  = help: convert the identifier to snake case: `s_h_w_c_[..]`
-  = note: `#[warn(non_snake_case)]` on by default
-
-[WARNING] `s-h_w_c_` (bin "s-h_w_c__[..]") generated 1 warning
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/s-h_w_c_/target/debug/s-h_w_c__[..]`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/s-h_w_c_/target/debug/s-h_w_c_[EXE]`
 "#,
         )
         .run();
@@ -472,7 +466,7 @@ fn main() {
 [COMPILING] script v1.0.0
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..] --help`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
 ",
         )
         .run();
@@ -509,7 +503,7 @@ fn main() {
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] script v0.0.0 ([ROOT]/home/.cargo/eval/target/eval/[..]/script)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script_[..] --help`
+[RUNNING] `[ROOT]/home/.cargo/eval/target/eval/[..]/script/target/debug/script[EXE] --help`
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

More immediately, this is to unblock rust-lang/rust#112601

The hash existed for sharing a target directory.  That code isn't
implemented yet and a per-user build cache might remove the need for it,
so let's remove it for now and more carefully weigh adding it back in.

In general, this is also the more appropriate way for a feature that would be first class.

### How should we test and review this PR?

This originally built on #12268 but now stands alone as the other PR has windows issues to work out

### Additional information