### PR TITLE
use split_once for cleaner code

### DIFF
--- a/crates/mdman/src/main.rs
+++ b/crates/mdman/src/main.rs
@@ -98,15 +98,16 @@ fn process_args() -> Result<Options, Error> {
                 let man = args
                     .next()
                     .ok_or_else(|| format_err!("--man requires a value"))?;
-                let parts: Vec<_> = man.splitn(2, '=').collect();
-                let key_parts: Vec<_> = parts[0].splitn(2, ':').collect();
-                if parts.len() != 2 || key_parts.len() != 2 {
-                    bail!("--man expected value with form name:1=link");
-                }
-                let section: u8 = key_parts[1].parse().with_context(|| {
-                    format!("expected unsigned integer for section, got `{}`", parts[1])
+                let parts = man.split_once('=').ok_or_else(|| {
+                    anyhow::format_err!("--man expected value with form name:1=link")
                 })?;
-                man_map.insert((key_parts[0].to_string(), section), parts[1].to_string());
+                let key_parts = parts.0.split_once(':').ok_or_else(|| {
+                    anyhow::format_err!("--man expected value with form name:1=link")
+                })?;
+                let section: u8 = key_parts.1.parse().with_context(|| {
+                    format!("expected unsigned integer for section, got `{}`", parts.1)
+                })?;
+                man_map.insert((key_parts.0.to_string(), section), parts.1.to_string());
             }
             s => {
                 sources.push(PathBuf::from(s));

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -634,19 +634,9 @@ where
 {
     let mut search_path = vec![];
     for dir in paths {
-        let dir = match dir.to_str() {
-            Some(s) => {
-                let mut parts = s.splitn(2, '=');
-                match (parts.next(), parts.next()) {
-                    (Some("native"), Some(path))
-                    | (Some("crate"), Some(path))
-                    | (Some("dependency"), Some(path))
-                    | (Some("framework"), Some(path))
-                    | (Some("all"), Some(path)) => path.into(),
-                    _ => dir.clone(),
-                }
-            }
-            None => dir.clone(),
+        let dir = match dir.to_str().and_then(|s| s.split_once("=")) {
+            Some(("native" | "crate" | "dependency" | "framework" | "all", path)) => path.into(),
+            _ => dir.clone(),
         };
         if dir.starts_with(&root_output) {
             search_path.push(dir);

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -123,24 +123,20 @@ impl PackageIdSpec {
                 )
             })?;
             match frag {
-                Some(fragment) => {
-                    let mut parts = fragment.splitn(2, [':', '@']);
-                    let name_or_version = parts.next().unwrap();
-                    match parts.next() {
-                        Some(part) => {
-                            let version = part.to_semver()?;
-                            (InternedString::new(name_or_version), Some(version))
-                        }
-                        None => {
-                            if name_or_version.chars().next().unwrap().is_alphabetic() {
-                                (InternedString::new(name_or_version), None)
-                            } else {
-                                let version = name_or_version.to_semver()?;
-                                (InternedString::new(path_name), Some(version))
-                            }
+                Some(fragment) => match fragment.split_once([':', '@']) {
+                    Some((name, part)) => {
+                        let version = part.to_semver()?;
+                        (InternedString::new(name), Some(version))
+                    }
+                    None => {
+                        if fragment.chars().next().unwrap().is_alphabetic() {
+                            (InternedString::new(&fragment), None)
+                        } else {
+                            let version = fragment.to_semver()?;
+                            (InternedString::new(path_name), Some(version))
                         }
                     }
-                }
+                },
                 None => (InternedString::new(path_name), None),
             }
         };

--- a/src/cargo/core/source/source_id.rs
+++ b/src/cargo/core/source/source_id.rs
@@ -148,10 +148,8 @@ impl SourceId {
     ///                     656c58fb7c5ef5f12bc747f");
     /// ```
     pub fn from_url(string: &str) -> CargoResult<SourceId> {
-        let mut parts = string.splitn(2, '+');
-        let kind = parts.next().unwrap();
-        let url = parts
-            .next()
+        let (kind, url) = string
+            .split_once('+')
             .ok_or_else(|| anyhow::format_err!("invalid source `{}`", string))?;
 
         match kind {

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -587,15 +587,13 @@ impl<'cfg> RegistryIndex<'cfg> {
         // `<pkg>=<p_req>o-><f_req>` where `<pkg>` is the name of a crate on
         // this source, `<p_req>` is the version installed and `<f_req> is the
         // version requested (argument to `--precise`).
-        let precise = match source_id.precise() {
-            Some(p) if p.starts_with(name) && p[name.len()..].starts_with('=') => {
-                let mut vers = p[name.len() + 1..].splitn(2, "->");
-                let current_vers = vers.next().unwrap().to_semver().unwrap();
-                let requested_vers = vers.next().unwrap().to_semver().unwrap();
-                Some((current_vers, requested_vers))
-            }
-            _ => None,
-        };
+        let precise = source_id
+            .precise()
+            .filter(|p| p.starts_with(name) && p[name.len()..].starts_with('='))
+            .map(|p| {
+                let (current, requested) = p[name.len() + 1..].split_once("->").unwrap();
+                (current.to_semver().unwrap(), requested.to_semver().unwrap())
+            });
         let summaries = summaries.filter(|s| match &precise {
             Some((current, requested)) => {
                 if req.matches(current) {


### PR DESCRIPTION
### What does this PR try to resolve?

Search the code base for `.splitn(2` and replace with `.split_once` where it was clearer. I don't think any of them matter in practice.

### How should we test and review this PR?

This was an internal re-factor, and the tests still pass.
The two methods have subtly different semantics, so please review carefully.