### PR TITLE
Don't attempt to read a token from stdin if a cmdline token is provided

### DIFF
--- a/src/cargo/ops/registry/login.rs
+++ b/src/cargo/ops/registry/login.rs
@@ -35,13 +35,15 @@ pub fn registry_login(
     };
 
     let mut token_from_stdin = None;
-    if !std::io::stdin().is_terminal() {
-        let token = std::io::read_to_string(std::io::stdin()).unwrap_or_default();
-        if !token.is_empty() {
-            token_from_stdin = Some(token);
+    let token = token_from_cmdline.or_else(|| {
+        if !std::io::stdin().is_terminal() {
+            let token = std::io::read_to_string(std::io::stdin()).unwrap_or_default();
+            if !token.is_empty() {
+                token_from_stdin = Some(token);
+            }
         }
-    }
-    let token = token_from_cmdline.or_else(|| token_from_stdin.as_deref().map(Secret::from));
+        token_from_stdin.as_deref().map(Secret::from)
+    });
 
     let options = LoginOptions {
         token,


### PR DESCRIPTION
Fixes #12438