### PR TITLE
Add MSRV validation GitHub Action for cargo-credential

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
     needs:
     - build_std
     - clippy
+    - credential_msrv
     - docs
     - lockfile
     - resolver
@@ -37,6 +38,7 @@ jobs:
     needs:
     - build_std
     - clippy
+    - credential_msrv
     - docs
     - lockfile
     - resolver
@@ -246,3 +248,10 @@ jobs:
         cd target
         curl -sSLO https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
         sh linkcheck.sh --all --path ../src/doc cargo
+
+  credential_msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - run: rustup update 1.70 && rustup default 1.70
+    - run: cargo test -p cargo-credential

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -3,6 +3,7 @@ name = "cargo-credential"
 version = "0.3.1"
 edition.workspace = true
 license.workspace = true
+rust-version = "1.70.0"
 repository = "https://github.com/rust-lang/cargo"
 description = "A library to assist writing Cargo credential helpers."
 


### PR DESCRIPTION
`cargo-credential` should have a separate MSRV from the rest of Cargo that is more relaxed.