### PR TITLE
feat: implement RFC 3127 `-Ztrim-paths`

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -496,6 +496,9 @@ features! {
 
      // Support for 2024 edition.
     (unstable, edition2024, "", "reference/unstable.html#edition-2024"),
+
+    // Allow setting trim-paths in a profile to control the sanitisation of file paths in build outputs.
+    (unstable, trim_paths, "", "reference/unstable.html#profile-trim-paths-option"),
 }
 
 pub struct Feature {
@@ -755,6 +758,7 @@ unstable_cli_options!(
     separate_nightlies: bool = (HIDDEN),
     skip_rustdoc_fingerprint: bool = (HIDDEN),
     target_applies_to_host: bool = ("Enable the `target-applies-to-host` key in the .cargo/config.toml file"),
+    trim_paths: bool = ("Enable the `trim-paths` option in profiles"),
     unstable_options: bool = ("Allow the usage of unstable options"),
 );
 
@@ -1089,6 +1093,7 @@ impl CliUnstable {
             "no-index-update" => self.no_index_update = parse_empty(k, v)?,
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "profile-rustflags" => self.profile_rustflags = parse_empty(k, v)?,
+            "trim-paths" => self.trim_paths = parse_empty(k, v)?,
             "publish-timeout" => self.publish_timeout = parse_empty(k, v)?,
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "rustdoc-scrape-examples" => self.rustdoc_scrape_examples = parse_empty(k, v)?,

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -28,6 +28,8 @@ pub struct Rustc {
     pub version: semver::Version,
     /// The host triple (arch-platform-OS), this comes from verbose_version.
     pub host: InternedString,
+    /// The rustc full commit hash, this comes from `verbose_version`.
+    pub commit_hash: Option<String>,
     cache: Mutex<Cache>,
 }
 
@@ -80,6 +82,17 @@ impl Rustc {
                 verbose_version
             )
         })?;
+        let commit_hash = extract("commit-hash: ").ok().map(|hash| {
+            debug_assert!(
+                hash.chars().all(|ch| ch.is_ascii_hexdigit()),
+                "commit hash must be a hex string"
+            );
+            debug_assert!(
+                hash.len() == 40 || hash.len() == 64,
+                "hex string must be generated from sha1 or sha256"
+            );
+            hash.to_string()
+        });
 
         Ok(Rustc {
             path,
@@ -88,6 +101,7 @@ impl Rustc {
             verbose_version,
             version,
             host,
+            commit_hash,
             cache: Mutex::new(cache),
         })
     }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1664,3 +1664,37 @@ note: Sources are not allowed to be defined multiple times.
         )
         .run();
 }
+
+#[cargo_test]
+fn bad_trim_paths() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+
+                [profile.dev]
+                trim-paths = "split-debuginfo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["trim-paths"])
+        .with_status(101)
+        .with_stderr(
+            r#"error: failed to parse manifest at `[..]`
+
+Caused by:
+  TOML parse error at line 7, column 30
+    |
+  7 |                 trim-paths = "split-debuginfo"
+    |                              ^^^^^^^^^^^^^^^^^
+  expected a boolean, "none", "diagnostics", "macro", "object", "all", or an array with these options
+"#,
+        )
+        .run();
+}

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1540,6 +1540,7 @@ fn all_profile_options() {
         package: None,
         build_override: None,
         rustflags: None,
+        trim_paths: None,
     };
     let mut overrides = BTreeMap::new();
     let key = cargo_toml::ProfilePackageSpec::Spec(PackageIdSpec::parse("foo").unwrap());

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -2,6 +2,8 @@
 
 use cargo::core::{PackageIdSpec, Shell};
 use cargo::util::config::{self, Config, Definition, JobsConfig, SslVersionConfig, StringList};
+use cargo::util::toml::TomlTrimPaths;
+use cargo::util::toml::TomlTrimPathsValue;
 use cargo::util::toml::{self as cargo_toml, TomlDebugInfo, VecStringOrBool as VSOB};
 use cargo::CargoResult;
 use cargo_test_support::compare;
@@ -1727,4 +1729,64 @@ jobs = 2
         JobsConfig::String(_) => panic!("Did not except an integer."),
         JobsConfig::Integer(v) => assert_eq!(v, 2),
     }
