### PR TITLE
feat(cli): Support `cargo Cargo.toml`

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -492,7 +492,7 @@ pub fn cli() -> Command {
     let usage = if is_rustup {
         "cargo [+toolchain] [OPTIONS] [COMMAND]\n       cargo [+toolchain] [OPTIONS] -Zscript <MANIFEST_RS> [ARGS]..."
     } else {
-        "cargo [OPTIONS] [COMMAND]\n       cargo [OPTIONS] -Zscript <MANIFEST_RS> [ARGS]..."
+        "cargo [OPTIONS] [COMMAND]\n       cargo [OPTIONS] -Zscript <MANIFEST> [ARGS]..."
     };
     Command::new("cargo")
         // Subcommands all count their args' display order independently (from 0),

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -87,7 +87,9 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
 
 pub fn is_manifest_command(arg: &str) -> bool {
     let path = Path::new(arg);
-    1 < path.components().count() || path.extension() == Some(OsStr::new("rs"))
+    1 < path.components().count()
+        || path.extension() == Some(OsStr::new("rs"))
+        || path.file_name() == Some(OsStr::new("Cargo.toml"))
 }
 
 pub fn exec_manifest_command(config: &Config, cmd: &str, args: &[OsString]) -> CliResult {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1462,16 +1462,19 @@ persistent lockfile.
 
 #### Manifest-commands
 
-You may pass single-file packages directly to the `cargo` command, without subcommand.  This is mostly intended for being put in `#!` lines.
+You may pass a manifest directly to the `cargo` command, without a subcommand,
+like `foo/Cargo.toml` or a single-file package like `foo.rs`.  This is mostly
+intended for being put in `#!` lines.
 
 The precedence for how to interpret `cargo <subcommand>` is
 1. Built-in xor single-file packages
 2. Aliases
 3. External subcommands
 
-A parameter is identified as a single-file package if it has one of:
+A parameter is identified as a manifest-command if it has one of:
 - Path separators
 - A `.rs` extension
+- The file name is `Cargo.toml`
 
 ### `[lints]`
 

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -73,13 +73,16 @@ fn basic_cargo_toml() {
 
     p.cargo("-Zscript Cargo.toml")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
-        .with_stdout("")
+        .with_stdout(
+            r#"bin: target/debug/foo[EXE]
+args: []
+"#,
+        )
         .with_stderr(
             "\
-error: no such command: `Cargo.toml`
-
-<tab>View all installed commands with `cargo --list`
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `target/debug/foo[EXE]`
 ",
         )
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -66,6 +66,26 @@ args: []
 }
 
 #[cargo_test]
+fn basic_cargo_toml() {
+    let p = cargo_test_support::project()
+        .file("src/main.rs", ECHO_SCRIPT)
+        .build();
+
+    p.cargo("-Zscript Cargo.toml")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stdout("")
+        .with_stderr(
+            "\
+error: no such command: `Cargo.toml`
+
+<tab>View all installed commands with `cargo --list`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn path_required() {
     let p = cargo_test_support::project()
         .file("echo", ECHO_SCRIPT)


### PR DESCRIPTION
### What does this PR try to resolve?

This is making the assumption that we want full unity between places accepting both single-file packages and `Cargo.toml` for #12207.   This has not been brought up before in any of the discussions (Internals, eRFC), so I can understand if there are concerns about this and we decide to hold off.

We might want to resolve symlinks before this so people can have a prettier name for these.

### How should we test and review this PR?

The test for this was added in a commit before the actual change, letting people see how the behavior changed.