### PR TITLE
Fix printing multiple warning messages for unused fields in [registries] table

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -106,6 +106,8 @@ pub use target::{TargetCfgConfig, TargetConfig};
 mod environment;
 use environment::Env;
 
+use super::auth::RegistryConfig;
+
 // Helper macro for creating typed access methods.
 macro_rules! get_value_typed {
     ($name:ident, $ty:ty, $variant:ident, $expected:expr) => {
@@ -208,6 +210,8 @@ pub struct Config {
     /// Cache of credentials from configuration or credential providers.
     /// Maps from url to credential value.
     credential_cache: LazyCell<RefCell<HashMap<CanonicalUrl, CredentialCacheValue>>>,
+    /// Cache of registry config from from the `[registries]` table.
+    registry_config: LazyCell<RefCell<HashMap<SourceId, Option<RegistryConfig>>>>,
     /// Lock, if held, of the global package cache along with the number of
     /// acquisitions so far.
     package_cache_lock: RefCell<Option<(Option<FileLock>, usize)>>,
@@ -299,6 +303,7 @@ impl Config {
             env,
             updated_sources: LazyCell::new(),
             credential_cache: LazyCell::new(),
+            registry_config: LazyCell::new(),
             package_cache_lock: RefCell::new(None),
             http_config: LazyCell::new(),
             future_incompat_config: LazyCell::new(),
@@ -484,6 +489,13 @@ impl Config {
     /// Cached credentials from credential providers or configuration.
     pub fn credential_cache(&self) -> RefMut<'_, HashMap<CanonicalUrl, CredentialCacheValue>> {
         self.credential_cache
+            .borrow_with(|| RefCell::new(HashMap::new()))
+            .borrow_mut()
+    }
+
+    /// Cache of already parsed registries from the `[registries]` table.
+    pub(crate) fn registry_config(&self) -> RefMut<'_, HashMap<SourceId, Option<RegistryConfig>>> {
+        self.registry_config
             .borrow_with(|| RefCell::new(HashMap::new()))
             .borrow_mut()
     }


### PR DESCRIPTION
Cargo currently prints the same warning message multiple times for unexpected fields in the `[registries.<registry>]` or `[registry]` tables. This is because Cargo warns each time that the structure is deserialized from `Config`. Depending on which code path is taken I've seen the warning printed up to 6 times.

* A cache of deserialized registry configurations is added to the `Config` struct.
* Registry authentication is changed to directly read the config when searching for a registry name, rather than deserializing each registry configuration.

A test is added to ensure both `[registries]` and `[registry]` only warn once for unexpected fields.