### PR TITLE
feat(resolver): **Very** preliminary MSRV resolver support

### DIFF
--- a/benches/benchsuite/benches/resolve.rs
+++ b/benches/benchsuite/benches/resolve.rs
@@ -31,6 +31,7 @@ fn do_resolve<'cfg>(config: &'cfg Config, ws_root: &Path) -> ResolveInfo<'cfg> {
     let specs = pkgs.to_package_id_specs(&ws).unwrap();
     let has_dev_units = HasDevUnits::Yes;
     let force_all_targets = ForceAllTargets::No;
+    let max_rust_version = None;
     // Do an initial run to download anything necessary so that it does
     // not confuse criterion's warmup.
     let ws_resolve = cargo::ops::resolve_ws_with_opts(
@@ -41,6 +42,7 @@ fn do_resolve<'cfg>(config: &'cfg Config, ws_root: &Path) -> ResolveInfo<'cfg> {
         &specs,
         has_dev_units,
         force_all_targets,
+        max_rust_version,
     )
     .unwrap();
     ResolveInfo {
@@ -82,6 +84,7 @@ fn resolve_ws(c: &mut Criterion) {
                 force_all_targets,
                 ..
             } = lazy_info.get_or_insert_with(|| do_resolve(&config, &ws_root));
+            let max_rust_version = None;
             b.iter(|| {
                 cargo::ops::resolve_ws_with_opts(
                     ws,
@@ -91,6 +94,7 @@ fn resolve_ws(c: &mut Criterion) {
                     specs,
                     *has_dev_units,
                     *force_all_targets,
+                    max_rust_version,
                 )
                 .unwrap();
             })

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -188,6 +188,7 @@ pub fn resolve_with_config_raw(
     .unwrap();
     let opts = ResolveOpts::everything();
     let start = Instant::now();
+    let max_rust_version = None;
     let resolve = resolver::resolve(
         &[(summary, opts)],
         &[],
@@ -195,6 +196,7 @@ pub fn resolve_with_config_raw(
         &VersionPreferences::default(),
         Some(config),
         true,
+        max_rust_version,
     );
 
     // The largest test in our suite takes less then 30 sec.

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -145,6 +145,7 @@ pub fn resolve_std<'cfg>(
     let cli_features = CliFeatures::from_command_line(
         &features, /*all_features*/ false, /*uses_default_features*/ false,
     )?;
+    let max_rust_version = ws.rust_version();
     let resolve = ops::resolve_ws_with_opts(
         &std_ws,
         target_data,
@@ -153,6 +154,7 @@ pub fn resolve_std<'cfg>(
         &specs,
         HasDevUnits::No,
         crate::core::resolver::features::ForceAllTargets::No,
+        max_rust_version,
     )?;
     Ok((
         resolve.pkg_set,

--- a/src/cargo/core/resolver/dep_cache.rs
+++ b/src/cargo/core/resolver/dep_cache.rs
@@ -21,6 +21,7 @@ use crate::core::{
 };
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
+use crate::util::PartialVersion;
 
 use anyhow::Context as _;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -36,6 +37,7 @@ pub struct RegistryQueryer<'a> {
     /// versions first. That allows `cargo update -Z minimal-versions` which will
     /// specify minimum dependency versions to be used.
     minimal_versions: bool,
+    max_rust_version: Option<PartialVersion>,
     /// a cache of `Candidate`s that fulfil a `Dependency` (and whether `first_minimal_version`)
     registry_cache: HashMap<(Dependency, bool), Poll<Rc<Vec<Summary>>>>,
     /// a cache of `Dependency`s that are required for a `Summary`
@@ -57,12 +59,14 @@ impl<'a> RegistryQueryer<'a> {
         replacements: &'a [(PackageIdSpec, Dependency)],
         version_prefs: &'a VersionPreferences,
         minimal_versions: bool,
+        max_rust_version: Option<PartialVersion>,
     ) -> Self {
         RegistryQueryer {
             registry,
             replacements,
             version_prefs,
             minimal_versions,
+            max_rust_version,
             registry_cache: HashMap::new(),
             summary_cache: HashMap::new(),
             used_replacements: HashMap::new(),
@@ -112,7 +116,9 @@ impl<'a> RegistryQueryer<'a> {
 
         let mut ret = Vec::new();
         let ready = self.registry.query(dep, QueryKind::Exact, &mut |s| {
-            ret.push(s);
+            if self.max_rust_version.is_none() || s.rust_version() <= self.max_rust_version {
+                ret.push(s);
+            }
         })?;
         if ready.is_pending() {
             self.registry_cache

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -23,6 +23,7 @@ use crate::util::edit_distance;
 use crate::util::errors::{CargoResult, ManifestError};
 use crate::util::interning::InternedString;
 use crate::util::toml::{read_manifest, InheritableFields, TomlDependency, TomlProfiles};
+use crate::util::PartialVersion;
 use crate::util::{config::ConfigRelativePath, Config, Filesystem, IntoUrl};
 use cargo_util::paths;
 use cargo_util::paths::normalize_path;
@@ -593,6 +594,12 @@ impl<'cfg> Workspace<'cfg> {
     pub fn set_ignore_lock(&mut self, ignore_lock: bool) -> &mut Workspace<'cfg> {
         self.ignore_lock = ignore_lock;
         self
+    }
+
+    /// Get the lowest-common denominator `package.rust-version` within the workspace, if specified
+    /// anywhere
+    pub fn rust_version(&self) -> Option<PartialVersion> {
+        self.members().filter_map(|pkg| pkg.rust_version()).min()
     }
 
     pub fn custom_metadata(&self) -> Option<&toml::Value> {

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -261,6 +261,7 @@ pub fn create_bcx<'a, 'cfg>(
             HasDevUnits::No
         }
     };
+    let max_rust_version = ws.rust_version();
     let resolve = ops::resolve_ws_with_opts(
         ws,
         &mut target_data,
@@ -269,6 +270,7 @@ pub fn create_bcx<'a, 'cfg>(
         &specs,
         has_dev_units,
         crate::core::resolver::features::ForceAllTargets::No,
+        max_rust_version,
     )?;
     let WorkspaceResolve {
         mut pkg_set,

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -21,6 +21,7 @@ pub struct UpdateOptions<'a> {
 
 pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
     let mut registry = PackageRegistry::new(ws.config())?;
+    let max_rust_version = ws.rust_version();
     let mut resolve = ops::resolve_with_previous(
         &mut registry,
         ws,
@@ -30,6 +31,7 @@ pub fn generate_lockfile(ws: &Workspace<'_>) -> CargoResult<()> {
         None,
         &[],
         true,
+        max_rust_version,
     )?;
     ops::write_pkg_lockfile(ws, &mut resolve)?;
     Ok(())
@@ -47,6 +49,8 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     // Updates often require a lot of modifications to the registry, so ensure
     // that we're synchronized against other Cargos.
     let _lock = ws.config().acquire_package_cache_lock()?;
+
+    let max_rust_version = ws.rust_version();
 
     let previous_resolve = match ops::load_pkg_lockfile(ws)? {
         Some(resolve) => resolve,
@@ -67,6 +71,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                         None,
                         &[],
                         true,
+                        max_rust_version,
                     )?
                 }
             }
@@ -125,6 +130,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
         Some(&to_avoid),
         &[],
         true,
+        max_rust_version,
     )?;
 
     // Summarize what is changing for the user.

--- a/src/cargo/ops/cargo_output_metadata.rs
+++ b/src/cargo/ops/cargo_output_metadata.rs
@@ -135,6 +135,8 @@ fn build_resolve_graph(
         crate::core::resolver::features::ForceAllTargets::No
     };
 
+    let max_rust_version = ws.rust_version();
+
     // Note that even with --filter-platform we end up downloading host dependencies as well,
     // as that is the behavior of download_accessible.
     let ws_resolve = ops::resolve_ws_with_opts(
@@ -145,6 +147,7 @@ fn build_resolve_graph(
         &specs,
         HasDevUnits::Yes,
         force_all,
+        max_rust_version,
     )?;
 
     let package_map: BTreeMap<PackageId, Package> = ws_resolve

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -423,6 +423,8 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
         TomlManifest::to_real_manifest(&toml_manifest, false, source_id, package_root, config)?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 
+    let max_rust_version = new_pkg.rust_version();
+
     // Regenerate Cargo.lock using the old one as a guide.
     let tmp_ws = Workspace::ephemeral(new_pkg, ws.config(), None, true)?;
     let mut tmp_reg = PackageRegistry::new(ws.config())?;
@@ -435,6 +437,7 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
         None,
         &[],
         true,
+        max_rust_version,
     )?;
     let pkg_set = ops::get_resolved_packages(&new_resolve, tmp_reg)?;
 

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -246,6 +246,8 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
     let mut target_data =
         RustcTargetData::new(ws, &opts.compile_opts.build_config.requested_kinds)?;
     let mut resolve_differences = |has_dev_units| -> CargoResult<(WorkspaceResolve<'_>, DiffMap)> {
+        let max_rust_version = ws.rust_version();
+
         let ws_resolve = ops::resolve_ws_with_opts(
             ws,
             &mut target_data,
@@ -254,6 +256,7 @@ fn check_resolver_change(ws: &Workspace<'_>, opts: &FixOptions) -> CargoResult<(
             &specs,
             has_dev_units,
             crate::core::resolver::features::ForceAllTargets::No,
+            max_rust_version,
         )?;
 
         let feature_opts = FeatureOpts::new_behavior(ResolveBehavior::V2, has_dev_units);

--- a/src/cargo/ops/tree/mod.rs
+++ b/src/cargo/ops/tree/mod.rs
@@ -150,6 +150,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
     } else {
         ForceAllTargets::No
     };
+    let max_rust_version = ws.rust_version();
     let ws_resolve = ops::resolve_ws_with_opts(
         ws,
         &mut target_data,
@@ -158,6 +159,7 @@ pub fn build_and_print(ws: &Workspace<'_>, opts: &TreeOptions) -> CargoResult<()
         &specs,
         has_dev,
         force_all,
+        max_rust_version,
     )?;
 
     let package_map: HashMap<PackageId, &Package> = ws_resolve

--- a/src/cargo/util/semver_ext.rs
+++ b/src/cargo/util/semver_ext.rs
@@ -108,7 +108,7 @@ impl From<VersionReq> for OptVersionReq {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]
 pub struct PartialVersion {
     pub major: u64,
     pub minor: Option<u64>,

--- a/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
@@ -26,7 +26,7 @@ fn case() {
         .current_dir(cwd)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
-        .success()
+        .code(101)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/tests/testsuite/cargo_add/rust_version_ignore/stderr.log
+++ b/tests/testsuite/cargo_add/rust_version_ignore/stderr.log
@@ -1,2 +1,7 @@
     Updating `dummy-registry` index
       Adding rust-version-user v0.2.1 to dependencies.
+error: failed to select a version for the requirement `rust-version-user = "^0.2.1"`
+candidate versions found which didn't match: 0.2.1, 0.1.0
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
+required by package `cargo-list-test-fixture v0.0.0 ([ROOT]/case)`
+perhaps a crate was updated and forgotten to be re-vendored?

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -213,21 +213,34 @@ fn dependency_rust_version_newer_than_package() {
         .build();
 
     p.cargo("check --ignore-rust-version")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        // This shouldn't fail
+        .with_status(101)
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
-[CHECKING] bar v1.6.0
-[CHECKING] [..]
-[FINISHED] [..]
+[ERROR] failed to select a version for the requirement `bar = \"^1.0.0\"`
+candidate versions found which didn't match: 1.6.0
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
+required by package `foo v0.0.1 ([CWD])`
+perhaps a crate was updated and forgotten to be re-vendored?
 ",
         )
         .run();
     p.cargo("check")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        .with_status(101)
+        // This should have a better error message
         .with_stderr(
             "\
-[FINISHED] [..]
+[UPDATING] `dummy-registry` index
+[ERROR] failed to select a version for the requirement `bar = \"^1.0.0\"`
+candidate versions found which didn't match: 1.6.0
+location searched: `dummy-registry` index (which is replacing registry `crates-io`)
+required by package `foo v0.0.1 ([CWD])`
+perhaps a crate was updated and forgotten to be re-vendored?
 ",
         )
         .run();
@@ -261,18 +274,23 @@ fn dependency_rust_version_older_and_newer_than_package() {
         .build();
 
     p.cargo("check --ignore-rust-version")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        // This should pick 1.6.0
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
-[CHECKING] bar v1.6.0
+[DOWNLOADED] bar v1.5.0 (registry `dummy-registry`)
+[CHECKING] bar v1.5.0
 [CHECKING] [..]
 [FINISHED] [..]
 ",
         )
         .run();
     p.cargo("check")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
             "\
 [FINISHED] [..]
@@ -329,18 +347,23 @@ fn workspace_with_mixed_rust_version() {
         .build();
 
     p.cargo("check --ignore-rust-version")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        // This should pick 1.6.0
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
-[CHECKING] bar v1.6.0
+[DOWNLOADED] bar v1.4.0 (registry `dummy-registry`)
+[CHECKING] bar v1.4.0
 [CHECKING] [..]
 [FINISHED] [..]
 ",
         )
         .run();
     p.cargo("check")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
             "\
 [FINISHED] [..]


### PR DESCRIPTION
### What does this PR try to resolve?

A bare bones implementation of an MSRV resolver that is good enough for people running on nightly when they really need it but is not ready for general use.  

Current limitations
- Does not honor `--ignore-version`
- Gives terrible error messages
- Nothing is done yet regarding `cargo install`
- Doesn't inform the user when choosing non-latest

These will be  noted in #9930 on merge.

Implementation wise, this is yet another hack (sorry @Eh2406).  Our expectation to get this GA is to refactor the resolver to make the cargo/resolver boundary look a little more like the cargo/pubgrub boundary so we can better control policy without any of these hacks which will also make having all of the policy we need for this easier to maintain.

This is a part of #9930

### How should we test and review this PR?

Per commit