### PR TITLE
fix(embedded): Don't auto-discover build.rs files

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -90,6 +90,9 @@ fn expand_manifest_(
         toml::Value::String(DEFAULT_EDITION.to_string())
     });
     package
+        .entry("build".to_owned())
+        .or_insert_with(|| toml::Value::Boolean(false));
+    package
         .entry("publish".to_owned())
         .or_insert_with(|| toml::Value::Boolean(DEFAULT_PUBLISH));
     for field in AUTO_FIELDS {
@@ -491,6 +494,7 @@ autobenches = false
 autobins = false
 autoexamples = false
 autotests = false
+build = false
 edition = "2021"
 name = "test-"
 publish = false
@@ -520,6 +524,7 @@ autobenches = false
 autobins = false
 autoexamples = false
 autotests = false
+build = false
 edition = "2021"
 name = "test-"
 publish = false

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -523,11 +523,16 @@ fn main() {
 
     p.cargo("-Zscript script.rs --help")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
-        .with_stdout(r#""#)
-        .with_stderr_contains(
+        .with_stdout(
+            r#"Hello world!
+"#,
+        )
+        .with_stderr(
             "\
-[ERROR] could not compile `script` (build script) due to previous error
+[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[COMPILING] script v0.0.0 ([ROOT]/foo)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -510,6 +510,30 @@ fn main() {
 }
 
 #[cargo_test]
+fn test_no_build_rs() {
+    let script = r#"#!/usr/bin/env cargo
+
+fn main() {
+    println!("Hello world!");
+}"#;
+    let p = cargo_test_support::project()
+        .file("script.rs", script)
+        .file("build.rs", "broken")
+        .build();
+
+    p.cargo("-Zscript script.rs --help")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stdout(r#""#)
+        .with_stderr_contains(
+            "\
+[ERROR] could not compile `script` (build script) due to previous error
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn test_no_autobins() {
     let script = r#"#!/usr/bin/env cargo
 


### PR DESCRIPTION
With #12268, we moved the manifest root to be the scripts parent
directory, making it so auto-discovery might pick some things up.

We previously ensured `auto*` don't pick things up but missed `build.rs`
This is now addressed.