### PR TITLE
Rustfmt with latest nightly.

### DIFF
--- a/crates/xtask-stale-label/src/main.rs
+++ b/crates/xtask-stale-label/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
 
     for (label, value) in autolabel.iter() {
         let Some(trigger_files) = value.get("trigger_files") else {
-            continue
+            continue;
         };
         let trigger_files = trigger_files.as_array().expect("an array");
         let missing_files: Vec<_> = trigger_files

--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -141,7 +141,7 @@ pub fn certificate_check(
     let Some(host_key) = cert.as_hostkey() else {
         // Return passthrough for TLS X509 certificates to use whatever validation
         // was done in git2.
-        return Ok(CertificateCheckStatus::CertificatePassthrough)
+        return Ok(CertificateCheckStatus::CertificatePassthrough);
     };
     // If a nonstandard port is in use, check for that first.
     // The fallback to check without a port is handled in the HostKeyNotFound handler.
@@ -611,10 +611,18 @@ impl KnownHost {
 }
 
 fn hashed_hostname_matches(host: &str, hashed: &str) -> bool {
-    let Some((b64_salt, b64_host)) = hashed.split_once('|') else { return false; };
-    let Ok(salt) = STANDARD.decode(b64_salt) else { return false; };
-    let Ok(hashed_host) = STANDARD.decode(b64_host) else { return false; };
-    let Ok(mut mac) = hmac::Hmac::<sha1::Sha1>::new_from_slice(&salt) else { return false; };
+    let Some((b64_salt, b64_host)) = hashed.split_once('|') else {
+        return false;
+    };
+    let Ok(salt) = STANDARD.decode(b64_salt) else {
+        return false;
+    };
+    let Ok(hashed_host) = STANDARD.decode(b64_host) else {
+        return false;
+    };
+    let Ok(mut mac) = hmac::Hmac::<sha1::Sha1>::new_from_slice(&salt) else {
+        return false;
+    };
     mac.update(host.as_bytes());
     let result = mac.finalize().into_bytes();
     hashed_host == &result[..]

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -808,7 +808,9 @@ impl<'cfg> Downloads<'cfg> {
     /// Updates the state of the progress bar for downloads.
     fn tick(&self) -> CargoResult<()> {
         let mut progress = self.progress.borrow_mut();
-        let Some(progress) = progress.as_mut() else { return Ok(()); };
+        let Some(progress) = progress.as_mut() else {
+            return Ok(());
+        };
 
         // Since the sparse protocol discovers dependencies as it goes,
         // it's not possible to get an accurate progress indication.

--- a/src/cargo/util/auth/asymmetric.rs
+++ b/src/cargo/util/auth/asymmetric.rs
@@ -73,7 +73,8 @@ pub fn public_token_from_credential(
     source_id: &SourceId,
     mutation: Option<&'_ Mutation<'_>>,
 ) -> CargoResult<Secret<String>> {
-    let RegistryCredentialConfig::AsymmetricKey((secret_key, secret_key_subject)) = credential else {
+    let RegistryCredentialConfig::AsymmetricKey((secret_key, secret_key_subject)) = credential
+    else {
         anyhow::bail!("credential must be an asymmetric secret key")
     };
 

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -207,7 +207,11 @@ impl DocFragment {
         let syn::Meta::NameValue(nv) = &attr.meta else {
             anyhow::bail!("unsupported attr meta for {:?}", attr.meta.path())
         };
-        let syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(lit), .. }) = &nv.value else {
+        let syn::Expr::Lit(syn::ExprLit {
+            lit: syn::Lit::Str(lit),
+            ..
+        }) = &nv.value
+        else {
             anyhow::bail!("only string literals are supported")
         };
         Ok(Self {
@@ -373,16 +377,21 @@ fn unindent_doc_fragments(docs: &mut [DocFragment]) {
     let Some(min_indent) = docs
         .iter()
         .map(|fragment| {
-            fragment.doc.as_str().lines().fold(usize::MAX, |min_indent, line| {
-                if line.chars().all(|c| c.is_whitespace()) {
-                    min_indent
-                } else {
-                    // Compare against either space or tab, ignoring whether they are
-                    // mixed or not.
-                    let whitespace = line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
-                    min_indent.min(whitespace)
-                }
-            })
+            fragment
+                .doc
+                .as_str()
+                .lines()
+                .fold(usize::MAX, |min_indent, line| {
+                    if line.chars().all(|c| c.is_whitespace()) {
+                        min_indent
+                    } else {
+                        // Compare against either space or tab, ignoring whether they are
+                        // mixed or not.
+                        let whitespace =
+                            line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
+                        min_indent.min(whitespace)
+                    }
+                })
         })
         .min()
     else {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2835,7 +2835,9 @@ fn parse_unstable_lints<T: Deserialize<'static>>(
     config: &Config,
     warnings: &mut Vec<String>,
 ) -> CargoResult<Option<T>> {
-    let Some(lints) = lints else { return Ok(None); };
+    let Some(lints) = lints else {
+        return Ok(None);
+    };
 
     if !config.cli_unstable().lints {
         warn_for_lint_feature(config, warnings);
@@ -2878,7 +2880,9 @@ switch to nightly channel you can pass
 }
 
 fn verify_lints(lints: Option<TomlLints>) -> CargoResult<Option<TomlLints>> {
-    let Some(lints) = lints else { return Ok(None); };
+    let Some(lints) = lints else {
+        return Ok(None);
+    };
 
     for (tool, lints) in &lints {
         let supported = ["rust", "clippy", "rustdoc"];


### PR DESCRIPTION
The latest nightly introduced a new version of rustfmt which handles let-else formatting.

These should be compatible with stable formatting.