### PR TITLE
cargo-credential: change serialization of cache expiration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.75"
 base64 = "0.21.3"
 bytesize = "1.3"
 cargo = { path = "" }
-cargo-credential = { version = "0.3.0", path = "credential/cargo-credential" }
+cargo-credential = { version = "0.4.0", path = "credential/cargo-credential" }
 cargo-credential-libsecret = { version = "0.3.1", path = "credential/cargo-credential-libsecret" }
 cargo-credential-wincred = { version = "0.3.0", path = "credential/cargo-credential-wincred" }
 cargo-credential-macos-keychain = { version = "0.3.0", path = "credential/cargo-credential-macos-keychain" }

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"

--- a/credential/cargo-credential/README.md
+++ b/credential/cargo-credential/README.md
@@ -18,7 +18,7 @@ Create a Cargo project with this as a dependency:
 # Add this to your Cargo.toml:
 
 [dependencies]
-cargo-credential = "0.3"
+cargo-credential = "0.4"
 ```
 
 And then include a `main.rs` binary which implements the `Credential` trait, and calls

--- a/credential/cargo-credential/src/lib.rs
+++ b/credential/cargo-credential/src/lib.rs
@@ -80,6 +80,7 @@ pub struct CredentialRequest<'a> {
     #[serde(borrow, flatten)]
     pub action: Action<'a>,
     /// Additional command-line arguments passed to the credential provider.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub args: Vec<&'a str>,
 }
 
@@ -90,6 +91,7 @@ pub struct RegistryInfo<'a> {
     pub index_url: &'a str,
     /// Name of the registry in configuration. May not be available.
     /// The crates.io registry will be `crates-io` (`CRATES_IO_REGISTRY`).
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<&'a str>,
     /// Headers from attempting to access a registry that resulted in a HTTP 401.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
@@ -123,8 +125,10 @@ impl<'a> Display for Action<'a> {
 #[serde(rename_all = "kebab-case")]
 pub struct LoginOptions<'a> {
     /// Token passed on the command line via --token or from stdin
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<Secret<&'a str>>,
     /// Optional URL that the user can visit to log in to the registry
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub login_url: Option<&'a str>,
 }
 

--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -563,7 +563,7 @@ fn auth_token_optional(
     let token = Secret::from(token);
     tracing::trace!("found token");
     let expiration = match cache_control {
-        CacheControl::Expires(expiration) => Some(expiration),
+        CacheControl::Expires { expiration } => Some(expiration),
         CacheControl::Session => None,
         CacheControl::Never | _ => return Ok(Some(token)),
     };

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1154,7 +1154,7 @@ Actual messages must not contain newlines.
     "operation":"read",
     // Registry information
     "registry":{"index-url":"sparse+https://registry-url/index/", "name": "my-registry"},
-    // Additional command-line args
+    // Additional command-line args (optional)
     "args":[]
 }
 ```
@@ -1178,7 +1178,7 @@ Actual messages must not contain newlines.
     "cksum":"...",
     // Registry information
     "registry":{"index-url":"sparse+https://registry-url/index/", "name": "my-registry"},
