### PR TITLE
fix: preserve jobserver file descriptors on rustc invocation to get `TargetInfo`

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -185,6 +185,12 @@ impl TargetInfo {
                 .args(&rustflags)
                 .env_remove("RUSTC_LOG");
 
+            // Removes `FD_CLOEXEC` set by `jobserver::Client` to pass jobserver
+            // as environment variables specify.
+            if let Some(client) = config.jobserver_from_env() {
+                process.inherit_jobserver(client);
+            }
+
             if let CompileKind::Target(target) = kind {
                 process.arg("--target").arg(target.rustc_target());
             }


### PR DESCRIPTION
Then cargo asks rustc for `TargetInfo`, cargo passes environment variables that describe jobserver file descriptors, but doesn't actually passed them, because `jobserver-rs` sets `FD_CLOEXEC` by default and expects users to explicitly call `Client::configure` to pass them further. Rustc respects make jobserver, so this causes error - env vars refers to nonexistent file descriptors, which is ignored now.

This PR makes cargo compatible with https://github.com/rust-lang/rust/pull/113730, which attempts to catch such situations.