### PR TITLE
chore: remove unstable-options for logout

### DIFF
--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -83,8 +83,7 @@ fn default_registry_configured() {
     check_token(Some("dummy-token"), Some("dummy-registry"));
     check_token(Some("crates-io-token"), None);
 
-    cargo_process("logout -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["cargo-logout"])
+    cargo_process("logout")
         .with_stderr(
             "\
 [LOGOUT] token for `dummy-registry` has been removed from local storage
@@ -97,8 +96,7 @@ fn default_registry_configured() {
     check_token(None, Some("dummy-registry"));
     check_token(Some("crates-io-token"), None);
 
-    cargo_process("logout -Zunstable-options")
-        .masquerade_as_nightly_cargo(&["cargo-logout"])
+    cargo_process("logout")
         .with_stderr("[LOGOUT] not currently logged in to `dummy-registry`")
         .run();
 }


### PR DESCRIPTION
`cargo logout` is stable, and doesn't need `masquerade_as_nightly_cargo`