### PR TITLE
Support dependencies from registries for artifact dependencies, take 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "curl",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ cargo-util = { version = "0.2.6", path = "crates/cargo-util" }
 cargo_metadata = "0.14.0"
 clap = "4.3.23"
 core-foundation = { version = "0.9.3", features = ["mac_os_10_7_support"] }
-crates-io = { version = "0.38.0", path = "crates/crates-io" }
+crates-io = { version = "0.39.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
 curl-sys = "0.4.65"

--- a/benches/benchsuite/benches/resolve.rs
+++ b/benches/benchsuite/benches/resolve.rs
@@ -25,7 +25,7 @@ struct ResolveInfo<'cfg> {
 fn do_resolve<'cfg>(config: &'cfg Config, ws_root: &Path) -> ResolveInfo<'cfg> {
     let requested_kinds = [CompileKind::Host];
     let ws = Workspace::new(&ws_root.join("Cargo.toml"), config).unwrap();
-    let target_data = RustcTargetData::new(&ws, &requested_kinds).unwrap();
+    let mut target_data = RustcTargetData::new(&ws, &requested_kinds).unwrap();
     let cli_features = CliFeatures::from_command_line(&[], false, true).unwrap();
     let pkgs = cargo::ops::Packages::Default;
     let specs = pkgs.to_package_id_specs(&ws).unwrap();
