### PR TITLE
doc: should be `.cargo-ok`

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -521,7 +521,7 @@ impl<'cfg> RegistrySource<'cfg> {
     ///
     /// No action is taken if the source looks like it's already unpacked.
     ///
-    /// # History of interruption detection with `.cargo-lock` file
+    /// # History of interruption detection with `.cargo-ok` file
     ///
     /// Cargo has always included a `.cargo-ok` file ([`PACKAGE_SOURCE_LOCK`])
     /// to detect if extraction was interrupted, but it was originally empty.


### PR DESCRIPTION
It was a mistake. Should be `.cargo-ok`. `.cargo-lock` is a file lock holding for `target/debug` when compiling stuff.