### PR TITLE
-Znext-lockfile-bump: Don't suggest using -Z on stable

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -159,11 +159,11 @@ impl EncodableResolve {
         let mut checksums = HashMap::new();
 
         let mut version = match self.version {
-            Some(4) => {
+            Some(4) if ws.config().nightly_features_allowed => {
                 if unstable_lockfile_version_allowed {
                     ResolveVersion::V4
                 } else {
-                    anyhow::bail!("lock file version 4 requires `-Znext-lockfile-bump`",)
+                    anyhow::bail!("lock file version 4 requires `-Znext-lockfile-bump`");
                 }
             }
             Some(3) => ResolveVersion::V3,

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -913,6 +913,21 @@ fn v4_is_unstable() {
 error: failed to parse lock file at: [CWD]/Cargo.lock
 
 Caused by:
+  lock file version `4` was found, but this version of Cargo does not \
+  understand this lock file, perhaps Cargo needs to be updated?
+",
+        )
+        .run();
+
+    // On nightly, let the user know about the `-Z` flag.
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["-Znext-lockfile-bump"])
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse lock file at: [CWD]/Cargo.lock
+
+Caused by:
   lock file version 4 requires `-Znext-lockfile-bump`
 ",
         )


### PR DESCRIPTION
This changes the lockfile version 4 error to not suggest using `-Znext-lockfile-bump` on the stable channel. I fear this could be confusing to users when the real version 4 is stabilized, and the user is using a too old version of cargo. Instead this produces the same error message as any unknown version would produce, with a suggestion to update.
