### PR TITLE
Use thiserror for credential provider errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,8 +347,10 @@ dependencies = [
 name = "cargo-credential"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "serde",
  "serde_json",
+ "thiserror",
  "time",
 ]
 

--- a/credential/cargo-credential-1password/src/lib.rs
+++ b/credential/cargo-credential-1password/src/lib.rs
@@ -80,7 +80,7 @@ impl OnePasswordKeychain {
         let mut cmd = Command::new("op");
         cmd.args(["signin", "--raw"]);
         cmd.stdout(Stdio::piped());
-        cmd.stdin(cargo_credential::tty()?);
+        cmd.stdin(cargo_credential::tty().map_err(Box::new)?);
         let mut child = cmd
             .spawn()
             .map_err(|e| format!("failed to spawn `op`: {}", e))?;
@@ -228,7 +228,7 @@ impl OnePasswordKeychain {
         // For unknown reasons, `op item create` seems to not be happy if
         // stdin is not a tty. Otherwise it returns with a 0 exit code without
         // doing anything.
-        cmd.stdin(cargo_credential::tty()?);
+        cmd.stdin(cargo_credential::tty().map_err(Box::new)?);
         self.run_cmd(cmd)?;
         Ok(())
     }

--- a/credential/cargo-credential-1password/src/lib.rs
+++ b/credential/cargo-credential-1password/src/lib.rs
@@ -243,7 +243,7 @@ impl OnePasswordKeychain {
             Some(password) => password
                 .value
                 .map(Secret::from)
-                .ok_or_else(|| format!("missing password value for entry").into()),
+                .ok_or("missing password value for entry".into()),
             None => Err("could not find password field".into()),
         }
     }

--- a/credential/cargo-credential-wincred/src/lib.rs
+++ b/credential/cargo-credential-wincred/src/lib.rs
@@ -58,7 +58,7 @@ mod win {
                             if err.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
                                 return Err(Error::NotFound);
                             }
-                            return Err(err.into());
+                            return Err(Box::new(err).into());
                         }
                         std::slice::from_raw_parts(
                             (*p_credential).CredentialBlob,
@@ -97,7 +97,7 @@ mod win {
                     let result = unsafe { CredWriteW(&credential, 0) };
                     if result != TRUE {
                         let err = std::io::Error::last_os_error();
-                        return Err(err.into());
+                        return Err(Box::new(err).into());
                     }
                     Ok(CredentialResponse::Login)
                 }
@@ -109,7 +109,7 @@ mod win {
                         if err.raw_os_error() == Some(ERROR_NOT_FOUND as i32) {
                             return Err(Error::NotFound);
                         }
-                        return Err(err.into());
+                        return Err(Box::new(err).into());
                     }
                     Ok(CredentialResponse::Logout)
                 }

--- a/credential/cargo-credential-wincred/src/lib.rs
+++ b/credential/cargo-credential-wincred/src/lib.rs
@@ -65,16 +65,13 @@ mod win {
                             (*p_credential).CredentialBlobSize as usize,
                         )
                     };
