### PR TITLE
Print environment variables for `cargo run` in extra verbose mode

### DIFF
--- a/src/cargo/ops/cargo_run.rs
+++ b/src/cargo/ops/cargo_run.rs
@@ -100,6 +100,10 @@ pub fn run(
     // by `compile.target_process` (the package's root directory)
     process.args(args).cwd(config.cwd());
 
+    if config.extra_verbose() {
+        process.display_env_vars();
+    }
+
     config.shell().status("Running", process.to_string())?;
 
     process.exec_replace()

--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -126,7 +126,7 @@ fn run_unit_tests(
         script_meta,
     } in compilation.tests.iter()
     {
-        let (exe_display, cmd) = cmd_builds(
+        let (exe_display, mut cmd) = cmd_builds(
             config,
             cwd,
             unit,
@@ -136,6 +136,11 @@ fn run_unit_tests(
             compilation,
             "unittests",
         )?;
+
+        if config.extra_verbose() {
+            cmd.display_env_vars();
+        }
+
         config
             .shell()
             .concise(|shell| shell.status("Running", &exe_display))?;
@@ -266,9 +271,14 @@ fn run_doc_tests(
             p.arg("-Zunstable-options");
         }
 
+        if config.extra_verbose() {
+            p.display_env_vars();
+        }
+
         config
             .shell()
             .verbose(|shell| shell.status("Running", p.to_string()))?;
+
         if let Err(e) = p.exec() {
             let code = fail_fast_code(&e);
             let unit_err = UnitTestError {

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1688,3 +1688,40 @@ error: unexpected argument `--keep-going` found
         .with_status(101)
         .run();
 }
+
+#[cargo_test(nightly, reason = "bench")]
+fn cargo_bench_print_env_verbose() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.1"))
+        .file(
+            "src/main.rs",
+            r#"
+            #![feature(test)]
+            #[cfg(test)]
+            extern crate test;
+
+            fn hello() -> &'static str {
+                "hello"
+            }
+
+            pub fn main() {
+                println!("{}", hello())
+            }
+
+            #[bench]
+            fn bench_hello(_b: &mut test::Bencher) {
+                assert_eq!(hello(), "hello")
+            }
+            "#,
+        )
+        .build();
+    p.cargo("bench -vv")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc[..]`
+[FINISHED] bench [optimized] target(s) in [..]
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] [CWD]/target/release/deps/foo-[..][EXE] --bench`",
+        )
+        .run();
+}

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -328,7 +328,7 @@ fn profile_selection_test() {
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test [..]
+[RUNNING] `[..] rustdoc [..]--test [..]
 ").run();
     p.cargo("test -vv")
         .with_stderr_unordered(
@@ -341,7 +341,7 @@ fn profile_selection_test() {
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test [..]
+[RUNNING] `[..] rustdoc [..]--test [..]
 ",
         )
         .run();
@@ -395,7 +395,7 @@ fn profile_selection_test_release() {
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test [..]`
+[RUNNING] `[..] rustdoc [..]--test [..]`
 ").run();
     p.cargo("test --release -vv")
         .with_stderr_unordered(
@@ -408,7 +408,7 @@ fn profile_selection_test_release() {
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
 [DOCTEST] foo
-[RUNNING] `rustdoc [..]--test [..]
+[RUNNING] `[..] rustdoc [..]--test [..]
 ",
         )
         .run();

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1,6 +1,8 @@
 //! Tests for the `cargo run` command.
 
-use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, project, Project};
+use cargo_test_support::{
+    basic_bin_manifest, basic_lib_manifest, basic_manifest, project, Project,
+};
 use cargo_util::paths::dylib_path_envvar;
 
 #[cargo_test]
@@ -1414,6 +1416,24 @@ fn default_run_workspace() {
         .build();
 
     p.cargo("run").with_stdout("run-a").run();
+}
+
+#[cargo_test]
+fn print_env_verbose() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("a", "0.0.1"))
+        .file("src/main.rs", r#"fn main() {println!("run-a");}"#)
+        .build();
+
+    p.cargo("run -vv")
+        .with_stderr(
+            "\
+[COMPILING] a v0.0.1 ([CWD])
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc --crate-name a[..]`
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] target/debug/a[EXE]`",
+        )
+        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4861,3 +4861,24 @@ error: unexpected argument `--keep-going` found
         .with_status(101)
         .run();
 }
+
+#[cargo_test]
+fn cargo_test_print_env_verbose() {
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.0.1"))
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("test -vv")
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc --crate-name foo[..]`
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc --crate-name foo[..]`
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] [CWD]/target/debug/deps/foo-[..][EXE]`
+[DOCTEST] foo
+[RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustdoc --crate-type lib --crate-name foo[..]",
+        )
+        .run();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This PR changes `cargo run` so that it prints the environment variables that it sets for the executed binary in extra verbose mode (`cargo run -vv`). This is particularly useful when it sets `LD_LIBRARY_PATH` which is needed to actually run the binary. Because if users want to run the binary without `cargo`, they will need to know where should they point that variable. This is described in issue https://github.com/rust-lang/cargo/issues/4879.

Fixes: https://github.com/rust-lang/cargo/issues/4879

### How should we test and review this PR?

I tried to write a functional test, but I'm not sure how to check that `stderr` contains only a given substring, not a whole line.
<!-- homu-ignore:end -->
