### PR TITLE
fix: only skip mtime check on `~/.cargo/{git,registry}`

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1857,14 +1857,27 @@ where
         Err(..) => return Some(StaleItem::MissingFile(reference.to_path_buf())),
     };
 
+    let skipable_dirs = if let Ok(cargo_home) = home::cargo_home() {
+        let skipable_dirs: Vec<_> = ["git", "registry"]
+            .into_iter()
+            .map(|subfolder| cargo_home.join(subfolder))
+            .collect();
+        Some(skipable_dirs)
+    } else {
+        None
+    };
+
     for path in paths {
         let path = path.as_ref();
 
-        // Assuming anything in cargo_home is immutable (see also #9455 about marking it readonly)
-        // which avoids rebuilds when CI caches $CARGO_HOME/registry/{index, cache} and
-        // $CARGO_HOME/git/db across runs, keeping the content the same but changing the mtime.
-        if let Ok(true) = home::cargo_home().map(|home| path.starts_with(home)) {
-            continue;
+        // Assuming anything in cargo_home/{git, registry} is immutable
+        // (see also #9455 about marking the src directory readonly) which avoids rebuilds when CI
+        // caches $CARGO_HOME/registry/{index, cache} and $CARGO_HOME/git/db across runs, keeping
+        // the content the same but changing the mtime.
+        if let Some(ref skipable_dirs) = skipable_dirs {
+            if skipable_dirs.iter().any(|dir| path.starts_with(dir)) {
+                continue;
+            }
         }
         let path_mtime = match mtime_cache.entry(path.to_path_buf()) {
             Entry::Occupied(o) => *o.get(),


### PR DESCRIPTION
Fixes #12090

Make cargo only skip mtime checks on `$CARGO_HOME/{git, registry}`.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