-                    let result = match String::from_utf8(bytes.to_vec()) {
-                        Err(_) => Err("failed to convert token to UTF8".into()),
-                        Ok(token) => Ok(CredentialResponse::Get {
-                            token: token.into(),
-                            cache: CacheControl::Session,
-                            operation_independent: true,
-                        }),
-                    };
-                    let _ = unsafe { CredFree(p_credential as *mut _) };
-                    result
+                    let token = String::from_utf8(bytes.to_vec()).map_err(Box::new);
+                    unsafe { CredFree(p_credential as *mut _) };
+                    Ok(CredentialResponse::Get {
+                        token: token?.into(),
+                        cache: CacheControl::Session,
+                        operation_independent: true,
+                    })
                 }
                 Action::Login(options) => {
                     let token = read_token(options, registry)?.expose();

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -7,6 +7,8 @@ repository = "https://github.com/rust-lang/cargo"
 description = "A library to assist writing Cargo credential helpers."
 
 [dependencies]
+anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+thiserror.workspace = true
 time.workspace = true

--- a/credential/cargo-credential/src/error.rs
+++ b/credential/cargo-credential/src/error.rs
@@ -1,0 +1,193 @@
+use serde::{Deserialize, Serialize};
+use std::error::Error as StdError;
+use thiserror::Error as ThisError;
+
+/// Credential provider error type.
+///
+/// `UrlNotSupported` and `NotFound` errors both cause Cargo
+/// to attempt another provider, if one is available. The other
+/// variants are fatal.
+///
+/// Note: Do not add a tuple variant, as it cannot be serialized.
+#[derive(Serialize, Deserialize, ThisError, Debug)]
+#[serde(rename_all = "kebab-case", tag = "kind")]
+#[non_exhaustive]
+pub enum Error {
+    #[error("registry not supported")]
+    UrlNotSupported,
+    #[error("credential not found")]
+    NotFound,
+    #[error("requested operation not supported")]
+    OperationNotSupported,
+    #[error("protocol version {version} not supported")]
+    ProtocolNotSupported { version: u32 },
+    #[error(transparent)]
+    #[serde(with = "error_serialize")]
+    Other(Box<dyn StdError + Sync + Send>),
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Box::new(err).into()
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Box::new(err).into()
+    }
+}
+
+impl From<String> for Error {
+    fn from(err: String) -> Self {
+        Box::new(StringTypedError {
+            message: err.to_string(),
+            source: None,
+        })
+        .into()
+    }
+}
+
+impl From<&str> for Error {
+    fn from(err: &str) -> Self {
+        err.to_string().into()
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        let mut prev = None;
+        for e in value.chain().rev() {
+            prev = Some(Box::new(StringTypedError {
+                message: e.to_string(),
+                source: prev,
+            }));
+        }
+        Error::Other(prev.unwrap())
+    }
+}
+
+impl<T: StdError + Send + Sync + 'static> From<Box<T>> for Error {
+    fn from(value: Box<T>) -> Self {
+        Error::Other(value)
+    }
+}
+
+/// String-based error type with an optional source
+#[derive(Debug)]
+struct StringTypedError {
+    message: String,
+    source: Option<Box<StringTypedError>>,
+}
+
+impl StdError for StringTypedError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source.as_ref().map(|err| err as &dyn StdError)
+    }
+}
+
+impl std::fmt::Display for StringTypedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(f)
+    }
+}
+
+/// Serializer / deserializer for any boxed error.
+/// The string representation of the error, and its `source` chain can roundtrip across
+/// the serialization. The actual types are lost (downcast will not work).
+mod error_serialize {
+    use std::error::Error as StdError;
+    use std::ops::Deref;
+
+    use serde::{ser::SerializeStruct, Deserialize, Deserializer, Serializer};
+
+    use crate::error::StringTypedError;
+
+    pub fn serialize<S>(
+        e: &Box<dyn StdError + Send + Sync>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("StringTypedError", 2)?;
+        state.serialize_field("message", &format!("{}", e))?;
+
+        // Serialize the source error chain recursively
+        let mut current_source: &dyn StdError = e.deref();
+        let mut sources = Vec::new();
+        while let Some(err) = current_source.source() {
+            sources.push(err.to_string());
+            current_source = err;
+        }
+        state.serialize_field("caused-by", &sources)?;
+        state.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Box<dyn StdError + Sync + Send>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "kebab-case")]
+        struct ErrorData {
+            message: String,
+            caused_by: Option<Vec<String>>,
+        }
+        let data = ErrorData::deserialize(deserializer)?;
+        let mut prev = None;
+        if let Some(source) = data.caused_by {
+            for e in source.into_iter().rev() {
+                prev = Some(Box::new(StringTypedError {
+                    message: e,
+                    source: prev,
+                }));
+            }
+        }
+        let e = Box::new(StringTypedError {
+            message: data.message,
+            source: prev,
+        });
+        Ok(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Error;
+
+    #[test]
+    pub fn roundtrip() {
+        // Construct an error with context
+        let e = anyhow::anyhow!("E1").context("E2").context("E3");
+        // Convert to a string with contexts.
+        let s1 = format!("{:?}", e);
+        // Convert the error into an `Error`
+        let e: Error = e.into();
+        // Convert that error into JSON
+        let json = serde_json::to_string_pretty(&e).unwrap();
+        // Convert that error back to anyhow
+        let e: anyhow::Error = e.into();
+        let s2 = format!("{:?}", e);
+        assert_eq!(s1, s2);
+
+        // Convert the error back from JSON
+        let e: Error = serde_json::from_str(&json).unwrap();
+        // Convert to back to anyhow
+        let e: anyhow::Error = e.into();
+        let s3 = format!("{:?}", e);
+        assert_eq!(s2, s3);
+
+        assert_eq!(
+            r#"{
+  "kind": "other",
+  "message": "E3",
+  "caused-by": [
+    "E2",
+    "E1"
+  ]
+}"#,
+            json
+        );
+    }
+}

