### PR TITLE
`#[allow(internal_features)]` in RUSTC_BOOTSTRAP test

### DIFF
--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -117,7 +117,10 @@ fn rustc_bootstrap() {
     "#;
     let p = project()
         .file("Cargo.toml", &basic_manifest("has-dashes", "0.0.1"))
-        .file("src/lib.rs", "#![feature(rustc_attrs)]")
+        .file(
+            "src/lib.rs",
+            "#![allow(internal_features)] #![feature(rustc_attrs)]",
+        )
         .file("build.rs", build_rs)
         .build();
     // RUSTC_BOOTSTRAP unset on stable should error
@@ -154,7 +157,10 @@ fn rustc_bootstrap() {
     // Tests for binaries instead of libraries
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.0.1"))
-        .file("src/main.rs", "#![feature(rustc_attrs)] fn main() {}")
+        .file(
+            "src/main.rs",
+            "#![allow(internal_features)] #![feature(rustc_attrs)] fn main() {}",
+        )
         .file("build.rs", build_rs)
         .build();
     // nightly should warn when there's no library whether or not RUSTC_BOOTSTRAP is set


### PR DESCRIPTION
This will be required in the future (where "the future" is rust-lang/rust#108955 which fails CI because of cargo here).

This does emit the unknown lints lint right now but that doesn't matter as it's just warn-by-default - internal_features is deny-by-default though, so it causes errors.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
