### PR TITLE
fix(lints): Fail when overriding inherited lints

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -3499,7 +3499,7 @@ impl fmt::Debug for PathValue {
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
-#[serde(expecting = "a map")]
+#[serde(expecting = "a lints table")]
 pub struct MaybeWorkspaceLints {
     #[serde(skip_serializing_if = "is_false")]
     #[serde(deserialize_with = "bool_no_false", default)]

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2579,8 +2579,7 @@ impl TomlManifest {
                 .badges
                 .as_ref()
                 .map(|_| MaybeWorkspace::Defined(metadata.badges.clone())),
-            lints: lints
-                .map(|lints| toml::Value::try_from(MaybeWorkspaceLints::Defined(lints)).unwrap()),
+            lints: lints.map(|lints| toml::Value::try_from(lints).unwrap()),
         };
         let mut manifest = Manifest::new(
             summary,

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -446,9 +446,12 @@ pub fn foo(num: i32) -> u32 {
     foo.cargo("check -Zlints")
         .masquerade_as_nightly_cargo(&["lints"])
         .with_status(101)
-        .with_stderr_contains(
+        .with_stderr(
             "\
-error: usage of an `unsafe` block
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  cannot override `workspace.lints` in `lints`, either remove the overrides or `lints.workspace = true` and manually specify the lints
 ",
         )
         .run();

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -172,7 +172,7 @@ fn malformed_on_nightly() {
 error: failed to parse manifest[..]
 
 Caused by:
-  invalid type: integer `20`, expected a map
+  invalid type: integer `20`, expected a lints table
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Overriding of inherited lints was reserved for the future but as pointed out in https://github.com/rust-lang/cargo/issues/12115#issuecomment-1695293006, we aren't failing on these when we should but silently ignoring the overrides.

This turns it into a hard error.

In fixing this, I had to add a `#[serde(expecting)]` attribute to maintain behavior on an error case (otherwise it would say "expecting struct WorkspaceLints").  Since this drew the error message to my attention, I also tweaked it to make it more specific.

### How should we test and review this PR?

Commits are broken down by the relevant tests and fixes to make the intended behavior changes obvious.