### PR TITLE
fix typo: "default branch branch" -> "default branch"

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -179,8 +179,8 @@ Cargo will fetch the `git` repository at this location then look for a
 of a workspace and setting `git` to the repository containing the workspace).
 
 Since we haven’t specified any other information, Cargo assumes that
-we intend to use the latest commit on the default branch branch 
-to build our package, which may not necessarily be the main branch.
+we intend to use the latest commit on the default branch to build
+our package, which may not necessarily be the main branch.
 You can combine the `git` key with the `rev`, `tag`, or `branch` keys to
 specify something else. Here's an example of specifying that you want to use
 the latest commit on a branch named `next`:


### PR DESCRIPTION
Fix a typo in the doc about git dependencies, I think the second "branch" might not be needed.