### PR TITLE
Error out if `cargo clean --doc` is mixed with `-p`.

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -7,7 +7,7 @@ use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{Config, Progress, ProgressStyle};
 
-use anyhow::Context as _;
+use anyhow::{bail, Context as _};
 use cargo_util::paths;
 use std::fs;
 use std::path::Path;
@@ -33,6 +33,15 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
 
     // If the doc option is set, we just want to delete the doc directory.
     if opts.doc {
+        if !opts.spec.is_empty() {
+            // FIXME: https://github.com/rust-lang/cargo/issues/8790
+            // This should support the ability to clean specific packages
+            // within the doc directory. It's a little tricky since it
+            // needs to find all documentable targets, but also consider
+            // the fact that target names might overlap with dependency
+            // names and such.
+            bail!("--doc cannot be used with -p");
+        }
         target_dir = target_dir.join("doc");
         return clean_entire_folder(&target_dir.into_path_unlocked(), config);
     }

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -673,3 +673,13 @@ fn clean_spec_reserved() {
         )
         .run();
 }
+
+#[cargo_test]
+fn doc_with_package_selection() {
+    // --doc with -p
+    let p = project().file("src/lib.rs", "").build();
+    p.cargo("clean --doc -p foo")
+        .with_status(101)
+        .with_stderr("error: --doc cannot be used with -p")
+        .run();
+}


### PR DESCRIPTION
This changes `cargo clean --doc -p foo` to generate an error instead of ignoring the `-p` flag. There is still an outstanding issue https://github.com/rust-lang/cargo/issues/8790 tracking this. It *should* support `-p`, but until it is supported, I think cargo should tell you that the flag is ignored. This is also in preparation for some code changes in #12634 which needs to handle any combination of various different clean flags.