### PR TITLE
Update serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -2906,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ rustfix = "0.6.1"
 same-file = "1.0.6"
 security-framework = "2.9.2"
 semver = { version = "1.0.18", features = ["serde"] }
-serde = "1.0.171"
+serde = "1.0.188"
 serde-value = "0.7.0"
 serde_ignored = "0.1.9"
 serde_json = "1.0.104"


### PR DESCRIPTION
This updates serde to the latest version (essentially reverting #12528). The current lock is preventing publishing of credential crates because they were published with a newer version.
