### PR TITLE
fix(embedded): Error on intentionally unsupported commands 

### DIFF
--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -40,6 +40,13 @@ pub fn cli() -> Command {
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(config)?;
+    if ws.root_maybe().is_embedded() {
+        return Err(anyhow::format_err!(
+            "{} is unsupported by `cargo package`",
+            ws.root_manifest().display()
+        )
+        .into());
+    }
     let specs = args.packages_from_flags()?;
 
     ops::package(

--- a/src/bin/cargo/commands/pkgid.rs
+++ b/src/bin/cargo/commands/pkgid.rs
@@ -15,6 +15,13 @@ pub fn cli() -> Command {
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let ws = args.workspace(config)?;
+    if ws.root_maybe().is_embedded() {
+        return Err(anyhow::format_err!(
+            "{} is unsupported by `cargo pkgid`",
+            ws.root_manifest().display()
+        )
+        .into());
+    }
     if args.is_present_with_zero_values("package") {
         print_available_packages(&ws)?
     }

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -30,6 +30,13 @@ pub fn cli() -> Command {
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let registry = args.registry(config)?;
     let ws = args.workspace(config)?;
+    if ws.root_maybe().is_embedded() {
+        return Err(anyhow::format_err!(
+            "{} is unsupported by `cargo publish`",
+            ws.root_manifest().display()
+        )
+        .into());
+    }
     let index = args.index()?;
 
     ops::publish(

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1182,3 +1182,62 @@ fn cmd_verify_project_with_embedded() {
         )
         .run();
 }
+
+#[cargo_test]
+fn cmd_pkgid_with_embedded() {
+    let p = cargo_test_support::project()
+        .file("script.rs", ECHO_SCRIPT)
+        .build();
+
+    p.cargo("-Zscript pkgid --manifest-path script.rs")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stderr(
+            "\
+[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[ERROR] a Cargo.lock must exist for this command
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn cmd_package_with_embedded() {
+    let p = cargo_test_support::project()
+        .file("script.rs", ECHO_SCRIPT)
+        .build();
+
+    p.cargo("-Zscript package --manifest-path script.rs")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stderr(
+            "\
+[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  no targets specified in the manifest
+  either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn cmd_publish_with_embedded() {
+    let p = cargo_test_support::project()
+        .file("script.rs", ECHO_SCRIPT)
+        .build();
+
+    p.cargo("-Zscript publish --manifest-path script.rs")
+        .masquerade_as_nightly_cargo(&["script"])
+        .with_status(101)
+        .with_stderr(
+            "\
+[WARNING] `package.edition` is unspecifiead, defaulting to `2021`
+[ERROR] `script` cannot be published.
+`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
+",
+        )
+        .run();
+}

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1195,7 +1195,7 @@ fn cmd_pkgid_with_embedded() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[ERROR] a Cargo.lock must exist for this command
+[ERROR] [ROOT]/foo/script.rs is unsupported by `cargo pkgid`
 ",
         )
         .run();
@@ -1213,11 +1213,7 @@ fn cmd_package_with_embedded() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  no targets specified in the manifest
-  either src/lib.rs, src/main.rs, a [lib] section, or [[bin]] section must be present
+[ERROR] [ROOT]/foo/script.rs is unsupported by `cargo package`
 ",
         )
         .run();
@@ -1235,8 +1231,7 @@ fn cmd_publish_with_embedded() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecifiead, defaulting to `2021`
-[ERROR] `script` cannot be published.
-`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
+[ERROR] [ROOT]/foo/script.rs is unsupported by `cargo publish`
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

We had talked about de-prioritizing some commands in the cargo team meeting today.  Looking through `cargo --list` and trying them out, the important ones to defer seemed to be:

- `cargo pkgid` is unsupported because we can't (yet) generate valid
  pkgids for embedded manifests.  Adding support for this would be a
  step towards workspace support
- `cargo package` and `cargo publish` are being deferred.  These would
  be more important for `[lib]` support.  `cargo install` for `[[bin]]`s
  is a small case and As single-file packages are fairly restrictive, a
  `[[bin]]` is a lower priority.

### How should we test and review this PR?

Per-commit
