### PR TITLE
Minor: Use "number" instead of "digit" when explaining Cargo's use of semver

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -22,7 +22,7 @@ time = "0.1.12"
 The string `"0.1.12"` is a version requirement. Although it looks like a
 specific *version* of the `time` crate, it actually specifies a *range* of
 versions and allows [SemVer] compatible updates. An update is allowed if the new
-version number does not modify the left-most non-zero digit in the major, minor,
+version number does not modify the left-most non-zero number in the major, minor,
 patch grouping. In this case, if we ran `cargo update -p time`, cargo should
 update us to version `0.1.13` if it is the latest `0.1.z` release, but would not
 update us to `0.2.0`. If instead we had specified the version string as `1.0`,


### PR DESCRIPTION
Digit is technically incorrect here, as it would imply that Cargo treats 0.10.0 and 0.11.0 as semver compatible (because they have the same leftmost non-zero *digit*, even though they do not have the same leftmost non-zero *number*).

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Making the documentation around Cargo's use of semver clearer. 

### How should we test and review this PR?

No testing should be necessary. This is a trivial doc fix.

### Additional information

See https://www.reddit.com/r/rust/comments/14vboxi/how_does_cargo_resolve_version_compatibility/ for a user who was confused by the current wording.
-->
<!-- homu-ignore:end -->
