### PR TITLE
Update docs for artifact JSON debuginfo levels.

### DIFF
--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -159,7 +159,8 @@ following structure:
     "profile": {
         /* The optimization level. */
         "opt_level": "0",
-        /* The debug level, an integer of 0, 1, or 2. If `null`, it implies
+        /* The debug level, an integer of 0, 1, or 2, or a string
+           "line-directives-only" or "line-tables-only". If `null`, it implies
            rustc's default of 0.
         */
         "debuginfo": 2,


### PR DESCRIPTION
String-based debuginfo levels were added in #11958, but the documentation wasn't updated to reflect that.
