### PR TITLE
fix(help): Explain --explain

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -564,7 +564,13 @@ See 'cargo help <command>' for more information on a specific command.\n",
         )
         .arg(flag("version", "Print version info and exit").short('V'))
         .arg(flag("list", "List installed commands"))
-        .arg(opt("explain", "Run `rustc --explain CODE`").value_name("CODE"))
+        .arg(
+            opt(
+                "explain",
+                "Provide a detailed explanation of a rustc error message",
+            )
+            .value_name("CODE"),
+        )
         .arg(
             opt(
                 "verbose",

--- a/tests/testsuite/cargo/help/stdout.log
+++ b/tests/testsuite/cargo/help/stdout.log
@@ -6,7 +6,7 @@ Usage: cargo [..][OPTIONS] [COMMAND]
 Options:
   -V, --version             Print version info and exit
       --list                List installed commands
-      --explain <CODE>      Run `rustc --explain CODE`
+      --explain <CODE>      Provide a detailed explanation of a rustc error message
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
   -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never


### PR DESCRIPTION
In working on #12578, I'm focusing on each help string to decide how it should be handled and I noticed this.  It feels weird to explain something in terms of another command's CLI, so I took `rustc --help`s message and added `rustc` to clarify it.

Looking back, the flag was added in #2551 with the message we have today.  Nothing seems to really be said about it.

In reflecting on this, I'm not 100% convinced and am open to other opinions.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
