### PR TITLE
[beta-1.73.0] add missing `windows-sys` features back

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,10 +193,12 @@ fwdansi.workspace = true
 workspace = true
 features = [
   "Win32_Foundation",
+  "Win32_Security",
   "Win32_Storage_FileSystem",
+  "Win32_System_IO",
   "Win32_System_Console",
-  "Win32_System_Threading",
   "Win32_System_JobObjects",
+  "Win32_System_Threading",
 ]
 
 [dev-dependencies]

--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -5,7 +5,7 @@
 //! rough outline is:
 //!
 //! 1. Resolve the dependency graph (see [`ops::resolve`]).
-//! 2. Download any packages needed (see [`PackageSet`](crate::core::PackageSet)).
+//! 2. Download any packages needed (see [`PackageSet`].
 //! 3. Generate a list of top-level "units" of work for the targets the user
 //!   requested on the command-line. Each [`Unit`] corresponds to a compiler
 //!   invocation. This is done in this module ([`UnitGenerator::generate_root_units`]).


### PR DESCRIPTION
Fixes <https://github.com/rust-lang/cargo/issues/12562>

Beta backports:

- <https://github.com/rust-lang/cargo/issues/12563>

In order to make CI pass, the following PRs are also cherry-picked:

- c508cb683ec70f0f298f48211f9a505805d6615e from #12538