### PR TITLE
ci: use pull request head commit whenever possible

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
-      HEAD_SHA: ${{ github.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha != '' && github.event.pull_request.head.sha || github.sha  }}
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION


<!-- homu-ignore:start -->
The `github.sha` is a merge commit with the parents of latest master and the head of the pr. Trying to diff the changes from that merge SHA to base will show all changes that have been made in-between.

And that doesn't seem about right.

We switch to `github.event.pull_request.head.sha` if there is a pr.

See: https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/version-bump.20CI.20failing
<!-- homu-ignore:end -->
