### PR TITLE
Hold the mutate exclusive lock when vendoring

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -4,6 +4,7 @@ use crate::core::{GitReference, Package, Workspace};
 use crate::ops;
 use crate::sources::path::PathSource;
 use crate::sources::CRATES_IO_REGISTRY;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::{try_canonicalize, CargoResult, Config};
 use anyhow::{bail, Context as _};
 use cargo_util::{paths, Sha256};
@@ -31,6 +32,7 @@ pub fn vendor(ws: &Workspace<'_>, opts: &VendorOptions<'_>) -> CargoResult<()> {
         extra_workspaces.push(ws);
     }
     let workspaces = extra_workspaces.iter().chain(Some(ws)).collect::<Vec<_>>();
+    let _lock = config.acquire_package_cache_lock(CacheLockMode::MutateExclusive)?;
     let vendor_config = sync(config, &workspaces, opts).with_context(|| "failed to sync")?;
 
     if config.shell().verbosity() != Verbosity::Quiet {


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/12254

Held the mutate exclusive lock when vendoring. This would block all other processes which want to read or change the unpacked files.

See: https://github.com/rust-lang/cargo/pull/12509#issuecomment-1732415990

r? @weihanglo 
<!-- homu-ignore:end -->
