### PR TITLE
cargo script example needs nightly -Zscript feature

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1407,7 +1407,7 @@ fn main() {}
 
 A user may optionally specify a manifest in a `cargo` code fence in a module-level comment, like:
 ```rust
-#!/usr/bin/env cargo
+#!/usr/bin/env -S cargo +nightly -Zscript
 
 //! ```cargo
 //! [dependencies]


### PR DESCRIPTION
### What does this PR try to resolve?
Update cargo script example. Cargo script currently needs nightly `-Zscript` feature.
Without this change users will see:
```
error: running `./cargo_script.rs` requires `-Zscript`
```

cc https://github.com/rust-lang/cargo/issues/12207

### How should we test and review this PR?
I don't think any additional tests are needed. All existing tests for cargo script already use `-Zscript`.

### Additional information
Thanks for designing and implementing cargo script @epage!