--- a/credential/cargo-credential/src/lib.rs
+++ b/credential/cargo-credential/src/lib.rs
@@ -63,7 +63,7 @@ pub struct RegistryInfo<'a> {
     /// The crates.io registry will be `crates-io` (`CRATES_IO_REGISTRY`).
     pub name: Option<&'a str>,
     /// Headers from attempting to access a registry that resulted in a HTTP 401.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub headers: Vec<String>,
 }
 

--- a/src/cargo/util/credential/adaptor.rs
+++ b/src/cargo/util/credential/adaptor.rs
@@ -22,7 +22,7 @@ impl Credential for BasicProcessCredential {
             Action::Get(_) => {
                 let mut args = args.iter();
                 let exe = args.next()
-                    .ok_or_else(||cargo_credential::Error::Other(format!("The first argument to the `cargo:basic` adaptor must be the path to the credential provider executable.")))?;
+                    .ok_or("The first argument to the `cargo:basic` adaptor must be the path to the credential provider executable.")?;
                 let args = args.map(|arg| arg.replace("{index_url}", registry.index_url));
 
                 let mut cmd = Command::new(exe);
@@ -32,32 +32,23 @@ impl Credential for BasicProcessCredential {
                     cmd.env("CARGO_REGISTRY_NAME_OPT", name);
                 }
                 cmd.stdout(Stdio::piped());
-                let mut child = cmd
-                    .spawn()
-                    .map_err(|e| cargo_credential::Error::Subprocess(e.to_string()))?;
+                let mut child = cmd.spawn()?;
                 let mut buffer = String::new();
-                child
-                    .stdout
-                    .take()
-                    .unwrap()
-                    .read_to_string(&mut buffer)
-                    .map_err(|e| cargo_credential::Error::Subprocess(e.to_string()))?;
+                child.stdout.take().unwrap().read_to_string(&mut buffer)?;
                 if let Some(end) = buffer.find('\n') {
                     if buffer.len() > end + 1 {
-                        return Err(cargo_credential::Error::Other(format!(
+                        return Err(format!(
                             "process `{}` returned more than one line of output; \
                             expected a single token",
                             exe
-                        )));
+                        )
+                        .into());
                     }
                     buffer.truncate(end);
                 }
                 let status = child.wait().expect("process was started");
                 if !status.success() {
-                    return Err(cargo_credential::Error::Subprocess(format!(
-                        "process `{}` failed with status `{status}`",
-                        exe
-                    )));
+                    return Err(format!("process `{}` failed with status `{status}`", exe).into());
                 }
                 Ok(CredentialResponse::Get {
                     token: Secret::from(buffer),

--- a/src/cargo/util/credential/process.rs
+++ b/src/cargo/util/credential/process.rs
@@ -36,17 +36,15 @@ impl<'a> Credential for CredentialProcessCredential {
         cmd.stdin(Stdio::piped());
         cmd.arg("--cargo-plugin");
         log::debug!("credential-process: {cmd:?}");
-        let mut child = cmd.spawn().with_context(|| {
-            format!(
-                "failed to spawn credential process `{}`",
-                self.path.display()
-            )
-        })?;
+        let mut child = cmd.spawn().context("failed to spawn credential process")?;
         let mut output_from_child = BufReader::new(child.stdout.take().unwrap());
         let mut input_to_child = child.stdin.take().unwrap();
         let mut buffer = String::new();
-        output_from_child.read_line(&mut buffer)?;
-        let credential_hello: CredentialHello = serde_json::from_str(&buffer)?;
+        output_from_child
+            .read_line(&mut buffer)
+            .context("failed to read hello from credential provider")?;
+        let credential_hello: CredentialHello =
+            serde_json::from_str(&buffer).context("failed to deserialize hello")?;
         log::debug!("credential-process > {credential_hello:?}");
 
         let req = CredentialRequest {
@@ -55,17 +53,19 @@ impl<'a> Credential for CredentialProcessCredential {
             registry: registry.clone(),
             args: args.to_vec(),
         };
-        let request = serde_json::to_string(&req)?;
+        let request = serde_json::to_string(&req).context("failed to serialize request")?;
         log::debug!("credential-process < {req:?}");
-        writeln!(input_to_child, "{request}")?;
+        writeln!(input_to_child, "{request}").context("failed to write to credential provider")?;
 
         buffer.clear();
-        output_from_child.read_line(&mut buffer)?;
+        output_from_child
+            .read_line(&mut buffer)
+            .context("failed to read response from credential provider")?;
         let response: Result<CredentialResponse, cargo_credential::Error> =
-            serde_json::from_str(&buffer)?;
+            serde_json::from_str(&buffer).context("failed to deserialize response")?;
         log::debug!("credential-process > {response:?}");
         drop(input_to_child);
-        let status = child.wait().expect("credential process never started");
+        let status = child.wait().context("credential process never started")?;
         if !status.success() {
             return Err(anyhow::anyhow!(
                 "credential process `{}` failed with status {}`",

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -161,7 +161,7 @@ fn basic_unsupported() {
 [ERROR] credential provider `cargo:basic false` failed action `login`
 
 Caused by:
-  credential provider does not support the requested operation
+  requested operation not supported
 ",
         )
         .run();
@@ -175,7 +175,7 @@ Caused by:
 [ERROR] credential provider `cargo:basic false` failed action `logout`
 
 Caused by:
-  credential provider does not support the requested operation
+  requested operation not supported
 ",
         )
         .run();
@@ -280,7 +280,7 @@ fn invalid_token_output() {
 [ERROR] credential provider `[..]test-cred[EXE]` failed action `get`
 
 Caused by:
-  error: process `[..]` returned more than one line of output; expected a single token
+  process `[..]` returned more than one line of output; expected a single token
 ",
         )
         .run();

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -116,7 +116,7 @@ fn empty_login_token() {
 [ERROR] credential provider `cargo:token` failed action `login`
 
 Caused by:
-  [ERROR] please provide a non-empty token
+  please provide a non-empty token
 ",
         )
         .with_status(101)
@@ -130,7 +130,7 @@ Caused by:
 [ERROR] credential provider `cargo:token` failed action `login`
 
 Caused by:
-  [ERROR] please provide a non-empty token
+  please provide a non-empty token
 ",
         )
         .with_status(101)
@@ -160,7 +160,7 @@ fn invalid_login_token() {
             "[ERROR] credential provider `cargo:token` failed action `login`
 
 Caused by:
-  [ERROR] token contains invalid characters.
+  token contains invalid characters.
   Only printable ISO-8859-1 characters are allowed as it is sent in a HTTPS header.",
             101,
         )


### PR DESCRIPTION
### What does this PR try to resolve?
Errors from credential providers currently must a single string. This leads to a lot of `.map_err(|e|cargo_credential::Error::Other(e.to_string())`, which loses the `source()` of these errors.

This changes the `cargo_credential::Error` to use `thiserror` and adds a custom serialization for `std::error::Error` that preserves the source error chain across serialization / deserialization.

A unit test is added to verify serialization / deserialization.