### PR TITLE
Update curl-sys to pull in curl 8.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.64+curl-8.2.0"
+version = "0.4.65+curl-8.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96069f0b1cb1241c838740659a771ef143363f52772a9ce1bd9c04c75eee0dc"
+checksum = "961ba061c9ef2fe34bbd12b807152d96f0badd2bebe7b90ce6c8c8b7572a0986"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.38.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
-curl-sys = "0.4.64"
+curl-sys = "0.4.65"
 env_logger = "0.10.0"
 filetime = "0.2.9"
 flate2 = { version = "1.0.3", default-features = false, features = ["zlib"] }


### PR DESCRIPTION
There were several regressions in 8.2.0. I'm not certain how much they affect cargo, but some of them look concerning.
Changelog: https://curl.se/changes.html#8_2_1
Summary: https://daniel.haxx.se/blog/2023/07/26/curl-8-2-1/
