### PR TITLE
fix(embeded): Don't pollute the scripts dir with `target/`

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -381,7 +381,11 @@ impl<'cfg> Workspace<'cfg> {
     pub fn target_dir(&self) -> Filesystem {
         self.target_dir
             .clone()
-            .unwrap_or_else(|| Filesystem::new(self.root().join("target")))
+            .unwrap_or_else(|| self.default_target_dir())
+    }
+
+    fn default_target_dir(&self) -> Filesystem {
+        Filesystem::new(self.root().join("target"))
     }
 
     /// Returns the root `[replace]` section of this workspace.

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -385,7 +385,17 @@ impl<'cfg> Workspace<'cfg> {
     }
 
     fn default_target_dir(&self) -> Filesystem {
-        Filesystem::new(self.root().join("target"))
+        if self.root_maybe().is_embedded() {
+            let hash = crate::util::hex::short_hash(&self.root_manifest().to_string_lossy());
+            let mut rel_path = PathBuf::new();
+            rel_path.push("target");
+            rel_path.push(&hash[0..2]);
+            rel_path.push(&hash[2..]);
+
+            self.config().home().join(rel_path)
+        } else {
+            Filesystem::new(self.root().join("target"))
+        }
     }
 
     /// Returns the root `[replace]` section of this workspace.

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -35,7 +35,7 @@ args: []
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
-[RUNNING] `[..]debug/echo[EXE]`
+[RUNNING] `[..]/debug/echo[EXE]`
 ",
         )
         .run();
@@ -533,6 +533,31 @@ fn main() {
 [COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] --help`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn implicit_target_dir() {
+    let script = ECHO_SCRIPT;
+    let p = cargo_test_support::project()
+        .file("script.rs", script)
+        .build();
+
+    p.cargo("-Zscript script.rs")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_stdout(
+            r#"bin: [ROOT]/home/.cargo/target/[..]/debug/script[EXE]
+args: []
+"#,
+        )
+        .with_stderr(
+            "\
+[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[COMPILING] script v0.0.0 ([ROOT]/foo)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `[ROOT]/home/.cargo/target/[..]/debug/script[EXE]`
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This PR is part of #12207.

This specific behavior was broken in #12268 when we stopped using an intermediate
`Cargo.toml` file.

Unlike pre-#12268,
- We are hashing the path, rather than the content, with the assumption
  that people change content more frequently than the path
- We are using a simpler hash than `blake3` in the hopes that we can get
  away with it

Unlike the Pre-RFC demo
- We are not forcing a single target dir for all scripts in the hopes
  that we get #5931

### How should we test and review this PR?

A new test was added specifically to show the target dir behavior, rather than overloading an existing test or making all tests sensitive to changes in this behavior.

### Additional information

In the future, we might want to resolve symlinks before we get to this point