### PR TITLE
cargo install: suggest --git when package name is url

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -121,6 +121,14 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             )
             .into());
         }
+
+        if let Ok(url) = crate_name.into_url() {
+            return Err(anyhow!(
+                "invalid package name: `{url}`
+    Use `cargo install --git {url}` if you meant to install from a git repository."
+            )
+            .into());
+        }
     }
 
     let mut from_cwd = false;

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -123,11 +123,13 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         }
 
         if let Ok(url) = crate_name.into_url() {
-            return Err(anyhow!(
-                "invalid package name: `{url}`
+            if matches!(url.scheme(), "http" | "https") {
+                return Err(anyhow!(
+                    "invalid package name: `{url}`
     Use `cargo install --git {url}` if you meant to install from a git repository."
-            )
-            .into());
+                )
+                .into());
+            }
         }
     }
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -72,6 +72,18 @@ fn toolchain() {
 }
 
 #[cargo_test]
+fn url() {
+    pkg("foo", "0.0.1");
+    cargo_process("install https://github.com/bar/foo")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] invalid package name: `https://github.com/bar/foo`
+    Use `cargo install --git https://github.com/bar/foo` if you meant to install from a git repository.")
+        .run();
+}
+
+#[cargo_test]
 fn simple_with_message_format() {
     pkg("foo", "0.0.1");
 


### PR DESCRIPTION
### What does this PR try to resolve?

Improve the error message when specifying a URL for a package name in `cargo install`.

Fixes #10485 

### How should we test and review this PR?

Just cargo test and trying a common case like `cargo install https://github.com/rust-lang/cargo`

### Additional information

I found this PR after finishing this one: #10522
But it seems have a larger scope to refactor some of the related code.

Perhaps this one would be easier to merge and that one could focus on the refactor, otherwise sorry for the noise and feel free to close.
