### PR TITLE
Define {{command}} for use in src/doc/man/includes

### DIFF
--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -1,5 +1,5 @@
 # cargo-add(1)
-
+{{*set command="add"}}
 {{*set actionverb="Add"}}
 {{*set nouns="adds"}}
 

--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -1,7 +1,7 @@
 # cargo-add(1)
-{{*set command="add"}}
-{{*set actionverb="Add"}}
-{{*set nouns="adds"}}
+{{~*set command="add"}}
+{{~*set actionverb="Add"}}
+{{~*set nouns="adds"}}
 
 ## NAME
 

--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -1,4 +1,5 @@
 # cargo-bench(1)
+{{*set command="bench"}}
 {{*set actionverb="Benchmark"}}
 {{*set nouns="benchmarks"}}
 {{*set multitarget=true}}

--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -1,8 +1,8 @@
 # cargo-bench(1)
-{{*set command="bench"}}
-{{*set actionverb="Benchmark"}}
-{{*set nouns="benchmarks"}}
-{{*set multitarget=true}}
+{{~*set command="bench"}}
+{{~*set actionverb="Benchmark"}}
+{{~*set nouns="benchmarks"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-build.md
+++ b/src/doc/man/cargo-build.md
@@ -1,4 +1,5 @@
 # cargo-build(1)
+{{*set command="build"}}
 {{*set actionverb="Build"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-build.md
+++ b/src/doc/man/cargo-build.md
@@ -1,7 +1,7 @@
 # cargo-build(1)
-{{*set command="build"}}
-{{*set actionverb="Build"}}
-{{*set multitarget=true}}
+{{~*set command="build"}}
+{{~*set actionverb="Build"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-check.md
+++ b/src/doc/man/cargo-check.md
@@ -1,4 +1,5 @@
 # cargo-check(1)
+{{*set command="check"}}
 {{*set actionverb="Check"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-check.md
+++ b/src/doc/man/cargo-check.md
@@ -1,7 +1,7 @@
 # cargo-check(1)
-{{*set command="check"}}
-{{*set actionverb="Check"}}
-{{*set multitarget=true}}
+{{~*set command="check"}}
+{{~*set actionverb="Check"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-clean.md
+++ b/src/doc/man/cargo-clean.md
@@ -1,7 +1,7 @@
 # cargo-clean(1)
-{{*set command="clean"}}
-{{*set actionverb="Clean"}}
-{{*set multitarget=true}}
+{{~*set command="clean"}}
+{{~*set actionverb="Clean"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-clean.md
+++ b/src/doc/man/cargo-clean.md
@@ -1,4 +1,5 @@
 # cargo-clean(1)
+{{*set command="clean"}}
 {{*set actionverb="Clean"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -1,4 +1,5 @@
 # cargo-doc(1)
+{{*set command="doc"}}
 {{*set actionverb="Document"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-doc.md
+++ b/src/doc/man/cargo-doc.md
@@ -1,7 +1,7 @@
 # cargo-doc(1)
-{{*set command="doc"}}
-{{*set actionverb="Document"}}
-{{*set multitarget=true}}
+{{~*set command="doc"}}
+{{~*set actionverb="Document"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-fetch.md
+++ b/src/doc/man/cargo-fetch.md
@@ -1,8 +1,8 @@
 # cargo-fetch(1)
-{{*set command="fetch"}}
-{{*set actionverb="Fetch"}}
-{{*set target-default-to-all-arch=true}}
-{{*set multitarget=true}}
+{{~*set command="fetch"}}
+{{~*set actionverb="Fetch"}}
+{{~*set target-default-to-all-arch=true}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-fetch.md
+++ b/src/doc/man/cargo-fetch.md
@@ -1,4 +1,5 @@
 # cargo-fetch(1)
+{{*set command="fetch"}}
 {{*set actionverb="Fetch"}}
 {{*set target-default-to-all-arch=true}}
 {{*set multitarget=true}}

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -1,7 +1,7 @@
 # cargo-fix(1)
-{{*set command="fix"}}
-{{*set actionverb="Fix"}}
-{{*set multitarget=true}}
+{{~*set command="fix"}}
+{{~*set actionverb="Fix"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-fix.md
+++ b/src/doc/man/cargo-fix.md
@@ -1,4 +1,5 @@
 # cargo-fix(1)
+{{*set command="fix"}}
 {{*set actionverb="Fix"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -1,7 +1,7 @@
 # cargo-install(1)
-{{*set command="install"}}
-{{*set actionverb="Install"}}
-{{*set temp-target-dir=true}}
+{{~*set command="install"}}
+{{~*set actionverb="Install"}}
+{{~*set temp-target-dir=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -1,4 +1,5 @@
 # cargo-install(1)
+{{*set command="install"}}
 {{*set actionverb="Install"}}
 {{*set temp-target-dir=true}}
 

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -1,8 +1,8 @@
 # cargo-package(1)
-{{*set command="package"}}
-{{*set actionverb="Package"}}
-{{*set noall=true}}
-{{*set multitarget=true}}
+{{~*set command="package"}}
+{{~*set actionverb="Package"}}
+{{~*set noall=true}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -1,4 +1,5 @@
 # cargo-package(1)
+{{*set command="package"}}
 {{*set actionverb="Package"}}
 {{*set noall=true}}
 {{*set multitarget=true}}

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -1,7 +1,7 @@
 # cargo-publish(1)
-{{*set command="publish"}}
-{{*set actionverb="Publish"}}
-{{*set multitarget=true}}
+{{~*set command="publish"}}
+{{~*set actionverb="Publish"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-publish.md
+++ b/src/doc/man/cargo-publish.md
@@ -1,4 +1,5 @@
 # cargo-publish(1)
+{{*set command="publish"}}
 {{*set actionverb="Publish"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-remove.md
+++ b/src/doc/man/cargo-remove.md
@@ -1,7 +1,7 @@
 # cargo-remove(1)
-{{*set command="remove"}}
-{{*set actionverb="Remove"}}
-{{*set nouns="removes"}}
+{{~*set command="remove"}}
+{{~*set actionverb="Remove"}}
+{{~*set nouns="removes"}}
 
 ## NAME
 

--- a/src/doc/man/cargo-remove.md
+++ b/src/doc/man/cargo-remove.md
@@ -1,4 +1,5 @@
 # cargo-remove(1)
+{{*set command="remove"}}
 {{*set actionverb="Remove"}}
 {{*set nouns="removes"}}
 

--- a/src/doc/man/cargo-run.md
+++ b/src/doc/man/cargo-run.md
@@ -1,6 +1,6 @@
 # cargo-run(1)
-{{*set command="run"}}
-{{*set actionverb="Run"}}
+{{~*set command="run"}}
+{{~*set actionverb="Run"}}
 
 ## NAME
 

--- a/src/doc/man/cargo-run.md
+++ b/src/doc/man/cargo-run.md
@@ -1,4 +1,5 @@
 # cargo-run(1)
+{{*set command="run"}}
 {{*set actionverb="Run"}}
 
 ## NAME

--- a/src/doc/man/cargo-rustc.md
+++ b/src/doc/man/cargo-rustc.md
@@ -1,4 +1,5 @@
 # cargo-rustc(1)
+{{*set command="rustc"}}
 {{*set actionverb="Build"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-rustc.md
+++ b/src/doc/man/cargo-rustc.md
@@ -1,7 +1,7 @@
 # cargo-rustc(1)
-{{*set command="rustc"}}
-{{*set actionverb="Build"}}
-{{*set multitarget=true}}
+{{~*set command="rustc"}}
+{{~*set actionverb="Build"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-rustdoc.md
+++ b/src/doc/man/cargo-rustdoc.md
@@ -1,4 +1,5 @@
 # cargo-rustdoc(1)
+{{*set command="rustdoc"}}
 {{*set actionverb="Document"}}
 {{*set multitarget=true}}
 

--- a/src/doc/man/cargo-rustdoc.md
+++ b/src/doc/man/cargo-rustdoc.md
@@ -1,7 +1,7 @@
 # cargo-rustdoc(1)
-{{*set command="rustdoc"}}
-{{*set actionverb="Document"}}
-{{*set multitarget=true}}
+{{~*set command="rustdoc"}}
+{{~*set actionverb="Document"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -1,8 +1,8 @@
 # cargo-test(1)
-{{*set command="test"}}
-{{*set actionverb="Test"}}
-{{*set nouns="tests"}}
-{{*set multitarget=true}}
+{{~*set command="test"}}
+{{~*set actionverb="Test"}}
+{{~*set nouns="tests"}}
+{{~*set multitarget=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-test.md
+++ b/src/doc/man/cargo-test.md
@@ -1,4 +1,5 @@
 # cargo-test(1)
+{{*set command="test"}}
 {{*set actionverb="Test"}}
 {{*set nouns="tests"}}
 {{*set multitarget=true}}

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -1,7 +1,7 @@
 # cargo-tree(1)
-{{*set command="tree"}}
-{{*set actionverb="Display"}}
-{{*set noall=true}}
+{{~*set command="tree"}}
+{{~*set actionverb="Display"}}
+{{~*set noall=true}}
 
 ## NAME
 

--- a/src/doc/man/cargo-tree.md
+++ b/src/doc/man/cargo-tree.md
@@ -1,4 +1,5 @@
 # cargo-tree(1)
+{{*set command="tree"}}
 {{*set actionverb="Display"}}
 {{*set noall=true}}
 

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -1,8 +1,5 @@
 # cargo-add(1)
 
-
-
-
 ## NAME
 
 cargo-add --- Add dependencies to a Cargo.toml manifest file

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -1,9 +1,5 @@
 # cargo-bench(1)
 
-
-
-
-
 ## NAME
 
 cargo-bench --- Execute benchmarks of a package

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -3,6 +3,7 @@
 
 
 
+
 ## NAME
 
 cargo-bench --- Execute benchmarks of a package

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-build --- Compile the current package

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -1,8 +1,5 @@
 # cargo-build(1)
 
-
-
-
 ## NAME
 
 cargo-build --- Compile the current package

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -1,8 +1,5 @@
 # cargo-check(1)
 
-
-
-
 ## NAME
 
 cargo-check --- Check the current package

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-check --- Check the current package

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -1,8 +1,5 @@
 # cargo-clean(1)
 
-
-
-
 ## NAME
 
 cargo-clean --- Remove generated artifacts

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-clean --- Remove generated artifacts

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -1,8 +1,5 @@
 # cargo-doc(1)
 
-
-
-
 ## NAME
 
 cargo-doc --- Build a package's documentation

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-doc --- Build a package's documentation

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -3,6 +3,7 @@
 
 
 
+
 ## NAME
 
 cargo-fetch --- Fetch dependencies of a package from the network

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -1,9 +1,5 @@
 # cargo-fetch(1)
 
-
-
-
-
 ## NAME
 
 cargo-fetch --- Fetch dependencies of a package from the network

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -1,8 +1,5 @@
 # cargo-fix(1)
 
-
-
-
 ## NAME
 
 cargo-fix --- Automatically fix lint warnings reported by rustc

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-fix --- Automatically fix lint warnings reported by rustc

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -1,8 +1,5 @@
 # cargo-install(1)
 
-
-
-
 ## NAME
 
 cargo-install --- Build and install a Rust binary

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-install --- Build and install a Rust binary

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -1,9 +1,5 @@
 # cargo-package(1)
 
-
-
-
-
 ## NAME
 
 cargo-package --- Assemble the local package into a distributable tarball

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -3,6 +3,7 @@
 
 
 
+
 ## NAME
 
 cargo-package --- Assemble the local package into a distributable tarball

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-publish --- Upload a package to the registry

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -1,8 +1,5 @@
 # cargo-publish(1)
 
-
-
-
 ## NAME
 
 cargo-publish --- Upload a package to the registry

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -1,8 +1,5 @@
 # cargo-remove(1)
 
-
-
-
 ## NAME
 
 cargo-remove --- Remove dependencies from a Cargo.toml manifest file

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-remove --- Remove dependencies from a Cargo.toml manifest file

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -1,6 +1,7 @@
 # cargo-run(1)
 
 
+
 ## NAME
 
 cargo-run --- Run the current package

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -1,7 +1,5 @@
 # cargo-run(1)
 
-
-
 ## NAME
 
 cargo-run --- Run the current package

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -1,8 +1,5 @@
 # cargo-rustc(1)
 
-
-
-
 ## NAME
 
 cargo-rustc --- Compile the current package, and pass extra options to the compiler

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-rustc --- Compile the current package, and pass extra options to the compiler

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-rustdoc --- Build a package's documentation, using specified custom flags

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -1,8 +1,5 @@
 # cargo-rustdoc(1)
 
-
-
-
 ## NAME
 
 cargo-rustdoc --- Build a package's documentation, using specified custom flags

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -3,6 +3,7 @@
 
 
 
+
 ## NAME
 
 cargo-test --- Execute unit and integration tests of a package

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -1,9 +1,5 @@
 # cargo-test(1)
 
-
-
-
-
 ## NAME
 
 cargo-test --- Execute unit and integration tests of a package

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -1,8 +1,5 @@
 # cargo-tree(1)
 
-
-
-
 ## NAME
 
 cargo-tree --- Display a tree visualization of a dependency graph

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -2,6 +2,7 @@
 
 
 
+
 ## NAME
 
 cargo-tree --- Display a tree visualization of a dependency graph


### PR DESCRIPTION
I am interested in using this in https://github.com/rust-lang/cargo/pull/12568.

```diff
  {{#option "`--keep-going`"}}
  Build as many crates in the dependency graph as possible, rather than aborting
  the build on the first one that fails to build.

  For example if the current package depends on dependencies `fails` and `works`,
- one of which fails to build, `cargo check -j1` may or may not build the one that
+ one of which fails to build, `cargo {{command}} -j1` may or may not build the one that
  succeeds (depending on which one of the two builds Cargo picked to run first),
- whereas `cargo check -j1 --keep-going` would definitely run both builds, even if
+ whereas `cargo {{command}} -j1 --keep-going` would definitely run both builds, even if
  the one run first fails.
  {{/option}}
```

