### PR TITLE
Clarify the default behavior of cargo-install.

### DIFF
--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -18,7 +18,7 @@ cargo-install --- Build and install a Rust binary
 This command manages Cargo's local set of installed binary crates. Only
 packages which have executable `[[bin]]` or `[[example]]` targets can be
 installed, and all executables are installed into the installation root's
-`bin` folder.
+`bin` folder. By default only binaries, not examples, are installed.
 
 {{> description-install-root }}
 
@@ -141,7 +141,7 @@ Install only the specified binary.
 {{/option}}
 
 {{#option "`--bins`" }}
-Install all binaries.
+Install all binaries. This is the default behavior.
 {{/option}}
 
 {{#option "`--example` _name_..." }}

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -13,7 +13,8 @@ DESCRIPTION
        This command manages Cargo’s local set of installed binary crates.
        Only packages which have executable [[bin]] or [[example]] targets can
        be installed, and all executables are installed into the installation
-       root’s bin folder.
+       root’s bin folder. By default only binaries, not examples, are
+       installed.
 
        The installation root is determined, in order of precedence:
 
@@ -137,7 +138,7 @@ OPTIONS
            Install only the specified binary.
 
        --bins
-           Install all binaries.
+           Install all binaries. This is the default behavior.
 
        --example name…
            Install only the specified example.

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -18,7 +18,7 @@ cargo-install --- Build and install a Rust binary
 This command manages Cargo's local set of installed binary crates. Only
 packages which have executable `[[bin]]` or `[[example]]` targets can be
 installed, and all executables are installed into the installation root's
-`bin` folder.
+`bin` folder. By default only binaries, not examples, are installed.
 
 The installation root is determined, in order of precedence:
 
@@ -150,7 +150,7 @@ same time.</dd>
 
 
 <dt class="option-term" id="option-cargo-install---bins"><a class="option-anchor" href="#option-cargo-install---bins"></a><code>--bins</code></dt>
-<dd class="option-desc">Install all binaries.</dd>
+<dd class="option-desc">Install all binaries. This is the default behavior.</dd>
 
 
 <dt class="option-term" id="option-cargo-install---example"><a class="option-anchor" href="#option-cargo-install---example"></a><code>--example</code> <em>name</em>…</dt>

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -17,7 +17,7 @@ cargo\-install \[em] Build and install a Rust binary
 This command manages Cargo\[cq]s local set of installed binary crates. Only
 packages which have executable \fB[[bin]]\fR or \fB[[example]]\fR targets can be
 installed, and all executables are installed into the installation root\[cq]s
-\fBbin\fR folder.
+\fBbin\fR folder. By default only binaries, not examples, are installed.
 .sp
 The installation root is determined, in order of precedence:
 .sp
@@ -177,7 +177,7 @@ Install only the specified binary.
 .sp
 \fB\-\-bins\fR
 .RS 4
-Install all binaries.
+Install all binaries. This is the default behavior.
 .RE
 .sp
 \fB\-\-example\fR \fIname\fR\[u2026]


### PR DESCRIPTION
The man page for `cargo install` is not explicit about what the default behavior is. This is important to clarify because `examples/` are typically unneeded and may not be maintained with the same care as "real" binaries, so it should be clear to users that example binaries won't be installed without directly asking for them.

Small doc-only update, hopefully this is acceptable. Please let me know if I need to seek further approval first (and, if so, apologies for the noise).