### PR TITLE
fix(update): Tweak CLI behavior

### DIFF
--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -9,10 +9,13 @@ pub fn cli() -> Command {
         .arg_quiet()
         .arg(flag("workspace", "Only update the workspace packages").short('w'))
         .arg_package_spec_simple("Package to update")
-        .arg(flag(
-            "aggressive",
-            "Force updating all dependencies of SPEC as well when used with -p",
-        ))
+        .arg(
+            flag(
+                "aggressive",
+                "Force updating all dependencies of SPEC as well when used with -p",
+            )
+            .conflicts_with("precise"),
+        )
         .arg_dry_run("Don't actually write the lockfile")
         .arg(
             opt(

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -16,7 +16,6 @@ pub fn cli() -> Command {
             )
             .conflicts_with("precise"),
         )
-        .arg_dry_run("Don't actually write the lockfile")
         .arg(
             opt(
                 "precise",
@@ -26,6 +25,7 @@ pub fn cli() -> Command {
             .requires("package"),
         )
         .arg_manifest_path()
+        .arg_dry_run("Don't actually write the lockfile")
         .after_help("Run `cargo help update` for more detailed information.\n")
 }
 

--- a/tests/testsuite/cargo_update/help/stdout.log
+++ b/tests/testsuite/cargo_update/help/stdout.log
@@ -7,9 +7,9 @@ Options:
   -w, --workspace             Only update the workspace packages
   -p, --package [<SPEC>]      Package to update
       --aggressive            Force updating all dependencies of SPEC as well when used with -p
-      --dry-run               Don't actually write the lockfile
       --precise <PRECISE>     Update a single dependency to exactly PRECISE when used with -p
       --manifest-path <PATH>  Path to Cargo.toml
+      --dry-run               Don't actually write the lockfile
   -h, --help                  Print help
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -491,10 +491,14 @@ fn update_aggressive_conflicts_with_precise() {
     Package::new("serde", "0.2.2").dep("log", "0.1").publish();
 
     p.cargo("update -p serde:0.2.1 --precise 0.2.2 --aggressive")
-        .with_status(101)
+        .with_status(1)
         .with_stderr(
             "\
-error: cannot specify both aggressive and precise simultaneously
+error: the argument '--precise <PRECISE>' cannot be used with '--aggressive'
+
+Usage: cargo[EXE] update --package [<SPEC>] --precise <PRECISE>
+
+For more information, try '--help'.
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -464,6 +464,42 @@ fn update_aggressive() {
         .run();
 }
 
+#[cargo_test]
+fn update_aggressive_conflicts_with_precise() {
+    Package::new("log", "0.1.0").publish();
+    Package::new("serde", "0.2.1").dep("log", "0.1").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.0.1"
+                authors = []
+
+                [dependencies]
+                serde = "0.2"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check").run();
+
+    Package::new("log", "0.1.1").publish();
+    Package::new("serde", "0.2.2").dep("log", "0.1").publish();
+
+    p.cargo("update -p serde:0.2.1 --precise 0.2.2 --aggressive")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: cannot specify both aggressive and precise simultaneously
+",
+        )
+        .run();
+}
+
 // cargo update should respect its arguments even without a lockfile.
 // See issue "Running cargo update without a Cargo.lock ignores arguments"
 // at <https://github.com/rust-lang/cargo/issues/6872>.


### PR DESCRIPTION
### What does this PR try to resolve?

When looking at `cargo update` for #12425, I noticed that the two flags related to `--package` were not next to it or each other.  I figured grouping them like that would make things easier to browse.

When looking into that, I noticed that the two flags conflict and figured we'd provide a better error message if we did that through clap.

### How should we test and review this PR?

Looking per commit will help show the behavior changes.

### Additional information

I wanted to scope this to being simple, non-controversial, low effort, incremental improvements with this change so I did not look into the history of `--aggressive` not requiring  `--package` like `--precise` does and figure out if there is any consistency we can be working towards.