### PR TITLE
feat: also try to auth for config if server returns status 403

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -967,9 +967,9 @@ To use this feature, the registry server must include `"auth-required": true` in
 `config.json`, and you must pass the `-Z registry-auth` flag on the Cargo command line.
 
 When using the sparse protocol, Cargo will attempt to fetch the `config.json` file before
-fetching any other files. If the server responds with an HTTP 401, then Cargo will assume
-that the registry requires authentication and re-attempt the request for `config.json`
-with the authentication token included.
+fetching any other files. If the server responds with an HTTP status code of 401 or 403, 
+then Cargo will assume that the registry requires authentication and re-attempt the
+request for `config.json` with the authentication token included.
 
 On authentication failure (or missing authentication token) the server MAY include a
 `WWW-Authenticate` header with a `Cargo login_url` challenge to indicate where the user


### PR DESCRIPTION
This makes it so that the `registry-auth` unstable feature also attempts to make authorized requests to a registry's `config.json` (in sparse mode) if the server's response code is 403, not just 401.

These status codes have very similar meanings and some 3rd-party registry providers (e.g. Artifactory) prefer to return 403 for unauthorized requests.

Also updates the docs on this feature to reflect this.

### What does this PR try to resolve?

Artifactory likes to return 403 for unauthorized requests.

The meanings of HTTP [`401 Unauthorized`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401) and HTTP [`403 Forbidden`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) are very similar and largely overlapping.

In order to make Cargo's `registry-auth` feature play better with 3rd-party registries, I would recommend also supporting attempting authentication for 403s even if that is not the perfectly semantic meaning.

### How should we test and review this PR?

Ideally, talk to a 3rd-party registry such as artifactory with this change included and all the config set on the 3rd party registry.

### Additional information

Related tracking issue for the whole `registry-auth` feature: https://github.com/rust-lang/cargo/issues/10474
