### PR TITLE
refactor: Clean up package metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bytesize",
- "cargo-platform 0.1.3",
+ "cargo-platform 0.1.4",
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,6 @@ license = "MIT OR Apache-2.0"
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo"
-readme = "README.md"
 description = """
 Cargo, a package manager for Rust.
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ base64 = "0.21.0"
 bytesize = "1.0"
 cargo = { path = "" }
 cargo-credential = { version = "0.2.0", path = "credential/cargo-credential" }
-cargo-platform = { path = "crates/cargo-platform", version = "0.1.3" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.4" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.5", path = "crates/cargo-util" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ exclude = [
   "target/", # exclude bench testing
 ]
 
+[workspace.package]
+edition = "2021"
+
 [workspace.dependencies]
 anyhow = "1.0.47"
 base64 = "0.21.0"
@@ -96,7 +99,7 @@ windows-sys = "0.48"
 [package]
 name = "cargo"
 version = "0.74.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ cargo-credential = { version = "0.2.0", path = "credential/cargo-credential" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.3" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
-cargo-util = { version = "0.2.4", path = "crates/cargo-util" }
+cargo-util = { version = "0.2.5", path = "crates/cargo-util" }
 cargo_metadata = "0.14.0"
 clap = "4.2.0"
 core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anyhow = "1.0.47"
@@ -100,7 +101,7 @@ windows-sys = "0.48"
 name = "cargo"
 version = "0.74.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo"

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchsuite"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -2,7 +2,7 @@
 name = "benchsuite"
 version = "0.0.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 description = "Benchmarking suite for Cargo."

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "capture"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Tool for capturing a real-world workspace for benchmarking."
 publish = false

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -2,7 +2,7 @@
 name = "capture"
 version = "0.1.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "Tool for capturing a real-world workspace for benchmarking."
 publish = false
 

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-platform"
 version = "0.1.3"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo-platform"

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-platform"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-platform"
 version = "0.1.3"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-test-macro"
 version = "0.1.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-test-macro"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-test-support"
 version = "0.1.0"
 license = "MIT OR Apache-2.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [lib]

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-test-support"
 version = "0.1.0"
-license = "MIT OR Apache-2.0"
+license.workspace = true
 edition.workspace = true
 publish = false
 

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-util"
 version = "0.2.4"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-util"
 version = "0.2.4"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 description = "Miscellaneous support code used by Cargo."

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -2,7 +2,7 @@
 name = "crates-io"
 version = "0.37.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = """
 Helpers for interacting with crates.io

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crates-io"
 version = "0.37.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = """

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -11,7 +11,7 @@ include = [
     "/LICENSE-*",
     "/README.md",
 ]
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "Shared definitions of home directories."
 

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -12,7 +12,6 @@ include = [
     "/README.md",
 ]
 license = "MIT OR Apache-2.0"
-readme = "README.md"
 repository = "https://github.com/rust-lang/cargo"
 description = "Shared definitions of home directories."
 

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -3,7 +3,7 @@ name = "home"
 version = "0.5.6" # also update `html_root_url` in `src/lib.rs`
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 documentation = "https://docs.rs/home"
-edition = "2018"
+edition.workspace = true
 include = [
     "/src",
     "/Cargo.toml",

--- a/crates/mdman/Cargo.toml
+++ b/crates/mdman/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mdman"
 version = "0.0.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 description = "Creates a man page page from markdown."
 publish = false
 

--- a/crates/mdman/Cargo.toml
+++ b/crates/mdman/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdman"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 description = "Creates a man page page from markdown."
 publish = false

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "resolver-tests"
 version = "0.0.0"
-edition = "2018"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/semver-check/Cargo.toml
+++ b/crates/semver-check/Cargo.toml
@@ -2,7 +2,7 @@
 name = "semver-check"
 version = "0.0.0"
 authors = ["Eric Huss"]
-edition = "2021"
+edition.workspace = true
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/xtask-build-man/Cargo.toml
+++ b/crates/xtask-build-man/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask-build-man"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/xtask-stale-label/Cargo.toml
+++ b/crates/xtask-stale-label/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask-stale-label"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/crates/xtask-unpublished/Cargo.toml
+++ b/crates/xtask-unpublished/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xtask-unpublished"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-credential-1password"
 version = "0.2.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a 1password vault."

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-credential-1password"
 version = "0.2.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a 1password vault."
 

--- a/credential/cargo-credential-gnome-secret/Cargo.toml
+++ b/credential/cargo-credential-gnome-secret/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-credential-gnome-secret"
 version = "0.2.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with GNOME libsecret."
 

--- a/credential/cargo-credential-gnome-secret/Cargo.toml
+++ b/credential/cargo-credential-gnome-secret/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-credential-gnome-secret"
 version = "0.2.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with GNOME libsecret."

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-credential-macos-keychain"
 version = "0.2.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a macOS keychain."

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-credential-macos-keychain"
 version = "0.2.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a macOS keychain."
 

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-credential-wincred"
 version = "0.2.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with Windows Credential Manager."

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-credential-wincred"
 version = "0.2.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with Windows Credential Manager."
 

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-credential"
 version = "0.2.0"
 edition.workspace = true
-license = "MIT OR Apache-2.0"
+license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A library to assist writing Cargo credential helpers."
 

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cargo-credential"
 version = "0.2.0"
-edition = "2021"
+edition.workspace = true
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rust-lang/cargo"
 description = "A library to assist writing Cargo credential helpers."


### PR DESCRIPTION
### What does this PR try to resolve?

Clean up workspace metadata
- Reduce noise by allowing fields to be inferred
  - I left documentation because that is runtime inferred on crates.io which has trade offs
- Default package fields at the workspace level

Align us on a single edition

### How should we test and review this PR?

Mostly relying on CI for this

### Additional information

I noticed this and decided to do this while I was considering the idea of setting an MSRV to "latest" by leveraging #12341 and whether that should just be for `cargo` or for all workspace members.  I'm leaning towards all workspace members as that is the only thing we test though strictly speaking people might be able to use lower versions; we just wouldn't officially support it.