### PR TITLE
Bump cargo-credential-1password to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-1password"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cargo-credential",
  "serde",

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-1password"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"


### PR DESCRIPTION
`cargo-credential` updated to version `0.4.0` in #12622. This updates `cargo-credential-1password` to `0.4.0` as well so it can be published to crates.io.