### PR TITLE
docs: further tweak rerun-if-env-changed docs

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -349,8 +349,9 @@ Note that the environment variables here are intended for global environment
 variables like `CC` and such, it is not possible to use this for environment
 variables like `TARGET` that [Cargo sets for build scripts][build-env]. The
 environment variables in use are those received by `cargo` invocations, not
-those received by the executable of the build script.
-
+those received by the executable of the build script. Due to Cargo's
+internal cache invalidation Cargo will effectively re-run the build script
+every time one of the variables that Cargo sets changes.
 
 ### The `links` Manifest Key
 


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/cargo/issues/12403 + https://github.com/rust-lang/cargo/pull/12482

I thought about this some more and I think its important we mention this as well.
Otherwise the user may think it is impossible to use the env vars set by cargo in the build.rs without incorrect behavior when those values change.

r? weihanglo
