### PR TITLE
Improve deserialization errors of untagged enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,6 +307,7 @@ dependencies = [
  "same-file",
  "semver",
  "serde",
+ "serde-untagged",
  "serde-value",
  "serde_ignored",
  "serde_json",
@@ -835,6 +836,15 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "erased-serde"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "errno"
@@ -2892,6 +2902,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e342997ced06c0793568a54cfc61109a8c5a7b5ecf8fd9de89a5066d82af936b"
+dependencies = [
+ "erased-serde",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ same-file = "1.0.6"
 security-framework = "2.9.2"
 semver = { version = "1.0.18", features = ["serde"] }
 serde = "1.0.188"
+serde-untagged = "0.1.0"
 serde-value = "0.7.0"
 serde_ignored = "0.1.9"
 serde_json = "1.0.104"
@@ -163,6 +164,7 @@ rand.workspace = true
 rustfix.workspace = true
 semver.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde-untagged.workspace = true
 serde-value.workspace = true
 serde_ignored.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -84,6 +84,7 @@ use curl::easy::Easy;
 use lazycell::LazyCell;
 use serde::de::IntoDeserializer as _;
 use serde::Deserialize;
+use serde_untagged::UntaggedEnumVisitor;
 use time::OffsetDateTime;
 use toml_edit::Item;
 use url::Url;
@@ -2453,11 +2454,22 @@ impl CargoFutureIncompatConfig {
 /// ssl-version.min = "tlsv1.2"
 /// ssl-version.max = "tlsv1.3"
 /// ```
-#[derive(Clone, Debug, Deserialize, PartialEq)]
-#[serde(untagged)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum SslVersionConfig {
     Single(String),
     Range(SslVersionConfigRange),
+}
+
+impl<'de> Deserialize<'de> for SslVersionConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        UntaggedEnumVisitor::new()
+            .string(|single| Ok(SslVersionConfig::Single(single.to_owned())))
+            .map(|map| map.deserialize().map(SslVersionConfig::Range))
+            .deserialize(deserializer)
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
@@ -2493,11 +2505,22 @@ pub struct CargoSshConfig {
 /// [build]
 /// jobs = "default" # Currently only support "default".
 /// ```
-#[derive(Debug, Deserialize, Clone)]
-#[serde(untagged)]
+#[derive(Debug, Clone)]
 pub enum JobsConfig {
     Integer(i32),
     String(String),
+}
+
+impl<'de> Deserialize<'de> for JobsConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        UntaggedEnumVisitor::new()
+            .i32(|int| Ok(JobsConfig::Integer(int)))
+            .string(|string| Ok(JobsConfig::String(string.to_owned())))
+            .deserialize(deserializer)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -2534,11 +2557,22 @@ pub struct BuildTargetConfig {
     inner: Value<BuildTargetConfigInner>,
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug)]
 enum BuildTargetConfigInner {
     One(String),
     Many(Vec<String>),
+}
+
+impl<'de> Deserialize<'de> for BuildTargetConfigInner {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        UntaggedEnumVisitor::new()
+            .string(|one| Ok(BuildTargetConfigInner::One(one.to_owned())))
+            .seq(|many| many.deserialize().map(BuildTargetConfigInner::Many))
+            .deserialize(deserializer)
+    }
 }
 
 impl BuildTargetConfig {
@@ -2652,17 +2686,42 @@ where
     deserializer.deserialize_option(ProgressVisitor)
 }
 
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
+#[derive(Debug)]
 enum EnvConfigValueInner {
     Simple(String),
     WithOptions {
         value: String,
-        #[serde(default)]
         force: bool,
-        #[serde(default)]
         relative: bool,
     },
+}
+
+impl<'de> Deserialize<'de> for EnvConfigValueInner {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WithOptions {
+            value: String,
+            #[serde(default)]
+            force: bool,
+            #[serde(default)]
+            relative: bool,
+        }
+
+        UntaggedEnumVisitor::new()
+            .string(|simple| Ok(EnvConfigValueInner::Simple(simple.to_owned())))
+            .map(|map| {
+                let with_options: WithOptions = map.deserialize()?;
+                Ok(EnvConfigValueInner::WithOptions {
+                    value: with_options.value,
+                    force: with_options.force,
+                    relative: with_options.relative,
+                })
+            })
+            .deserialize(deserializer)
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1421,6 +1421,108 @@ fn warn_semver_metadata() {
 }
 
 #[cargo_test]
+fn bad_http_ssl_version() {
+    // Invalid type in SslVersionConfig.
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [http]
+            ssl-version = ["tlsv1.2", "tlsv1.3"]
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] error in [..]/config.toml: could not load config key `http.ssl-version`
+
+Caused by:
+  invalid type: sequence, expected a string or map
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bad_http_ssl_version_range() {
+    // Invalid type in SslVersionConfigRange.
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [http]
+            ssl-version.min = false
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] data did not match any variant of untagged enum SslVersionConfig
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bad_build_jobs() {
+    // Invalid type in JobsConfig.
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            jobs = { default = true }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] data did not match any variant of untagged enum JobsConfig
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bad_build_target() {
+    // Invalid type in BuildTargetConfig.
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+            [build]
+            target.'cfg(unix)' = "x86_64"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] error in [..]/config.toml: could not load config key `build.target`
+
+Caused by:
+  data did not match any variant of untagged enum BuildTargetConfigInner
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn bad_target_cfg() {
     // Invalid type in a StringList.
     //

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1392,7 +1392,7 @@ Caused by:
     |
   6 |                 build = 3
     |                         ^
-  expected a boolean or a string
+  invalid type: integer `3`, expected a boolean or string
 ",
         )
         .run();
@@ -1465,7 +1465,10 @@ fn bad_http_ssl_version_range() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] data did not match any variant of untagged enum SslVersionConfig
+[ERROR] error in [..]/config.toml: could not load config key `http.ssl-version`
+
+Caused by:
+  error in [..]/config.toml: `http.ssl-version.min` expected a string, but found a boolean
 ",
         )
         .run();
