### PR TITLE
fix(embedded): Always generate valid package names

### DIFF
--- a/src/cargo/util/restricted_names.rs
+++ b/src/cargo/util/restricted_names.rs
@@ -100,6 +100,9 @@ pub fn sanitize_package_name(name: &str, placeholder: char) -> String {
             slug.push(placeholder);
         }
     }
+    if slug.is_empty() {
+        slug.push_str("package");
+    }
     slug
 }
 

--- a/src/cargo/util/restricted_names.rs
+++ b/src/cargo/util/restricted_names.rs
@@ -87,17 +87,13 @@ pub fn validate_package_name(name: &str, what: &str, help: &str) -> CargoResult<
 pub fn sanitize_package_name(name: &str, placeholder: char) -> String {
     let mut slug = String::new();
     let mut chars = name.chars();
-    if let Some(ch) = chars.next() {
-        if ch.is_digit(10) {
-            slug.push(placeholder);
+    while let Some(ch) = chars.next() {
+        if (unicode_xid::UnicodeXID::is_xid_start(ch) || ch == '_') && !ch.is_digit(10) {
             slug.push(ch);
-        } else if unicode_xid::UnicodeXID::is_xid_start(ch) || ch == '_' {
-            slug.push(ch);
-        } else {
-            slug.push(placeholder);
+            break;
         }
     }
-    for ch in chars {
+    while let Some(ch) = chars.next() {
         if unicode_xid::UnicodeXID::is_xid_continue(ch) || ch == '-' {
             slug.push(ch);
         } else {

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -552,13 +552,16 @@ fn test_name_has_leading_number() {
 
     p.cargo("-Zscript -v 42answer.rs")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
+        .with_stdout(
+            r#"bin: [..]/debug/answer[EXE]
+args: []
+"#,
+        )
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[ERROR] failed to parse manifest at `[ROOT]/foo/42answer.rs`
-
-Caused by:
-  invalid character `-` in package name: `-42answer`, the first character must be a Unicode XID start character (most letters or `_`)
+[COMPILING] answer v0.0.0 ([ROOT]/foo)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `[..]/debug/answer[EXE]`
 "#,
         )
         .run();
@@ -577,7 +580,7 @@ fn test_name_is_number() {
 [ERROR] failed to parse manifest at `[ROOT]/foo/42.rs`
 
 Caused by:
-  invalid character `-` in package name: `-42`, the first character must be a Unicode XID start character (most letters or `_`)
+  package name cannot be an empty string
 "#,
         )
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -544,6 +544,46 @@ args: []
 }
 
 #[cargo_test]
+fn test_name_has_leading_number() {
+    let script = ECHO_SCRIPT;
+    let p = cargo_test_support::project()
+        .file("42answer.rs", script)
+        .build();
+
+    p.cargo("-Zscript -v 42answer.rs")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stderr(
+            r#"[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[ERROR] failed to parse manifest at `[ROOT]/foo/42answer.rs`
+
+Caused by:
+  invalid character `-` in package name: `-42answer`, the first character must be a Unicode XID start character (most letters or `_`)
+"#,
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_name_is_number() {
+    let script = ECHO_SCRIPT;
+    let p = cargo_test_support::project().file("42.rs", script).build();
+
+    p.cargo("-Zscript -v 42.rs")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stderr(
+            r#"[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[ERROR] failed to parse manifest at `[ROOT]/foo/42.rs`
+
+Caused by:
+  invalid character `-` in package name: `-42`, the first character must be a Unicode XID start character (most letters or `_`)
+"#,
+        )
+        .run();
+}
+
+#[cargo_test]
 fn script_like_dir() {
     let p = cargo_test_support::project()
         .file("script.rs/foo", "something")

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -574,13 +574,16 @@ fn test_name_is_number() {
 
     p.cargo("-Zscript -v 42.rs")
         .masquerade_as_nightly_cargo(&["script"])
-        .with_status(101)
+        .with_stdout(
+            r#"bin: [..]/debug/package[EXE]
+args: []
+"#,
+        )
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[ERROR] failed to parse manifest at `[ROOT]/foo/42.rs`
-
-Caused by:
-  package name cannot be an empty string
+[COMPILING] package v0.0.0 ([ROOT]/foo)
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[RUNNING] `[..]/debug/package[EXE]`
 "#,
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

The sanitization logic uses a placeholder for the first character that isn't valid in the first character position.  #12329 took the approach of always using `_` which has the problem of mixing separators if the user used `-` or we had other placeholders to insert.  Instead, this takes the approach of stripping the leading invalid characters and using a placeholder name if nothing is left.

Fixes #12330

### How should we test and review this PR?

Per-commit.  The first adds tests so the change in behavior can be observed over each additional commit.

### Additional information

I was also hoping to make the binary name not use placeholders by setting `bin.name` to `file_stem` but then I got
```
   Compiling s-h-w-c- v0.0.0 (/home/epage/src/personal/cargo/target/tmp/cit/t133/foo)
error: invalid character `'.'` in crate name: `s_h.w§c!`

error: invalid character `'§'` in crate name: `s_h.w§c!`

error: invalid character `'!'` in crate name: `s_h.w§c!`

error: could not compile `s-h-w-c-` (bin "s-h.w§c!") due to 3 previous errors
```
I decided to not get into what are or aren't valid characters according to rustc.