### PR TITLE
test: bypass `rustc --test` impl details for `-Zfuture-incompat-test`

### DIFF
--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -164,7 +164,7 @@ fn test_multi_crate() {
                 second-dep = "*"
               "#,
         )
-        .file("src/main.rs", "fn main() {}")
+        .file("src/lib.rs", "")
         .build();
 
     for command in &["build", "check", "rustc", "test"] {


### PR DESCRIPTION
Switch to an empty `lib.rs` from `main.rs`.

See https://github.com/rust-lang/rust/issues/114804#issuecomment-1677233355

Closes https://github.com/rust-lang/rust/issues/114804