### PR TITLE
fix(cargo-credential): should enable feature `serde/derive`

### DIFF
--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -7,6 +7,6 @@ repository = "https://github.com/rust-lang/cargo"
 description = "A library to assist writing Cargo credential helpers."
 
 [dependencies]
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 time.workspace = true


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This is detected during the integration of `cargo-semver-checks` in #12395.

`cargo-credential`, as a independent library, should enable `derive` feature in `serde`. Otherwise people cannot run `cargo b -p cargo-credential` or `cargo doc -p cargo-credential` since Cargo can't find the required macros.

### How should we test and review this PR?

Run `cargo b -p cargo-credential` with and without this commit.
<!-- homu-ignore:end -->
