### PR TITLE
docs(unstable): Point stable-unstable docs to nightly docs

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -52,10 +52,12 @@ how the feature works:
   ```
 
 Each new feature described below should explain how to use it.
+For the latest nightly, see the [nightly version] of this page.
 
 [config file]: config.md
 [nightly channel]: ../../book/appendix-07-nightly-rust.html
 [stabilized]: https://doc.crates.io/contrib/process/unstable.html#stabilization
+[nightly version]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#script
 
 ### List of unstable features
 


### PR DESCRIPTION
I ran into this in trying to find the "cargo script" docs.  Unless its the rare case of `RUSTC_BOOTRAP=1 cargo +stable ...`, someone reading about features on `+nightly` likely would want to see the latest version of this document, so we should help people find it.