### PR TITLE
fix: align `cargo --help` text

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -518,7 +518,7 @@ pub fn cli() -> Command {
     let usage = if is_rustup {
         "cargo [+toolchain] [OPTIONS] [COMMAND]\n       cargo [+toolchain] [OPTIONS] -Zscript <MANIFEST_RS> [ARGS]..."
     } else {
-        "cargo [OPTIONS] [COMMAND]\n       cargo [OPTIONS] -Zscript <MANIFEST> [ARGS]..."
+        "cargo [OPTIONS] [COMMAND]\n       cargo [OPTIONS] -Zscript <MANIFEST_RS> [ARGS]..."
     };
     Command::new("cargo")
         // Subcommands all count their args' display order independently (from 0),


### PR DESCRIPTION
<!-- homu-ignore:start -->
Too caseless of me. #12416 didn't fix them all.

The two help texts should be aligned after this PR.

To test this, change the value of `is_rustup` and run `cargo t --test testsuite cargo::help`.
<!-- homu-ignore:end -->
