### PR TITLE
ci: test `resolver-tests` in a separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
       run: 'cargo test -p cargo --test testsuite -- fix::'
       env:
         __CARGO_TEST_FORCE_ARGFILE: 1
-    - run: cargo test --workspace --exclude cargo --exclude benchsuite
+    - run: cargo test --workspace --exclude cargo --exclude benchsuite --exclude resolver-tests
     - name: Check benchmarks
       run: |
         # This only tests one benchmark since it can take over 10 minutes to


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

resolver-tests was run a separate job but accidentally included in <https://github.com/rust-lang/cargo/pull/12342>. This PR excludes it again.
<!-- homu-ignore:end -->
