### PR TITLE
[beta-1.72.0] bump cargo-util to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cargo-credential = { version = "0.2.0", path = "credential/cargo-credential" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.3" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
-cargo-util = { version = "0.2.4", path = "crates/cargo-util" }
+cargo-util = { version = "0.2.5", path = "crates/cargo-util" }
 cargo_metadata = "0.14.0"
 clap = "4.2.0"
 core-foundation = { version = "0.9.0", features = ["mac_os_10_7_support"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/rust-lang/cargo"

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -295,6 +295,7 @@ fn allow_features_to_rustc() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(test_2018_feature)]
             "#,
         )

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -4,6 +4,7 @@ use cargo_test_support::{basic_manifest, project};
 use std::fs;
 
 const MINIMAL_LIB: &str = r#"
+#![allow(internal_features)]
 #![feature(no_core)]
 #![feature(lang_items)]
 #![no_core]
@@ -80,6 +81,7 @@ fn custom_target_dependency() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(no_core)]
                 #![feature(lang_items)]
                 #![feature(auto_traits)]

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -756,6 +756,7 @@ fn doc_target() {
         .file(
             "src/lib.rs",
             r#"
+                #![allow(internal_features)]
                 #![feature(no_core, lang_items)]
                 #![no_core]
 

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -164,7 +164,7 @@ fn test_multi_crate() {
                 second-dep = "*"
               "#,
         )
-        .file("src/main.rs", "fn main() {}")
+        .file("src/lib.rs", "")
         .build();
 
     for command in &["build", "check", "rustc", "test"] {


### PR DESCRIPTION
#11442 changed `cargo-util` at the last minute but we failed to bump the version.

And due to https://github.com/rust-lang/cargo/issues/12347, version bump check didn't work well at that time.

In order to make CI pass, the following PRs are also cherry-picked:

* https://github.com/rust-lang/cargo/pull/12450
* https://github.com/rust-lang/cargo/pull/12491