### PR TITLE
Don't allow custom build script path to escape package root

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -105,7 +105,7 @@ pub fn targets(
     )?);
 
     // processing the custom build script
-    if let Some(custom_build) = manifest.maybe_custom_build(custom_build, package_root) {
+    if let Some(custom_build) = manifest.maybe_custom_build(custom_build, package_root)? {
         if metabuild.is_some() {
             anyhow::bail!("cannot specify both `metabuild` and `build`");
         }


### PR DESCRIPTION
### What does this PR try to resolve?
Don't allow custom build script path to escape package root.
Specifically the PR:
* shows an error for absolute paths in [build](https://doc.rust-lang.org/cargo/reference/manifest.html#the-build-field) field of Cargo.toml, since it will affect reproducibility.
* checks if the relative path in [build](https://doc.rust-lang.org/cargo/reference/manifest.html#the-build-field) field of Cargo.toml escapes the package root and if so, shows an error.

Fixes [11383](https://github.com/rust-lang/cargo/issues/11383)

### How should we test and review this PR?
This PR is still in the exploration stage and I will add tests after we settle on the general approach.

### Additional information
This PR is still in the exploration stage and I want to get feedback from the team on the general approach.