### PR TITLE
prompt the use of `--nocapture` flag if `cargo test` process is terminated via a signal.

### DIFF
--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4799,12 +4799,47 @@ Caused by:
         .with_status(4)
         .run();
 
+    p.cargo("test --test t2 -- --nocapture")
+        .with_stderr(
+            "\
+[FINISHED] test [..]
+[RUNNING] tests/t2.rs (target/debug/deps/t2[..])
+error: test failed, to rerun pass `--test t2`
+
+Caused by:
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2[..]` (exit [..]: 4)
+",
+        )
+        .with_status(4)
+        .run();
+
     // no-fail-fast always uses 101
     p.cargo("test --no-fail-fast")
         .with_stderr(
             "\
 [FINISHED] test [..]
 [RUNNING] tests/t1.rs (target/debug/deps/t1[..])
+error: test failed, to rerun pass `--test t1`
+[RUNNING] tests/t2.rs (target/debug/deps/t2[..])
+error: test failed, to rerun pass `--test t2`
+
+Caused by:
+  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2[..]` (exit [..]: 4)
+error: 2 targets failed:
+    `--test t1`
+    `--test t2`
+",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo("test --no-fail-fast -- --nocapture")
+        .with_stderr(
+            "\
+[FINISHED] test [..]
+[RUNNING] tests/t1.rs (target/debug/deps/t1[..])
+thread 't' panicked at 'this is a normal error', tests/t1[..]
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 error: test failed, to rerun pass `--test t1`
 [RUNNING] tests/t2.rs (target/debug/deps/t2[..])
 error: test failed, to rerun pass `--test t2`

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4794,6 +4794,7 @@ error: test failed, to rerun pass `--test t2`
 
 Caused by:
   process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2[..]` (exit [..]: 4)
+note: test exited abnormally; to see the full output pass --nocapture to the harness.
 ",
         )
         .with_status(4)
@@ -4825,6 +4826,7 @@ error: test failed, to rerun pass `--test t2`
 
 Caused by:
   process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2[..]` (exit [..]: 4)
+note: test exited abnormally; to see the full output pass --nocapture to the harness.
 error: 2 targets failed:
     `--test t1`
     `--test t2`
@@ -4834,23 +4836,10 @@ error: 2 targets failed:
         .run();
 
     p.cargo("test --no-fail-fast -- --nocapture")
-        .with_stderr(
-            "\
-[FINISHED] test [..]
-[RUNNING] tests/t1.rs (target/debug/deps/t1[..])
-thread 't' panicked at 'this is a normal error', tests/t1[..]
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-error: test failed, to rerun pass `--test t1`
-[RUNNING] tests/t2.rs (target/debug/deps/t2[..])
-error: test failed, to rerun pass `--test t2`
-
-Caused by:
-  process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2[..]` (exit [..]: 4)
-error: 2 targets failed:
-    `--test t1`
-    `--test t2`
-",
-        )
-        .with_status(101)
-        .run();
+    .with_stderr_does_not_contain("test exited abnormally; to see the full output pass --nocapture to the harness.")
+    .with_stderr_contains("[..]thread 't' panicked [..] tests/t1[..]")
+    .with_stderr_contains("note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace")
+    .with_stderr_contains("[..]process didn't exit successfully: `[ROOT]/foo/target/debug/deps/t2[..]` (exit [..]: 4)")
+    .with_status(101)
+    .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fixes #10855 

As per the discussion on this issue, we want to prompt the user to use `--nocapture` if a test is terminated abnormally. The motivation for this change is described in the issue.

We check for 3 things before we display this flag. - 
- `!is_simple` (if the test ended with a non 101 status code)
- `harness` (if the standard test harness was used), and
- `!nocapture` (whether or not the `--nocapture` flag was already passed to the test)

There's further tests added to `test::nonzero_exit_status` that check that the `stderr` is correct for the various combinations possible when a test ends with a non-101 status code.

The new expected behavior is - 
- Display `--nocapture` note for only non-zero exit statuses, when the `--nocapture` flag is not passed. 
- Only display the note if we use a standard test harness since custom test harnesses do not implement the `--nocapture` flag.

To implement the check for the `--nocapture` flag, the function definition for `report_test_errors` was changed to add the `test_args: &[&str]` parameter. This parameter is passed from the immediate calling function. This private function is only called twice change and is not causing regression after making the appropriate changes to both the places it's called in. 