### PR TITLE
chore: add missing `windows-sys` features back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,10 +194,12 @@ fwdansi.workspace = true
 workspace = true
 features = [
   "Win32_Foundation",
+  "Win32_Security",
   "Win32_Storage_FileSystem",
+  "Win32_System_IO",
   "Win32_System_Console",
-  "Win32_System_Threading",
   "Win32_System_JobObjects",
+  "Win32_System_Threading",
 ]
 
 [dev-dependencies]


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fixes #12562

This is kinda a revert of <https://github.com/rust-lang/cargo/pull/12176>. I feel like it's better declaring all features direct in use in `Cargo.toml` regardless features are already unified from dependencies.

I've manually checked all windows-sys API usages in each workspace member and only `cargo` crate needs these being added.

### How should we test and review this PR?

Build them on your windows machine (I don't have one and too lazy to create a VM at this moment 😜)

### Additional information

Have some long-term plans in mind <https://github.com/rust-lang/cargo/issues/12562#issuecomment-1694242076>.

I believe backports is needed.

* `rust-1.73.0` branch (beta) for `0.74.0` crate release https://github.com/rust-lang/cargo/pull/12564
* `rust-1.72.0` branch (stable) for `0.73.1` crate release https://github.com/rust-lang/cargo/pull/12565
<!-- homu-ignore:end -->
