### PR TITLE
Add allow(internal_features)

### DIFF
--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -295,6 +295,7 @@ fn allow_features_to_rustc() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(test_2018_feature)]
             "#,
         )

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -4,6 +4,7 @@ use cargo_test_support::{basic_manifest, project};
 use std::fs;
 
 const MINIMAL_LIB: &str = r#"
+#![allow(internal_features)]
 #![feature(no_core)]
 #![feature(lang_items)]
 #![no_core]
@@ -80,6 +81,7 @@ fn custom_target_dependency() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(no_core)]
                 #![feature(lang_items)]
                 #![feature(auto_traits)]

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -756,6 +756,7 @@ fn doc_target() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(no_core, lang_items)]
                 #![no_core]
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/108955 has added a new deny-by-default lint to reject internal features, which is causing tests to fail on nightly. This adds an `allow` to work around that.
