### PR TITLE
docs: make the env var source of rerun-if-env-changed clearer

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -346,8 +346,10 @@ The `rerun-if-env-changed` instruction tells Cargo to re-run the build script
 if the value of an environment variable of the given name has changed.
 
 Note that the environment variables here are intended for global environment
-variables like `CC` and such, it is not necessary to use this for environment
-variables like `TARGET` that Cargo sets.
+variables like `CC` and such, it is not possible to use this for environment
+variables like `TARGET` that [Cargo sets for build scripts][build-env]. The
+environment variables in use are those received by `cargo` invocations, not
+those received by the executable of the build script.
 
 
 ### The `links` Manifest Key


### PR DESCRIPTION
closes https://github.com/rust-lang/cargo/issues/12403

### What does this PR try to resolve?

The wording of the documentation on [rerun-if-env-changed](https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorerun-if-env-changedname) was misleading which led me to be confused by the behavior of cargo and then raise https://github.com/rust-lang/cargo/issues/12403
These changes should avoid users being confused by this in the future.
