### PR TITLE
fix: improve warning for both token & credential-provider

### DIFF
--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -108,21 +108,26 @@ fn credential_provider(config: &Config, sid: &SourceId) -> CargoResult<Vec<Vec<S
             secret_key,
             ..
         }) if config.cli_unstable().credential_process => {
+            let provider = resolve_credential_alias(config, provider);
             if let Some(token) = token {
-                config.shell().warn(format!(
-                    "{sid} has a token configured in {} that will be ignored \
-                    because a credential-provider is configured for this registry`",
-                    token.definition
-                ))?;
+                if provider[0] != "cargo:token" {
+                    config.shell().warn(format!(
+                        "{sid} has a token configured in {} that will be ignored \
+                        because this registry is configured to use credential-provider `{}`",
+                        token.definition, provider[0],
+                    ))?;
+                }
             }
             if let Some(secret_key) = secret_key {
-                config.shell().warn(format!(
-                    "{sid} has a secret-key configured in {} that will be ignored \
-                    because a credential-provider is configured for this registry`",
-                    secret_key.definition
-                ))?;
+                if provider[0] != "cargo:paseto" {
+                    config.shell().warn(format!(
+                        "{sid} has a secret-key configured in {} that will be ignored \
+                        because this registry is configured to use credential-provider `{}`",
+                        secret_key.definition, provider[0],
+                    ))?;
+                }
             }
-            vec![resolve_credential_alias(config, provider)]
+            vec![provider]
         }
 
         // Warning for both `token` and `secret-key`, stating which will be ignored


### PR DESCRIPTION
Cargo issues a warning when both a `credential-provider` and a `token` are configured for a registry.

This change removes the warning if the `credential-provider` is `cargo:token` since that *will* use the token. The warning message text is also tweaked to include the name of the `credential-provider` that's overriding the token.