### PR TITLE
test: relax help text assertion

### DIFF
--- a/tests/testsuite/cargo/help/stdout.log
+++ b/tests/testsuite/cargo/help/stdout.log
@@ -1,7 +1,7 @@
 Rust's package manager
 
-Usage: cargo [+toolchain] [OPTIONS] [COMMAND]
-       cargo [+toolchain] [OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
+Usage: cargo [..][OPTIONS] [COMMAND]
+       cargo [..][OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
 
 Options:
   -h, --help                Print help


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

When running test in rust-lang/rust via `./x test src/tool/cargo`, there is no rustup integrated.

### How should we test and review this PR?

Update the submodule and run `./x test src/tool/cargo` in rust-lang/rust repo.
<!-- homu-ignore:end -->
