### PR TITLE
Perform atomic write to avoid corrupting files

### DIFF
--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -271,7 +271,10 @@ fn gc_workspace(workspace: &Workspace<'_>) -> CargoResult<()> {
     }
 
     if is_modified {
-        cargo_util::paths::write(workspace.root_manifest(), manifest.to_string().as_bytes())?;
+        cargo_util::paths::atomic_write(
+            workspace.root_manifest(),
+            manifest.to_string().as_bytes(),
+        )?;
     }
 
     Ok(())

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -1047,7 +1047,7 @@ impl RustDocFingerprint {
 
         let fingerprint_path = cx.files().host_root().join(".rustdoc_fingerprint.json");
         let write_fingerprint = || -> CargoResult<()> {
-            paths::write(
+            paths::atomic_write(
                 &fingerprint_path,
                 serde_json::to_string(&actual_rustdoc_target_data)?,
             )

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -536,12 +536,12 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
         // This is also the location where we provide feedback into the build
         // state informing what variables were discovered via our script as
         // well.
-        paths::write(&output_file, &output.stdout)?;
+        paths::atomic_write(&output_file, &output.stdout)?;
         // This mtime shift allows Cargo to detect if a source file was
         // modified in the middle of the build.
         paths::set_file_time_no_err(output_file, timestamp);
-        paths::write(&err_file, &output.stderr)?;
-        paths::write(&root_output_file, paths::path2bytes(&script_out_dir)?)?;
+        paths::atomic_write(&err_file, &output.stderr)?;
+        paths::atomic_write(&root_output_file, paths::path2bytes(&script_out_dir)?)?;
         let parsed_output = BuildOutput::parse(
             &output.stdout,
             library_name,
@@ -966,7 +966,7 @@ fn prepare_metabuild(cx: &Context<'_, '_>, unit: &Unit, deps: &[String]) -> Carg
     let output = output.join("");
     let path = unit.pkg.manifest().metabuild_path(cx.bcx.ws.target_dir());
     paths::create_dir_all(path.parent().unwrap())?;
-    paths::write_if_changed(path, &output)?;
+    paths::atomic_write_if_changed(path, &output)?;
     Ok(())
 }
 

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -483,7 +483,7 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
         // still log the reason for the fingerprint failure instead of just
         // reporting "failed to read fingerprint" during the next build if
         // this build fails.
-        paths::write(&loc, b"")?;
+        paths::atomic_write(&loc, b"")?;
     }
 
     let write_fingerprint = if unit.mode.is_run_custom_build() {
@@ -1696,14 +1696,14 @@ fn write_fingerprint(loc: &Path, fingerprint: &Fingerprint) -> CargoResult<()> {
     // as we can use the full hash.
     let hash = fingerprint.hash_u64();
     debug!("write fingerprint ({:x}) : {}", hash, loc.display());
-    paths::write(loc, util::to_hex(hash).as_bytes())?;
+    paths::atomic_write(loc, util::to_hex(hash).as_bytes())?;
 
     let json = serde_json::to_string(fingerprint).unwrap();
     if cfg!(debug_assertions) {
         let f: Fingerprint = serde_json::from_str(&json).unwrap();
         assert_eq!(f.hash_u64(), hash);
     }
-    paths::write(&loc.with_extension("json"), json.as_bytes())?;
+    paths::atomic_write(&loc.with_extension("json"), json.as_bytes())?;
     Ok(())
 }
 
@@ -2019,7 +2019,7 @@ pub fn translate_dep_info(
         };
         on_disk_info.files.push((ty, path.to_owned()));
     }
-    paths::write(cargo_dep_info, on_disk_info.serialize()?)?;
+    paths::atomic_write(cargo_dep_info, on_disk_info.serialize()?)?;
     Ok(())
 }
 

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -836,7 +836,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
         }
     }
 
-    paths::write(&manifest_path, manifest.to_string())?;
+    paths::atomic_write(&manifest_path, manifest.to_string())?;
 
     // Create all specified source files (with respective parent directories) if they don't exist.
     for i in &opts.source_files {
@@ -872,7 +872,7 @@ mod tests {
         };
 
         if !path_of_source_file.is_file() {
-            paths::write(&path_of_source_file, default_file_content)?;
+            paths::atomic_write(&path_of_source_file, default_file_content)?;
 
             // Format the newly created source file
             if let Err(e) = cargo_util::ProcessBuilder::new("rustfmt")

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -420,7 +420,7 @@ pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
             if config.get_env_os(BROKEN_CODE_ENV_INTERNAL).is_none() {
                 for (path, file) in fixes.files.iter() {
                     debug!("reverting {:?} due to errors", path);
-                    paths::write(path, &file.original_code)?;
+                    paths::atomic_write(path, &file.original_code)?;
                 }
             }
 
@@ -703,7 +703,7 @@ fn rustfix_and_fix(
             }
         }
         let new_code = fixed.finish()?;
-        paths::write(&file, new_code)?;
+        paths::atomic_write(&file, new_code)?;
     }
 
     Ok(())

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -235,7 +235,7 @@ fn sync(
             "files": map,
         });
 
-        paths::write(&cksum, json.to_string())?;
+        paths::atomic_write(&cksum, json.to_string())?;
     }
 
     for path in to_remove {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -286,7 +286,7 @@ impl Drop for Cache {
         }
         if let Some(ref path) = self.cache_location {
             let json = serde_json::to_string(&self.data).unwrap();
-            match paths::write(path, json.as_bytes()) {
+            match paths::atomic_write(path, json.as_bytes()) {
                 Ok(()) => info!("updated rustc info cache"),
                 Err(e) => warn!("failed to update rustc info cache: {}", e),
             }

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -296,7 +296,7 @@ impl LocalManifest {
         let s = self.manifest.data.to_string();
         let new_contents_bytes = s.as_bytes();
 
-        cargo_util::paths::write(&self.path, new_contents_bytes)
+        cargo_util::paths::atomic_write(&self.path, new_contents_bytes)
     }
 
     /// Lookup a dependency.

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -58,7 +58,7 @@ fn default_registry_configured() {
     // --registry is not used.
     let cargo_home = paths::home().join(".cargo");
     cargo_home.mkdir_p();
-    cargo_util::paths::write(
+    cargo_util::paths::atomic_write(
         &cargo_home.join("config.toml"),
         r#"
             [registry]
@@ -69,7 +69,7 @@ fn default_registry_configured() {
         "#,
     )
     .unwrap();
-    cargo_util::paths::write(
+    cargo_util::paths::atomic_write(
         &cargo_home.join("credentials.toml"),
         r#"
         [registry]


### PR DESCRIPTION
Fix #11386 with @epage's suggestion, atomic writes.

Instead of applying the fix just to `cargo-add`, I applied it to everything, we might want to review each specific case to tell if cases.