### PR TITLE
fix(lints): Doctest extraction should respect `[lints]`

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -260,6 +260,8 @@ fn run_doc_tests(
             p.arg("--test-args").arg("--quiet");
         }
 
+        p.args(unit.pkg.manifest().lint_rustflags());
+
         p.args(args);
 
         if *unstable_opts {

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -637,3 +637,70 @@ error: unresolved link to `bar`
         )
         .run();
 }
+
+#[cargo_test]
+fn doctest_respects_lints() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [lints.rust]
+                confusable-idents = 'allow'
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+/// Test
+///
+/// [`Foo`]
+///
+/// ```
+/// let s = "rust";
+/// let ｓ_ｓ = "rust2";
+/// ```
+pub fn f() {}
+pub const Ě: i32 = 1;
+pub const Ĕ: i32 = 2;
+"#,
+        )
+        .build();
+
+    foo.cargo("check -Zlints")
+        .masquerade_as_nightly_cargo(&["lints"])
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+
+    foo.cargo("test --doc -Zlints")
+        .masquerade_as_nightly_cargo(&["lints"])
+        .with_stderr(
+            "\
+[COMPILING] foo v0.0.1 ([CWD])
+[FINISHED] test [unoptimized + debuginfo] target(s) in [..]s
+[DOCTEST] foo
+warning: identifier pair considered confusable between `Ě` and `Ĕ`
+  --> src/lib.rs:12:11
+   |
+11 | pub const Ě: i32 = 1;
+   |           - this is where the previous identifier occurred
+12 | pub const Ĕ: i32 = 2;
+   |           ^
+   |
+   = note: `#[warn(confusable_idents)]` on by default
+
+[WARNING] 1 warning emitted
+
+",
+        )
+        .run();
+}

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -688,18 +688,6 @@ pub const Ĕ: i32 = 2;
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] test [unoptimized + debuginfo] target(s) in [..]s
 [DOCTEST] foo
-warning: identifier pair considered confusable between `Ě` and `Ĕ`
-  --> src/lib.rs:12:11
-   |
-11 | pub const Ě: i32 = 1;
-   |           - this is where the previous identifier occurred
-12 | pub const Ĕ: i32 = 2;
-   |           ^
-   |
-   = note: `#[warn(confusable_idents)]` on by default
-
-[WARNING] 1 warning emitted
-
 ",
         )
         .run();


### PR DESCRIPTION
Note the first commit shows the bug and the second commit fixes it

Fixes #12497