### PR TITLE
docs: some tweaks around `cargo test`

### DIFF
--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -59,9 +59,9 @@ on writing doc tests.
 
 ### Working directory of tests
 
-The working directory of every test is set to the root directory of the package 
-the test belongs to.
-Setting the working directory of tests to the package's root directory makes it 
+The working directory when running each unit and integration test is set to the
+root directory of the package the test belongs to.
+Setting the working directory of tests to the package's root directory makes it
 possible for tests to reliably access the package's files using relative paths,
 regardless from where `cargo test` was executed from.
 

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -69,7 +69,7 @@ For documentation tests, the working directory when invoking `rustdoc` is set to
 the workspace root directory, and is also the directory `rustdoc` uses as the
 compilation directory of each documentation test.
 The working directory when running each documentation test is set to the root
-directory of the package the test belongs to, and is controlled via `rustdoc`s
+directory of the package the test belongs to, and is controlled via `rustdoc`'s
 `--test-run-directory` option.
 
 ## OPTIONS

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -64,7 +64,7 @@ DESCRIPTION
        uses as the compilation directory of each documentation test. The
        working directory when running each documentation test is set to the
        root directory of the package the test belongs to, and is controlled via
-       rustdocs --test-run-directory option.
+       rustdoc’s --test-run-directory option.
 
 OPTIONS
    Test Options

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -53,11 +53,11 @@ DESCRIPTION
        information on writing doc tests.
 
    Working directory of tests
-       The working directory of every test is set to the root directory of the
-       package the test belongs to. Setting the working directory of tests to
-       the package’s root directory makes it possible for tests to reliably
-       access the package’s files using relative paths, regardless from where
-       cargo test was executed from.
+       The working directory when running each unit and integration test is set
+       to the root directory of the package the test belongs to. Setting the
+       working directory of tests to the package’s root directory makes it
+       possible for tests to reliably access the package’s files using
+       relative paths, regardless from where cargo test was executed from.
 
        For documentation tests, the working directory when invoking rustdoc is
        set to the workspace root directory, and is also the directory rustdoc

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -59,9 +59,9 @@ on writing doc tests.
 
 ### Working directory of tests
 
-The working directory of every test is set to the root directory of the package 
-the test belongs to.
-Setting the working directory of tests to the package's root directory makes it 
+The working directory when running each unit and integration test is set to the
+root directory of the package the test belongs to.
+Setting the working directory of tests to the package's root directory makes it
 possible for tests to reliably access the package's files using relative paths,
 regardless from where `cargo test` was executed from.
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -69,7 +69,7 @@ For documentation tests, the working directory when invoking `rustdoc` is set to
 the workspace root directory, and is also the directory `rustdoc` uses as the
 compilation directory of each documentation test.
 The working directory when running each documentation test is set to the root
-directory of the package the test belongs to, and is controlled via `rustdoc`s
+directory of the package the test belongs to, and is controlled via `rustdoc`'s
 `--test-run-directory` option.
 
 ## OPTIONS

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1185,24 +1185,6 @@ cargo +nightly -Zunstable-options config get build.rustflags
 If no config value is included, it will display all config values. See the
 `--help` output for more options available.
 
-### `doctest-in-workspace`
-
-* Tracking Issue: [#9427](https://github.com/rust-lang/cargo/issues/9427)
-
-The `-Z doctest-in-workspace` flag changes the behavior of the current working
-directory used when running doctests. Historically, Cargo has run `rustdoc
---test` relative to the root of the package, with paths relative from that
-root. However, this is inconsistent with how `rustc` and `rustdoc` are
-normally run in a workspace, where they are run relative to the workspace
-root. This inconsistency causes problems in various ways, such as when passing
-RUSTDOCFLAGS with relative paths, or dealing with diagnostic output.
-
-The `-Z doctest-in-workspace` flag causes cargo to switch to running `rustdoc`
-from the root of the workspace. It also passes the `--test-run-directory` to
-`rustdoc` so that when *running* the tests, they are run from the root of the
-package. This preserves backwards compatibility and is consistent with how
-normal unittests are run.
-
 ### rustc `--print`
 
 * Tracking Issue: [#9357](https://github.com/rust-lang/cargo/issues/9357)

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -54,9 +54,9 @@ and may change in the future; beware of depending on it.
 See the \fIrustdoc book\fR <https://doc.rust\-lang.org/rustdoc/> for more information
 on writing doc tests.
 .SS "Working directory of tests"
-The working directory of every test is set to the root directory of the package 
-the test belongs to.
-Setting the working directory of tests to the package\[cq]s root directory makes it 
+The working directory when running each unit and integration test is set to the
+root directory of the package the test belongs to.
+Setting the working directory of tests to the package\[cq]s root directory makes it
 possible for tests to reliably access the package\[cq]s files using relative paths,
 regardless from where \fBcargo test\fR was executed from.
 .sp

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -64,7 +64,7 @@ For documentation tests, the working directory when invoking \fBrustdoc\fR is se
 the workspace root directory, and is also the directory \fBrustdoc\fR uses as the
 compilation directory of each documentation test.
 The working directory when running each documentation test is set to the root
-directory of the package the test belongs to, and is controlled via \fBrustdoc\fRs
+directory of the package the test belongs to, and is controlled via \fBrustdoc\fR\[cq]s
 \fB\-\-test\-run\-directory\fR option.
 .SH "OPTIONS"
 .SS "Test Options"


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

* It is overlooked that #12221 didn't remove the tracking issue part for `-Zdoctest-in-workspace`.
* Make it clear that the working directory of tests is for running tests.
<!-- homu-ignore:end -->
