### PR TITLE
fix(script): Process config relative to script, not CWD

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1481,6 +1481,9 @@ A parameter is identified as a manifest-command if it has one of:
 - A `.rs` extension
 - The file name is `Cargo.toml`
 
+Differences between `cargo run --manifest-path <path>` and `cargo <path>`
+- `cargo <path>` runs with the config for `<path>` and not the current dir, more like `cargo install --path <path>`
+
 ### `[lints]`
 
 * Tracking Issue: [#12115](https://github.com/rust-lang/cargo/issues/12115)

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -352,7 +352,7 @@ rustc = "non-existent-rustc"
         .build();
 
     // Verify the config is bad
-    p.cargo("-Zscript script.rs")
+    p.cargo("-Zscript script.rs -NotAnArg")
         .masquerade_as_nightly_cargo(&["script"])
         .with_status(101)
         .with_stderr_contains(
@@ -362,14 +362,13 @@ rustc = "non-existent-rustc"
         )
         .run();
 
-    // Verify that the config is still used
-    p.cargo("-Zscript ../script/script.rs")
+    // Verify that the config isn't used
+    p.cargo("-Zscript ../script/script.rs -NotAnArg")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
-        .with_stderr_contains(
-            "\
-[ERROR] could not execute process `non-existent-rustc -vV` (never executed)
-",
+        .with_stdout(
+            r#"bin: [..]/debug/script[EXE]
+args: ["-NotAnArg"]
+"#,
         )
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of the work for #12207.

When you put in your path `foo.rs`:
```rust
#!/usr/bin/env cargo

fn main() {}
```

You expect it to build once and then repeatedly run the same version.  However, `.cargo/config.toml` doesn't work like that (normally).  It is an environment file, like `.env`, and is based on your current working directory.  So if you run `foo.rs` from within a random project, it might rebuild due to RUSTFLAGS in `.cargo/config.toml`.

I had some concern about whether this current behavior is right or not and [noted this in the Pre-RFC](https://github.com/epage/cargo-script-mvs/blob/main/0000-cargo-script.md#unresolved-questions).  This came up again while we were [discussing editions on zulip](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/cargo.20script.20and.20edition).  In looking further into this, it turns out we already have precedence for this with `cargo install --path <path>`.

### How should we test and review this PR?

The second commit has the fix, the docs, and a change to a test (from the first commit) to show that the fix actually changed behavior.