+}
+
+#[cargo_test]
+fn trim_paths_parsing() {
+    let config = ConfigBuilder::new().build();
+    let p: cargo_toml::TomlProfile = config.get("profile.dev").unwrap();
+    assert_eq!(p.trim_paths, None);
+
+    let test_cases = [
+        (TomlTrimPathsValue::Diagnostics.into(), "diagnostics"),
+        (TomlTrimPathsValue::Macro.into(), "macro"),
+        (TomlTrimPathsValue::Object.into(), "object"),
+    ];
+    for (expected, val) in test_cases {
+        // env
+        let config = ConfigBuilder::new()
+            .env("CARGO_PROFILE_DEV_TRIM_PATHS", val)
+            .build();
+        let trim_paths: TomlTrimPaths = config.get("profile.dev.trim-paths").unwrap();
+        assert_eq!(trim_paths, expected, "failed to parse {val}");
+
+        // config.toml
+        let config = ConfigBuilder::new()
+            .config_arg(format!("profile.dev.trim-paths='{val}'"))
+            .build();
+        let trim_paths: TomlTrimPaths = config.get("profile.dev.trim-paths").unwrap();
+        assert_eq!(trim_paths, expected, "failed to parse {val}");
+    }
+
+    let test_cases = [(TomlTrimPaths::none(), false), (TomlTrimPaths::All, true)];
+
+    for (expected, val) in test_cases {
+        // env
+        let config = ConfigBuilder::new()
+            .env("CARGO_PROFILE_DEV_TRIM_PATHS", format!("{val}"))
+            .build();
+        let trim_paths: TomlTrimPaths = config.get("profile.dev.trim-paths").unwrap();
+        assert_eq!(trim_paths, expected, "failed to parse {val}");
+
+        // config.toml
+        let config = ConfigBuilder::new()
+            .config_arg(format!("profile.dev.trim-paths={val}"))
+            .build();
+        let trim_paths: TomlTrimPaths = config.get("profile.dev.trim-paths").unwrap();
+        assert_eq!(trim_paths, expected, "failed to parse {val}");
+    }
+
+    let expected = vec![
+        TomlTrimPathsValue::Diagnostics,
+        TomlTrimPathsValue::Macro,
+        TomlTrimPathsValue::Object,
+    ]
+    .into();
+    let val = r#"["diagnostics", "macro", "object"]"#;
+    // config.toml
+    let config = ConfigBuilder::new()
+        .config_arg(format!("profile.dev.trim-paths={val}"))
+        .build();
+    let trim_paths: TomlTrimPaths = config.get("profile.dev.trim-paths").unwrap();
+    assert_eq!(trim_paths, expected, "failed to parse {val}");
 }

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -138,6 +138,7 @@ mod profile_config;
 mod profile_custom;
 mod profile_overrides;
 mod profile_targets;
+mod profile_trim_paths;
 mod profiles;
 mod progress;
 mod pub_priv;

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1,0 +1,59 @@
+//! Tests for `-Ztrim-paths`.
+
+use cargo_test_support::project;
+
+#[cargo_test]
+fn gated_manifest() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [profile.dev]
+                trim-paths = "macro"
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  feature `trim-paths` is required",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn gated_config_toml() {
+    let p = project()
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [profile.dev]
+                trim-paths = "macro"
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[ERROR] config profile `dev` is not valid (defined in `[CWD]/.cargo/config.toml`)
+
+Caused by:
+  feature `trim-paths` is required",
+        )
+        .run();
+}

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1,6 +1,10 @@
 //! Tests for `-Ztrim-paths`.
 
+use cargo_test_support::basic_manifest;
+use cargo_test_support::git;
+use cargo_test_support::paths;
 use cargo_test_support::project;
