### PR TITLE
refactor: Use `Config::emit_diagnostic` to emit warnings

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -219,7 +219,7 @@ fn get_base_commit<'a>(
             let upstream_ref = upstream_branches[0].get();
             if upstream_branches.len() > 1 {
                 let name = upstream_ref.name().expect("name is valid UTF-8");
-                let _ = config.shell().warn(format!(
+                let _ = config.emit_diagnostic(format!(
                     "multiple `{UPSTREAM_BRANCH}` found, picking {name}"
                 ));
             }

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -266,7 +266,7 @@ fn expand_aliases(
         match (exec, aliased_cmd) {
             (Some(_), Ok(Some(_))) => {
                 // User alias conflicts with a built-in subcommand
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "user-defined alias `{}` is ignored, because it is shadowed by a built-in command",
                     cmd,
                 ))?;
@@ -296,7 +296,7 @@ To pass the arguments to the subcommand, remove `--`",
                 // a hard error.
                 if super::builtin_aliases_execs(cmd).is_none() {
                     if let Some(path) = super::find_external_subcommand(config, cmd) {
-                        config.shell().warn(format!(
+                        config.emit_diagnostic(format!(
                         "\
 user-defined alias `{}` is shadowing an external subcommand found at: `{}`
 This was previously accepted but is being phased out; it will become a hard error in a future release.
@@ -310,7 +310,7 @@ For more information, see issue #10049 <https://github.com/rust-lang/cargo/issue
                     if config.cli_unstable().script {
                         return Ok((args, GlobalArgs::default()));
                     } else {
-                        config.shell().warn(format_args!(
+                        config.emit_diagnostic(format_args!(
                             "\
 user-defined alias `{cmd}` has the appearance of a manfiest-command
 This was previously accepted but will be phased out when `-Zscript` is stabilized.
@@ -445,7 +445,7 @@ impl Exec {
             Self::Manifest(cmd) => {
                 let ext_path = super::find_external_subcommand(config, &cmd);
                 if !config.cli_unstable().script && ext_path.is_some() {
-                    config.shell().warn(format_args!(
+                    config.emit_diagnostic(format_args!(
                         "\
 external subcommand `{cmd}` has the appearance of a manfiest-command
 This was previously accepted but will be phased out when `-Zscript` is stabilized.

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -34,7 +34,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
 
     let version = match args.get_one::<String>("format-version") {
         None => {
-            config.shell().warn(
+            config.emit_diagnostic(
                 "please specify `--format-version` flag explicitly \
                  to avoid compatibility problems",
             )?;

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -107,14 +107,10 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         return Ok(());
     }
     let prefix = if args.flag("no-indent") {
-        config
-            .shell()
-            .warn("the --no-indent flag has been changed to --prefix=none")?;
+        config.emit_diagnostic("the --no-indent flag has been changed to --prefix=none")?;
         "none"
     } else if args.flag("prefix-depth") {
-        config
-            .shell()
-            .warn("the --prefix-depth flag has been changed to --prefix=depth")?;
+        config.emit_diagnostic("the --prefix-depth flag has been changed to --prefix=depth")?;
         "depth"
     } else {
         args.get_one::<String>("prefix").unwrap().as_str()
@@ -123,7 +119,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
 
     let no_dedupe = args.flag("no-dedupe") || args.flag("all");
     if args.flag("all") {
-        config.shell().warn(
+        config.emit_diagnostic(
             "The `cargo tree` --all flag has been changed to --no-dedupe, \
              and may be removed in a future version.\n\
              If you are looking to display all workspace members, use the --workspace flag.",
@@ -131,9 +127,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     }
 
     let targets = if args.flag("all-targets") {
-        config
-            .shell()
-            .warn("the --all-targets flag has been changed to --target=all")?;
+        config.emit_diagnostic("the --all-targets flag has been changed to --target=all")?;
         vec!["all".to_string()]
     } else {
         args._values_of("target")
@@ -228,9 +222,7 @@ fn parse_edge_kinds(config: &Config, args: &ArgMatches) -> CargoResult<(HashSet<
         );
 
         if args.flag("no-dev-dependencies") {
-            config
-                .shell()
-                .warn("the --no-dev-dependencies flag has changed to -e=no-dev")?;
+            config.emit_diagnostic("the --no-dev-dependencies flag has changed to -e=no-dev")?;
             kinds.push("no-dev");
         }
 

--- a/src/cargo/core/compiler/build_config.rs
+++ b/src/cargo/core/compiler/build_config.rs
@@ -73,7 +73,7 @@ impl BuildConfig {
         let cfg = config.build_config()?;
         let requested_kinds = CompileKind::from_requested_targets(config, requested_targets)?;
         if jobs.is_some() && config.jobserver_from_env().is_some() {
-            config.shell().warn(
+            config.emit_diagnostic(
                 "a `-j` argument was passed to Cargo but Cargo is \
                  also configured with an external jobserver in \
                  its environment, ignoring the `-j` parameter",

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -302,7 +302,7 @@ impl TargetInfo {
                 continue;
             }
             if !reached_fixed_point {
-                config.shell().warn("non-trivial mutual dependency between target-specific configuration and RUSTFLAGS")?;
+                config.emit_diagnostic("non-trivial mutual dependency between target-specific configuration and RUSTFLAGS")?;
             }
 
             return Ok(TargetInfo {

--- a/src/cargo/core/compiler/context/mod.rs
+++ b/src/cargo/core/compiler/context/mod.rs
@@ -465,7 +465,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                                 suggestion: &str|
          -> CargoResult<()> {
             if unit.target.name() == other_unit.target.name() {
-                self.bcx.config.shell().warn(format!(
+                self.bcx.config.emit_diagnostic(format!(
                     "output filename collision.\n\
                      {}\
                      The targets should have unique names.\n\
@@ -474,7 +474,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                     suggestion
                 ))
             } else {
-                self.bcx.config.shell().warn(format!(
+                self.bcx.config.emit_diagnostic(format!(
                     "output filename collision.\n\
                     {}\
                     The output filenames should be unique.\n\
@@ -560,7 +560,7 @@ impl<'a, 'cfg> Context<'a, 'cfg> {
                 }
                 if let Some(ref export_path) = output.export_path {
                     if let Some(other_unit) = output_collisions.insert(export_path.clone(), unit) {
-                        self.bcx.config.shell().warn(format!(
+                        self.bcx.config.emit_diagnostic(format!(
                             "`--out-dir` filename collision.\n\
                              {}\
                              The exported filenames should be unique.\n\

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -180,7 +180,7 @@ impl OnDiskReports {
             crate::display_warning_with_error(
                 "failed to write on-disk future incompatible report",
                 &e,
-                &mut ws.config().shell(),
+                ws.config(),
             );
         }
 
@@ -395,7 +395,7 @@ pub fn save_and_display_report(
             crate::display_warning_with_error(
                 "failed to read future-incompat config from disk",
                 &e,
-                &mut bcx.config.shell(),
+                bcx.config,
             );
             true
         }
@@ -434,7 +434,7 @@ pub fn save_and_display_report(
     let package_vers: Vec<_> = package_ids.iter().map(|pid| pid.to_string()).collect();
 
     if should_display_message || bcx.build_config.future_incompat_report {
-        drop(bcx.config.shell().warn(&format!(
+        drop(bcx.config.emit_diagnostic(&format!(
             "the following packages contain code that will be rejected by a future \
              version of Rust: {}",
             package_vers.join(", ")

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1272,7 +1272,7 @@ fn build_deps_args(cmd: &mut ProcessBuilder, cx: &Context<'_, '_>, unit: &Unit) 
         if let Some(dep) = deps.iter().find(|dep| {
             !dep.unit.mode.is_doc() && dep.unit.target.is_lib() && !dep.unit.artifact.is_true()
         }) {
-            bcx.config.shell().warn(format!(
+            bcx.config.emit_diagnostic(format!(
                 "The package `{}` \
                  provides no linkable target. The compiler might raise an error while compiling \
                  `{}`. Consider adding 'dylib' or 'rlib' to key `crate-type` in `{}`'s \

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -68,8 +68,7 @@ pub fn resolve_std<'cfg>(
 ) -> CargoResult<(PackageSet<'cfg>, Resolve, ResolvedFeatures)> {
     if build_config.build_plan {
         ws.config()
-            .shell()
-            .warn("-Zbuild-std does not currently fully support --build-plan")?;
+            .emit_diagnostic("-Zbuild-std does not currently fully support --build-plan")?;
     }
 
     let src_path = detect_sysroot_src_path(target_data)?;

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -597,7 +597,7 @@ impl<'cfg> PackageSet<'cfg> {
                         .map(|artifact| artifact.is_lib())
                         .unwrap_or(true)
                 }) {
-                    ws.config().shell().warn(&format!(
+                    ws.config().emit_diagnostic(&format!(
                         "{} ignoring invalid dependency `{}` which is missing a lib target",
                         pkg_id,
                         dep.name_in_toml(),

--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -303,7 +303,7 @@ impl<'cfg> PackageRegistry<'cfg> {
                 );
 
                 if dep.features().len() != 0 || !dep.uses_default_features() {
-                    self.source_config.config().shell().warn(format!(
+                    self.source_config.config().emit_diagnostic(format!(
                         "patch for `{}` uses the features mechanism. \
                         default-features and features will not take effect because the patch dependency does not support this mechanism",
                         dep.package_name()
@@ -546,7 +546,7 @@ https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
                 dep.package_name(),
                 boilerplate
             );
-            self.source_config.config().shell().warn(&msg)?;
+            self.source_config.config().emit_diagnostic(&msg)?;
             return Ok(());
         }
 
@@ -559,7 +559,7 @@ https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html
                 dep.package_name(),
                 boilerplate
             );
-            self.source_config.config().shell().warn(&msg)?;
+            self.source_config.config().emit_diagnostic(&msg)?;
             return Ok(());
         }
 

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::io::prelude::*;
 use std::io::IsTerminal;
 
-use termcolor::Color::{Cyan, Green, Red, Yellow};
+use termcolor::Color::{Cyan, Green, Red};
 use termcolor::{self, Color, ColorSpec, StandardStream, WriteColor};
 
 use crate::util::errors::CargoResult;
@@ -126,7 +126,7 @@ impl Shell {
 
     /// Prints a message, where the status will have `color` color, and can be justified. The
     /// messages follows without color.
-    fn print(
+    pub(crate) fn print(
         &mut self,
         status: &dyn fmt::Display,
         message: Option<&dyn fmt::Display>,
@@ -256,14 +256,6 @@ impl Shell {
         }
         self.output
             .message_stderr(&"error", Some(&message), Red, false)
-    }
-
-    /// Prints an amber 'warning' message.
-    pub fn warn<T: fmt::Display>(&mut self, message: T) -> CargoResult<()> {
-        match self.verbosity {
-            Verbosity::Quiet => Ok(()),
-            _ => self.print(&"warning", Some(&message), Yellow, false),
-        }
     }
 
     /// Prints a cyan 'note' message.

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -454,8 +454,7 @@ impl<'cfg> Workspace<'cfg> {
 
         for message in warnings {
             self.config
-                .shell()
-                .warn(format!("[patch] in cargo config: {}", message))?
+                .emit_diagnostic(format!("[patch] in cargo config: {}", message))?
         }
 
         Ok(patch)
@@ -993,7 +992,7 @@ impl<'cfg> Workspace<'cfg> {
                         pkg.manifest_path().display(),
                         root_manifest.display(),
                     );
-                    self.config.shell().warn(&msg)
+                    self.config.emit_diagnostic(&msg)
                 };
                 if manifest.original().has_profiles() {
                     emit_warning("profiles")?;
@@ -1021,7 +1020,7 @@ impl<'cfg> Workspace<'cfg> {
                         .max()
                     {
                         let resolver = edition.default_resolve_behavior().to_manifest();
-                        self.config.shell().warn(format_args!("some crates are on edition {edition} which defaults to `resolver = \"{resolver}\"`, but virtual workspaces default to `resolver = \"1\"`"))?;
+                        self.config.emit_diagnostic(format_args!("some crates are on edition {edition} which defaults to `resolver = \"{resolver}\"`, but virtual workspaces default to `resolver = \"1\"`"))?;
                         self.config.shell().note(
                             "to keep the current resolver, specify `workspace.resolver = \"1\"` in the workspace root's manifest",
                         )?;
@@ -1098,7 +1097,7 @@ impl<'cfg> Workspace<'cfg> {
                         // originated, so include the path.
                         format!("{}: {}", path.display(), warning.message)
                     };
-                    self.config.shell().warn(msg)?
+                    self.config.emit_diagnostic(msg)?
                 }
             }
         }

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -205,10 +205,11 @@ pub fn display_error(err: &Error, shell: &mut Shell) {
 
 /// Displays a warning, with an error object providing detailed information
 /// and context.
-pub fn display_warning_with_error(warning: &str, err: &Error, shell: &mut Shell) {
-    drop(shell.warn(warning));
+pub fn display_warning_with_error(warning: &str, err: &Error, config: &Config) {
+    drop(config.emit_diagnostic(warning));
+    let mut shell = config.shell();
     drop(writeln!(shell.err()));
-    _display_error(err, shell, false);
+    _display_error(err, &mut shell, false);
 }
 
 fn _display_error(err: &Error, shell: &mut Shell, as_err: bool) -> bool {

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -217,7 +217,9 @@ pub fn add(workspace: &Workspace<'_>, options: &AddOptions<'_>) -> CargoResult<(
     }
 
     if options.dry_run {
-        options.config.shell().warn("aborting add due to dry run")?;
+        options
+            .config
+            .emit_diagnostic("aborting add due to dry run")?;
     } else {
         manifest.write()?;
     }
@@ -291,7 +293,7 @@ fn resolve_dependency(
             let dependency = crate_spec.to_dependency()?.set_source(src);
             let selected = select_package(&dependency, config, registry)?;
             if dependency.name != selected.name {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "translating `{}` to `{}`",
                     dependency.name, selected.name,
                 ))?;
@@ -316,7 +318,7 @@ fn resolve_dependency(
             let dependency = crate_spec.to_dependency()?.set_source(src);
             let selected = select_package(&dependency, config, registry)?;
             if dependency.name != selected.name {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "translating `{}` to `{}`",
                     dependency.name, selected.name,
                 ))?;
@@ -384,7 +386,7 @@ fn resolve_dependency(
             )?;
 
             if dependency.name != latest.name {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "translating `{}` to `{}`",
                     dependency.name, latest.name,
                 ))?;
@@ -611,7 +613,7 @@ fn get_latest_dependency(
                         })?;
 
                     if latest_msrv.version() < latest.version() {
-                        config.shell().warn(format_args!(
+                        config.emit_diagnostic(format_args!(
                             "ignoring `{dependency}@{latest_version}` (which has a rust-version of \
                              {latest_rust_version}) to satisfy this package's rust-version of \
                              {rust_version} (use `--ignore-rust-version` to override)",

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -100,7 +100,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         // Translate the spec to a Package.
         let spec = PackageIdSpec::parse(spec_str)?;
         if spec.version().is_some() {
-            config.shell().warn(&format!(
+            config.emit_diagnostic(&format!(
                 "version qualifier in `-p {}` is ignored, \
                 cleaning all versions of `{}` found",
                 spec_str,
@@ -108,7 +108,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             ))?;
         }
         if spec.url().is_some() {
-            config.shell().warn(&format!(
+            config.emit_diagnostic(&format!(
                 "url qualifier in `-p {}` ignored, \
                 cleaning all versions of `{}` found",
                 spec_str,

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -222,14 +222,14 @@ pub fn create_bcx<'a, 'cfg>(
         | CompileMode::Bench
         | CompileMode::RunCustomBuild => {
             if ws.config().get_env("RUST_FLAGS").is_ok() {
-                config.shell().warn(
+                config.emit_diagnostic(
                     "Cargo does not read `RUST_FLAGS` environment variable. Did you mean `RUSTFLAGS`?",
                 )?;
             }
         }
         CompileMode::Doc { .. } | CompileMode::Doctest | CompileMode::Docscrape => {
             if ws.config().get_env("RUSTDOC_FLAGS").is_ok() {
-                config.shell().warn(
+                config.emit_diagnostic(
                     "Cargo does not read `RUSTDOC_FLAGS` environment variable. Did you mean `RUSTDOCFLAGS`?"
                 )?;
             }
@@ -331,7 +331,7 @@ pub fn create_bcx<'a, 'cfg>(
     let profiles = Profiles::new(ws, build_config.requested_profile)?;
     profiles.validate_packages(
         ws.profiles(),
-        &mut config.shell(),
+        config,
         workspace_resolve.as_ref().unwrap_or(&resolve),
     )?;
 

--- a/src/cargo/ops/cargo_compile/packages.rs
+++ b/src/cargo/ops/cargo_compile/packages.rs
@@ -59,7 +59,7 @@ impl Packages {
                     .map(Package::package_id)
                     .map(PackageIdSpec::from_package_id)
                     .collect();
-                let warn = |e| ws.config().shell().warn(e);
+                let warn = |e| ws.config().emit_diagnostic(e);
                 emit_package_not_found(ws, names, true).or_else(warn)?;
                 emit_pattern_not_found(ws, patterns, true).or_else(warn)?;
                 specs

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,4 +1,4 @@
-use crate::core::{Shell, Workspace};
+use crate::core::Workspace;
 use crate::ops;
 use crate::util::config::{Config, PathAndArgs};
 use crate::util::CargoResult;
@@ -35,9 +35,8 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
                 cfg.map(|path_args| (path_args.path.resolve_program(ws.config()), path_args.args))
             };
 
-            let mut shell = ws.config().shell();
-            shell.status("Opening", path.display())?;
-            open_docs(&path, &mut shell, config_browser, ws.config())?;
+            ws.config().shell().status("Opening", path.display())?;
+            open_docs(&path, config_browser, ws.config())?;
         }
     }
 
@@ -46,7 +45,6 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
 
 fn open_docs(
     path: &Path,
-    shell: &mut Shell,
     config_browser: Option<(PathBuf, Vec<String>)>,
     config: &Config,
 ) -> CargoResult<()> {
@@ -56,7 +54,7 @@ fn open_docs(
     match browser {
         Some((browser, initial_args)) => {
             if let Err(e) = Command::new(&browser).args(initial_args).arg(path).status() {
-                shell.warn(format!(
+                config.emit_diagnostic(format!(
                     "Couldn't open docs with {}: {}",
                     browser.to_string_lossy(),
                     e
@@ -66,7 +64,7 @@ fn open_docs(
         None => {
             if let Err(e) = opener::open(&path) {
                 let e = e.into();
-                crate::display_warning_with_error("couldn't open docs", &e, shell);
+                crate::display_warning_with_error("couldn't open docs", &e, config);
             }
         }
     };

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -159,8 +159,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     }
     if opts.dry_run {
         opts.config
-            .shell()
-            .warn("not updating lockfile due to dry run")?;
+            .emit_diagnostic("not updating lockfile due to dry run")?;
     } else {
         ops::write_pkg_lockfile(ws, &mut resolve)?;
     }

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -175,7 +175,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
         // If we're installing in --locked mode and there's no `Cargo.lock` published
         // ie. the bin was published before https://github.com/rust-lang/cargo/pull/7026
         if config.locked() && !ws.root().join("Cargo.lock").exists() {
-            config.shell().warn(format!(
+            config.emit_diagnostic(format!(
                 "no Cargo.lock file published in {}",
                 pkg.to_string()
             ))?;
@@ -201,7 +201,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
 
         if from_cwd {
             if pkg.manifest().edition() == Edition::Edition2015 {
-                config.shell().warn(
+                config.emit_diagnostic(
                     "Using `cargo install` to install the binaries for the \
                      package in current working directory is deprecated, \
                      use `cargo install --path .` instead. \
@@ -378,8 +378,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
                 .collect();
             if !binaries.is_empty() {
                 self.config
-                    .shell()
-                    .warn(make_warning_about_missing_features(&binaries))?;
+                    .emit_diagnostic(make_warning_about_missing_features(&binaries))?;
             }
 
             return Ok(false);
@@ -472,8 +471,7 @@ impl<'cfg, 'a> InstallablePackage<'cfg, 'a> {
             {
                 // Don't hard error on remove.
                 self.config
-                    .shell()
-                    .warn(format!("failed to remove orphan: {:?}", e))?;
+                    .emit_diagnostic(format!("failed to remove orphan: {:?}", e))?;
             }
 
             match tracker.save() {
@@ -717,7 +715,7 @@ pub fn install(
         let dst_in_path = env::split_paths(&path).any(|path| path == dst);
 
         if !dst_in_path {
-            config.shell().warn(&format!(
+            config.emit_diagnostic(&format!(
                 "be sure to add `{}` to your PATH to be \
              able to run the installed binaries",
                 dst.display()

--- a/src/cargo/ops/cargo_read_manifest.rs
+++ b/src/cargo/ops/cargo_read_manifest.rs
@@ -187,7 +187,7 @@ fn read_nested_packages(
             // by users so we can hide the warning about those since the user is unlikely
             // to care about those cases.
             if pkg.publish().is_none() {
-                let _ = config.shell().warn(format!(
+                let _ = config.emit_diagnostic(format!(
                     "skipping duplicate package `{}` found at `{}`",
                     pkg.name(),
                     path.display()

--- a/src/cargo/ops/cargo_remove.rs
+++ b/src/cargo/ops/cargo_remove.rs
@@ -55,8 +55,7 @@ pub fn remove(options: &RemoveOptions<'_>) -> CargoResult<()> {
     if options.dry_run {
         options
             .config
-            .shell()
-            .warn("aborting remove due to dry run")?;
+            .emit_diagnostic("aborting remove due to dry run")?;
     } else {
         manifest.write()?;
     }

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -250,7 +250,7 @@ fn wait_for_publish(
 
         let elapsed = now.elapsed();
         if timeout < elapsed {
-            config.shell().warn(format!(
+            config.emit_diagnostic(format!(
                 "timed out waiting for `{short_pkg_description}` to be available in {source_description}",
             ))?;
             config.shell().note(
@@ -387,7 +387,7 @@ fn transmit(
 
     // Do not upload if performing a dry run
     if dry_run {
-        config.shell().warn("aborting upload due to dry run")?;
+        config.emit_diagnostic("aborting upload due to dry run")?;
         return Ok(());
     }
 
@@ -438,7 +438,7 @@ fn transmit(
              ",
             warnings.invalid_categories.join(", ")
         );
-        config.shell().warn(&msg)?;
+        config.emit_diagnostic(&msg)?;
     }
 
     if !warnings.invalid_badges.is_empty() {
@@ -450,12 +450,12 @@ fn transmit(
              for valid badge types and their required attributes.",
             warnings.invalid_badges.join(", ")
         );
-        config.shell().warn(&msg)?;
+        config.emit_diagnostic(&msg)?;
     }
 
     if !warnings.other.is_empty() {
         for msg in warnings.other {
-            config.shell().warn(&msg)?;
+            config.emit_diagnostic(&msg)?;
         }
     }
 

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -155,14 +155,11 @@ pub fn resolve_ws_with_opts<'cfg>(
                 .any(|r| replace_spec.matches(r) && !dep.matches_id(r))
             {
                 ws.config()
-                    .shell()
-                    .warn(format!("package replacement is not used: {}", replace_spec))?
+                    .emit_diagnostic(format!("package replacement is not used: {}", replace_spec))?
             }
 
             if dep.features().len() != 0 || !dep.uses_default_features() {
-                ws.config()
-                .shell()
-                .warn(format!(
+                ws.config().emit_diagnostic(format!(
                     "replacement for `{}` uses the features mechanism. \
                     default-features and features will not take effect because the replacement dependency does not support this mechanism",
                     dep.package_name()
@@ -845,7 +842,7 @@ fn emit_warnings_of_unused_patches(
                 for id in ids.iter() {
                     write!(msg, "\n    {}", id.display_registry_name())?;
                 }
-                ws.config().shell().warn(msg)?;
+                ws.config().emit_diagnostic(msg)?;
             }
             _ => unemitted_unused_patches.push(unused),
         }
@@ -857,9 +854,11 @@ fn emit_warnings_of_unused_patches(
             .iter()
             .map(|pkgid| format!("Patch `{}` {}", pkgid, MESSAGE))
             .collect();
-        ws.config()
-            .shell()
-            .warn(format!("{}\n{}", warnings.join("\n"), UNUSED_PATCH_WARNING))?;
+        ws.config().emit_diagnostic(format!(
+            "{}\n{}",
+            warnings.join("\n"),
+            UNUSED_PATCH_WARNING
+        ))?;
     }
 
     return Ok(());

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -214,7 +214,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         .collect::<CargoResult<Vec<PackageIdSpec>>>()?;
 
     if root_indexes.len() == 0 {
-        ws.config().shell().warn(
+        ws.config().emit_diagnostic(
             "nothing to print.\n\n\
         To find dependencies that require specific target platforms, \
         try to use option `--target all` first, and then narrow your search scope accordingly.",

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -462,7 +462,7 @@ impl<'cfg> PathSource<'cfg> {
                     }
                 }
                 Err(err) if err.loop_ancestor().is_some() => {
-                    self.config.shell().warn(err)?;
+                    self.config.emit_diagnostic(err)?;
                 }
                 Err(err) => match err.path() {
                     // If an error occurs with a path, filter it again.

--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -110,14 +110,14 @@ fn credential_provider(config: &Config, sid: &SourceId) -> CargoResult<Vec<Vec<S
             ..
         }) if allow_cred_proc => {
             if let Some(token) = token {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "{sid} has a token configured in {} that will be ignored \
                     because a credential-provider is configured for this registry`",
                     token.definition
                 ))?;
             }
             if let Some(secret_key) = secret_key {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "{sid} has a secret-key configured in {} that will be ignored \
                     because a credential-provider is configured for this registry`",
                     secret_key.definition
@@ -141,14 +141,14 @@ fn credential_provider(config: &Config, sid: &SourceId) -> CargoResult<Vec<Vec<S
             match (token_pos, paseto_pos) {
                 (Some(token_pos), Some(paseto_pos)) => {
                     if token_pos < paseto_pos {
-                        config.shell().warn(format!(
+                        config.emit_diagnostic(format!(
                             "{sid} has a `secret_key` configured in {} that will be ignored \
                         because a `token` is also configured, and the `cargo:token` provider is \
                         configured with higher precedence",
                             secret_key.definition
                         ))?;
                     } else {
-                        config.shell().warn(format!("{sid} has a `token` configured in {} that will be ignored \
+                        config.emit_diagnostic(format!("{sid} has a `token` configured in {} that will be ignored \
                         because a `secret_key` is also configured, and the `cargo:paseto` provider is \
                         configured with higher precedence", token.definition))?;
                     }
@@ -168,7 +168,7 @@ fn credential_provider(config: &Config, sid: &SourceId) -> CargoResult<Vec<Vec<S
                 .iter()
                 .any(|p| p.first().map(String::as_str) == Some("cargo:token"))
             {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "{sid} has a token configured in {} that will be ignored \
                     because the `cargo:token` credential provider is not listed in \
                     `registry.global-credential-providers`",
@@ -187,7 +187,7 @@ fn credential_provider(config: &Config, sid: &SourceId) -> CargoResult<Vec<Vec<S
                 .iter()
                 .any(|p| p.first().map(String::as_str) == Some("cargo:paseto"))
             {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "{sid} has a secret-key configured in {} that will be ignored \
                     because the `cargo:paseto` credential provider is not listed in \
                     `registry.global-credential-providers`",

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -454,7 +454,7 @@ pub trait ArgMatchesExt {
             // `cargo fix` and `cargo check` has legacy handling of this profile name
             | (Some(name @ "test"), ProfileChecking::LegacyTestOnly) => {
                 if self.flag("release") {
-                    config.shell().warn(
+                    config.emit_diagnostic(
                         "the `--release` flag should not be specified with the `--profile` flag\n\
                          The `--release` flag will be ignored.\n\
                          This was historically accepted, but will become an error \

--- a/src/cargo/util/config/de.rs
+++ b/src/cargo/util/config/de.rs
@@ -249,7 +249,7 @@ impl<'config> ConfigMapAccess<'config> {
                 .iter()
                 .filter(|(k, _v)| !given_fields.iter().any(|gk| gk == k));
             for (unused_key, unused_value) in unused_keys {
-                de.config.shell().warn(format!(
+                de.config.emit_diagnostic(format!(
                     "unused config key `{}.{}` in `{}`",
                     de.key,
                     unused_key,

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -53,7 +53,7 @@ pub(super) fn load_target_cfgs(config: &Config) -> CargoResult<Vec<(String, Targ
             // solution might be to create a special "Any" type, but I think
             // that will be quite difficult with the current design.
             for other_key in cfg.other.keys() {
-                config.shell().warn(format!(
+                config.emit_diagnostic(format!(
                     "unused key `{}` in [target] config table `{}`",
                     other_key, key
                 ))?;
@@ -210,7 +210,7 @@ fn parse_links_overrides(
                         let list = value.list(key)?;
                         output.check_cfgs.extend(list.iter().map(|v| v.0.clone()));
                     } else {
-                        config.shell().warn(format!(
+                        config.emit_diagnostic(format!(
                             "target config `{}.{}` requires -Zcheck-cfg=output flag",
                             target_key, key
                         ))?;

--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -125,7 +125,7 @@ impl<'a> DiagnosticPrinter<'a> {
             }
             Message::ReplaceFailed { file, message } => {
                 let msg = format!("error applying suggestions to `{}`\n", file);
-                self.config.shell().warn(&msg)?;
+                self.config.emit_diagnostic(&msg)?;
                 write!(
                     self.config.shell().err(),
                     "The full error message was:\n\n> {}\n\n",
@@ -146,15 +146,15 @@ impl<'a> DiagnosticPrinter<'a> {
                 abnormal_exit,
             } => {
                 if let Some(ref krate) = *krate {
-                    self.config.shell().warn(&format!(
+                    self.config.emit_diagnostic(&format!(
                         "failed to automatically apply fixes suggested by rustc \
                          to crate `{}`",
                         krate,
                     ))?;
                 } else {
-                    self.config
-                        .shell()
-                        .warn("failed to automatically apply fixes suggested by rustc")?;
+                    self.config.emit_diagnostic(
+                        "failed to automatically apply fixes suggested by rustc",
+                    )?;
                 }
                 if !files.is_empty() {
                     writeln!(
@@ -207,7 +207,7 @@ impl<'a> DiagnosticPrinter<'a> {
                     message: "".to_string(), // Dummy, so that this only long-warns once.
                     edition: *edition,
                 }) {
-                    self.config.shell().warn(&format!("\
+                    self.config.emit_diagnostic(&format!("\
 {}
 
 If you are trying to migrate from the previous edition ({prev_edition}), the
@@ -224,7 +224,7 @@ https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-proje
                         message, this_edition=edition, prev_edition=edition.previous().unwrap()
                     ))
                 } else {
-                    self.config.shell().warn(message)
+                    self.config.emit_diagnostic(message)
                 }
             }
         }

--- a/src/cargo/util/network/retry.rs
+++ b/src/cargo/util/network/retry.rs
@@ -52,7 +52,7 @@ impl<'a> Retry<'a> {
                     "spurious network error ({} tries remaining): {err_msg}",
                     self.max_retries - self.retries,
                 );
-                if let Err(e) = self.config.shell().warn(msg) {
+                if let Err(e) = self.config.emit_diagnostic(msg) {
                     return RetryResult::Err(e);
                 }
                 self.retries += 1;

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -83,7 +83,7 @@ fn expand_manifest_(
         .entry("version".to_owned())
         .or_insert_with(|| toml::Value::String(DEFAULT_VERSION.to_owned()));
     package.entry("edition".to_owned()).or_insert_with(|| {
-        let _ = config.shell().warn(format_args!(
+        let _ = config.emit_diagnostic(format_args!(
             "`package.edition` is unspecified, defaulting to `{}`",
             DEFAULT_EDITION
         ));

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1952,7 +1952,7 @@ impl TomlManifest {
         let mut package = match (&me.package, &me.project) {
             (Some(_), Some(project)) => {
                 if source_id.is_path() {
-                    config.shell().warn(format!(
+                    config.emit_diagnostic(format!(
                         "manifest at `{}` contains both `project` and `package`, \
                     this could become a hard error in the future",
                         package_root.display()
@@ -1963,7 +1963,7 @@ impl TomlManifest {
             (Some(package), None) => package.clone(),
             (None, Some(project)) => {
                 if source_id.is_path() {
-                    config.shell().warn(format!(
+                    config.emit_diagnostic(format!(
                         "manifest at `{}` contains `[project]` instead of `[package]`, \
                                 this could become a hard error in the future",
                         package_root.display()


### PR DESCRIPTION
#12235 is tracking user control over warnings. Part of the effort means moving warnings from being emitted by `Shell` to `Config`. This is for a few reasons:
1. `Shell` should not know what a user wants to do with a given warning other than emit anything that is passed to it
2. `Config` should (eventually) know what a user wants to do for each warning `cargo` is attempting to display, be that `forbid`, `deny`, `warn`, or `allow`.

In both scenarios, it makes sense to move things to `Config`, which is what this PR does. It adds a new function `Config::emit_diagnostic`, which is a copy of  [`Shell::warn`](https://github.com/rust-lang/cargo/blob/80eca0e58fb2ff52c1e94fc191b55b37ed73e0e4/src/cargo/core/shell.rs#L262), and moves all calls from `Shell::warn` to this new function.
