### PR TITLE
Fix elided lifetime in associated const

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -887,7 +887,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
 
 impl RegistryConfig {
     /// File name of [`RegistryConfig`].
-    const NAME: &str = "config.json";
+    const NAME: &'static str = "config.json";
 }
 
 /// Get the maximum upack size that Cargo permits


### PR DESCRIPTION
Fix an unelided lifetime in an associated const.

The old code was equivalent to:

```rust
impl<'a> RegistryConfig {
    /// File name of [`RegistryConfig`].
    const NAME: &'a str = "config.json";
}
```

and not `&'static str`, as it might be in a regular `const` item. 

This "regressed" in rust-lang/rust#97313, which started allowing this behavior (inadvertently, as far as I can tell). It's not necessarily clear to me that this is sound (or at least, it's not something we intended to be able to express), but it's also preventing me from doing crater runs to investigate fallout of this issue (rust-lang/rust#114713 and rust-lang/rust#114716).