### PR TITLE
fix: Set MSRV for internal packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,33 @@
   ignorePaths: [
     "**/tests/**",
   ],
+  regexManagers: [
+    {
+      customType: 'regex',
+      fileMatch: [
+        '^Cargo.toml$',
+      ],
+      matchStrings: [
+        'rust-version.*?(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
+      ],
+      depNameTemplate: 'latest-msrv',
+      packageNameTemplate: 'rust-lang/rust',
+      datasourceTemplate: 'github-releases',
+    },
+  ],
   packageRules: [
+    {
+      commitMessageTopic: 'Latest MSRV',
+      matchManagers: [
+        'regex',
+      ],
+      matchPackageNames: [
+        'latest-msrv',
+      ],
+      schedule: [
+        '* * * * *',
+      ],
+    },
     // Goals:
     // - Rollup safe upgrades to reduce CI runner load
     // - Have lockfile and manifest in-sync (implicit rules)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "core-foundation",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.38.0"
+version = "0.38.1"
 dependencies = [
  "curl",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
+rust-version = "1.71.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "benchsuite"
 version = "0.0.0"
+rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "capture"
 version = "0.1.0"
+rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Tool for capturing a real-world workspace for benchmarking."

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cargo-test-macro"
 version = "0.1.0"
+rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cargo-test-support"
 version = "0.1.0"
+rust-version.workspace = true
 license.workspace = true
 edition.workspace = true
 publish = false

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cargo-util"
-version = "0.2.6"
+version = "0.2.7"
+rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "crates-io"
-version = "0.38.0"
+version = "0.38.1"
+rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"

--- a/crates/mdman/Cargo.toml
+++ b/crates/mdman/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "mdman"
 version = "0.0.0"
+rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Creates a man page page from markdown."

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "resolver-tests"
 version = "0.0.0"
+rust-version.workspace = true
 edition.workspace = true
 publish = false
 

--- a/crates/semver-check/Cargo.toml
+++ b/crates/semver-check/Cargo.toml
@@ -2,6 +2,7 @@
 name = "semver-check"
 version = "0.0.0"
 authors = ["Eric Huss"]
+rust-version.workspace = true
 edition.workspace = true
 publish = false
 

--- a/crates/xtask-build-man/Cargo.toml
+++ b/crates/xtask-build-man/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "xtask-build-man"
 version = "0.0.0"
+rust-version.workspace = true
 edition.workspace = true
 publish = false
 

--- a/crates/xtask-bump-check/Cargo.toml
+++ b/crates/xtask-bump-check/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "xtask-bump-check"
 version = "0.0.0"
+rust-version.workspace = true
 edition.workspace = true
 publish = false
 

--- a/crates/xtask-stale-label/Cargo.toml
+++ b/crates/xtask-stale-label/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "xtask-stale-label"
 version = "0.0.0"
+rust-version.workspace = true
 edition.workspace = true
 publish = false
 


### PR DESCRIPTION
### What does this PR try to resolve?

Correctly communicates the MSRV we support to our users.

For packages that are more generally mean to be used by other people, I've punted on for now (see ehuss' comment on this PR).  We'll likely need to figure this out for #12432 though

### Additional information

This is prep for a future change which will have us use a fixed rust version for the semver tests with a PR updating them.