### PR TITLE
chore(cargo-util): bump version to 0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cargo-credential-macos-keychain = { version = "0.3.0", path = "credential/cargo-
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.4" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
-cargo-util = { version = "0.2.5", path = "crates/cargo-util" }
+cargo-util = { version = "0.2.6", path = "crates/cargo-util" }
 cargo_metadata = "0.14.0"
 clap = "4.3.19"
 core-foundation = { version = "0.9.3", features = ["mac_os_10_7_support"] }

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"


### PR DESCRIPTION
<!-- homu-ignore:start -->
Bumped acccording due to a bump from <https://github.com/rust-lang/cargo/pull/12505>.

See also <https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/cargo-util.20changes>.
<!-- homu-ignore:end -->
