### PR TITLE
Remove environment variable suggestion from `AuthorizationError`

### DIFF
--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     sources::CRATES_IO_REGISTRY,
-    util::{config::ConfigKey, CanonicalUrl, CargoResult, Config, IntoUrl},
+    util::{CanonicalUrl, CargoResult, Config, IntoUrl},
 };
 use anyhow::{bail, Context as _};
 use cargo_credential::{
@@ -372,19 +372,13 @@ impl fmt::Display for AuthorizationError {
             } else {
                 ""
             };
-            write!(
-                f,
-                "{}, please run `cargo login{args}`\nor use environment variable CARGO_REGISTRY_TOKEN",
-                self.reason
-            )
+            write!(f, "{}, please run `cargo login{args}`", self.reason)
         } else if let Some(name) = self.sid.alt_registry_key() {
-            let key = ConfigKey::from_str(&format!("registries.{name}.token"));
             write!(
                 f,
-                "{} for `{}`, please run `cargo login --registry {name}`\nor use environment variable {}",
+                "{} for `{}`, please run `cargo login --registry {name}`",
                 self.reason,
                 self.sid.display_registry_name(),
-                key.as_env_key(),
             )
         } else if self.reason == AuthorizationErrorReason::TokenMissing {
             write!(

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -432,8 +432,7 @@ fn block_publish_due_to_no_token() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-error: no token found for `alternative`, please run `cargo login --registry alternative`
-or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
+error: no token found for `alternative`, please run `cargo login --registry alternative`",
         )
         .run();
 }
@@ -459,8 +458,7 @@ fn cargo_registries_crates_io_protocol() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-error: no token found for `alternative`, please run `cargo login --registry alternative`
-or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
+error: no token found for `alternative`, please run `cargo login --registry alternative`",
         )
         .run();
 }
@@ -1531,8 +1529,7 @@ fn warn_for_unused_fields() {
             "\
 [UPDATING] `alternative` index
 [WARNING] unused config key `registries.alternative.unexpected-field` in `[..]config.toml`
-[ERROR] no token found for `alternative`, please run `cargo login --registry alternative`
-or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
+[ERROR] no token found for `alternative`, please run `cargo login --registry alternative`",
         )
         .run();
 
@@ -1542,8 +1539,7 @@ or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
             "\
 [UPDATING] crates.io index
 [WARNING] unused config key `registry.unexpected-field` in `[..]config.toml`
-[ERROR] no token found, please run `cargo login`
-or use environment variable CARGO_REGISTRY_TOKEN",
+[ERROR] no token found, please run `cargo login`",
         )
         .run();
 }

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -38,7 +38,6 @@ fn gated() {
             "\
 [UPDATING] [..]
 [ERROR] no token found, please run `cargo login`
-or use environment variable CARGO_REGISTRY_TOKEN
 ",
         )
         .run();
@@ -58,7 +57,6 @@ or use environment variable CARGO_REGISTRY_TOKEN
             "\
 [UPDATING] [..]
 [ERROR] no token found for `alternative`, please run `cargo login --registry alternative`
-or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 ",
         )
         .run();
@@ -354,7 +352,6 @@ fn all_not_found() {
 
 Caused by:
   no token found, please run `cargo login`
-  or use environment variable CARGO_REGISTRY_TOKEN
 "#,
         )
         .run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -3224,7 +3224,6 @@ fn default_auth_error() {
             "\
 [UPDATING] crates.io index
 error: no token found, please run `cargo login`
-or use environment variable CARGO_REGISTRY_TOKEN
 ",
         )
         .with_status(101)
@@ -3236,7 +3235,6 @@ or use environment variable CARGO_REGISTRY_TOKEN
             "\
 [UPDATING] `alternative` index
 error: no token found for `alternative`, please run `cargo login --registry alternative`
-or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 ",
         )
         .with_status(101)
@@ -3258,7 +3256,6 @@ or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
             "\
 [UPDATING] `alternative` index
 error: no token found for `alternative`, please run `cargo login --registry alternative`
-or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 ",
         )
         .with_status(101)
@@ -3270,7 +3267,6 @@ or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
             "\
 [UPDATING] crates.io index
 error: no token found, please run `cargo login --registry crates-io`
-or use environment variable CARGO_REGISTRY_TOKEN
 ",
         )
         .with_status(101)

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -247,8 +247,7 @@ fn missing_token() {
 [ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([..])`
 
 Caused by:
-  no token found for `alternative`, please run `cargo login --registry alternative`
-  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
+  no token found for `alternative`, please run `cargo login --registry alternative`",
         )
         .run();
 }
@@ -273,8 +272,7 @@ Caused by:
   unable to get packages from source
 
 Caused by:
-  no token found for `alternative`, please run `cargo login --registry alternative`
-  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
+  no token found for `alternative`, please run `cargo login --registry alternative`",
         )
         .run();
 }
@@ -299,7 +297,6 @@ fn incorrect_token() {
 
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`
-  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 
 Caused by:
   failed to get successful HTTP response from `http://[..]/index/config.json`, got 401


### PR DESCRIPTION
When a registry token cannot be found, or a token is invalid, cargo displays an error recommending `cargo login`.

Starting in rust 1.67 with [#10592](https://github.com/rust-lang/cargo/pull/10592), the message was amended to include the environment variable that could also be used to include the token.

```
error: no token found for `alternative`, please run `cargo login --registry alternative`
or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
```

With `-Z credential-process`, if `cargo:token` is not in `registry.global-credential-providers` or `registries.<NAME>.credential-provider` the suggested environment variable will not work.

This PR resolves the issue by removing the suggested environment variable.

Alternatives:
* Check the available credential providers and determine if `cargo:token` was/will be used, and only display the message then.
* Make the `*_INDEX`, `*_TOKEN` environment variables have precedence over credential providers.