### PR TITLE
Fixes error count display is different when there's only one error left

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -422,7 +422,7 @@ fn rustc(cx: &mut Context<'_, '_>, unit: &Unit, exec: &Arc<dyn Executor>) -> Car
                     };
                     let errors = match output_options.errors_seen {
                         0 => String::new(),
-                        1 => " due to previous error".to_string(),
+                        1 => " due to 1 previous error".to_string(),
                         count => format!(" due to {} previous errors", count),
                     };
                     let name = descriptive_pkg_name(&name, &target, &mode);

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -760,7 +760,7 @@ fn cargo_compile_with_invalid_code() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_contains(
-            "[ERROR] could not compile `foo` (bin \"foo\") due to previous error\n",
+            "[ERROR] could not compile `foo` (bin \"foo\") due to 1 previous error\n",
         )
         .run();
     assert!(p.root().join("Cargo.lock").is_file());

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1716,7 +1716,7 @@ fn build_deps_not_for_normal() {
         .with_stderr_contains("[..]can't find crate for `aaaaa`[..]")
         .with_stderr_contains(
             "\
-[ERROR] could not compile `foo` (lib) due to previous error
+[ERROR] could not compile `foo` (lib) due to 1 previous error
 
 Caused by:
   process didn't exit successfully: [..]

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -804,7 +804,7 @@ fn short_message_format() {
         .with_stderr_contains(
             "\
 src/lib.rs:1:27: error[E0308]: mismatched types
-error: could not compile `foo` (lib) due to previous error
+error: could not compile `foo` (lib) due to 1 previous error
 ",
         )
         .run();
@@ -1250,7 +1250,7 @@ fn check_fixable_error_no_fix() {
 [CHECKING] foo v0.0.1 ([..])
 {}\
 [WARNING] `foo` (lib) generated 1 warning
-[ERROR] could not compile `foo` (lib) due to previous error; 1 warning emitted
+[ERROR] could not compile `foo` (lib) due to 1 previous error; 1 warning emitted
 ",
         rustc_message
     );

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -29,7 +29,7 @@ fn do_not_fix_broken_builds() {
     p.cargo("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_status(101)
-        .with_stderr_contains("[ERROR] could not compile `foo` (lib) due to previous error")
+        .with_stderr_contains("[ERROR] could not compile `foo` (lib) due to 1 previous error")
         .run();
     assert!(p.read_file("src/lib.rs").contains("let mut x = 3;"));
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1010,7 +1010,7 @@ fn compile_failure() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[ERROR] could not compile `foo` (bin \"foo\") due to previous error
+[ERROR] could not compile `foo` (bin \"foo\") due to 1 previous error
 [ERROR] failed to compile `foo v0.0.1 ([..])`, intermediate artifacts can be \
     found at `[..]target`.\nTo reuse those artifacts with a future compilation, \
     set the environment variable `CARGO_TARGET_DIR` to that path.

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -136,7 +136,7 @@ fn deduplicate_errors() {
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.1 [..]
-{}error: could not compile `foo` (lib) due to previous error
+{}error: could not compile `foo` (lib) due to 1 previous error
 ",
             rustc_message
         ))

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -1399,7 +1399,7 @@ fn override_respects_spec_metadata() {
 [..]
 [..]
 [..]
-error: could not compile `foo` (lib) due to previous error
+error: could not compile `foo` (lib) due to 1 previous error
 ",
         )
         .with_status(101)


### PR DESCRIPTION
### What does this PR try to resolve?

When there's only 1 error left, the number 1 appears in the output so that it scans the same as the output when there's more than 1 error, so:

```
error: could not compile `crate` (lib test) due to 1 previous error
``` 
instead of the current:
```
error: could not compile `crate` (lib test) due to a previous error
``` 

Fixes #12390 

rustc related PR [#114759](https://github.com/rust-lang/rust/pull/114759)
