### PR TITLE
feat(crates-io): expose HTTP headers and Error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,7 +587,6 @@ dependencies = [
 name = "crates-io"
 version = "0.38.0"
 dependencies = [
- "anyhow",
  "curl",
  "percent-encoding",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "curl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
+ "thiserror",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ syn = { version = "2.0.14", features = ["extra-traits", "full"] }
 tar = { version = "0.4.38", default-features = false }
 tempfile = "3.1.0"
 termcolor = "1.1.2"
+thiserror = "1.0.40"
 time = { version = "0.3", features = ["parsing", "formatting"] }
 toml = "0.7.0"
 toml_edit = "0.19.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ cargo-util = { version = "0.2.5", path = "crates/cargo-util" }
 cargo_metadata = "0.14.0"
 clap = "4.2.0"
 core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
-crates-io = { version = "0.37.0", path = "crates/crates-io" }
+crates-io = { version = "0.38.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
 curl-sys = "0.4.63"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -13,7 +13,6 @@ name = "crates_io"
 path = "lib.rs"
 
 [dependencies]
-anyhow.workspace = true
 curl.workspace = true
 percent-encoding.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.37.0"
+version = "0.38.0"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -17,4 +17,5 @@ curl.workspace = true
 percent-encoding.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+thiserror.workspace = true
 url.workspace = true

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -428,6 +428,10 @@ impl Registry {
                 // Headers contain trailing \r\n, trim them to make it easier
                 // to work with.
                 let s = String::from_utf8_lossy(data).trim().to_string();
+                // Don't let server sneak extra lines anywhere.
+                if s.contains('\n') {
+                    return true;
+                }
                 headers.push(s);
                 true
             })?;
@@ -448,7 +452,11 @@ impl Registry {
 
         match (self.handle.response_code()?, errors) {
             (0, None) | (200, None) => Ok(body),
-        (code, Some(errors)) => Err(ResponseError::Api { code, headers, errors }),
+            (code, Some(errors)) => Err(ResponseError::Api {
+                code,
+                headers,
+                errors,
+            }),
             (code, None) => Err(ResponseError::Code {
                 code,
                 headers,

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -130,6 +130,7 @@ pub enum ResponseError {
     Curl(curl::Error),
     Api {
         code: u32,
+        headers: Vec<String>,
         errors: Vec<String>,
     },
     Code {
@@ -155,7 +156,7 @@ impl fmt::Display for ResponseError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ResponseError::Curl(e) => write!(f, "{}", e),
-            ResponseError::Api { code, errors } => {
+            ResponseError::Api { code, errors, .. } => {
                 f.write_str("the remote server responded with an error")?;
                 if *code != 200 {
                     write!(f, " (status {} {})", code, reason(*code))?;
@@ -447,7 +448,7 @@ impl Registry {
 
         match (self.handle.response_code()?, errors) {
             (0, None) | (200, None) => Ok(body),
-            (code, Some(errors)) => Err(ResponseError::Api { code, errors }),
+        (code, Some(errors)) => Err(ResponseError::Api { code, headers, errors }),
             (code, None) => Err(ResponseError::Code {
                 code,
                 headers,

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2023,10 +2023,10 @@ fn api_other_error() {
 [ERROR] failed to publish to registry at http://127.0.0.1:[..]/
 
 Caused by:
-  invalid response from server
+  invalid response body from server
 
 Caused by:
-  response body was not valid utf-8
+  invalid utf-8 sequence of [..]
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #11521.

[RFC 3231] mentions the authentication process could have an additional **challenge-response mechanism** to prevent potential replay attacks. The challenge usually comes from HTTP `www-authenticate` header as a opaque string. When a client gets a 401/403 response with such a challenge, it may attach the `challenge` to the payload and request again to anwser the challenge.

```
➡️ cargo  requests
⬅️ server responds with `www-authenticate` containing some opaque challenge string
➡️ cargo  automatically requests again without any user perception
⬅️ server responds ok
```

However, `crates-io` crate doesn't expose HTTP headers. There is no access to `www-authenticate` header. 

This PR make it expose HTTP headers and the custom `Error` type, so `cargo` can access and do further on the authentication process.

[RFC 3231]: https://rust-lang.github.io/rfcs/3231-cargo-asymmetric-tokens.html#the-authentication-process

<!-- homu-ignore:start -->

### How should we test and review this PR?

By commit.

This removes the dependency `anyhow` and uses our own custom `Error` enum, so that `crates-io` consumer can access `Error::API::challenge` field. It optionally uses `thiserror` to reduce boilerplates but this part can be dropped if we don't want.

<!-- homu-ignore:end -->
