### PR TITLE
Bump cargo library to 0.72.2 for CVE patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.72.1"
+version = "0.72.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ windows-sys = "0.48"
 
 [package]
 name = "cargo"
-version = "0.72.1"
+version = "0.72.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://crates.io"

--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -408,7 +408,7 @@ fn check_ssh_known_hosts_loaded(
     // fingerprints (see FingerprintHash ssh config option). Here we only
     // support SHA256.
     let mut remote_fingerprint = cargo_util::Sha256::new();
-    remote_fingerprint.update(remote_host_key.clone());
+    remote_fingerprint.update(remote_host_key);
     let remote_fingerprint = STANDARD_NO_PAD.encode(remote_fingerprint.finish());
     let remote_host_key_encoded = STANDARD.encode(remote_host_key);
 

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -313,9 +313,8 @@ fn cargo_bench_failing_test() {
 [FINISHED] bench [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
-        .with_stdout_contains(
-            "[..]thread '[..]' panicked at 'assertion failed: `(left == right)`[..]",
-        )
+        .with_stdout_contains("[..]thread '[..]' panicked at[..]")
+        .with_stdout_contains("[..]assertion failed[..]")
         .with_stdout_contains("[..]left: `\"hello\"`[..]")
         .with_stdout_contains("[..]right: `\"nope\"`[..]")
         .with_stdout_contains("[..]src/main.rs:15[..]")

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -117,7 +117,10 @@ fn rustc_bootstrap() {
     "#;
     let p = project()
         .file("Cargo.toml", &basic_manifest("has-dashes", "0.0.1"))
-        .file("src/lib.rs", "#![feature(rustc_attrs)]")
+        .file(
+            "src/lib.rs",
+            "#![allow(internal_features)] #![feature(rustc_attrs)]",
+        )
         .file("build.rs", build_rs)
         .build();
     // RUSTC_BOOTSTRAP unset on stable should error
@@ -154,7 +157,10 @@ fn rustc_bootstrap() {
     // Tests for binaries instead of libraries
     let p = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.0.1"))
-        .file("src/main.rs", "#![feature(rustc_attrs)] fn main() {}")
+        .file(
+            "src/main.rs",
+            "#![allow(internal_features)] #![feature(rustc_attrs)] fn main() {}",
+        )
         .file("build.rs", build_rs)
         .build();
     // nightly should warn when there's no library whether or not RUSTC_BOOTSTRAP is set

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -295,6 +295,7 @@ fn allow_features_to_rustc() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(test_2018_feature)]
             "#,
         )

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -4,6 +4,7 @@ use cargo_test_support::{basic_manifest, project};
 use std::fs;
 
 const MINIMAL_LIB: &str = r#"
+#![allow(internal_features)]
 #![feature(no_core)]
 #![feature(lang_items)]
 #![no_core]
@@ -80,6 +81,7 @@ fn custom_target_dependency() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(no_core)]
                 #![feature(lang_items)]
                 #![feature(auto_traits)]

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -756,6 +756,7 @@ fn doc_target() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(no_core, lang_items)]
                 #![no_core]
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1269,7 +1269,8 @@ fn reports_unsuccessful_subcommand_result() {
         .run();
     cargo_process("fail")
         .with_status(101)
-        .with_stderr_contains("thread '[..]' panicked at 'explicit panic', [..]")
+        .with_stderr_contains("thread '[..]' panicked at [..]src/main.rs:1:[..]")
+        .with_stderr_contains("[..]explicit panic[..]")
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -387,8 +387,9 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-[..]thread '[..]' panicked at 'assertion failed:[..]",
+[..]thread '[..]' panicked at [..]",
         )
+        .with_stdout_contains("[..]assertion failed[..]")
         .with_stdout_contains("[..]`(left == right)`[..]")
         .with_stdout_contains("[..]left: `\"hello\"`,[..]")
         .with_stdout_contains("[..]right: `\"nope\"`[..]")
@@ -437,10 +438,10 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-[..]thread '[..]' panicked at 'assertion failed: false', \
-      tests/footest.rs:1[..]
+[..]thread '[..]' panicked at [..]tests/footest.rs:1:[..]
 ",
         )
+        .with_stdout_contains("[..]assertion failed[..]")
         .with_stdout_contains(
             "\
 failures:
@@ -473,10 +474,10 @@ test test_hello ... FAILED
 failures:
 
 ---- test_hello stdout ----
-[..]thread '[..]' panicked at 'assertion failed: false', \
-      src/lib.rs:1[..]
+[..]thread '[..]' panicked at [..]src/lib.rs:1:[..]
 ",
         )
+        .with_stdout_contains("[..]assertion failed[..]")
         .with_stdout_contains(
             "\
 failures:


### PR DESCRIPTION
<!-- homu-ignore:start -->
Fixes #12460 

In order to make CI pass, these pull request has been cherr-picked:

* #12213
* #12413
* #12429
* #12450 

<!-- homu-ignore:end -->
