### PR TITLE
chore: Automatically update dependencies monthly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,35 @@
+{
+  schedule: [
+    'before 3am on the first day of the month',
+  ],
+  semanticCommits: 'enabled',
+  configMigration: true,
+  dependencyDashboard: false,
+  packageRules: [
+    // Goals:
+    // - Rollup safe upgrades to reduce CI runner load
+    // - Have lockfile and manifest in-sync (implicit rules)
+    {
+      matchManagers: [
+        'cargo',
+      ],
+      matchCurrentVersion: '>=0.1.0',
+      matchUpdateTypes: [
+        'patch',
+      ],
+      automerge: false,
+      groupName: 'compatible',
+    },
+    {
+      matchManagers: [
+        'cargo',
+      ],
+      matchCurrentVersion: '>=1.0.0',
+      matchUpdateTypes: [
+        'minor',
+      ],
+      automerge: false,
+      groupName: 'compatible',
+    },
+  ],
+}


### PR DESCRIPTION
### What does this PR try to resolve?

This will create PRs that will update `Cargo.toml` and `Cargo.lock` at the same time.  By default, RenovateBot will update all dependencies, so we pull out the compatible dependencies into a consolidated PR to reduce disruptions and CI load.

This doesn't just cover Rust dependencies but github workflows as well.

### How should we test and review this PR?

This starts off with the dependency dashboard and automerging being disabled but explicitly specified to call attention to the potential for this.  We can evaluate these later.

The frequency of monthly was chosen to consolidate disruptions.  The main risk is doing an update right before a beta branch but we can't have a cron schedule for once every 6 weeks (I assume) which would be ideal.  At least its not daily or instant.

I chose `json5` over `json` for comments and trailing commas, to make human-editing easier.

I pulled the config from https://github.com/gitext-rs/git-stack/blob/main/.github/renovate.json5
- [Dependency dashboard](https://github.com/gitext-rs/git-stack/issues/309)
- [Compatible PR](https://github.com/gitext-rs/git-stack/pull/255)
- [Incompatible PR](https://github.com/gitext-rs/git-stack/pull/310)

CC @Turbo87 