### PR TITLE
fix: don't print _TOKEN suggestion when not applicable

### DIFF
--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -588,12 +588,13 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
                     }
                     .into());
                     if self.auth_required {
-                        return Poll::Ready(err.context(auth::AuthorizationError {
-                            sid: self.source_id.clone(),
-                            default_registry: self.config.default_registry()?,
-                            login_url: self.login_url.clone(),
-                            reason: auth::AuthorizationErrorReason::TokenRejected,
-                        }));
+                        let auth_error = auth::AuthorizationError::new(
+                            self.config,
+                            self.source_id,
+                            self.login_url.clone(),
+                            auth::AuthorizationErrorReason::TokenRejected,
+                        )?;
+                        return Poll::Ready(err.context(auth_error));
                     } else {
                         return Poll::Ready(err);
                     }


### PR DESCRIPTION
### What does this PR try to resolve?
When a registry token cannot be found, or a token is invalid, cargo displays an error recommending either `cargo login` or the appropriate environment variable.

For example:
```
error: no token found for `alternative`, please run `cargo login --registry alternative`
or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
```

With `-Z credential-process`, if `cargo:token` is not in `registry.global-credential-providers` or `registries.<NAME>.credential-provider` the suggested environment variable will not work.

Fixes #12642 by not including the `_TOKEN` environment variable if `cargo:token` is not enabled as a credential provider.

### How should we test and review this PR?

Two tests (`not_found` and `all_not_found` cover this case by having a registry-specific and global credential providers respectively that return `not-found`.

Other tests that emit this error are not affected, since they still have the `cargo:token` provider available.