### PR TITLE
Fix panic when enabling http.debug for certain strings

### DIFF
--- a/src/cargo/util/network/http.rs
+++ b/src/cargo/util/network/http.rs
@@ -152,6 +152,8 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
                 _ => return,
             };
             let starts_with_ignore_case = |line: &str, text: &str| -> bool {
+                let line = line.as_bytes();
+                let text = text.as_bytes();
                 line[..line.len().min(text.len())].eq_ignore_ascii_case(text)
             };
             match str::from_utf8(data) {


### PR DESCRIPTION
Fixes an issue where enabling HTTP debugging may attempt to slice a string across a character boundary resulting in a panic. This likely occurs when binary HTTP data happens to be valid UTF-8.

By interpreting the strings as `&[u8]` before slicing, (which is what `eq_ignore_ascii_case` did internally anyway), the panic is no longer possible.

Closes #12459

r? @weihanglo