### PR TITLE
Add some enhancements to `cargo clean`

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -206,6 +206,7 @@ fn substitute_macros(input: &str) -> String {
         ("[UPDATING]", "    Updating"),
         ("[ADDING]", "      Adding"),
         ("[REMOVING]", "    Removing"),
+        ("[REMOVED]", "     Removed"),
         ("[DOCTEST]", "   Doc-tests"),
         ("[PACKAGING]", "   Packaging"),
         ("[PACKAGED]", "    Packaged"),

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -14,6 +14,13 @@ pub fn cli() -> Command {
         .arg_target_triple("Target triple to clean output for")
         .arg_target_dir()
         .arg_manifest_path()
+        .arg(
+            flag(
+                "dry-run",
+                "Display what would be deleted without deleting anything",
+            )
+            .short('n'),
+        )
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help clean</>` for more detailed information.\n"
         ))
@@ -33,6 +40,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         requested_profile: args.get_profile_name(config, "dev", ProfileChecking::Custom)?,
         profile_specified: args.contains_id("profile") || args.flag("release"),
         doc: args.flag("doc"),
+        dry_run: args.flag("dry-run"),
     };
     ops::clean(&ws, &opts)?;
     Ok(())

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -14,13 +14,7 @@ pub fn cli() -> Command {
         .arg_target_triple("Target triple to clean output for")
         .arg_target_dir()
         .arg_manifest_path()
-        .arg(
-            flag(
-                "dry-run",
-                "Display what would be deleted without deleting anything",
-            )
-            .short('n'),
-        )
+        .arg_dry_run("Display what would be deleted without deleting anything")
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help clean</>` for more detailed information.\n"
         ))
@@ -40,7 +34,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         requested_profile: args.get_profile_name(config, "dev", ProfileChecking::Custom)?,
         profile_specified: args.contains_id("profile") || args.flag("release"),
         doc: args.flag("doc"),
-        dry_run: args.flag("dry-run"),
+        dry_run: args.dry_run(),
     };
     ops::clean(&ws, &opts)?;
     Ok(())

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -417,7 +417,13 @@ impl<'cfg> CleanContext<'cfg> {
         };
         self.config
             .shell()
