### PR TITLE
test: new options of debuginfo are no longer unstable

### DIFF
--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -744,7 +744,7 @@ Caused by:
         .run();
 }
 
-#[cargo_test(nightly, reason = "debug options stabilized in 1.70")]
+#[cargo_test]
 fn debug_options_valid() {
     let build = |option| {
         let p = project()


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

New debuginfo options is stabilized in 1.70.0

<!-- homu-ignore:end -->
