### PR TITLE
fix(toml): Improve parse errors

### DIFF
--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -2,7 +2,6 @@ use std::io::prelude::*;
 
 use crate::core::{resolver, Resolve, ResolveVersion, Workspace};
 use crate::util::errors::CargoResult;
-use crate::util::toml as cargo_toml;
 use crate::util::Filesystem;
 
 use anyhow::Context as _;
@@ -20,8 +19,7 @@ pub fn load_pkg_lockfile(ws: &Workspace<'_>) -> CargoResult<Option<Resolve>> {
         .with_context(|| format!("failed to read file: {}", f.path().display()))?;
 
     let resolve = (|| -> CargoResult<Option<Resolve>> {
-        let resolve: toml::Table = cargo_toml::parse_document(&s, f.path(), ws.config())?;
-        let v: resolver::EncodableResolve = resolve.try_into()?;
+        let v: resolver::EncodableResolve = toml::from_str(&s)?;
         Ok(Some(v.into_resolve(&s, ws)?))
     })()
     .with_context(|| format!("failed to parse lock file at: {}", f.path().display()))?;

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -194,8 +194,7 @@ fn read_manifest_from_str(
 
 pub fn parse_document(toml: &str, _file: &Path, _config: &Config) -> CargoResult<toml::Table> {
     // At the moment, no compatibility checks are needed.
-    toml.parse()
-        .map_err(|e| anyhow::Error::from(e).context("could not parse input as TOML"))
+    toml.parse().map_err(Into::into)
 }
 
 /// Warn about paths that have been deprecated and may conflict.

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -196,8 +196,11 @@ fn bad_cargo_lock() {
 [ERROR] failed to parse lock file at: [..]Cargo.lock
 
 Caused by:
+  TOML parse error at line 1, column 1
+    |
+  1 | [[package]]
+    | ^^^^^^^^^^^
   missing field `name`
-  in `package`
 ",
         )
         .run();
@@ -300,8 +303,11 @@ fn bad_source_in_cargo_lock() {
 [ERROR] failed to parse lock file at: [..]
 
 Caused by:
+  TOML parse error at line 12, column 26
+     |
+  12 |                 source = \"You shall not parse\"
+     |                          ^^^^^^^^^^^^^^^^^^^^^
   invalid source `You shall not parse`
-  in `package.source`
 ",
         )
         .run();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1285,8 +1285,11 @@ fn bad_dependency() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
+  TOML parse error at line 8, column 23
+    |
+  8 |                 bar = 3
+    |                       ^
   invalid type: integer `3`, expected a version string like [..]
-  in `dependencies.bar`
 ",
         )
         .run();
@@ -1317,8 +1320,11 @@ fn bad_debuginfo() {
 error: failed to parse manifest [..]
 
 Caused by:
+  TOML parse error at line 8, column 25
+    |
+  8 |                 debug = 'a'
+    |                         ^^^
   invalid value: string \"a\", expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
-  in `profile.dev.debug`
 ",
         )
         .run();
@@ -1349,8 +1355,11 @@ fn bad_debuginfo2() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
+  TOML parse error at line 8, column 25
+    |
+  8 |                 debug = 3.6
+    |                         ^^^
   invalid type: floating point `3.6`, expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
-  in `profile.dev.debug`
 ",
         )
         .run();
@@ -1379,8 +1388,11 @@ fn bad_opt_level() {
 error: failed to parse manifest at `[..]`
 
 Caused by:
+  TOML parse error at line 6, column 25
+    |
+  6 |                 build = 3
+    |                         ^
   expected a boolean or a string
-  in `package.build`
 ",
         )
         .run();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -172,9 +172,6 @@ Caused by:
   could not parse TOML configuration in `[..]`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
   TOML parse error at line 1, column 2
     |
   1 | 4
