### PR TITLE
Replace invalid `panic_unwind` std feature with `panic-unwind`

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -399,7 +399,7 @@ the tracking repository, and if it's not there please file a new issue!
 This flag is a sibling to the `-Zbuild-std` feature flag. This will configure
 the features enabled for the standard library itself when building the standard
 library. The default enabled features, at this time, are `backtrace` and
-`panic_unwind`. This flag expects a comma-separated list and, if provided, will
+`panic-unwind`. This flag expects a comma-separated list and, if provided, will
 override the default list of features enabled.
 
 ### binary-dep-depinfo


### PR DESCRIPTION
### What does this PR try to resolve?

The documentation for the unstable `build-std-features` flag mentions that a default-enabled feature for `std` is `panic_unwind`. However, as of 2023-07-16, that feature does not even exist in the latest nightlies:

![Cargo error shown when trying to use the `panic_unwind` feature](https://github.com/rust-lang/cargo/assets/7822554/daeec810-0cd9-4a6d-ab54-a6336704cc08)

[The `std` `Cargo.toml`](https://github.com/rust-lang/rust/blob/master/library/std/Cargo.toml#L54-L79) does not contain the `panic_unwind` feature either, but it defines a `panic-unwind` feature, which works as intended with the `build-std-features` flag.

Therefore, let's update the documentation to refer to the intended feature instead, which improves its accuracy and reduces developer time waste.

### How should we test and review this PR?

Run e.g. `cargo build --release -Z build-std -Z build-std-features=panic-unwind --target x86_64-unknown-linux-gnu` instead of `cargo build --release -Z build-std -Z build-std-features=panic_unwind --target x86_64-unknown-linux-gnu`, and watch how the first one works as intended but the second one just shows an error.