@@ -35,7 +35,7 @@ fn do_resolve<'cfg>(config: &'cfg Config, ws_root: &Path) -> ResolveInfo<'cfg> {
     // not confuse criterion's warmup.
     let ws_resolve = cargo::ops::resolve_ws_with_opts(
         &ws,
-        &target_data,
+        &mut target_data,
         &requested_kinds,
         &cli_features,
         &specs,

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.38.1"
+version = "0.39.0"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -73,6 +73,16 @@ pub struct NewCrateDependency {
     pub registry: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub explicit_name_in_toml: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bindep_target: Option<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub lib: bool,
+}
+
+fn is_false(x: &bool) -> bool {
+    *x == false
 }
 
 #[derive(Deserialize)]

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -948,7 +948,7 @@ impl<'cfg> RustcTargetData<'cfg> {
     }
 
     /// Insert `kind` into our `target_info` and `target_config` members if it isn't present yet.
-    fn merge_compile_kind(&mut self, kind: CompileKind) -> CargoResult<()> {
+    pub fn merge_compile_kind(&mut self, kind: CompileKind) -> CargoResult<()> {
         if let CompileKind::Target(target) = kind {
             if !self.target_config.contains_key(&target) {
                 self.target_config

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -62,7 +62,7 @@ pub(crate) fn std_crates(config: &Config, units: Option<&[Unit]>) -> Option<Vec<
 /// Resolve the standard library dependencies.
 pub fn resolve_std<'cfg>(
     ws: &Workspace<'cfg>,
-    target_data: &RustcTargetData<'cfg>,
+    target_data: &mut RustcTargetData<'cfg>,
     build_config: &BuildConfig,
     crates: &[String],
 ) -> CargoResult<(PackageSet<'cfg>, Resolve, ResolvedFeatures)> {

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -45,7 +45,7 @@ use crate::core::resolver::{Resolve, ResolveBehavior};
 use crate::core::{FeatureValue, PackageId, PackageIdSpec, PackageSet, Workspace};
 use crate::util::interning::InternedString;
 use crate::util::CargoResult;
-use anyhow::bail;
+use anyhow::{bail, Context};
 use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
@@ -871,8 +871,11 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                                 // not all targets may be queried before resolution since artifact dependencies
                                 // and per-pkg-targets are not immediately known.
                                 let mut activate_target = |target| {
+                                    let name = dep.name_in_toml();
                                     self.target_data
                                         .merge_compile_kind(CompileKind::Target(target))
+                                        .with_context(|| format!("failed to determine target information for target `{target}`.\n  \
+                                        Artifact dependency `{name}` in package `{pkg_id}` requires building for `{target}`", target = target.rustc_target()))
                                 };
                                 CargoResult::Ok((
                                     artifact.is_lib(),

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -46,6 +46,7 @@ use crate::core::{FeatureValue, PackageId, PackageIdSpec, PackageSet, Workspace}
 use crate::util::interning::InternedString;
 use crate::util::CargoResult;
 use anyhow::bail;
+use itertools::Itertools;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
 
@@ -408,7 +409,7 @@ pub type DiffMap = BTreeMap<PackageFeaturesKey, BTreeSet<InternedString>>;
 /// [module-level documentation]: crate::core::resolver::features
 pub struct FeatureResolver<'a, 'cfg> {
     ws: &'a Workspace<'cfg>,
-    target_data: &'a RustcTargetData<'cfg>,
+    target_data: &'a mut RustcTargetData<'cfg>,
     /// The platforms to build for, requested by the user.
     requested_targets: &'a [CompileKind],
     resolve: &'a Resolve,
@@ -445,7 +446,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
     /// with the result.
     pub fn resolve(
         ws: &Workspace<'cfg>,
-        target_data: &RustcTargetData<'cfg>,
+        target_data: &'a mut RustcTargetData<'cfg>,
         resolve: &Resolve,
         package_set: &'a PackageSet<'cfg>,
         cli_features: &CliFeatures,
@@ -544,7 +545,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
             // features that enable other features.
             return Ok(());
         }
-        for (dep_pkg_id, deps) in self.deps(pkg_id, fk) {
+        for (dep_pkg_id, deps) in self.deps(pkg_id, fk)? {
             for (dep, dep_fk) in deps {
                 if dep.is_optional() {
                     // Optional dependencies are enabled in `activate_fv` when
@@ -647,7 +648,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
             .deferred_weak_dependencies
             .remove(&(pkg_id, fk, dep_name));
         // Activate the optional dep.
-        for (dep_pkg_id, deps) in self.deps(pkg_id, fk) {
+        for (dep_pkg_id, deps) in self.deps(pkg_id, fk)? {
             for (dep, dep_fk) in deps {
                 if dep.name_in_toml() != dep_name {
                     continue;
@@ -681,7 +682,7 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
         dep_feature: InternedString,
         weak: bool,
     ) -> CargoResult<()> {
-        for (dep_pkg_id, deps) in self.deps(pkg_id, fk) {
+        for (dep_pkg_id, deps) in self.deps(pkg_id, fk)? {
             for (dep, dep_fk) in deps {
                 if dep.name_in_toml() != dep_name {
                     continue;
@@ -777,12 +778,17 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
 
     /// Returns the dependencies for a package, filtering out inactive targets.
     fn deps(
-        &self,
+        &mut self,
         pkg_id: PackageId,
         fk: FeaturesFor,
-    ) -> Vec<(PackageId, Vec<(&'a Dependency, FeaturesFor)>)> {
+    ) -> CargoResult<Vec<(PackageId, Vec<(&'a Dependency, FeaturesFor)>)>> {
         // Helper for determining if a platform is activated.
-        let platform_activated = |dep: &Dependency| -> bool {
+        fn platform_activated(
+            dep: &Dependency,
+            fk: FeaturesFor,
+            target_data: &RustcTargetData<'_>,
+            requested_targets: &[CompileKind],
+        ) -> bool {
             // We always count platforms as activated if the target stems from an artifact
             // dependency's target specification. This triggers in conjunction with
             // `[target.'cfg(…)'.dependencies]` manifest sections.
@@ -791,18 +797,17 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                     // We always care about build-dependencies, and they are always
                     // Host. If we are computing dependencies "for a build script",
                     // even normal dependencies are host-only.
-                    self.target_data
-                        .dep_platform_activated(dep, CompileKind::Host)
+                    target_data.dep_platform_activated(dep, CompileKind::Host)
                 }
-                (_, FeaturesFor::NormalOrDev) => self
-                    .requested_targets
+                (_, FeaturesFor::NormalOrDev) => requested_targets
                     .iter()
-                    .any(|kind| self.target_data.dep_platform_activated(dep, *kind)),
-                (_, FeaturesFor::ArtifactDep(target)) => self
-                    .target_data
-                    .dep_platform_activated(dep, CompileKind::Target(target)),
+                    .any(|kind| target_data.dep_platform_activated(dep, *kind)),
+                (_, FeaturesFor::ArtifactDep(target)) => {
+                    target_data.dep_platform_activated(dep, CompileKind::Target(target))
+                }
             }
-        };
+        }
+
         self.resolve
             .deps(pkg_id)
             .map(|(dep_id, deps)| {
@@ -811,7 +816,12 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                     .filter(|dep| {
                         if dep.platform().is_some()
                             && self.opts.ignore_inactive_targets
-                            && !platform_activated(dep)
+                            && !platform_activated(
+                                dep,
+                                fk,
+                                self.target_data,
+                                self.requested_targets,
+                            )
                         {
                             return false;
                         }
@@ -820,7 +830,9 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                         }
                         true
                     })
-                    .flat_map(|dep| {
+                    .collect_vec() // collect because the next closure mutably borrows `self.target_data`
+                    .into_iter()
+                    .map(|dep| {
                         // Each `dep`endency can be built for multiple targets. For one, it
                         // may be a library target which is built as initially configured
                         // by `fk`. If it appears as build dependency, it must be built
@@ -852,28 +864,49 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                         };
 
                         // `artifact_target_keys` are produced to fulfil the needs of artifacts that have a target specification.
-                        let artifact_target_keys = dep.artifact().map(|artifact| {
-                            (
-                                artifact.is_lib(),
-                                artifact.target().map(|target| match target {
-                                    ArtifactTarget::Force(target) => {
-                                        vec![FeaturesFor::ArtifactDep(target)]
-                                    }
-                                    ArtifactTarget::BuildDependencyAssumeTarget => self
-                                        .requested_targets
-                                        .iter()
-                                        .map(|kind| match kind {
-                                            CompileKind::Host => {
-                                                let host_triple = self.target_data.rustc.host;
-                                                CompileTarget::new(&host_triple).unwrap()
-                                            }
-                                            CompileKind::Target(target) => *target,
+                        let artifact_target_keys = dep
+                            .artifact()
+                            .map(|artifact| {
+                                let host_triple = self.target_data.rustc.host;
+                                // not all targets may be queried before resolution since artifact dependencies
+                                // and per-pkg-targets are not immediately known.
+                                let mut activate_target = |target| {
+                                    self.target_data
+                                        .merge_compile_kind(CompileKind::Target(target))
+                                };
+                                CargoResult::Ok((
+                                    artifact.is_lib(),
+                                    artifact
+                                        .target()
+                                        .map(|target| {
+                                            CargoResult::Ok(match target {
+                                                ArtifactTarget::Force(target) => {
+                                                    activate_target(target)?;
+                                                    vec![FeaturesFor::ArtifactDep(target)]
+                                                }
+                                                // FIXME: this needs to interact with the `default-target` and `forced-target` values
+                                                // of the dependency
+                                                ArtifactTarget::BuildDependencyAssumeTarget => self
+                                                    .requested_targets
+                                                    .iter()
+                                                    .map(|kind| match kind {
+                                                        CompileKind::Host => {
+                                                            CompileTarget::new(&host_triple)
+                                                                .unwrap()
+                                                        }
+                                                        CompileKind::Target(target) => *target,
+                                                    })
+                                                    .map(|target| {
+                                                        activate_target(target)?;
+                                                        Ok(FeaturesFor::ArtifactDep(target))
+                                                    })
+                                                    .collect::<CargoResult<_>>()?,
+                                            })
                                         })
-                                        .map(FeaturesFor::ArtifactDep)
-                                        .collect(),
-                                }),
-                            )
-                        });
+                                        .transpose()?,
+                                ))
+                            })
+                            .transpose()?;
 
                         let dep_fks = match artifact_target_keys {
                             // The artifact is also a library and does specify custom
@@ -893,12 +926,13 @@ impl<'a, 'cfg> FeatureResolver<'a, 'cfg> {
                             // Use the standard feature key without any alteration.
                             Some((_, None)) | None => vec![lib_fk],
                         };
-                        dep_fks.into_iter().map(move |dep_fk| (dep, dep_fk))
+                        Ok(dep_fks.into_iter().map(move |dep_fk| (dep, dep_fk)))
                     })
-                    .collect::<Vec<_>>();
-                (dep_id, deps)
+                    .flatten_ok()
+                    .collect::<CargoResult<Vec<_>>>()?;
+                Ok((dep_id, deps))
             })
-            .filter(|(_id, deps)| !deps.is_empty())
+            .filter(|res| res.as_ref().map_or(true, |(_id, deps)| !deps.is_empty()))
             .collect()
     }
 

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -237,7 +237,7 @@ pub fn create_bcx<'a, 'cfg>(
     }
     config.validate_term_config()?;
 
-    let target_data = RustcTargetData::new(ws, &build_config.requested_kinds)?;
+    let mut target_data = RustcTargetData::new(ws, &build_config.requested_kinds)?;
 
     let specs = spec.to_package_id_specs(ws)?;
     let has_dev_units = {
@@ -263,7 +263,7 @@ pub fn create_bcx<'a, 'cfg>(
     };
     let resolve = ops::resolve_ws_with_opts(
         ws,
-        &target_data,
+        &mut target_data,
         &build_config.requested_kinds,
         cli_features,
         &specs,
@@ -279,7 +279,7 @@ pub fn create_bcx<'a, 'cfg>(
 
     let std_resolve_features = if let Some(crates) = &config.cli_unstable().build_std {
         let (std_package_set, std_resolve, std_features) =
-            standard_lib::resolve_std(ws, &target_data, &build_config, crates)?;
+            standard_lib::resolve_std(ws, &mut target_data, &build_config, crates)?;
         pkg_set.add_set(std_package_set);
         Some((std_resolve, std_features))
     } else {

--- a/src/cargo/ops/cargo_fetch.rs
+++ b/src/cargo/ops/cargo_fetch.rs
@@ -31,7 +31,7 @@ pub fn fetch<'a>(
         &options.targets,
         CompileMode::Build,
     )?;
-    let data = RustcTargetData::new(ws, &build_config.requested_kinds)?;
+    let mut data = RustcTargetData::new(ws, &build_config.requested_kinds)?;
     let mut fetched_packages = HashSet::new();
     let mut deps_to_fetch = ws.members().map(|p| p.package_id()).collect::<Vec<_>>();
     let mut to_download = Vec::new();
@@ -70,7 +70,8 @@ pub fn fetch<'a>(
     // If -Zbuild-std was passed, download dependencies for the standard library.
     // We don't know ahead of time what jobs we'll be running, so tell `std_crates` that.
     if let Some(crates) = standard_lib::std_crates(config, None) {
-        let (std_package_set, _, _) = standard_lib::resolve_std(ws, &data, &build_config, &crates)?;
+        let (std_package_set, _, _) =
+            standard_lib::resolve_std(ws, &mut data, &build_config, &crates)?;
         packages.add_set(std_package_set);
     }
 

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -126,7 +126,7 @@ fn build_resolve_graph(
     // How should this work?
     let requested_kinds =
         CompileKind::from_requested_targets(ws.config(), &metadata_opts.filter_platforms)?;
-    let target_data = RustcTargetData::new(ws, &requested_kinds)?;
+    let mut target_data = RustcTargetData::new(ws, &requested_kinds)?;
     // Resolve entire workspace.
     let specs = Packages::All.to_package_id_specs(ws)?;
     let force_all = if metadata_opts.filter_platforms.is_empty() {
@@ -139,7 +139,7 @@ fn build_resolve_graph(
     // as that is the behavior of download_accessible.
     let ws_resolve = ops::resolve_ws_with_opts(
         ws,
-        &target_data,
+        &mut target_data,
         &requested_kinds,
         &metadata_opts.cli_features,
         &specs,

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -243,11 +243,12 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
     // 2018 without `resolver` set must be V1
     assert_eq!(ws.resolve_behavior(), ResolveBehavior::V1);
     let specs = opts.compile_opts.spec.to_package_id_specs(ws)?;
-    let target_data = RustcTargetData::new(ws, &opts.compile_opts.build_config.requested_kinds)?;
-    let resolve_differences = |has_dev_units| -> CargoResult<(WorkspaceResolve<'_>, DiffMap)> {
+    let mut target_data =
+        RustcTargetData::new(ws, &opts.compile_opts.build_config.requested_kinds)?;
+    let mut resolve_differences = |has_dev_units| -> CargoResult<(WorkspaceResolve<'_>, DiffMap)> {
         let ws_resolve = ops::resolve_ws_with_opts(
             ws,
-            &target_data,
+            &mut target_data,
             &opts.compile_opts.build_config.requested_kinds,
             &opts.compile_opts.cli_features,
             &specs,
@@ -258,7 +259,7 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
         let feature_opts = FeatureOpts::new_behavior(ResolveBehavior::V2, has_dev_units);
         let v2_features = FeatureResolver::resolve(
             ws,
-            &target_data,
+            &mut target_data,
             &ws_resolve.targeted_resolve,
             &ws_resolve.pkg_set,
             &opts.compile_opts.cli_features,

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -353,6 +353,17 @@ fn transmit(
                 .to_string(),
                 registry: dep_registry,
                 explicit_name_in_toml: dep.explicit_name_in_toml().map(|s| s.to_string()),
+                artifact: dep.artifact().map(|artifact| {
+                    artifact
+                        .kinds()
+                        .iter()
+                        .map(|x| x.as_str().into_owned())
+                        .collect()
+                }),
+                bindep_target: dep.artifact().and_then(|artifact| {
+                    artifact.target().map(|target| target.as_str().to_owned())
+                }),
+                lib: dep.artifact().map_or(false, |artifact| artifact.is_lib()),
             })
         })
         .collect::<CargoResult<Vec<NewCrateDependency>>>()?;

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -124,7 +124,7 @@ pub fn resolve_ws<'a>(ws: &Workspace<'a>) -> CargoResult<(PackageSet<'a>, Resolv
 /// members. In this case, `opts.all_features` must be `true`.
 pub fn resolve_ws_with_opts<'cfg>(
     ws: &Workspace<'cfg>,
-    target_data: &RustcTargetData<'cfg>,
+    target_data: &mut RustcTargetData<'cfg>,
     requested_targets: &[CompileKind],
     cli_features: &CliFeatures,
     specs: &[PackageIdSpec],

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -135,7 +135,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     // TODO: Target::All is broken with -Zfeatures=itarget. To handle that properly,
     // `FeatureResolver` will need to be taught what "all" means.
     let requested_kinds = CompileKind::from_requested_targets(ws.config(), &requested_targets)?;
-    let target_data = RustcTargetData::new(ws, &requested_kinds)?;
+    let mut target_data = RustcTargetData::new(ws, &requested_kinds)?;
     let specs = opts.packages.to_package_id_specs(ws)?;
     let has_dev = if opts
         .edge_kinds
@@ -152,7 +152,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     };
     let ws_resolve = ops::resolve_ws_with_opts(
         ws,
-        &target_data,
+        &mut target_data,
         &requested_kinds,
         &opts.cli_features,
         &specs,

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -85,7 +85,7 @@
 //! [`RemoteRegistry`]: super::remote::RemoteRegistry
 //! [`Dependency`]: crate::core::Dependency
 
-use crate::core::dependency::{DepKind, Artifact};
+use crate::core::dependency::{Artifact, DepKind};
 use crate::core::Dependency;
 use crate::core::{PackageId, SourceId, Summary};
 use crate::sources::registry::{LoadResponse, RegistryData};

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -178,7 +178,7 @@ struct Summaries {
 /// A lazily parsed [`IndexSummary`].
 enum MaybeIndexSummary {
     /// A summary which has not been parsed, The `start` and `end` are pointers
-    /// into [`Summaries::raw_data`] which this isRegistryDependency an entry of.
+    /// into [`Summaries::raw_data`] which this is an entry of.
     Unparsed { start: usize, end: usize },
 
     /// An actually parsed summary.
@@ -312,6 +312,9 @@ pub struct IndexPackage<'a> {
     /// versions are ignored.
     ///
     /// Version `2` schema adds the `features2` field.
+    ///
+    /// Version `3` schema adds `artifact`, `bindep_targes`, and `lib` for
+    /// artifact dependencies support.
     ///
     /// This provides a method to safely introduce changes to index entries
     /// and allow older versions of cargo to ignore newer entries it doesn't
@@ -821,7 +824,7 @@ impl<'a> SummariesCache<'a> {
             .get(..4)
             .ok_or_else(|| anyhow::anyhow!("cache expected 4 bytes for index schema version"))?;
         let index_v = u32::from_le_bytes(index_v_bytes.try_into().unwrap());
-        if index_v != INDEX_V_MAX && index_v != 3 {
+        if index_v != INDEX_V_MAX {
             bail!(
                 "index schema version {index_v} doesn't match the version I know ({INDEX_V_MAX})",
             );

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -3287,7 +3287,7 @@ impl<P: ResolveToPath + Clone> DetailedTomlDependency<P> {
             self.target.as_deref(),
         ) {
             if cx.config.cli_unstable().bindeps {
-                let artifact = Artifact::parse(artifact, is_lib, target)?;
+                let artifact = Artifact::parse(&artifact.0, is_lib, target)?;
                 if dep.kind() != DepKind::Build
                     && artifact.target() == Some(ArtifactTarget::BuildDependencyAssumeTarget)
                 {

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1458,6 +1458,7 @@ fn targets_are_picked_up_from_non_workspace_artifact_deps() {
 
     let mut dep = registry::Dependency::new("artifact", "1.0.0");
     Package::new("uses-artifact", "1.0.0")
+        .schema_version(3)
         .file(
             "src/lib.rs",
             r#"pub fn uses_artifact() { let _b = include_bytes!(env!("CARGO_BIN_FILE_ARTIFACT")); }"#,
@@ -1486,6 +1487,127 @@ fn targets_are_picked_up_from_non_workspace_artifact_deps() {
 
     p.cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
+        .run();
+}
+
+#[cargo_test]
+fn index_version_filtering() {
+    if cross_compile::disabled() {
+        return;
+    }
+    let target = cross_compile::alternate();
+
+    Package::new("artifact", "1.0.0")
+        .file("src/main.rs", r#"fn main() {}"#)
+        .file("src/lib.rs", r#"pub fn lib() {}"#)
+        .publish();
+
+    let mut dep = registry::Dependency::new("artifact", "1.0.0");
+
+    Package::new("bar", "1.0.0").publish();
+    Package::new("bar", "1.0.1")
+        .schema_version(3)
+        .add_dep(dep.artifact("bin", Some(target.to_string())))
+        .publish();
+
+    // Verify that without `-Zbindeps` that it does not use 1.0.1.
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("tree")
+        .with_stdout("foo v0.1.0 [..]\n└── bar v1.0.0")
+        .run();
+
+    // And with -Zbindeps it can use 1.0.1.
+    p.cargo("update -Zbindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[ADDING] artifact v1.0.0
+[UPDATING] bar v1.0.0 -> v1.0.1",
+        )
+        .run();
+
+    // And without -Zbindeps, now that 1.0.1 is in Cargo.lock, it should fail.
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] [..]
+error: failed to select a version for the requirement `bar = \"^1.0\"` (locked to 1.0.1)
+candidate versions found which didn't match: 1.0.0
+location searched: [..]
+required by package `foo v0.1.0 [..]`
+perhaps a crate was updated and forgotten to be re-vendored?",
+        )
+        .run();
+}
+
+// FIXME: `download_accessible` should work properly for artifact dependencies
+#[cargo_test]
+#[ignore = "broken, needs download_accessible fix"]
+fn proc_macro_in_artifact_dep() {
+    // Forcing FeatureResolver to check a proc-macro for a dependency behind a
+    // target dependency.
+    if cross_compile::disabled() {
+        return;
+    }
+    Package::new("pm", "1.0.0")
+        .file("src/lib.rs", "")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "pm"
+                version = "1.0.0"
+
+                [lib]
+                proc-macro = true
+
+            "#,
+        )
+        .publish();
+    let alternate = cross_compile::alternate();
+    Package::new("bin-uses-pm", "1.0.0")
+        .target_dep("pm", "1.0", alternate)
+        .file("src/main.rs", "fn main() {}")
+        .publish();
+    // Simulate a network error downloading the proc-macro.
+    std::fs::remove_file(cargo_test_support::paths::root().join("dl/pm/1.0.0/download")).unwrap();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2021"
+
+                [dependencies]
+                bin-uses-pm = {{ version = "1.0", artifact = "bin", target = "{alternate}"}}
+            "#
+            ),
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr("")
         .run();
 }
 
@@ -2896,7 +3018,8 @@ fn check_transitive_artifact_dependency_with_different_target() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(
-            "error: failed to run `rustc` to learn about target-specific information",
+            "error: failed to determine target information for target `custom-target`.\n  \
+            Artifact dependency `baz` in package `bar v0.0.0 [..]` requires building for `custom-target`",
         )
         .with_status(101)
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1445,13 +1445,7 @@ foo v0.0.0 ([CWD])
         )
         .run();
 }
-
-// TODO: Fix this potentially by reverting 887562bfeb8c540594d7d08e6e9a4ab7eb255865 which adds artifact information to the registry
-//       followed by 0ff93733626f7cbecaf9dce9ab62b4ced0be088e which picks it up.
-//       For reference, see comments by ehuss https://github.com/rust-lang/cargo/pull/9992#discussion_r801086315 and
-//       joshtriplett https://github.com/rust-lang/cargo/pull/9992#issuecomment-1033394197 .
 #[cargo_test]
-#[ignore = "broken, need artifact info in index"]
 fn targets_are_picked_up_from_non_workspace_artifact_deps() {
     if cross_compile::disabled() {
         return;
@@ -1926,15 +1920,23 @@ You may press ctrl-c [..]
           "badges": {},
           "categories": [],
           "deps": [{
+              "artifact": ["bin"],
               "default_features": true,
               "features": [],
               "kind": "normal",
+              "lib": true,
               "name": "bar",
               "optional": false,
               "target": null,
               "version_req": "^1.0"
             },
             {
+              "artifact": [
+                "bin:a",
+                "cdylib",
+                "staticlib"
+              ],
+              "bindep_target": "target",
               "default_features": true,
               "features": [],
               "kind": "build",
@@ -2894,8 +2896,7 @@ fn check_transitive_artifact_dependency_with_different_target() {
     p.cargo("check -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains(
-            "error: could not find specification for target `custom-target`.\n  \
-            Dependency `baz v0.0.0 [..]` requires to build for target `custom-target`.",
+            "error: failed to run `rustc` to learn about target-specific information",
         )
         .with_status(101)
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

This is a continuation of #12062, and closes #10405.

r? @ehuss

Here are things this PR changes:

1. Add information about artifact dependencies to the index. This bumps index_v to 3 for people using bindeps.
2. Make `RustcTargetData` mutable for the feature resolver. This is so that we can query rustc for target info as late as resolving features, as that is when we really know if a package is really going to be used.