### PR TITLE
credential-providers: make 1password no longer built-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,7 +263,6 @@ dependencies = [
  "base64",
  "bytesize",
  "cargo-credential",
- "cargo-credential-1password",
  "cargo-credential-macos-keychain",
  "cargo-credential-wincred",
  "cargo-platform 0.1.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ base64 = "0.21.2"
 bytesize = "1.2"
 cargo = { path = "" }
 cargo-credential = { version = "0.3.0", path = "credential/cargo-credential" }
-cargo-credential-1password = { version = "0.3.0", path = "credential/cargo-credential-1password" }
 cargo-credential-wincred = { version = "0.3.0", path = "credential/cargo-credential-wincred" }
 cargo-credential-macos-keychain = { version = "0.3.0", path = "credential/cargo-credential-macos-keychain" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.4" }
@@ -123,7 +122,6 @@ base64.workspace = true
 bytesize.workspace = true
 cargo-platform.workspace = true
 cargo-credential.workspace = true
-cargo-credential-1password.workspace = true
 cargo-credential-macos-keychain.workspace = true
 cargo-credential-wincred.workspace = true
 cargo-util.workspace = true

--- a/credential/cargo-credential-1password/src/main.rs
+++ b/credential/cargo-credential-1password/src/main.rs
@@ -301,3 +301,7 @@ impl Credential for OnePasswordCredential {
         }
     }
 }
+
+fn main() {
+    cargo_credential::main(OnePasswordCredential {});
+}

--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -449,7 +449,6 @@ fn credential_action(
             "cargo:token" => Box::new(TokenCredential::new(config)),
             "cargo:paseto" => Box::new(PasetoCredential::new(config)),
             "cargo:token-from-stdout" => Box::new(BasicProcessCredential {}),
-            "cargo:1password" => Box::new(cargo_credential_1password::OnePasswordCredential {}),
             "cargo:wincred" => Box::new(cargo_credential_wincred::WindowsCredential {}),
             "cargo:macos-keychain" => Box::new(cargo_credential_macos_keychain::MacKeychain {}),
             process => Box::new(CredentialProcessCredential::new(process)),

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1108,18 +1108,27 @@ executed within the Cargo process. They are identified with the `cargo:` prefix.
   * `CARGO_REGISTRY_NAME_OPT` --- Optional name of the registry. Should not be used as a storage key. Not always available.
 
 * `cargo:paseto` - implements asymmetric token support (RFC3231) as a credential provider.
-* `cargo:1password`: Uses the 1password `op` CLI to store the token. You must
-  install the `op` CLI from the [1password
-  website](https://1password.com/downloads/command-line/). You must run `op
-  signin` at least once with the appropriate arguments (such as `op signin
-  my.1password.com user@example.com`), unless you provide the sign-in-address
-  and email arguments. The master password will be required on each request
-  unless the appropriate `OP_SESSION` environment variable is set. It supports
-  the following command-line arguments:
-  * `--account`: The account shorthand name to use.
-  * `--vault`: The vault name to use.
-  * `--sign-in-address`: The sign-in-address, which is a web address such as `my.1password.com`.
-  * `--email`: The email address to sign in with.
+
+
+`cargo-credential-1password` uses the 1password `op` CLI to store the token. You must
+install the `op` CLI from the [1password
+website](https://1password.com/downloads/command-line/). You must run `op
+signin` at least once with the appropriate arguments (such as `op signin
+my.1password.com user@example.com`), unless you provide the sign-in-address
+and email arguments. The master password will be required on each request
+unless the appropriate `OP_SESSION` environment variable is set. It supports
+the following command-line arguments:
+* `--account`: The account shorthand name to use.
+* `--vault`: The vault name to use.
+* `--sign-in-address`: The sign-in-address, which is a web address such as `my.1password.com`.
+* `--email`: The email address to sign in with.
+
+Install the provider with `cargo install cargo-credential-1password`
+In the config, add it to `global-credential-providers`:
+```toml
+[registry]
+global-credential-providers = ["cargo-credential-1password"]
+```
 
 A wrapper is available for GNOME
 [libsecret](https://wiki.gnome.org/Projects/Libsecret) to store tokens on


### PR DESCRIPTION
Since 1password is just one of many potential CLI-based credential providers, it makes more sense for it to be installable as a plugin rather than built-in to Cargo.

This means that `cargo:1password` will no longer work as a credential provider. 

The replacement would be `cargo install cargo-credential-1password` and using `cargo-credential-1password` instead.

r? @ehuss 