+use cargo_test_support::registry::Package;
 
 #[cargo_test]
 fn gated_manifest() {
@@ -56,4 +60,349 @@ Caused by:
   feature `trim-paths` is required",
         )
         .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn release_profile_default_to_object() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build --release --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn one_option() {
+    let build = |option| {
+        let p = project()
+            .file(
+                "Cargo.toml",
+                &format!(
+                    r#"
+                    [package]
+                    name = "foo"
+                    version = "0.0.1"
+
+                    [profile.dev]
+                    trim-paths = "{option}"
+                "#
+                ),
+            )
+            .file("src/lib.rs", "")
+            .build();
+
+        p.cargo("build -v -Ztrim-paths")
+    };
+
+    for option in ["macro", "diagnostics", "object", "all"] {
+        build(option)
+            .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+            .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+            .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+            .run();
+    }
+    build("none")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn multiple_options() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [profile.dev]
+                trim-paths = ["diagnostics", "macro", "object"]
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("build --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn registry_dependency() {
+    Package::new("bar", "0.0.1")
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("src/lib.rs", r#"pub fn f() { println!("{}", file!()); }"#)
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                bar = "0.0.1"
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/main.rs", "fn main() { bar::f(); }")
+        .build();
+
+    let registry_src = paths::home().join(".cargo/registry/src");
+    let registry_src = registry_src.display();
+
+    p.cargo("run --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stdout(format!("{registry_src}/[..]/bar-0.0.1/src/lib.rs"))
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn git_dependency() {
+    let git_project = git::new("bar", |project| {
+        project
+            .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+            .file("src/lib.rs", r#"pub fn f() { println!("{}", file!()); }"#)
+    });
+    let url = git_project.url();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                bar = {{ git = "{url}" }}
+
+                [profile.dev]
+                trim-paths = "object"
+           "#
+            ),
+        )
+        .file("src/main.rs", "fn main() { bar::f(); }")
+        .build();
+
+    let git_checkouts_src = paths::home().join(".cargo/git/checkouts");
+    let git_checkouts_src = git_checkouts_src.display();
+
+    p.cargo("run --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stdout(format!("{git_checkouts_src}/bar-[..]/[..]/src/lib.rs"))
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn path_dependency() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                bar = { path = "cocktail-bar" }
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/main.rs", "fn main() { bar::f(); }")
+        .file("cocktail-bar/Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file(
+            "cocktail-bar/src/lib.rs",
+            r#"pub fn f() { println!("{}", file!()); }"#,
+        )
+        .build();
+
+    p.cargo("run --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stdout("cocktail-bar/src/lib.rs")
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn path_dependency_outside_workspace() {
+    let bar = project()
+        .at("bar")
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("src/lib.rs", r#"pub fn f() { println!("{}", file!()); }"#)
+        .build();
+    let bar_path = bar.url().to_file_path().unwrap();
+    let bar_path = bar_path.display();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                bar = { path = "../bar" }
+
+                [profile.dev]
+                trim-paths = "object"
+           "#,
+        )
+        .file("src/main.rs", "fn main() { bar::f(); }")
+        .build();
+
+    p.cargo("run --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stdout(format!("{bar_path}/src/lib.rs"))
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cargo_test(nightly, reason = "-Zremap-path-scope is unstable")]
+fn diagnostics_works() {
+    Package::new("bar", "0.0.1")
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("src/lib.rs", r#"pub fn f() { let unused = 0; }"#)
+        .publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                bar = "0.0.1"
+
+                [profile.dev]
+                trim-paths = "diagnostics"
+           "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    let registry_src = paths::home().join(".cargo/registry/src");
+    let registry_src = registry_src.display();
+
+    p.cargo("build -vv -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_contains(format!("[..]{registry_src}/[..]/bar-0.0.1/src/lib.rs:1[..]"))
+        .with_stderr_contains("[..]unused_variables[..]")
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+}
+
+#[cfg(target_os = "linux")]
+#[cargo_test(requires_readelf, nightly, reason = "-Zremap-path-scope is unstable")]
+fn object_works() {
+    use std::os::unix::ffi::OsStrExt;
+
+    let run_readelf = |path| {
+        std::process::Command::new("readelf")
+            .arg("-wi")
+            .arg(path)
+            .output()
+            .expect("readelf works")
+    };
+
+    let registry_src = paths::home().join(".cargo/registry/src");
+    let registry_src_bytes = registry_src.as_os_str().as_bytes();
+
+    Package::new("bar", "0.0.1")
+        .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
+        .file("src/lib.rs", r#"pub fn f() { println!("{}", file!()); }"#)
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                bar = "0.0.1"
+           "#,
+        )
+        .file("src/main.rs", "fn main() { bar::f(); }")
+        .build();
+
+    let pkg_root = p.root();
+    let pkg_root = pkg_root.as_os_str().as_bytes();
+
+    p.cargo("build").run();
+
+    let bin_path = p.bin("foo");
+    assert!(bin_path.is_file());
+    let stdout = run_readelf(bin_path).stdout;
+    // TODO: re-enable this check when rustc bootstrap disables remapping
+    // <https://github.com/rust-lang/cargo/pull/12625#discussion_r1371714791>
+    // assert!(memchr::memmem::find(&stdout, rust_src).is_some());
+    assert!(memchr::memmem::find(&stdout, registry_src_bytes).is_some());
+    assert!(memchr::memmem::find(&stdout, pkg_root).is_some());
+
+    p.cargo("clean").run();
+
+    p.change_file(
+        "Cargo.toml",
+        r#"
+            [package]
+            name = "foo"
+            version = "0.0.1"
+
+            [dependencies]
+            bar = "0.0.1"
+
+            [profile.dev]
+            trim-paths = "object"
+       "#,
+    );
+
+    p.cargo("build --verbose -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .with_stderr_does_not_contain("[..]-Zremap-path-scope=[..]")
+        .with_stderr_does_not_contain("[..]--remap-path-prefix=[..]")
+        .run();
+
+    let bin_path = p.bin("foo");
+    assert!(bin_path.is_file());
+    let stdout = run_readelf(bin_path).stdout;
+    // TODO: re-enable this check when rustc bootstrap disables remapping
+    // <https://github.com/rust-lang/cargo/pull/12625#discussion_r1371714791>
+    // assert!(memchr::memmem::find(&stdout, rust_src).is_some());
+    assert!(memchr::memmem::find(&stdout, registry_src_bytes).is_some());
+    assert!(memchr::memmem::find(&stdout, pkg_root).is_some());
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Implement [RFC 3127 trim paths](https://rust-lang.github.io/rfcs/3127-trim-paths.html) on Cargo side. The counterpart of the compiler is in <https://github.com/rust-lang/rust/pull/115214>. The tracking issue for Cargo is <https://github.com/rust-lang/rust/issues/111540>.

### How should we test and review this PR?

By commits. I would recommend reading the doc first to get the an overview on this.

#### Things I am uncertain

- [x] The correct path prefix for sysroot remap. See https://github.com/rust-lang/cargo/pull/12625#discussion_r1371044041.
    - @Urgau has pointed out the remapping of sysroot has already been done by rustc bootstrap [here](https://github.com/rust-lang/rust/blob/c2ef35161fc7477b38f2e556be2fd6d85d9f4905/src/bootstrap/src/lib.rs#L1107-L1119). Changing that may require `-Ztrim-paths` being stabilized, and may leak CI details into all pre-built std, core…. This is something requiring to collaborate with `T-bootstrap`. We'll postpone it for this pull request.
- [x] Do we want to verify the final artifact is actually sanitized? See https://github.com/rust-lang/cargo/pull/12625#discussion_r1371087973
    - Current we're satisfied with testing only on Linux.
    - For other platforms we verify Cargo passing in correct arguments to rustc.

#### Things to decide (but can postpone to follow-up PRs)

- Is remapping dependencies to `<pkg>-<version>` good enough for all source kinds?
    - How to tell if a package is from Git or registry? IDE may wants that information?
    - Should we use `SourceId` hash or something instead?
- The remap of workspace was not clear in the RFC. This PR choses to remap from workspace root instead. See https://github.com/rust-lang/cargo/pull/12625#discussion_r1371066017

### Additional information

Things to do:

- [x] Support `trim-paths = "all"` and `trim-paths = "none"` but not `trim-paths = ["all", "none"]`.
- [x] Support `trim-paths = true/false`.
- [x] Default value for `dev` and `release` profile.
- [ ] Set `CARGO_TRIM_PATHS` environment variable for build scripts. (plan to do in follow-up)
- [ ] Fingerprint should take trim-paths settings into account. (plan to do in follow-up)
- [ ] Make `--remap-path-prefix` works with `rustdoc` invocations (which `rustdoc` need an update)
<!-- homu-ignore:end -->
