### PR TITLE
Index summary enum

### DIFF
--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -430,7 +430,7 @@ impl<'cfg> RegistryIndex<'cfg> {
     ///
     /// Internally there's quite a few layer of caching to amortize this cost
     /// though since this method is called quite a lot on null builds in Cargo.
-    pub fn summaries<'a, 'b>(
+    fn summaries<'a, 'b>(
         &'a mut self,
         name: &str,
         req: &'b OptVersionReq,

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -695,11 +695,10 @@ impl<'cfg> RegistrySource<'cfg> {
             .index
             .summaries(&package.name(), &req, &mut *self.ops)?
             .expect("a downloaded dep now pending!?")
-            .map(|s| s.summary.clone())
-            .filter(|s| s.version() == package.version())
+            .filter(|s| s.package_id().version() == package.version())
             .next()
             .expect("summary not found");
-        if let Some(cksum) = summary_with_cksum.checksum() {
+        if let Some(cksum) = summary_with_cksum.as_summary().checksum() {
             pkg.manifest_mut()
                 .summary_mut()
                 .set_checksum(cksum.to_string());

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2604,7 +2604,9 @@ fn ignores_unknown_index_version_git() {
 fn ignores_unknown_index_version() {
     // If the version field is not understood, it is ignored.
     Package::new("bar", "1.0.0").publish();
-    Package::new("bar", "1.0.1").schema_version(9999).publish();
+    Package::new("bar", "1.0.1")
+        .schema_version(u32::MAX)
+        .publish();
 
     let p = project()
         .file(

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2633,6 +2633,41 @@ fn ignores_unknown_index_version() {
 }
 
 #[cargo_test]
+fn unknown_index_version_error() {
+    // If the version field is not understood, it is ignored.
+    Package::new("bar", "1.0.1")
+        .schema_version(u32::MAX)
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("generate-lockfile")
+        .with_status(101)
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[ERROR] no matching package named `bar` found
+location searched: registry `crates-io`
+required by package `foo v0.1.0 ([CWD])`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn protocol() {
     cargo_process("install bar")
         .with_status(101)


### PR DESCRIPTION
### What does this PR try to resolve?

This is a tiny incremental part of allowing registries to return richer information about summaries that are not available for resolution. Eventually this should lead to better error messages, but for now it's just an internal re-factor. Discussion of the overall approach is at https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/better.20error.20messages.20for.20filtered.20versions.2E

### How should we test and review this PR?

Internal re-factor and tests still pass.
