### PR TITLE
Retry docs

### DIFF
--- a/src/cargo/util/network/sleep.rs
+++ b/src/cargo/util/network/sleep.rs
@@ -68,7 +68,6 @@ impl<T> SleepTracker<T> {
         let now = Instant::now();
         let mut result = Vec::new();
         while let Some(next) = self.heap.peek() {
-            tracing::debug!("ERIC: now={now:?} next={:?}", next.wakeup);
             if next.wakeup < now {
                 result.push(self.heap.pop().unwrap().data);
             } else {


### PR DESCRIPTION
This adds some more documentation to the `retry` module.

(Also removes a stray log message that should not have been committed).
