### PR TITLE
Create dedicated unstable flag for asymmetric-token

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -718,6 +718,7 @@ unstable_cli_options!(
     // All other unstable features.
     // Please keep this list lexicographically ordered.
     advanced_env: bool = (HIDDEN),
+    asymmetric_token: bool = ("Allows authenticating with asymmetric tokens"),
     avoid_dev_deps: bool = ("Avoid installing dev-dependencies if possible"),
     binary_dep_depinfo: bool = ("Track changes to dependency artifacts"),
     bindeps: bool = ("Allow Cargo packages to depend on bin, cdylib, and staticlib crates, and use the artifacts built by those crates"),
@@ -744,7 +745,7 @@ unstable_cli_options!(
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     profile_rustflags: bool = ("Enable the `rustflags` option in profiles in .cargo/config.toml file"),
     publish_timeout: bool = ("Enable the `publish.timeout` key in .cargo/config.toml file"),
-    registry_auth: bool = ("Authentication for alternative registries, and generate registry authentication tokens using asymmetric cryptography"),
+    registry_auth: bool = ("Authentication for alternative registries"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     rustdoc_scrape_examples: bool = ("Allows Rustdoc to scrape code examples from reverse-dependencies"),
     script: bool = ("Enable support for single-file, `.rs` packages"),
@@ -1087,6 +1088,7 @@ impl CliUnstable {
             // Unstable features
             // Sorted alphabetically:
             "advanced-env" => self.advanced_env = parse_empty(k, v)?,
+            "asymmetric-token" => self.asymmetric_token = parse_empty(k, v)?,
             "avoid-dev-deps" => self.avoid_dev_deps = parse_empty(k, v)?,
             "binary-dep-depinfo" => self.binary_dep_depinfo = parse_empty(k, v)?,
             "bindeps" => self.bindeps = parse_empty(k, v)?,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -989,7 +989,7 @@ can go to get a token.
 WWW-Authenticate: Cargo login_url="https://test-registry-login/me
 ```
 
-This same flag is also used to enable asymmetric authentication tokens.
+### asymmetric-token
 * Tracking Issue: [10519](https://github.com/rust-lang/cargo/issues/10519)
 * RFC: [#3231](https://github.com/rust-lang/rfcs/pull/3231)
 
@@ -1115,7 +1115,7 @@ executed within the Cargo process. They are identified with the `cargo:` prefix.
   * `CARGO_REGISTRY_INDEX_URL` --- The URL of the registry index.
   * `CARGO_REGISTRY_NAME_OPT` --- Optional name of the registry. Should not be used as a storage key. Not always available.
 
-* `cargo:paseto` - implements asymmetric token support (RFC3231) as a credential provider.
+* `cargo:paseto` - implements asymmetric token support (RFC3231) as a credential provider. Requires `-Zasymmetric-token`.
 
 
 `cargo-credential-1password` uses the 1password `op` CLI to store the token. You must

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -492,8 +492,8 @@ fn both_asymmetric_and_token() {
     )
     .unwrap();
 
-    cargo_process("login -Z credential-process -v abcdefg")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+    cargo_process("login -Zasymmetric-token -v abcdefg")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .replace_crates_io(server.index_url())
         .with_stderr(
             r#"[UPDATING] [..]

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -197,8 +197,8 @@ fn bad_asymmetric_token_args() {
         .build();
 
     // These cases are kept brief as the implementation is covered by clap, so this is only smoke testing that we have clap configured correctly.
-    cargo_process("login -Zcredential-process -- --key-subject")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+    cargo_process("login -Zcredential-process -Zasymmetric-token -- --key-subject")
+        .masquerade_as_nightly_cargo(&["credential-process", "asymmetric-token"])
         .replace_crates_io(registry.index_url())
         .with_stderr_contains(
             "  error: a value is required for '--key-subject <SUBJECT>' but none was supplied",
@@ -228,7 +228,7 @@ fn login_with_asymmetric_token_and_subject_on_stdin() {
         .no_configure_token()
         .build();
     let credentials = credentials_toml();
-    cargo_process("login -v -Z credential-process -- --key-subject=foo")
+    cargo_process("login -v -Z credential-process -Z asymmetric-token -- --key-subject=foo")
         .masquerade_as_nightly_cargo(&["credential-process"])
         .replace_crates_io(registry.index_url())
         .with_stderr_contains(
@@ -286,8 +286,8 @@ fn login_with_asymmetric_token_on_stdin() {
         .no_configure_token()
         .build();
     let credentials = credentials_toml();
-    cargo_process("login -vZ credential-process --registry alternative")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+    cargo_process("login -vZ credential-process -Z asymmetric-token --registry alternative")
+        .masquerade_as_nightly_cargo(&["credential-process", "asymmetric-token"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -308,8 +308,8 @@ fn login_with_generate_asymmetric_token() {
         .no_configure_token()
         .build();
     let credentials = credentials_toml();
-    cargo_process("login -Z credential-process --registry alternative")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+    cargo_process("login -Z credential-process -Z asymmetric-token --registry alternative")
+        .masquerade_as_nightly_cargo(&["credential-process", "asymmetric-token"])
         .with_stderr("[UPDATING] `alternative` index\nk3.public.[..]")
         .run();
     let credentials = fs::read_to_string(&credentials).unwrap();

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -117,8 +117,8 @@ fn simple_add_with_asymmetric() {
     // The http_api server will check that the authorization is correct.
     // If the authorization was not sent then we would get an unauthorized error.
     p.cargo("owner -a username")
-        .arg("-Zcredential-process")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+        .arg("-Zasymmetric-token")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .replace_crates_io(registry.index_url())
         .with_status(0)
         .run();
@@ -184,9 +184,9 @@ fn simple_remove_with_asymmetric() {
     // The http_api server will check that the authorization is correct.
     // If the authorization was not sent then we would get an unauthorized error.
     p.cargo("owner -r username")
-        .arg("-Zcredential-process")
+        .arg("-Zasymmetric-token")
         .replace_crates_io(registry.index_url())
-        .masquerade_as_nightly_cargo(&["credential-process"])
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .with_status(0)
         .run();
 }

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -194,8 +194,8 @@ fn simple_publish_with_asymmetric() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("publish --no-verify -Zcredential-process --registry dummy-registry")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+    p.cargo("publish --no-verify -Zasymmetric-token --registry dummy-registry")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -6,9 +6,10 @@ use cargo_test_support::{project, Execs, Project};
 
 fn cargo(p: &Project, s: &str) -> Execs {
     let mut e = p.cargo(s);
-    e.masquerade_as_nightly_cargo(&["registry-auth", "credential-process"])
+    e.masquerade_as_nightly_cargo(&["registry-auth", "credential-process", "asymmetric-token"])
         .arg("-Zregistry-auth")
-        .arg("-Zcredential-process");
+        .arg("-Zcredential-process")
+        .arg("-Zasymmetric-token");
     e
 }
 

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -76,14 +76,14 @@ fn explicit_version_with_asymmetric() {
     // The http_api server will check that the authorization is correct.
     // If the authorization was not sent then we would get an unauthorized error.
     p.cargo("yank --version 0.0.1")
-        .arg("-Zcredential-process")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+        .arg("-Zasymmetric-token")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .replace_crates_io(registry.index_url())
         .run();
 
     p.cargo("yank --undo --version 0.0.1")
-        .arg("-Zcredential-process")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+        .arg("-Zasymmetric-token")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .replace_crates_io(registry.index_url())
         .run();
 }


### PR DESCRIPTION
Asymmetric tokens are gated by `-Zcredential-process`. Since we're considering stabilizing that soon, this moves asymmetric token support to have its own unstable flag.

It was previously gated by `-Zregistry-auth`, and some of the docs were not updated when it moved.

r? @Eh2406 