### PR TITLE
chore: update `home` to 0.5.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "windows-sys 0.48.0",
 ]

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "home"
-version = "0.5.6" # also update `html_root_url` in `src/lib.rs`
+version = "0.5.7" # also update `html_root_url` in `src/lib.rs`
 authors = ["Brian Anderson <andersrb@gmail.com>"]
 documentation = "https://docs.rs/home"
 edition.workspace = true


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This was caught by #12395.

Home has been bumped on beta. On nightly we got more changes but failed to detect the required version bump.
<!-- homu-ignore:end -->
