### PR TITLE
refactor: Use more serde_untagged 

### DIFF
--- a/src/cargo/util/interning.rs
+++ b/src/cargo/util/interning.rs
@@ -1,4 +1,5 @@
 use serde::{Serialize, Serializer};
+use serde_untagged::UntaggedEnumVisitor;
 use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::HashSet;
@@ -150,28 +151,14 @@ impl Serialize for InternedString {
     }
 }
 
-struct InternedStringVisitor;
-
 impl<'de> serde::Deserialize<'de> for InternedString {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_str(InternedStringVisitor)
-    }
-}
-
-impl<'de> serde::de::Visitor<'de> for InternedStringVisitor {
-    type Value = InternedString;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("an String like thing")
-    }
-
-    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-    where
-        E: serde::de::Error,
-    {
-        Ok(InternedString::new(v))
+        UntaggedEnumVisitor::new()
+            .expecting("an String like thing")
+            .string(|value| Ok(InternedString::new(value)))
+            .deserialize(deserializer)
     }
 }

--- a/src/cargo/util/semver_ext.rs
+++ b/src/cargo/util/semver_ext.rs
@@ -1,4 +1,5 @@
 use semver::{Comparator, Op, Version, VersionReq};
+use serde_untagged::UntaggedEnumVisitor;
 use std::fmt::{self, Display};
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug)]
@@ -198,25 +199,10 @@ impl<'de> serde::Deserialize<'de> for PartialVersion {
     where
         D: serde::Deserializer<'de>,
     {
-        struct VersionVisitor;
-
-        impl<'de> serde::de::Visitor<'de> for VersionVisitor {
-            type Value = PartialVersion;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-                formatter.write_str("SemVer version")
-            }
-
-            fn visit_str<E>(self, string: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                string.parse().map_err(serde::de::Error::custom)
-            }
-        }
-
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
+        UntaggedEnumVisitor::new()
+            .expecting("SemVer version")
+            .string(|value| value.parse().map_err(serde::de::Error::custom))
+            .deserialize(deserializer)
     }
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #12574 that replaces hand-implemented Visitors with `serde_untagged` because I felt it is cleaner code

Due to an error reporting limitation in `serde_untagged`, I'm not using
this for some `MaybeWorkspace` types because it makes the errors worse.  See dtolnay/serde-untagged#2

I also held off on some config visitors because they seemed more
complicated and I didn't want to risk that code.

### How should we test and review this PR?

The main caveat is we might not have tests for every single error case.

### Additional information