-            .status(status, format!("{file_count}{byte_count}"))
+            .status(status, format!("{file_count}{byte_count}"))?;
+        if self.dry_run {
+            self.config
+                .shell()
+                .warn("no files deleted due to --dry-run")?;
+        }
+        Ok(())
     }
 
     /// Deletes all of the given paths, showing a progress bar as it proceeds.

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -262,7 +262,7 @@ fn escape_glob_path(pattern: &Path) -> CargoResult<String> {
 }
 
 impl<'cfg> CleanContext<'cfg> {
-    pub fn new(config: &'cfg Config) -> CleanContext<'cfg> {
+    pub fn new(config: &'cfg Config) -> Self {
         // This progress bar will get replaced, this is just here to avoid needing
         // an Option until the actual bar is created.
         let progress = CleaningFolderBar::new(config, 0);

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -334,13 +334,8 @@ impl<'cfg> CleanContext<'cfg> {
             }
         };
 
-        if self.dry_run {
-            // Concise because if in verbose mode, the path will be written in
-            // the loop below.
-            self.config
-                .shell()
-                .concise(|shell| Ok(writeln!(shell.out(), "{}", path.display())?))?;
-        } else {
+        // dry-run displays paths while walking, so don't print here.
+        if !self.dry_run {
             self.config
                 .shell()
                 .verbose(|shell| shell.status("Removing", path.display()))?;
@@ -369,6 +364,10 @@ impl<'cfg> CleanContext<'cfg> {
             let entry = entry?;
             self.progress.on_clean()?;
             if self.dry_run {
+                // This prints the path without the "Removing" status since I feel
+                // like it can be surprising or even frightening if cargo says it
+                // is removing something without actually removing it. And I can't
+                // come up with a different verb to use as the status.
                 self.config
                     .shell()
                     .verbose(|shell| Ok(writeln!(shell.out(), "{}", entry.path().display())?))?;

--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -6,14 +6,13 @@ use crate::util::edit_distance;
 use crate::util::errors::CargoResult;
 use crate::util::interning::InternedString;
 use crate::util::{Config, Progress, ProgressStyle};
-
-use anyhow::{bail, Context as _};
+use anyhow::bail;
 use cargo_util::paths;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-pub struct CleanOptions<'a> {
-    pub config: &'a Config,
+pub struct CleanOptions<'cfg> {
+    pub config: &'cfg Config,
     /// A list of packages to clean. If empty, everything is cleaned.
     pub spec: Vec<String>,
     /// The target arch triple to clean, or None for the host arch
@@ -26,12 +25,17 @@ pub struct CleanOptions<'a> {
     pub doc: bool,
 }
 
-/// Cleans the package's build artifacts.
+pub struct CleanContext<'cfg> {
+    pub config: &'cfg Config,
+    progress: Box<dyn CleaningProgressBar + 'cfg>,
+}
+
+/// Cleans various caches.
 pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     let mut target_dir = ws.target_dir();
-    let config = ws.config();
+    let config = opts.config;
+    let mut ctx = CleanContext::new(config);
 
-    // If the doc option is set, we just want to delete the doc directory.
     if opts.doc {
         if !opts.spec.is_empty() {
             // FIXME: https://github.com/rust-lang/cargo/issues/8790
@@ -42,31 +46,44 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             // names and such.
             bail!("--doc cannot be used with -p");
         }
+        // If the doc option is set, we just want to delete the doc directory.
         target_dir = target_dir.join("doc");
-        return clean_entire_folder(&target_dir.into_path_unlocked(), config);
+        ctx.remove_paths(&[target_dir.into_path_unlocked()])?;
+    } else {
+        let profiles = Profiles::new(&ws, opts.requested_profile)?;
+
+        if opts.profile_specified {
+            // After parsing profiles we know the dir-name of the profile, if a profile
+            // was passed from the command line. If so, delete only the directory of
+            // that profile.
+            let dir_name = profiles.get_dir_name();
+            target_dir = target_dir.join(dir_name);
+        }
+
+        // If we have a spec, then we need to delete some packages, otherwise, just
+        // remove the whole target directory and be done with it!
+        //
+        // Note that we don't bother grabbing a lock here as we're just going to
+        // blow it all away anyway.
+        if opts.spec.is_empty() {
+            ctx.remove_paths(&[target_dir.into_path_unlocked()])?;
+        } else {
+            clean_specs(&mut ctx, &ws, &profiles, &opts.targets, &opts.spec)?;
+        }
     }
 
-    let profiles = Profiles::new(ws, opts.requested_profile)?;
+    Ok(())
+}
 
-    if opts.profile_specified {
-        // After parsing profiles we know the dir-name of the profile, if a profile
-        // was passed from the command line. If so, delete only the directory of
-        // that profile.
-        let dir_name = profiles.get_dir_name();
-        target_dir = target_dir.join(dir_name);
-    }
-
-    // If we have a spec, then we need to delete some packages, otherwise, just
-    // remove the whole target directory and be done with it!
-    //
-    // Note that we don't bother grabbing a lock here as we're just going to
-    // blow it all away anyway.
-    if opts.spec.is_empty() {
-        return clean_entire_folder(&target_dir.into_path_unlocked(), config);
-    }
-
+fn clean_specs(
+    ctx: &mut CleanContext<'_>,
+    ws: &Workspace<'_>,
+    profiles: &Profiles,
+    targets: &[String],
+    spec: &[String],
+) -> CargoResult<()> {
     // Clean specific packages.
-    let requested_kinds = CompileKind::from_requested_targets(config, &opts.targets)?;
+    let requested_kinds = CompileKind::from_requested_targets(ctx.config, targets)?;
     let target_data = RustcTargetData::new(ws, &requested_kinds)?;
     let (pkg_set, resolve) = ops::resolve_ws(ws)?;
     let prof_dir_name = profiles.get_dir_name();
@@ -84,7 +101,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
         .collect::<CargoResult<_>>()?;
     // A Vec of layouts. This is a little convoluted because there can only be
     // one host_layout.
-    let layouts = if opts.targets.is_empty() {
+    let layouts = if targets.is_empty() {
         vec![(CompileKind::Host, &host_layout)]
     } else {
         target_layouts
@@ -105,11 +122,11 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
 
     // Get Packages for the specified specs.
     let mut pkg_ids = Vec::new();
-    for spec_str in opts.spec.iter() {
+    for spec_str in spec.iter() {
         // Translate the spec to a Package.
         let spec = PackageIdSpec::parse(spec_str)?;
         if spec.partial_version().is_some() {
-            config.shell().warn(&format!(
+            ctx.config.shell().warn(&format!(
                 "version qualifier in `-p {}` is ignored, \
                 cleaning all versions of `{}` found",
                 spec_str,
@@ -117,7 +134,7 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
             ))?;
         }
         if spec.url().is_some() {
-            config.shell().warn(&format!(
+            ctx.config.shell().warn(&format!(
                 "url qualifier in `-p {}` ignored, \
                 cleaning all versions of `{}` found",
                 spec_str,
@@ -142,20 +159,16 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
     }
     let packages = pkg_set.get_many(pkg_ids)?;
 
-    let mut progress = CleaningPackagesBar::new(config, packages.len());
+    ctx.progress = Box::new(CleaningPackagesBar::new(ctx.config, packages.len()));
+
     for pkg in packages {
         let pkg_dir = format!("{}-*", pkg.name());
-        progress.on_cleaning_package(&pkg.name())?;
+        ctx.progress.on_cleaning_package(&pkg.name())?;
 
         // Clean fingerprints.
         for (_, layout) in &layouts_with_host {
             let dir = escape_glob_path(layout.fingerprint())?;
-            rm_rf_package_glob_containing_hash(
-                &pkg.name(),
-                &Path::new(&dir).join(&pkg_dir),
-                config,
-                &mut progress,
-            )?;
+            ctx.rm_rf_package_glob_containing_hash(&pkg.name(), &Path::new(&dir).join(&pkg_dir))?;
         }
 
         for target in pkg.targets() {
@@ -163,11 +176,9 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                 // Get both the build_script_build and the output directory.
                 for (_, layout) in &layouts_with_host {
                     let dir = escape_glob_path(layout.build())?;
-                    rm_rf_package_glob_containing_hash(
+                    ctx.rm_rf_package_glob_containing_hash(
                         &pkg.name(),
                         &Path::new(&dir).join(&pkg_dir),
-                        config,
-                        &mut progress,
                     )?;
                 }
                 continue;
@@ -199,35 +210,35 @@ pub fn clean(ws: &Workspace<'_>, opts: &CleanOptions<'_>) -> CargoResult<()> {
                         let dir_glob = escape_glob_path(dir)?;
                         let dir_glob = Path::new(&dir_glob);
 
-                        rm_rf_glob(&dir_glob.join(&hashed_name), config, &mut progress)?;
-                        rm_rf(&dir.join(&unhashed_name), config, &mut progress)?;
+                        ctx.rm_rf_glob(&dir_glob.join(&hashed_name))?;
+                        ctx.rm_rf(&dir.join(&unhashed_name))?;
                         // Remove dep-info file generated by rustc. It is not tracked in
                         // file_types. It does not have a prefix.
                         let hashed_dep_info = dir_glob.join(format!("{}-*.d", crate_name));
-                        rm_rf_glob(&hashed_dep_info, config, &mut progress)?;
+                        ctx.rm_rf_glob(&hashed_dep_info)?;
                         let unhashed_dep_info = dir.join(format!("{}.d", crate_name));
-                        rm_rf(&unhashed_dep_info, config, &mut progress)?;
+                        ctx.rm_rf(&unhashed_dep_info)?;
                         // Remove split-debuginfo files generated by rustc.
                         let split_debuginfo_obj = dir_glob.join(format!("{}.*.o", crate_name));
-                        rm_rf_glob(&split_debuginfo_obj, config, &mut progress)?;
+                        ctx.rm_rf_glob(&split_debuginfo_obj)?;
                         let split_debuginfo_dwo = dir_glob.join(format!("{}.*.dwo", crate_name));
-                        rm_rf_glob(&split_debuginfo_dwo, config, &mut progress)?;
+                        ctx.rm_rf_glob(&split_debuginfo_dwo)?;
                         let split_debuginfo_dwp = dir_glob.join(format!("{}.*.dwp", crate_name));
-                        rm_rf_glob(&split_debuginfo_dwp, config, &mut progress)?;
+                        ctx.rm_rf_glob(&split_debuginfo_dwp)?;
 
                         // Remove the uplifted copy.
                         if let Some(uplift_dir) = uplift_dir {
                             let uplifted_path = uplift_dir.join(file_type.uplift_filename(target));
-                            rm_rf(&uplifted_path, config, &mut progress)?;
+                            ctx.rm_rf(&uplifted_path)?;
                             // Dep-info generated by Cargo itself.
                             let dep_info = uplifted_path.with_extension("d");
-                            rm_rf(&dep_info, config, &mut progress)?;
+                            ctx.rm_rf(&dep_info)?;
                         }
                     }
                     // TODO: what to do about build_script_build?
                     let dir = escape_glob_path(layout.incremental())?;
                     let incremental = Path::new(&dir).join(format!("{}-*", crate_name));
-                    rm_rf_glob(&incremental, config, &mut progress)?;
+                    ctx.rm_rf_glob(&incremental)?;
                 }
             }
         }
@@ -243,92 +254,124 @@ fn escape_glob_path(pattern: &Path) -> CargoResult<String> {
     Ok(glob::Pattern::escape(pattern))
 }
 
-/// Glob remove artifacts for the provided `package`
-///
-/// Make sure the artifact is for `package` and not another crate that is prefixed by
-/// `package` by getting the original name stripped of the trailing hash and possible
-/// extension
-fn rm_rf_package_glob_containing_hash(
-    package: &str,
-    pattern: &Path,
-    config: &Config,
-    progress: &mut dyn CleaningProgressBar,
-) -> CargoResult<()> {
-    // TODO: Display utf8 warning to user?  Or switch to globset?
-    let pattern = pattern
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("expected utf-8 path"))?;
-    for path in glob::glob(pattern)? {
-        let path = path?;
-
-        let pkg_name = path
-            .file_name()
-            .and_then(std::ffi::OsStr::to_str)
-            .and_then(|artifact| artifact.rsplit_once('-'))
-            .ok_or_else(|| anyhow::anyhow!("expected utf-8 path"))?
-            .0;
-
-        if pkg_name != package {
-            continue;
-        }
-
-        rm_rf(&path, config, progress)?;
-    }
-    Ok(())
-}
-
-fn rm_rf_glob(
-    pattern: &Path,
-    config: &Config,
-    progress: &mut dyn CleaningProgressBar,
-) -> CargoResult<()> {
-    // TODO: Display utf8 warning to user?  Or switch to globset?
-    let pattern = pattern
-        .to_str()
-        .ok_or_else(|| anyhow::anyhow!("expected utf-8 path"))?;
-    for path in glob::glob(pattern)? {
-        rm_rf(&path?, config, progress)?;
-    }
-    Ok(())
-}
-
-fn rm_rf(path: &Path, config: &Config, progress: &mut dyn CleaningProgressBar) -> CargoResult<()> {
-    if fs::symlink_metadata(path).is_err() {
-        return Ok(());
-    }
-
-    config
-        .shell()
-        .verbose(|shell| shell.status("Removing", path.display()))?;
-    progress.display_now()?;
-
-    for entry in walkdir::WalkDir::new(path).contents_first(true) {
-        let entry = entry?;
-        progress.on_clean()?;
-        if entry.file_type().is_dir() {
-            // The contents should have been removed by now, but sometimes a race condition is hit
-            // where other files have been added by the OS. `paths::remove_dir_all` also falls back
-            // to `std::fs::remove_dir_all`, which may be more reliable than a simple walk in
-            // platform-specific edge cases.
-            paths::remove_dir_all(entry.path())
-                .with_context(|| "could not remove build directory")?;
-        } else {
-            paths::remove_file(entry.path()).with_context(|| "failed to remove build artifact")?;
+impl<'cfg> CleanContext<'cfg> {
+    pub fn new(config: &'cfg Config) -> CleanContext<'cfg> {
+        // This progress bar will get replaced, this is just here to avoid needing
+        // an Option until the actual bar is created.
+        let progress = CleaningFolderBar::new(config, 0);
+        CleanContext {
+            config,
+            progress: Box::new(progress),
         }
     }
 
-    Ok(())
-}
+    /// Glob remove artifacts for the provided `package`
+    ///
+    /// Make sure the artifact is for `package` and not another crate that is prefixed by
+    /// `package` by getting the original name stripped of the trailing hash and possible
+    /// extension
+    fn rm_rf_package_glob_containing_hash(
+        &mut self,
+        package: &str,
+        pattern: &Path,
+    ) -> CargoResult<()> {
+        // TODO: Display utf8 warning to user?  Or switch to globset?
+        let pattern = pattern
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("expected utf-8 path"))?;
+        for path in glob::glob(pattern)? {
+            let path = path?;
 
-fn clean_entire_folder(path: &Path, config: &Config) -> CargoResult<()> {
-    let num_paths = walkdir::WalkDir::new(path).into_iter().count();
-    let mut progress = CleaningFolderBar::new(config, num_paths);
-    rm_rf(path, config, &mut progress)
+            let pkg_name = path
+                .file_name()
+                .and_then(std::ffi::OsStr::to_str)
+                .and_then(|artifact| artifact.rsplit_once('-'))
+                .ok_or_else(|| anyhow::anyhow!("expected utf-8 path"))?
+                .0;
+
+            if pkg_name != package {
+                continue;
+            }
+
+            self.rm_rf(&path)?;
+        }
+        Ok(())
+    }
+
+    fn rm_rf_glob(&mut self, pattern: &Path) -> CargoResult<()> {
+        // TODO: Display utf8 warning to user?  Or switch to globset?
+        let pattern = pattern
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("expected utf-8 path"))?;
+        for path in glob::glob(pattern)? {
+            self.rm_rf(&path?)?;
+        }
+        Ok(())
+    }
+
+    pub fn rm_rf(&mut self, path: &Path) -> CargoResult<()> {
+        let meta = match fs::symlink_metadata(path) {
+            Ok(meta) => meta,
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    self.config
+                        .shell()
+                        .warn(&format!("cannot access {}: {e}", path.display()))?;
+                }
+                return Ok(());
+            }
+        };
+
+        self.config
+            .shell()
+            .verbose(|shell| shell.status("Removing", path.display()))?;
+        self.progress.display_now()?;
+
+        if !meta.is_dir() {
+            return paths::remove_file(path);
+        }
+
+        for entry in walkdir::WalkDir::new(path).contents_first(true) {
+            let entry = entry?;
+            self.progress.on_clean()?;
+            if entry.file_type().is_dir() {
+                // The contents should have been removed by now, but sometimes a race condition is hit
+                // where other files have been added by the OS. `paths::remove_dir_all` also falls back
+                // to `std::fs::remove_dir_all`, which may be more reliable than a simple walk in
+                // platform-specific edge cases.
+                paths::remove_dir_all(entry.path())?;
+            } else {
+                paths::remove_file(entry.path())?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Deletes all of the given paths, showing a progress bar as it proceeds.
+    ///
+    /// If any path does not exist, or is not accessible, this will not
+    /// generate an error. This only generates an error for other issues, like
+    /// not being able to write to the console.
+    pub fn remove_paths(&mut self, paths: &[PathBuf]) -> CargoResult<()> {
+        let num_paths = paths
+            .iter()
+            .map(|path| walkdir::WalkDir::new(path).into_iter().count())
+            .sum();
+        self.progress = Box::new(CleaningFolderBar::new(self.config, num_paths));
+        for path in paths {
+            self.rm_rf(path)?;
+        }
+        Ok(())
+    }
 }
 
 trait CleaningProgressBar {
     fn display_now(&mut self) -> CargoResult<()>;
     fn on_clean(&mut self) -> CargoResult<()>;
+    fn on_cleaning_package(&mut self, _package: &str) -> CargoResult<()> {
+        Ok(())
+    }
 }
 
 struct CleaningFolderBar<'cfg> {
@@ -381,13 +424,6 @@ impl<'cfg> CleaningPackagesBar<'cfg> {
         }
     }
 
-    fn on_cleaning_package(&mut self, package: &str) -> CargoResult<()> {
-        self.cur += 1;
-        self.package_being_cleaned = String::from(package);
-        self.bar
-            .tick(self.cur_progress(), self.max, &self.format_message())
-    }
-
     fn cur_progress(&self) -> usize {
         std::cmp::min(self.cur, self.max)
     }
@@ -411,5 +447,12 @@ impl<'cfg> CleaningProgressBar for CleaningPackagesBar<'cfg> {
             .tick(self.cur_progress(), self.max, &self.format_message())?;
         self.num_files_folders_cleaned += 1;
         Ok(())
+    }
+
+    fn on_cleaning_package(&mut self, package: &str) -> CargoResult<()> {
+        self.cur += 1;
+        self.package_being_cleaned = String::from(package);
+        self.bar
+            .tick(self.cur_progress(), self.max, &self.format_message())
     }
 }

--- a/src/doc/man/cargo-clean.md
+++ b/src/doc/man/cargo-clean.md
@@ -36,6 +36,11 @@ multiple times. See {{man "cargo-pkgid" 1}} for the SPEC format.
 
 {{#options}}
 
+{{#option "`--dry-run`" }}
+Displays a summary of what would be deleted without deleting anything.
+Use with `--verbose` to display the actual files that would be deleted.
+{{/option}}
+
 {{#option "`--doc`" }}
 This option will cause `cargo clean` to remove only the `doc` directory in
 the target directory.

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -22,6 +22,11 @@ OPTIONS
            multiple times. See cargo-pkgid(1) for the SPEC format.
 
    Clean Options
+       --dry-run
+           Displays a summary of what would be deleted without deleting
+           anything. Use with --verbose to display the actual files that would
+           be deleted.
+
        --doc
            This option will cause cargo clean to remove only the doc directory
            in the target directory.

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -34,6 +34,11 @@ multiple times. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the SPEC f
 
 <dl>
 
+<dt class="option-term" id="option-cargo-clean---dry-run"><a class="option-anchor" href="#option-cargo-clean---dry-run"></a><code>--dry-run</code></dt>
+<dd class="option-desc">Displays a summary of what would be deleted without deleting anything.
+Use with <code>--verbose</code> to display the actual files that would be deleted.</dd>
+
+
 <dt class="option-term" id="option-cargo-clean---doc"><a class="option-anchor" href="#option-cargo-clean---doc"></a><code>--doc</code></dt>
 <dd class="option-desc">This option will cause <code>cargo clean</code> to remove only the <code>doc</code> directory in
 the target directory.</dd>

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -25,6 +25,12 @@ multiple times. See \fBcargo\-pkgid\fR(1) for the SPEC format.
 .RE
 .SS "Clean Options"
 .sp
+\fB\-\-dry\-run\fR
+.RS 4
+Displays a summary of what would be deleted without deleting anything.
+Use with \fB\-\-verbose\fR to display the actual files that would be deleted.
+.RE
+.sp
 \fB\-\-doc\fR
 .RS 4
 This option will cause \fBcargo clean\fR to remove only the \fBdoc\fR directory in

--- a/tests/testsuite/cargo_clean/help/stdout.log
+++ b/tests/testsuite/cargo_clean/help/stdout.log
@@ -5,6 +5,7 @@ Usage: cargo[EXE] clean [OPTIONS]
 Options:
       --doc                 Whether or not to clean just the documentation directory
   -q, --quiet               Do not print cargo log messages
+  -n, --dry-run             Display what would be deleted without deleting anything
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -417,7 +417,7 @@ fn clean_verbose() {
             expected.push_str(&format!("[REMOVING] [..]{}\n", obj.unwrap().display()));
         }
     }
-    expected.push_str("[REMOVED] [..] files/directories, [..] total\n");
+    expected.push_str("[REMOVED] [..] files, [..] total\n");
     p.cargo("clean -p bar --verbose")
         .with_stderr_unordered(&expected)
         .run();
@@ -609,7 +609,7 @@ error: package ID specification `baz` did not match any packages
         .with_stderr(
             "warning: version qualifier in `-p bar:0.1.0` is ignored, \
             cleaning all versions of `bar` found\n\
-            [REMOVED] [..] files/directories, [..] total",
+            [REMOVED] [..] files, [..] total",
         )
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
@@ -664,7 +664,7 @@ error: package ID specification `baz` did not match any packages
         .with_stderr(
             "warning: version qualifier in `-p bar:0.1` is ignored, \
             cleaning all versions of `bar` found\n\
-            [REMOVED] [..] files/directories, [..] total",
+            [REMOVED] [..] files, [..] total",
         )
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
@@ -719,7 +719,7 @@ error: package ID specification `baz` did not match any packages
         .with_stderr(
             "warning: version qualifier in `-p bar:0` is ignored, \
             cleaning all versions of `bar` found\n\
-            [REMOVED] [..] files/directories, [..] total",
+            [REMOVED] [..] files, [..] total",
         )
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
@@ -817,13 +817,13 @@ fn clean_dry_run() {
     // Start with no files.
     p.cargo("clean --dry-run")
         .with_stdout("")
-        .with_stderr("[SUMMARY] 0 files/directories")
+        .with_stderr("[SUMMARY] 0 files")
         .run();
     p.cargo("check").run();
     let before = ls_r();
     p.cargo("clean --dry-run")
         .with_stdout("[CWD]/target")
-        .with_stderr("[SUMMARY] [..] files/directories, [..] total")
+        .with_stderr("[SUMMARY] [..] files, [..] total")
         .run();
     // Verify it didn't delete anything.
     let after = ls_r();
@@ -833,7 +833,7 @@ fn clean_dry_run() {
     // Verify the verbose output.
     p.cargo("clean --dry-run -v")
         .with_stdout_unordered(expected)
-        .with_stderr("[SUMMARY] [..] files/directories, [..] total")
+        .with_stderr("[SUMMARY] [..] files, [..] total")
         .run();
 }
 

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -825,7 +825,6 @@ fn clean_dry_run() {
     p.cargo("check").run();
     let before = ls_r();
     p.cargo("clean --dry-run")
-        .with_stdout("[CWD]/target")
         .with_stderr(
             "[SUMMARY] [..] files, [..] total\n\
              [WARNING] no files deleted due to --dry-run",

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -817,13 +817,19 @@ fn clean_dry_run() {
     // Start with no files.
     p.cargo("clean --dry-run")
         .with_stdout("")
-        .with_stderr("[SUMMARY] 0 files")
+        .with_stderr(
+            "[SUMMARY] 0 files\n\
+             [WARNING] no files deleted due to --dry-run",
+        )
         .run();
     p.cargo("check").run();
     let before = ls_r();
     p.cargo("clean --dry-run")
         .with_stdout("[CWD]/target")
-        .with_stderr("[SUMMARY] [..] files, [..] total")
+        .with_stderr(
+            "[SUMMARY] [..] files, [..] total\n\
+             [WARNING] no files deleted due to --dry-run",
+        )
         .run();
     // Verify it didn't delete anything.
     let after = ls_r();
@@ -833,7 +839,10 @@ fn clean_dry_run() {
     // Verify the verbose output.
     p.cargo("clean --dry-run -v")
         .with_stdout_unordered(expected)
-        .with_stderr("[SUMMARY] [..] files, [..] total")
+        .with_stderr(
+            "[SUMMARY] [..] files, [..] total\n\
+             [WARNING] no files deleted due to --dry-run",
+        )
         .run();
 }
 

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -544,7 +544,7 @@ fn clean_custom_dirname() {
 
     // This should clean 'other'
     p.cargo("clean --profile=other")
-        .with_stderr("[REMOVED] [..] files/directories, [..] total")
+        .with_stderr("[REMOVED] [..] files, [..] total")
         .run();
     assert!(p.build_dir().join("debug").is_dir());
     assert!(!p.build_dir().join("other").is_dir());

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -543,7 +543,9 @@ fn clean_custom_dirname() {
     assert!(!p.build_dir().join("release").is_dir());
 
     // This should clean 'other'
-    p.cargo("clean --profile=other").with_stderr("").run();
+    p.cargo("clean --profile=other")
+        .with_stderr("[REMOVED] [..] files/directories, [..] total")
+        .run();
     assert!(p.build_dir().join("debug").is_dir());
     assert!(!p.build_dir().join("other").is_dir());
 }

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -980,6 +980,7 @@ fn cmd_clean_with_embedded() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
+[REMOVED] [..] files/directories, [..] total
 ",
         )
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -980,7 +980,7 @@ fn cmd_clean_with_embedded() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
-[REMOVED] [..] files/directories, [..] total
+[REMOVED] [..] files, [..] total
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This adds some enhancements to `cargo clean` that fell out as a result of some refactorings in #12634 for supporting an interface for cleaning from other places in cargo, and these were relatively easy to add and assist with testing in #12634. 

The changes are:
- Introduce some refactoring to offer a cleaning interface that can be used elsewhere in cargo.
- Adds a `--dry-run` CLI option which will print what `cargo clean` will delete without deleting it. **NOTE** This PR makes the flag insta-stable. I don't figure there is too much that can be learned about it keeping it unstable, though we could change that. #12634 has this flag gated with `-Zgc`.
- Adds a summary line at the end of the `cargo clean` operation that indicates how much was deleted.

### How should we test and review this PR?

Note that this PR also includes the changes from #12635 and #12637. Those commits can be dropped if those PRs are merged.

For the most part, this involves wrapping the cleaning operations in a `CleanContext` which provides an interface for performing cleaning operations. The dry run is just a flag that is checked at the deletion points. The summary data is also collected at those same points.
