### PR TITLE
Set tracing target for networking messages.

### DIFF
--- a/src/cargo/util/network/http.rs
+++ b/src/cargo/util/network/http.rs
@@ -135,7 +135,7 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
 
     if let Some(true) = http.debug {
         handle.verbose(true)?;
-        tracing::debug!("{:#?}", curl::Version::get());
+        tracing::debug!(target: "network", "{:#?}", curl::Version::get());
         handle.debug_function(|kind, data| {
             enum LogLevel {
                 Debug,
@@ -167,16 +167,20 @@ pub fn configure_http_handle(config: &Config, handle: &mut Easy) -> CargoResult<
                             line = "set-cookie: [REDACTED]";
                         }
                         match level {
-                            Debug => debug!("http-debug: {prefix} {line}"),
-                            Trace => trace!("http-debug: {prefix} {line}"),
+                            Debug => debug!(target: "network", "http-debug: {prefix} {line}"),
+                            Trace => trace!(target: "network", "http-debug: {prefix} {line}"),
                         }
                     }
                 }
                 Err(_) => {
                     let len = data.len();
                     match level {
-                        Debug => debug!("http-debug: {prefix} ({len} bytes of data)"),
-                        Trace => trace!("http-debug: {prefix} ({len} bytes of data)"),
+                        Debug => {
+                            debug!(target: "network", "http-debug: {prefix} ({len} bytes of data)")
+                        }
+                        Trace => {
+                            trace!(target: "network", "http-debug: {prefix} ({len} bytes of data)")
+                        }
                     }
                 }
             }

--- a/src/cargo/util/network/mod.rs
+++ b/src/cargo/util/network/mod.rs
@@ -29,7 +29,7 @@ macro_rules! try_old_curl {
         let result = $e;
         if cfg!(target_os = "macos") {
             if let Err(e) = result {
-                ::tracing::warn!("ignoring libcurl {} error: {}", $msg, e);
+                ::tracing::warn!(target: "network", "ignoring libcurl {} error: {}", $msg, e);
             }
         } else {
             use ::anyhow::Context;

--- a/src/doc/contrib/src/implementation/debugging.md
+++ b/src/doc/contrib/src/implementation/debugging.md
@@ -16,7 +16,7 @@ CARGO_LOG=debug cargo generate-lockfile
 CARGO_LOG=cargo::core::resolver=trace cargo generate-lockfile
 
 # This will print lots of info about the download process. `trace` prints even more.
-CARGO_HTTP_DEBUG=true CARGO_LOG=cargo::ops::registry=debug cargo fetch
+CARGO_HTTP_DEBUG=true CARGO_LOG=network=debug cargo fetch
 
 # This is an important command for diagnosing fingerprint issues.
 CARGO_LOG=cargo::core::compiler::fingerprint=trace cargo build

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -622,8 +622,8 @@ crate dependencies and accessing remote git repositories.
 * Environment: `CARGO_HTTP_DEBUG`
 
 If `true`, enables debugging of HTTP requests. The debug information can be
-seen by setting the `CARGO_LOG=cargo::ops::registry=debug` environment
-variable (or use `trace` for even more information).
+seen by setting the `CARGO_LOG=network=debug` environment
+variable (or use `network=trace` for even more information).
 
 Be wary when posting logs from this output in a public location. The output
 may include headers with authentication tokens which you don't want to leak!


### PR DESCRIPTION
This changes the log messages for messages related to network traffic to use the "network" tracing target. This makes it easier to do `CARGO_LOG=network=trace CARGO_HTTP_DEBUG=true` instead of trying to figure out which modules to include (and to avoid `CARGO_LOG=trace` which can be too noisy). For example, #12290 moved the location of some log messages to a different module, which broke the documented workflow of using `CARGO_LOG=cargo::ops::registry=debug` to get networking information.
