### PR TITLE
docs: raise awareness of resolver used inside workspace

### DIFF
--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -94,7 +94,6 @@ the workspace:
 [workspace]
 members = ["member1", "path/to/member2", "crates/*"]
 exclude = ["crates/foo", "path/to/other"]
-resolver = "2"
 ```
 
 All [`path` dependencies] residing in the workspace directory automatically
@@ -136,7 +135,6 @@ used:
 [workspace]
 members = ["path/to/member1", "path/to/member2", "path/to/member3/*"]
 default-members = ["path/to/member2", "path/to/member3/foo"]
-resolver = "2"
 ```
 
 When specified, `default-members` must expand to a subset of `members`.
@@ -168,7 +166,6 @@ Example:
 # [PROJECT_DIR]/Cargo.toml
 [workspace]
 members = ["bar"]
-resolver = "2"
 
 [workspace.package]
 version = "1.2.3"
@@ -203,7 +200,6 @@ Example:
 # [PROJECT_DIR]/Cargo.toml
 [workspace]
 members = ["bar"]
-resolver = "2"
 
 [workspace.dependencies]
 cc = "1.0.73"
@@ -236,7 +232,6 @@ configuration in `Cargo.toml`. For example:
 ```toml
 [workspace]
 members = ["member1", "member2"]
-resolver = "2"
 
 [workspace.metadata.webcontents]
 root = "path/to/webproject"

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -49,7 +49,6 @@ where the workspace's `Cargo.toml` is located.
 
 ```toml
 [workspace]
-resolver = "2"
 
 [package]
 name = "hello_world" # the name of the package

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -39,9 +39,6 @@ To create a workspace, you add the `[workspace]` table to a `Cargo.toml`:
 
 At minimum, a workspace has to have a member, either with a root package or as
 a virtual manifest.
-It's also a good practice to specify the `resolver = "2"` unless it is necessary
-to rely on the old one. It is a default resolver for all packages in the `2021` edition
-but it has to be explicitely set under the workspace.
 
 #### Root package
 
@@ -79,8 +76,14 @@ resolver = "2"
 [package]
 name = "hello_world" # the name of the package
 version = "0.1.0"    # the current version, obeying semver
+edition = "2021"     # the edition, will have no effect on a resolver used in the workspace
 authors = ["Alice <a@example.com>", "Bob <b@example.com>"]
 ```
+
+Note that in a virtual manifest the [`resolver = "2"`](resolver.md#resolver-versions)
+should be specified manually. It is usually deduced from the [`package.edition`][package-edition]
+field which is absent in virtual manifests and the edition field of a member
+won't affect the resolver used by the workspace.
 
 ### The `members` and `exclude` fields 
 
@@ -251,6 +254,7 @@ if that makes sense for the tool in question.
 [package]: manifest.md#the-package-section
 [`Cargo.lock`]: ../guide/cargo-toml-vs-cargo-lock.md
 [package-metadata]: manifest.md#the-metadata-table
+[package-edition]: manifest.md#the-edition-field
 [output directory]: ../guide/build-cache.md
 [patch]: overriding-dependencies.md#the-patch-section
 [replace]: overriding-dependencies.md#the-replace-section

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -39,6 +39,9 @@ To create a workspace, you add the `[workspace]` table to a `Cargo.toml`:
 
 At minimum, a workspace has to have a member, either with a root package or as
 a virtual manifest.
+It's also a good practice to specify the `resolver = "2"` unless it is necessary
+to rely on the old one. It is a default resolver for all packages in the `2021` edition
+but it has to be explicitely set under the workspace.
 
 #### Root package
 
@@ -49,6 +52,7 @@ where the workspace's `Cargo.toml` is located.
 
 ```toml
 [workspace]
+resolver = "2"
 
 [package]
 name = "hello_world" # the name of the package
@@ -67,6 +71,7 @@ you want to keep all the packages organized in separate directories.
 # [PROJECT_DIR]/Cargo.toml
 [workspace]
 members = ["hello_world"]
+resolver = "2"
 ```
 
 ```toml
@@ -86,6 +91,7 @@ the workspace:
 [workspace]
 members = ["member1", "path/to/member2", "crates/*"]
 exclude = ["crates/foo", "path/to/other"]
+resolver = "2"
 ```
 
 All [`path` dependencies] residing in the workspace directory automatically
@@ -127,6 +133,7 @@ used:
 [workspace]
 members = ["path/to/member1", "path/to/member2", "path/to/member3/*"]
 default-members = ["path/to/member2", "path/to/member3/foo"]
+resolver = "2"
 ```
 
 When specified, `default-members` must expand to a subset of `members`.
@@ -158,6 +165,7 @@ Example:
 # [PROJECT_DIR]/Cargo.toml
 [workspace]
 members = ["bar"]
+resolver = "2"
 
 [workspace.package]
 version = "1.2.3"
@@ -192,6 +200,7 @@ Example:
 # [PROJECT_DIR]/Cargo.toml
 [workspace]
 members = ["bar"]
+resolver = "2"
 
 [workspace.dependencies]
 cc = "1.0.73"
@@ -224,6 +233,7 @@ configuration in `Cargo.toml`. For example:
 ```toml
 [workspace]
 members = ["member1", "member2"]
+resolver = "2"
 
 [workspace.metadata.webcontents]
 root = "path/to/webproject"


### PR DESCRIPTION
Workspaces by default use the resolver in version 1. It's been some time already since the 2021 edition which made version 2 a default for alone packages, but yet most of the projects that make a use of the workspaces still depends on  an old resolver.

By being explicit about the resolver tag inside the workspace we can lower the usage of older resolver for the new projects.

This can raise the awareness of this behavior and prevent issues like https://github.com/rust-lang/cargo/issues/12387. I also wasn't aware of this behavior before while not being so new to Rust, and we have the resolver 2 for good reasons, so I think we should be more explicit about it in the documentation.
When someone looks for the 'how to make cargo workspace' answers, he's unlikely to get to the `Dependency Resolution` section at the same time, he'll likely just copy paste the workspace example from the `Workspaces` and call it a day, yet extending the usage of an old resolver and not benefiting from the new one.