### PR TITLE
fix(git): respect scp-like URL for nested submodules

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3633,7 +3633,7 @@ fn different_user_relative_submodules() {
             .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file("src/lib.rs", "")
     });
-    let user2_git_project2 = git::new("user2/dep2", |project| {
+    let _user2_git_project2 = git::new("user2/dep2", |project| {
         project
             .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file("src/lib.rs", "")
@@ -3673,14 +3673,14 @@ fn different_user_relative_submodules() {
             "\
 [UPDATING] git repository `{}`
 [UPDATING] git submodule `{}`
-[UPDATING] git submodule `{}`
+[UPDATING] git submodule `{}/../dep2`
 [COMPILING] dep1 v0.5.0 ({}#[..])
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             path2url(&user1_git_project.root()),
             path2url(&user2_git_project.root()),
-            path2url(&user2_git_project2.root()),
+            path2url(&user2_git_project.root()),
             path2url(&user1_git_project.root()),
         ))
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

`parent_remote_url` used to be `&str` before #12244. However, we changed
the type to `Url` and it started failing to parse scp-like URLs since
they are not compliant with WHATWG URL spec.

In this commit, we change it back to `&str` and construct the URL
manually. This should be safe since Cargo already checks if it is a
relative URL for that if branch.

### How should we test and review this PR?

This is current a draft because I had a hard time adding a test around it. 

* Scp-like URL (e.g. `git@github.com:rust-lang/cargo.git`) doesn't accept custom port. In our `container_test` we need to specify a custom port number.
* There seems to be no way to configure a git submodule without cloning the repo. Otherwise we could have configured it and perceived it fail when fetching instead of parsing URL.

To test it, I ended up manually creating a repo with a submodule with scp-like URL.

### Additional information

I feel like this worth a beta backport (we missed the nightly window).

I also feel like it is pretty safe to merge without adding a test if we cannot figure out how to.

Fixes #12295 
<!-- homu-ignore:end -->