-    // Additional command-line args
+    // Additional command-line args (optional)
     "args":[]
 }
 ```
@@ -1195,8 +1195,10 @@ Actual messages must not contain newlines.
     // Cache control. Can be one of the following:
     // * "never"
     // * "session"
-    // * { "expires": UNIX timestamp }
-    "cache":{"expires":1684251794},
+    // * "expires"
+    "cache":"expires",
+    // Unix timestamp (only for "cache": "expires")
+    "expiration":1693942857,
     // Is the token operation independent?
     "operation_independent":true
 }}

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -520,13 +520,13 @@ fn token_caching() {
 
     // Token should not be re-used if it is expired
     let expired_provider = build_provider(
-        "test-cred",
-        r#"{"Ok":{"kind":"get","token":"sekrit","cache":{"expires":0},"operation_independent":true}}"#,
+        "expired_provider",
+        r#"{"Ok":{"kind":"get","token":"sekrit","cache":"expires","expiration":0,"operation_independent":true}}"#,
     );
 
     // Token should not be re-used for a different operation if it is not operation_independent
     let non_independent_provider = build_provider(
-        "test-cred",
+        "non_independent_provider",
         r#"{"Ok":{"kind":"get","token":"sekrit","cache":"session","operation_independent":false}}"#,
     );
 

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -129,10 +129,10 @@ fn publish() {
         .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             r#"[UPDATING] [..]
-{"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read"}
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
-{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]"}
 [UPLOADING] foo v0.1.0 [..]
 [UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]
@@ -217,7 +217,7 @@ fn logout() {
         .masquerade_as_nightly_cargo(&["credential-process"])
         .replace_crates_io(server.index_url())
         .with_stderr(
-            r#"{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"logout","args":[]}
+            r#"{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"logout"}
 "#,
         )
         .run();
@@ -231,8 +231,8 @@ fn yank() {
         .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             r#"[UPDATING] [..]
-{"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read","args":[]}
-{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"yank","name":"foo","vers":"0.1.0","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read"}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"yank","name":"foo","vers":"0.1.0"}
 [YANK] foo@0.1.0
 "#,
         )
@@ -247,8 +247,8 @@ fn owner() {
         .masquerade_as_nightly_cargo(&["credential-process"])
         .with_stderr(
             r#"[UPDATING] [..]
-{"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read","args":[]}
-{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"owners","name":"foo","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative","headers":[..]},"kind":"get","operation":"read"}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"owners","name":"foo"}
 [OWNER] completed!
 "#,
         )
@@ -349,7 +349,7 @@ fn all_not_found() {
         .with_stderr(
             r#"[UPDATING] [..]
 [CREDENTIAL] [..]not_found[..] get crates-io
-{"v":1,"registry":{"index-url":"[..]","name":"crates-io","headers":[[..]"WWW-Authenticate: Cargo login_url=\"https://test-registry-login/me\""[..]]},"kind":"get","operation":"read","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"crates-io","headers":[[..]"WWW-Authenticate: Cargo login_url=\"https://test-registry-login/me\""[..]]},"kind":"get","operation":"read"}
 [ERROR] failed to query replaced source registry `crates-io`
 
 Caused by:
@@ -390,7 +390,7 @@ fn all_not_supported() {
         .with_stderr(
             r#"[UPDATING] [..]
 [CREDENTIAL] [..]not_supported[..] get crates-io
-{"v":1,"registry":{"index-url":"[..]","name":"crates-io","headers":[[..]"WWW-Authenticate: Cargo login_url=\"https://test-registry-login/me\""[..]]},"kind":"get","operation":"read","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"crates-io","headers":[[..]"WWW-Authenticate: Cargo login_url=\"https://test-registry-login/me\""[..]]},"kind":"get","operation":"read"}
 [ERROR] failed to query replaced source registry `crates-io`
 
 Caused by:
@@ -437,9 +437,9 @@ fn multiple_providers() {
         .with_stderr(
             r#"[UPDATING] [..]
 [CREDENTIAL] [..]url_not_supported[..] login crates-io
-{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]","args":[]}
+{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]"}
 [CREDENTIAL] [..]success_provider[..] login crates-io
-{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]","args":[]}
+{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]"}
 "#,
         )
         .run();
@@ -557,10 +557,10 @@ fn token_caching() {
         .build();
 
     let output = r#"[UPDATING] `alternative` index
-{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"read","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"read"}
 [PACKAGING] foo v0.1.0 [..]
 [PACKAGED] [..]
-{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]","args":[]}
+{"v":1,"registry":{"index-url":"[..]","name":"alternative"},"kind":"get","operation":"publish","name":"foo","vers":"0.1.0","cksum":"[..]"}
 [UPLOADING] foo v0.1.0 [..]
 [UPLOADED] foo v0.1.0 [..]
 note: Waiting [..]


### PR DESCRIPTION
Serde has [multiple options](https://serde.rs/enum-representations.html) for serialization of enum types. The default is to use the field name in a map (for variants with data), or a string (for variants without data). This causes forward compatibility problems when switching between these two cases. To avoid this, all `enum`s within `cargo-credential` used the "internally tagged" approach, but `CacheControl` did not.

* Changes `CacheControl` to be internally tagged and `flattened` within `CredentialResponse::Get`
* Adds forward compatibility tests to ensure adding additional fields will not break deserialization

Within a credential response, this is the change:
```diff
- "cache":{"expires":1684251794},
+ "cache":"expires", "expiration":1684251794,
```
Other variants, such as `"cache":"session"` remain the same.

## How to review
This PR contains two commits, one for the breaking change for `CacheControl` serialization, and one non-breaking change that makes several other fields skipped if none/empty.

r? @ehuss 