### PR TITLE
login: allow passing additional args to provider

### DIFF
--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -7,16 +7,28 @@ pub fn cli() -> Command {
         .about("Log in to a registry.")
         .arg(Arg::new("token").action(ArgAction::Set))
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg(
+            Arg::new("args")
+                .help("Arguments for the credential provider (unstable)")
+                .num_args(0..)
+                .last(true),
+        )
         .arg_quiet()
         .after_help("Run `cargo help login` for more detailed information.\n")
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let registry = args.registry(config)?;
+    let extra_args = args
+        .get_many::<String>("args")
+        .unwrap_or_default()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
     ops::registry_login(
         config,
         args.get_one::<String>("token").map(|s| s.as_str().into()),
         registry.as_deref(),
+        &extra_args,
     )?;
     Ok(())
 }

--- a/src/cargo/ops/registry/login.rs
+++ b/src/cargo/ops/registry/login.rs
@@ -21,6 +21,7 @@ pub fn registry_login(
     config: &Config,
     token_from_cmdline: Option<Secret<&str>>,
     reg: Option<&str>,
+    args: &[&str],
 ) -> CargoResult<()> {
     let source_ids = get_source_id(config, None, reg)?;
 
@@ -50,6 +51,6 @@ pub fn registry_login(
         login_url: login_url.as_deref(),
     };
 
-    auth::login(config, &source_ids.original, options)?;
+    auth::login(config, &source_ids.original, options, args)?;
     Ok(())
 }

--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -429,6 +429,7 @@ fn credential_action(
     sid: &SourceId,
     action: Action<'_>,
     headers: Vec<String>,
+    args: &[&str],
 ) -> CargoResult<CredentialResponse> {
     let name = if sid.is_crates_io() {
         Some(CRATES_IO_REGISTRY)
@@ -442,7 +443,11 @@ fn credential_action(
     };
     let providers = credential_provider(config, sid)?;
     for provider in providers {
-        let args: Vec<&str> = provider.iter().map(String::as_str).collect();
+        let args: Vec<&str> = provider
+            .iter()
+            .map(String::as_str)
+            .chain(args.iter().map(|s| *s))
+            .collect();
         let process = args[0];
         tracing::debug!("attempting credential provider: {args:?}");
         let provider: Box<dyn Credential> = match process {
@@ -529,7 +534,7 @@ fn auth_token_optional(
         }
     }
 
-    let credential_response = credential_action(config, sid, Action::Get(operation), headers);
+    let credential_response = credential_action(config, sid, Action::Get(operation), headers, &[]);
     if let Some(e) = credential_response.as_ref().err() {
         if let Some(e) = e.downcast_ref::<cargo_credential::Error>() {
             if matches!(e, cargo_credential::Error::NotFound) {
@@ -568,7 +573,7 @@ fn auth_token_optional(
 
 /// Log out from the given registry.
 pub fn logout(config: &Config, sid: &SourceId) -> CargoResult<()> {
-    let credential_response = credential_action(config, sid, Action::Logout, vec![]);
+    let credential_response = credential_action(config, sid, Action::Logout, vec![], &[]);
     if let Some(e) = credential_response.as_ref().err() {
         if let Some(e) = e.downcast_ref::<cargo_credential::Error>() {
             if matches!(e, cargo_credential::Error::NotFound) {
@@ -591,8 +596,13 @@ pub fn logout(config: &Config, sid: &SourceId) -> CargoResult<()> {
 }
 
 /// Log in to the given registry.
-pub fn login(config: &Config, sid: &SourceId, options: LoginOptions<'_>) -> CargoResult<()> {
-    let credential_response = credential_action(config, sid, Action::Login(options), vec![])?;
+pub fn login(
+    config: &Config,
+    sid: &SourceId,
+    options: LoginOptions<'_>,
+    args: &[&str],
+) -> CargoResult<()> {
+    let credential_response = credential_action(config, sid, Action::Login(options), vec![], args)?;
     let CredentialResponse::Login = credential_response else {
         bail!("credential provider produced unexpected response for `login` request: {credential_response:?}")
     };

--- a/tests/testsuite/cargo_login/help/stdout.log
+++ b/tests/testsuite/cargo_login/help/stdout.log
@@ -1,9 +1,10 @@
 Log in to a registry.
 
-Usage: cargo[EXE] login [OPTIONS] [token]
+Usage: cargo[EXE] login [OPTIONS] [token] [-- [args]...]
 
 Arguments:
-  [token]  
+  [token]    
+  [args]...  Arguments for the credential provider (unstable)
 
 Options:
       --registry <REGISTRY>  Registry to use

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -185,15 +185,19 @@ Caused by:
 fn login() {
     let registry = registry::RegistryBuilder::new()
         .no_configure_token()
-        .credential_provider(&[&build_provider("test-cred", r#"{"Ok": {"kind": "login"}}"#)])
+        .credential_provider(&[
+            &build_provider("test-cred", r#"{"Ok": {"kind": "login"}}"#),
+            "cfg1",
+            "--cfg2",
+        ])
         .build();
 
-    cargo_process("login -Z credential-process abcdefg")
+    cargo_process("login -Z credential-process abcdefg -- cmd3 --cmd4")
         .masquerade_as_nightly_cargo(&["credential-process"])
         .replace_crates_io(registry.index_url())
         .with_stderr(
             r#"[UPDATING] [..]
-{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]","args":[]}
+{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]","args":["cfg1","--cfg2","cmd3","--cmd4"]}
 "#,
         )
         .run();


### PR DESCRIPTION
As part of moving asymmetric token support to a credential provider in #12334, support for passing `--key-subject` to `cargo login` was removed.

This change allows passing additional arguments to credential providers when running `cargo login`. For example:
`cargo login -- --key-subject foo`.

The asymmetric token provider (`cargo:paseto`) is updated to take advantage of this and re-enables setting `--key-subject` from `cargo login`.

r? @Eh2406

cc #8933