### PR TITLE
fix(update): Clarify meaning of --aggressive as --recursive

### DIFF
--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -24,9 +24,10 @@ pub fn cli() -> Command {
         .arg_dry_run("Don't actually write the lockfile")
         .arg(
             flag(
-                "aggressive",
+                "recursive",
                 "Force updating all dependencies of [SPEC]... as well",
             )
+            .alias("aggressive")
             .conflicts_with("precise"),
         )
         .arg(
@@ -68,7 +69,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     }
 
     let update_opts = UpdateOptions {
-        aggressive: args.flag("aggressive"),
+        recursive: args.flag("recursive"),
         precise: args.get_one::<String>("precise").map(String::as_str),
         to_update,
         dry_run: args.dry_run(),

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -14,7 +14,7 @@ pub struct UpdateOptions<'a> {
     pub config: &'a Config,
     pub to_update: Vec<String>,
     pub precise: Option<&'a str>,
-    pub aggressive: bool,
+    pub recursive: bool,
     pub dry_run: bool,
     pub workspace: bool,
 }
@@ -38,8 +38,8 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
 }
 
 pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoResult<()> {
-    if opts.aggressive && opts.precise.is_some() {
-        anyhow::bail!("cannot specify both aggressive and precise simultaneously")
+    if opts.recursive && opts.precise.is_some() {
+        anyhow::bail!("cannot specify both recursive and precise simultaneously")
     }
 
     if ws.members().count() == 0 {
@@ -89,7 +89,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
         let mut sources = Vec::new();
         for name in opts.to_update.iter() {
             let dep = previous_resolve.query(name)?;
-            if opts.aggressive {
+            if opts.recursive {
                 fill_with_deps(&previous_resolve, dep, &mut to_avoid, &mut HashSet::new());
             } else {
                 to_avoid.insert(dep);

--- a/src/doc/man/cargo-update.md
+++ b/src/doc/man/cargo-update.md
@@ -33,7 +33,7 @@ will remain locked at their currently recorded versions.
 If _spec_ is not specified, all dependencies are updated.
 {{/option}}
 
-{{#option "`--aggressive`" }}
+{{#option "`--recursive`" }}
 When used with _spec_, dependencies of _spec_ are forced to update as well.
 Cannot be used with `--precise`.
 {{/option}}

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -26,7 +26,7 @@ OPTIONS
 
            If spec is not specified, all dependencies are updated.
 
-       --aggressive
+       --recursive
            When used with spec, dependencies of spec are forced to update as
            well. Cannot be used with --precise.
 

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -31,7 +31,7 @@ will remain locked at their currently recorded versions.</p>
 <p>If <em>spec</em> is not specified, all dependencies are updated.</dd>
 
 
-<dt class="option-term" id="option-cargo-update---aggressive"><a class="option-anchor" href="#option-cargo-update---aggressive"></a><code>--aggressive</code></dt>
+<dt class="option-term" id="option-cargo-update---recursive"><a class="option-anchor" href="#option-cargo-update---recursive"></a><code>--recursive</code></dt>
 <dd class="option-desc">When used with <em>spec</em>, dependencies of <em>spec</em> are forced to update as well.
 Cannot be used with <code>--precise</code>.</dd>
 

--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -342,7 +342,7 @@ instead.
 [`cargo update`] can be used to update the entries in `Cargo.lock` when new
 versions are published. Without any options, it will attempt to update all
 packages in the lock file. The `-p` flag can be used to target the update for
-a specific package, and other flags such as `--aggressive` or `--precise` can
+a specific package, and other flags such as `--recursive` or `--precise` can
 be used to control how versions are selected.
 
 [`cargo build`]: ../commands/cargo-build.md

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -342,6 +342,7 @@ _cargo() {
                 update)
                     _arguments -s -S $common $manifest \
                         '--aggressive=[force dependency update]' \
+                        '--recursive=[force dependency update]' \
                         "--dry-run[don't actually write the lockfile]" \
                         '(-p --package)'{-p+,--package=}'[specify package to update]:package:_cargo_package_names' \
                         '--precise=[update single dependency to precise release]:release' \

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -87,7 +87,7 @@ _cargo()
 	local opt__t="$opt__test"
 	local opt__tree="$opt_common $opt_pkg_spec $opt_feat $opt_mani $opt_lock --target -i --invert --prefix --no-dedupe --duplicates -d --charset -f --format -e --edges"
 	local opt__uninstall="$opt_common $opt_lock $opt_pkg --bin --root"
-	local opt__update="$opt_common $opt_mani $opt_lock $opt_pkg --aggressive --precise --dry-run"
+	local opt__update="$opt_common $opt_mani $opt_lock $opt_pkg --aggressive --recursive --precise --dry-run"
 	local opt__vendor="$opt_common $opt_mani $opt_lock $opt_sync --no-delete --respect-source-config --versioned-dirs"
 	local opt__verify_project="$opt_common $opt_mani $opt_lock"
 	local opt__version="$opt_common $opt_lock"

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -28,7 +28,7 @@ will remain locked at their currently recorded versions.
 If \fIspec\fR is not specified, all dependencies are updated.
 .RE
 .sp
-\fB\-\-aggressive\fR
+\fB\-\-recursive\fR
 .RS 4
 When used with \fIspec\fR, dependencies of \fIspec\fR are forced to update as well.
 Cannot be used with \fB\-\-precise\fR\&.

--- a/tests/testsuite/cargo_update/help/stdout.log
+++ b/tests/testsuite/cargo_update/help/stdout.log
@@ -4,7 +4,7 @@ Usage: cargo[EXE] update [OPTIONS] [SPEC]...
 
 Options:
       --dry-run             Don't actually write the lockfile
-      --aggressive          Force updating all dependencies of [SPEC]... as well
+      --recursive           Force updating all dependencies of [SPEC]... as well
       --precise <PRECISE>   Update [SPEC] to exactly PRECISE
   -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -769,9 +769,9 @@ Caused by:
         .with_stdout("")
         .run();
 
-    // Updating aggressively should, however, update the repo.
-    println!("dep1 aggressive update");
-    p.cargo("update dep1 --aggressive")
+    // Updating recursively should, however, update the repo.
+    println!("dep1 recursive update");
+    p.cargo("update dep1 --recursive")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
              [UPDATING] bar v0.5.0 ([..]) -> #[..]\n\


### PR DESCRIPTION
When working on cargo-upgrade, I found the meaning of `--aggressive` confusing and named it `--recursive` there.

Renaming this in `cargo update` (with a backwards compatible alias) was referenced in #12425.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
