### PR TITLE
Add READMEs for the credential helpers.

### DIFF
--- a/credential/cargo-credential-1password/README.md
+++ b/credential/cargo-credential-1password/README.md
@@ -1,0 +1,7 @@
+# cargo-credential-1password
+
+This is the implementation for the Cargo credential helper for [1password].
+See the [credential-process] documentation for how to use this.
+
+[1password]: https://1password.com/
+[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process

--- a/credential/cargo-credential-gnome-secret/README.md
+++ b/credential/cargo-credential-gnome-secret/README.md
@@ -1,0 +1,7 @@
+# cargo-credential-gnome-secret
+
+This is the implementation for the Cargo credential helper for [GNOME libsecret].
+See the [credential-process] documentation for how to use this.
+
+[GNOME libsecret]: https://wiki.gnome.org/Projects/Libsecret
+[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process

--- a/credential/cargo-credential-macos-keychain/README.md
+++ b/credential/cargo-credential-macos-keychain/README.md
@@ -1,0 +1,7 @@
+# cargo-credential-macos-keychain
+
+This is the implementation for the Cargo credential helper for [macOS Keychain].
+See the [credential-process] documentation for how to use this.
+
+[macOS Keychain]: https://support.apple.com/guide/keychain-access/welcome/mac
+[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process

--- a/credential/cargo-credential-wincred/README.md
+++ b/credential/cargo-credential-wincred/README.md
@@ -1,0 +1,7 @@
+# cargo-credential-wincred
+
+This is the implementation for the Cargo credential helper for [Windows Credential Manager].
+See the [credential-process] documentation for how to use this.
+
+[Windows Credential Manager]: https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0
+[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process


### PR DESCRIPTION
This adds some READMEs for these crates. These are pretty bare bones for now, but I suspect they may get extended in the future based on how we decide to deploy them.