@@ -1489,7 +1492,10 @@ fn bad_build_jobs() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] data did not match any variant of untagged enum JobsConfig
+[ERROR] error in [..]/config.toml: could not load config key `build.jobs`
+
+Caused by:
+  invalid type: map, expected an integer or string
 ",
         )
         .run();
@@ -1516,7 +1522,10 @@ fn bad_build_target() {
 [ERROR] error in [..]/config.toml: could not load config key `build.target`
 
 Caused by:
-  data did not match any variant of untagged enum BuildTargetConfigInner
+  error in [..]/config.toml: could not load config key `build.target`
+
+Caused by:
+  invalid type: map, expected a string or array
 ",
         )
         .run();

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -211,6 +211,38 @@ Caused by:
 }
 
 #[cargo_test]
+fn invalid_type_in_lint_value() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [workspace.lints.rust]
+                rust-2018-idioms = -1
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    foo.cargo("check -Zlints")
+        .masquerade_as_nightly_cargo(&["lints"])
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]/Cargo.toml`
+
+Caused by:
+  data did not match any variant of untagged enum TomlLint
+  in `rust.rust-2018-idioms`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn fail_on_tool_injection() {
     let foo = project()
         .file(

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -235,7 +235,7 @@ fn invalid_type_in_lint_value() {
 error: failed to parse manifest at `[..]/Cargo.toml`
 
 Caused by:
-  data did not match any variant of untagged enum TomlLint
+  invalid type: integer `-1`, expected a string or map
   in `rust.rust-2018-idioms`
 ",
         )


### PR DESCRIPTION
### What does this PR try to resolve?

```toml
# .cargo/config.toml

[http]
ssl-version.min = false
```

**Before:**

```console
$ cargo check
error: data did not match any variant of untagged enum SslVersionConfig
```

**After:**

```console
$ cargo check
error: error in /path/to/.cargo/config.toml: could not load config key `http.ssl-version`

Caused by:
  error in /path/to/.cargo/config.toml: `http.ssl-version.min` expected a string, but found a boolean
```

### How should we test and review this PR?

The first commit adds tests showing the pre-existing error messages &mdash; mostly just _"data did not match any variant of untagged enum T"_ with no location information. The second commit replaces all `#[derive(Deserialize)] #[serde(untagged)]` with Deserialize impls based on https://docs.rs/serde-untagged/0.1, showing the effect on the error messages.

Tested with `cargo test`, and by handwriting some bad .cargo/config.toml files and looking at the error produced by `rust-lang/cargo/target/release/cargo check`.