### PR TITLE
Update curl-sys to pull in curl 8.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.63+curl-8.1.2"
+version = "0.4.64+curl-8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb0fef7046022a1e2ad67a004978f0e3cacb9e3123dc62ce768f92197b771dc"
+checksum = "f96069f0b1cb1241c838740659a771ef143363f52772a9ce1bd9c04c75eee0dc"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.38.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
-curl-sys = "0.4.63"
+curl-sys = "0.4.64"
 env_logger = "0.10.0"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }


### PR DESCRIPTION
This is a routine update to curl-sys 0.4.64, updating curl from 8.1.2 to 8.2.0.
Changelog: https://curl.se/changes.html#8_2_0
