### PR TITLE
Allow the edition specifier to be an integer

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -149,6 +149,8 @@ examples, etc.
 edition = '2021'
 ```
 
+For the value of the `edition` key, both strings and integers are supported.
+
 Most manifests have the `edition` field filled in automatically by [`cargo new`]
 with the latest stable edition. By default `cargo new` creates a manifest with
 the 2021 edition currently.


### PR DESCRIPTION
This PR allows for edition specifiers to be toml integers:

```toml
[package]
name = "foo"
version = "0.1.0"
edition = 2018
```

So far, each edition was fully described by its year number: `2015`, `2018`, `2021`. Also for the future, the intent is that editions will always just be year numbers. Therefore, the natural choice for the type is an integer, instead of the current requirement for toml strings. Using an integer saves two characters in each Cargo.toml. Over the roughly hundred thousand Cargo.toml files on crates.io alone, you'll get some nice savings. Strings are still allowed to support legacy use cases and for the (unlikely) case of non-integral editions in the future.

I've proposed this 5 years ago before the 2018 edition even shipped, and received positive feedback from some people (#5617). I ended up closing it because of unrelated reasons. Also, back then it was less clear whether one would have sth like `2018-beta` or such which would have required a string, which eventually didn't end up being a thing (but even then, one could make the case that one could still allow integers for the finally released  `2018`). With the cargo-script support (cc #12207), I'd say that interest is large again in minimizing the number of characters/keystrokes needed, so I'm bringing back this old proposal.

I feel it's a very small feature in scope so one doesn't need a feature gate to evaluate its impact, but feel free to suggest gating.