### PR TITLE
credential: rename cargo:basic to cargo:token-from-stdout

### DIFF
--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -448,7 +448,7 @@ fn credential_action(
         let provider: Box<dyn Credential> = match process {
             "cargo:token" => Box::new(TokenCredential::new(config)),
             "cargo:paseto" => Box::new(PasetoCredential::new(config)),
-            "cargo:basic" => Box::new(BasicProcessCredential {}),
+            "cargo:token-from-stdout" => Box::new(BasicProcessCredential {}),
             "cargo:1password" => Box::new(cargo_credential_1password::OnePasswordCredential {}),
             "cargo:wincred" => Box::new(cargo_credential_wincred::WindowsCredential {}),
             "cargo:macos-keychain" => Box::new(cargo_credential_macos_keychain::MacKeychain {}),

--- a/src/cargo/util/credential/adaptor.rs
+++ b/src/cargo/util/credential/adaptor.rs
@@ -23,7 +23,7 @@ impl Credential for BasicProcessCredential {
             Action::Get(_) => {
                 let mut args = args.iter();
                 let exe = args.next()
-                    .ok_or("The first argument to the `cargo:basic` adaptor must be the path to the credential provider executable.")?;
+                    .ok_or("The first argument to `cargo:token-from-stdout` must be a command that prints a token on stdout")?;
                 let args = args.map(|arg| arg.replace("{index_url}", registry.index_url));
 
                 let mut cmd = Command::new(exe);

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1094,9 +1094,9 @@ executed within the Cargo process. They are identified with the `cargo:` prefix.
 * `cargo:token` - Uses Cargo's config and `credentials.toml` to store the token (default).
 * `cargo:wincred` - Uses the Windows Credential Manager to store the token.
 * `cargo:macos-keychain` - Uses the macOS Keychain to store the token.
-* `cargo:basic` - A basic authenticator is a process that returns a token on stdout. Newlines
-  will be trimmed. The process inherits the user's stdin and stderr. It should
-  exit 0 on success, and nonzero on error.
+* `cargo:token-from-stdout <command>` - Launch a subprocess that returns a token
+  on stdout. Newlines will be trimmed. The process inherits the user's stdin and stderr.
+  It should exit 0 on success, and nonzero on error.
   
   With this form, [`cargo login`] and [`cargo logout`] are not supported and
   return an error if used.

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -148,7 +148,7 @@ fn basic_unsupported() {
     // Non-action commands don't support login/logout.
     let registry = registry::RegistryBuilder::new()
         .no_configure_token()
-        .credential_provider(&["cargo:basic", "false"])
+        .credential_provider(&["cargo:token-from-stdout", "false"])
         .build();
 
     cargo_process("login -Z credential-process abcdefg")
@@ -158,7 +158,7 @@ fn basic_unsupported() {
         .with_stderr(
             "\
 [UPDATING] crates.io index
-[ERROR] credential provider `cargo:basic false` failed action `login`
+[ERROR] credential provider `cargo:token-from-stdout false` failed action `login`
 
 Caused by:
   requested operation not supported
@@ -172,7 +172,7 @@ Caused by:
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] credential provider `cargo:basic false` failed action `logout`
+[ERROR] credential provider `cargo:token-from-stdout false` failed action `logout`
 
 Caused by:
   requested operation not supported
@@ -262,7 +262,10 @@ fn invalid_token_output() {
     cred_proj.cargo("build").run();
     let _server = registry::RegistryBuilder::new()
         .alternative()
-        .credential_provider(&["cargo:basic", &toml_bin(&cred_proj, "test-cred")])
+        .credential_provider(&[
+            "cargo:token-from-stdout",
+            &toml_bin(&cred_proj, "test-cred"),
+        ])
         .no_configure_token()
         .build();
 
@@ -523,7 +526,10 @@ fn basic_provider() {
 
     let _server = registry::RegistryBuilder::new()
         .no_configure_token()
-        .credential_provider(&["cargo:basic", &toml_bin(&cred_proj, "test-cred")])
+        .credential_provider(&[
+            "cargo:token-from-stdout",
+            &toml_bin(&cred_proj, "test-cred"),
+        ])
         .token(cargo_test_support::registry::Token::Plaintext(
             "sekrit".to_string(),
         ))


### PR DESCRIPTION
Multiple people have said that the name of the `cargo:basic` credential provider is confusing, since it's not doing HTTP Basic authentication.

Rename `cargo:basic` to `cargo:token-from-stdout`, which more accurately describes what it does.