@@ -447,9 +444,6 @@ fn malformed_override() {
         .with_stderr(
             "\
 [ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  could not parse input as TOML
 
 Caused by:
   TOML parse error at line 8, column 27
@@ -802,9 +796,6 @@ error: could not load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]`
-
-Caused by:
-  could not parse input as TOML
 
 Caused by:
   TOML parse error at line 1, column 7

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -259,9 +259,6 @@ fn cargo_compile_with_invalid_manifest2() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
   TOML parse error at line 3, column 23
     |
   3 |                 foo = bar
@@ -282,9 +279,6 @@ fn cargo_compile_with_invalid_manifest3() {
         .with_stderr(
             "\
 [ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  could not parse input as TOML
 
 Caused by:
   TOML parse error at line 1, column 5
@@ -3034,9 +3028,6 @@ fn bad_cargo_config() {
 
 Caused by:
   could not parse TOML configuration in `[..]`
-
-Caused by:
-  could not parse input as TOML
 
 Caused by:
   TOML parse error at line 1, column 6

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -340,8 +340,11 @@ fn cargo_compile_with_invalid_version() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
+  TOML parse error at line 4, column 19
+    |
+  4 |         version = \"1.0\"
+    |                   ^^^^^
   unexpected end of input while parsing minor version number
-  in `package.version`
 ",
         )
         .run();

--- a/tests/testsuite/cargo_add/invalid_manifest/stderr.log
+++ b/tests/testsuite/cargo_add/invalid_manifest/stderr.log
@@ -1,9 +1,6 @@
 error: failed to parse manifest at `[ROOT]/case/Cargo.toml`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
   TOML parse error at line 8, column 7
     |
   8 | key = invalid-value

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -53,9 +53,6 @@ Caused by:
   could not parse TOML configuration in `[..]/config`
 
 Caused by:
-  [..]
-
-Caused by:
   TOML parse error at line [..]
     |
   3 |                 b-cargo-test = `

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -676,8 +676,8 @@ fn wrong_position() {
 error: failed to parse manifest at [..]
 
 Caused by:
-  cargo-features = [\"test-dummy-unstable\"] was found in the wrong location: it \
-  should be set at the top of Cargo.toml before any tables
+  the field `cargo-features` should be set at the top of Cargo.toml before any tables
+  in `package.cargo-features`
 ",
         )
         .run();

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -676,8 +676,11 @@ fn wrong_position() {
 error: failed to parse manifest at [..]
 
 Caused by:
+  TOML parse error at line 5, column 34
+    |
+  5 |                 cargo-features = [\"test-dummy-unstable\"]
+    |                                  ^^^^^^^^^^^^^^^^^^^^^^^
   the field `cargo-features` should be set at the top of Cargo.toml before any tables
-  in `package.cargo-features`
 ",
         )
         .run();

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -722,9 +722,6 @@ Caused by:
   could not parse TOML configuration in `[..]/.cargo/config`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
   TOML parse error at line 1, column 5
   |
 1 | asdf
@@ -1089,9 +1086,6 @@ could not load Cargo configuration
 
 Caused by:
   could not parse TOML configuration in `[..]/.cargo/config`
-
-Caused by:
-  could not parse input as TOML
 
 Caused by:
   TOML parse error at line 3, column 1

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2578,9 +2578,6 @@ Caused by:
   failed to parse manifest at `[..]`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
   TOML parse error at line 8, column 21
     |
   8 |                     categories = [\"algorithms\"]

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1234,8 +1234,11 @@ fn error_workspace_false() {
 [ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
+  TOML parse error at line 7, column 41
+    |
+  7 |             description = { workspace = false }
+    |                                         ^^^^^
   `workspace` cannot be false
-  in `package.description.workspace`
 ",
         )
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1323,9 +1323,6 @@ fn error_malformed_workspace_root() {
 
 Caused by:
   [..]
-
-Caused by:
-  [..]
     |
   3 |             members = [invalid toml
     |                        ^

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1821,8 +1821,11 @@ fn cargo_metadata_with_invalid_authors_field() {
             r#"[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: string "", expected a vector of strings or workspace
-  in `package.authors`"#,
+  TOML parse error at line 3, column 27
+    |
+  3 |                 authors = ""
+    |                           ^^
+  invalid type: string "", expected a vector of strings or workspace"#,
         )
         .run();
 }
@@ -1846,8 +1849,11 @@ fn cargo_metadata_with_invalid_version_field() {
             r#"[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: integer `1`, expected SemVer version
-  in `package.version`"#,
+  TOML parse error at line 3, column 27
+    |
+  3 |                 version = 1
+    |                           ^
+  invalid type: integer `1`, expected SemVer version"#,
         )
         .run();
 }
@@ -1871,8 +1877,11 @@ fn cargo_metadata_with_invalid_publish_field() {
             r#"[ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  invalid type: string "foo", expected a boolean, a vector of strings, or workspace
-  in `package.publish`"#,
+  TOML parse error at line 3, column 27
+    |
+  3 |                 publish = "foo"
+    |                           ^^^^^
+  invalid type: string "foo", expected a boolean, a vector of strings, or workspace"#,
         )
         .run();
 }

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1091,9 +1091,6 @@ fn new_warning_with_corrupt_ws() {
 failed to parse manifest at `[..]foo/Cargo.toml`
 
 Caused by:
-  could not parse input as TOML
-
-Caused by:
   TOML parse error at line 1, column 5
     |
   1 | asdf


### PR DESCRIPTION
### What does this PR try to resolve?

When we adopted `toml_edit`, we got TOML syntax errors that showed the context for where the error occurred.  However, the work was not done to extend this to semantic errors reported by serde.

This updates `Cargo.toml` and `Cargo.lock` code to provide that context on semantic errors.  `config.toml` is not done because the schema is decentralized.

In theory, this will also improve performance because we aren't having to allocate a lot of intermediate data to then throw away for every `Cargo.toml` we read.

### How should we test and review this PR?

Check by commit to see this change gradually.
- The `package.cargo-features` change was made to drop out dependence on `toml::Table` so we could do the direct deserialization
