### PR TITLE
fix: normalize relative git submodule urls with `ssh://`

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3633,7 +3633,7 @@ fn different_user_relative_submodules() {
             .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file("src/lib.rs", "")
     });
-    let _user2_git_project2 = git::new("user2/dep2", |project| {
+    let user2_git_project2 = git::new("user2/dep2", |project| {
         project
             .file("Cargo.toml", &basic_lib_manifest("dep1"))
             .file("src/lib.rs", "")
@@ -3673,14 +3673,14 @@ fn different_user_relative_submodules() {
             "\
 [UPDATING] git repository `{}`
 [UPDATING] git submodule `{}`
-[UPDATING] git submodule `{}/../dep2`
+[UPDATING] git submodule `{}`
 [COMPILING] dep1 v0.5.0 ({}#[..])
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
             path2url(&user1_git_project.root()),
             path2url(&user2_git_project.root()),
-            path2url(&user2_git_project.root()),
+            path2url(&user2_git_project2.root()),
             path2url(&user1_git_project.root()),
         ))
         .run();


### PR DESCRIPTION

<!-- homu-ignore:start -->

### What does this PR try to resolve?

Git only assumes a URL is a relative path if it starts with `./` or `../`.
See <https://git-scm.com/docs/git-submodule>. To fetch the current repo,
we need to construct the complete submodule URL.

At this moment it comes with some limitations:

* GitHub doesn't accept non-normalized URLs wth relative paths.
  (`ssh://git@github.com/rust-lang/cargo.git/relative/..` is invalid)
* `url` crate cannot parse SCP-like URLs.
  (`git@github.com:rust-lang/cargo.git` is not a valid WHATWG URL)

To overcome these, this patch always tries `url` first to normalize the
path. If it couldn't, append the relative path as the last resort and
pray the remote git service supports non-normalized URLs.



### How should we test and review this PR?

I did testing by hand. Not sure how to construct a proper test around it.

cc @ehuss if you can help with this. I am a bit lost.

## Additional information

See rust-lang/cargo#12404 and rust-lang/cargo#12295.

Fixes #12404.

I'd like to nominate this as a beta backport (again 😂).
<!-- homu-ignore:end -->
