### PR TITLE
feat: stabilize credential-process and registry-auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "cargo-credential",
  "security-framework",

--- a/credential/cargo-credential-1password/README.md
+++ b/credential/cargo-credential-1password/README.md
@@ -1,7 +1,18 @@
 # cargo-credential-1password
 
-This is the implementation for the Cargo credential helper for [1password].
-See the [credential-process] documentation for how to use this.
+A Cargo [credential provider] for [1password].
+
+`cargo-credential-1password` uses the 1password `op` CLI to store the token. You must
+install the `op` CLI from the [1password
+website](https://1password.com/downloads/command-line/). You must run `op signin`
+at least once with the appropriate arguments (such as `op signin my.1password.com user@example.com`),
+unless you provide the sign-in-address and email arguments. The master password will be required on each request
+unless the appropriate `OP_SESSION` environment variable is set. It supports
+the following command-line arguments:
+* `--account`: The account shorthand name to use.
+* `--vault`: The vault name to use.
+* `--sign-in-address`: The sign-in-address, which is a web address such as `my.1password.com`.
+* `--email`: The email address to sign in with.
 
 [1password]: https://1password.com/
-[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process
+[credential provider]: https://doc.rust-lang.org/nightly/cargo/reference/registry-authentication.html

--- a/credential/cargo-credential-libsecret/README.md
+++ b/credential/cargo-credential-libsecret/README.md
@@ -1,7 +1,9 @@
 # cargo-credential-libsecret
 
 This is the implementation for the Cargo credential helper for [GNOME libsecret].
-See the [credential-process] documentation for how to use this.
+See the [credential-provider] documentation for how to use this.
+
+This credential provider is built-in to cargo as `cargo:libsecret`.
 
 [GNOME libsecret]: https://wiki.gnome.org/Projects/Libsecret
-[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process
+[credential-provider]: https://doc.rust-lang.org/nightly/cargo/reference/registry-authentication.html

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-macos-keychain"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"

--- a/credential/cargo-credential-macos-keychain/README.md
+++ b/credential/cargo-credential-macos-keychain/README.md
@@ -1,7 +1,10 @@
 # cargo-credential-macos-keychain
 
 This is the implementation for the Cargo credential helper for [macOS Keychain].
-See the [credential-process] documentation for how to use this.
+See the [credential-provider] documentation for how to use this.
+
+This credential provider is built-in to cargo as `cargo:macos-keychain`.
 
 [macOS Keychain]: https://support.apple.com/guide/keychain-access/welcome/mac
-[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process
+[credential-provider]: https://doc.rust-lang.org/nightly/cargo/reference/registry-authentication.html
+

--- a/credential/cargo-credential-wincred/README.md
+++ b/credential/cargo-credential-wincred/README.md
@@ -1,7 +1,9 @@
 # cargo-credential-wincred
 
 This is the implementation for the Cargo credential helper for [Windows Credential Manager].
-See the [credential-process] documentation for how to use this.
+See the [credential-provider] documentation for how to use this.
+
+This credential provider is built-in to cargo as `cargo:wincred`.
 
 [Windows Credential Manager]: https://support.microsoft.com/en-us/windows/accessing-credential-manager-1b5c916a-6a16-889f-8581-fc16e8165ac0
-[credential-process]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process
+[credential-provider]: https://doc.rust-lang.org/nightly/cargo/reference/registry-authentication.html

--- a/credential/cargo-credential/README.md
+++ b/credential/cargo-credential/README.md
@@ -5,7 +5,7 @@ provides an interface to store tokens for authorizing access to a registry
 such as https://crates.io/.
 
 Documentation about credential processes may be found at
-https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process
+https://doc.rust-lang.org/nightly/cargo/reference/credential-provider-protocol.html
 
 Example implementations may be found at
 https://github.com/rust-lang/cargo/tree/master/credential

--- a/publish.py
+++ b/publish.py
@@ -17,6 +17,11 @@ from urllib.error import HTTPError
 
 
 TO_PUBLISH = [
+    'credential/cargo-credential',
+    'credential/cargo-credential-libsecret',
+    'credential/cargo-credential-wincred',
+    'credential/cargo-credential-1password',
+    'credential/cargo-credential-macos-keychain',
     'crates/cargo-platform',
     'crates/cargo-util',
     'crates/crates-io',

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -9,7 +9,7 @@ pub fn cli() -> Command {
         .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
         .arg(
             Arg::new("args")
-                .help("Arguments for the credential provider (unstable)")
+                .help("Additional arguments for the credential provider")
                 .num_args(0..)
                 .last(true),
         )

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -728,7 +728,6 @@ unstable_cli_options!(
     check_cfg: Option<(/*features:*/ bool, /*well_known_names:*/ bool, /*well_known_values:*/ bool, /*output:*/ bool)> = ("Specify scope of compile-time checking of `cfg` names/values"),
     codegen_backend: bool = ("Enable the `codegen-backend` option in profiles in .cargo/config.toml file"),
     config_include: bool = ("Enable the `include` key in config files"),
-    credential_process: bool = ("Add a config setting to fetch registry authentication tokens by calling an external process"),
     direct_minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum (direct dependencies only)"),
     doctest_xcompile: bool = ("Compile and run doctests for non-host target using runner config"),
     dual_proc_macros: bool = ("Build proc-macros for both the host and the target"),
@@ -744,7 +743,6 @@ unstable_cli_options!(
     panic_abort_tests: bool = ("Enable support to run tests with -Cpanic=abort"),
     profile_rustflags: bool = ("Enable the `rustflags` option in profiles in .cargo/config.toml file"),
     publish_timeout: bool = ("Enable the `publish.timeout` key in .cargo/config.toml file"),
-    registry_auth: bool = ("Authentication for alternative registries"),
     rustdoc_map: bool = ("Allow passing external documentation mappings to rustdoc"),
     rustdoc_scrape_examples: bool = ("Allows Rustdoc to scrape code examples from reverse-dependencies"),
     script: bool = ("Enable support for single-file, `.rs` packages"),
@@ -817,6 +815,12 @@ const STABILIZED_TERMINAL_WIDTH: &str =
     "The -Zterminal-width option is now always enabled for terminal output.";
 
 const STABILISED_SPARSE_REGISTRY: &str = "The sparse protocol is now the default for crates.io";
+
+const STABILIZED_CREDENTIAL_PROCESS: &str =
+    "Authentication with a credential provider is always available.";
+
+const STABILIZED_REGISTRY_AUTH: &str =
+    "Authenticated registries are available if a credential provider is configured.";
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
@@ -1081,6 +1085,8 @@ impl CliUnstable {
             "sparse-registry" => stabilized_warn(k, "1.68", STABILISED_SPARSE_REGISTRY),
             "terminal-width" => stabilized_warn(k, "1.68", STABILIZED_TERMINAL_WIDTH),
             "doctest-in-workspace" => stabilized_warn(k, "1.72", STABILIZED_DOCTEST_IN_WORKSPACE),
+            "credential-process" => stabilized_warn(k, "1.74", STABILIZED_CREDENTIAL_PROCESS),
+            "registry-auth" => stabilized_warn(k, "1.74", STABILIZED_REGISTRY_AUTH),
 
             // Unstable features
             // Sorted alphabetically:
@@ -1098,7 +1104,6 @@ impl CliUnstable {
             }
             "codegen-backend" => self.codegen_backend = parse_empty(k, v)?,
             "config-include" => self.config_include = parse_empty(k, v)?,
-            "credential-process" => self.credential_process = parse_empty(k, v)?,
             "direct-minimal-versions" => self.direct_minimal_versions = parse_empty(k, v)?,
             "doctest-xcompile" => self.doctest_xcompile = parse_empty(k, v)?,
             "dual-proc-macros" => self.dual_proc_macros = parse_empty(k, v)?,
@@ -1119,7 +1124,6 @@ impl CliUnstable {
             "panic-abort-tests" => self.panic_abort_tests = parse_empty(k, v)?,
             "profile-rustflags" => self.profile_rustflags = parse_empty(k, v)?,
             "publish-timeout" => self.publish_timeout = parse_empty(k, v)?,
-            "registry-auth" => self.registry_auth = parse_empty(k, v)?,
             "rustdoc-map" => self.rustdoc_map = parse_empty(k, v)?,
             "rustdoc-scrape-examples" => self.rustdoc_scrape_examples = parse_empty(k, v)?,
             "separate-nightlies" => self.separate_nightlies = parse_empty(k, v)?,

--- a/src/cargo/lib.rs
+++ b/src/cargo/lib.rs
@@ -78,9 +78,7 @@
 //!   This is the `#[cargo_test]` proc-macro used by the test suite to define tests.
 //! - [`credential`](https://github.com/rust-lang/cargo/tree/master/credential)
 //!   This subdirectory contains several packages for implementing the
-//!   experimental
-//!   [credential-process](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#credential-process)
-//!   feature.
+//!   [credential providers](https://doc.rust-lang.org/nightly/cargo/reference/registry-authentication.html).
 //! - [`mdman`](https://github.com/rust-lang/cargo/tree/master/crates/mdman)
 //!   ([nightly docs](https://doc.rust-lang.org/nightly/nightly-rustc/mdman/index.html)):
 //!   This is a utility for generating cargo's man pages. See [Building the man

--- a/src/cargo/ops/registry/mod.rs
+++ b/src/cargo/ops/registry/mod.rs
@@ -145,6 +145,7 @@ fn registry(
             None,
             operation,
             vec![],
+            false,
         )?)
     } else {
         None

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -161,6 +161,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
             None,
             operation,
             vec![],
+            false,
         )?));
     }
 

--- a/src/cargo/sources/registry/download.rs
+++ b/src/cargo/sources/registry/download.rs
@@ -85,6 +85,7 @@ pub(super) fn download(
             None,
             Operation::Read,
             vec![],
+            true,
         )?)
     } else {
         None

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -306,10 +306,7 @@ impl<'cfg> RegistryData for RemoteRegistry<'cfg> {
         match ready!(self.load(Path::new(""), Path::new(RegistryConfig::NAME), None)?) {
             LoadResponse::Data { raw_data, .. } => {
                 trace!("config loaded");
-                let mut cfg: RegistryConfig = serde_json::from_slice(&raw_data)?;
-                if !self.config.cli_unstable().registry_auth {
-                    cfg.auth_required = false;
-                }
+                let cfg: RegistryConfig = serde_json::from_slice(&raw_data)?;
                 Poll::Ready(Ok(Some(cfg)))
             }
             _ => Poll::Ready(Ok(None)),

--- a/src/doc/man/cargo-login.md
+++ b/src/doc/man/cargo-login.md
@@ -2,18 +2,25 @@
 
 ## NAME
 
-cargo-login --- Save an API token from the registry locally
+cargo-login --- Log in to a registry
 
 ## SYNOPSIS
 
-`cargo login` [_options_] [_token_]
+`cargo login` [_options_] [_token_] -- [_args_]
 
 ## DESCRIPTION
 
-This command will save the API token to disk so that commands that require
-authentication, such as {{man "cargo-publish" 1}}, will be automatically
-authenticated. The token is saved in `$CARGO_HOME/credentials.toml`. `CARGO_HOME`
-defaults to `.cargo` in your home directory.
+This command will run a credential provider to save a token so that commands
+that require authentication, such as {{man "cargo-publish" 1}}, will be
+automatically authenticated.
+
+For the default `cargo:token` credential provider, the token is saved
+in `$CARGO_HOME/credentials.toml`. `CARGO_HOME` defaults to `.cargo`
+in your home directory.
+
+If a registry has a credential-provider specified, it will be used. Otherwise,
+the providers from the config value `registry.global-credential-providers` will
+be attempted, starting from the end of the list.
 
 If the _token_ argument is not specified, it will be read from stdin.
 
@@ -43,9 +50,13 @@ Take care to keep the token secret, it should not be shared with anyone else.
 
 ## EXAMPLES
 
-1. Save the API token to disk:
+1. Save the token for the default registry:
 
        cargo login
+
+2. Save the token for a specific registry:
+
+       cargo login --registry my-registry
 
 ## SEE ALSO
 {{man "cargo" 1}}, {{man "cargo-logout" 1}}, {{man "cargo-publish" 1}}

--- a/src/doc/man/cargo-logout.md
+++ b/src/doc/man/cargo-logout.md
@@ -10,9 +10,15 @@ cargo-logout --- Remove an API token from the registry locally
 
 ## DESCRIPTION
 
-This command will remove the API token from the local credential storage.
-Credentials are stored in `$CARGO_HOME/credentials.toml` where `$CARGO_HOME`
-defaults to `.cargo` in your home directory.
+This command will run a credential provider to remove a saved token.
+
+For the default `cargo:token` credential provider, credentials are stored
+in `$CARGO_HOME/credentials.toml` where `$CARGO_HOME` defaults to `.cargo`
+in your home directory.
+
+If a registry has a credential-provider specified, it will be used. Otherwise,
+the providers from the config value `registry.global-credential-providers` will
+be attempted, starting from the end of the list.
 
 If `--registry` is not specified, then the credentials for the default
 registry will be removed (configured by

--- a/src/doc/man/generated_txt/cargo-login.txt
+++ b/src/doc/man/generated_txt/cargo-login.txt
@@ -1,16 +1,24 @@
 CARGO-LOGIN(1)
 
 NAME
-       cargo-login — Save an API token from the registry locally
+       cargo-login — Log in to a registry
 
 SYNOPSIS
-       cargo login [options] [token]
+       cargo login [options] [token] – [args]
 
 DESCRIPTION
-       This command will save the API token to disk so that commands that
-       require authentication, such as cargo-publish(1), will be automatically
-       authenticated. The token is saved in $CARGO_HOME/credentials.toml.
-       CARGO_HOME defaults to .cargo in your home directory.
+       This command will run a credential provider to save a token so that
+       commands that require authentication, such as cargo-publish(1), will be
+       automatically authenticated.
+
+       For the default cargo:token credential provider, the token is saved in
+       $CARGO_HOME/credentials.toml. CARGO_HOME defaults to .cargo in your home
+       directory.
+
+       If a registry has a credential-provider specified, it will be used.
+       Otherwise, the providers from the config value
+       registry.global-credential-providers will be attempted, starting from
+       the end of the list.
 
        If the token argument is not specified, it will be read from stdin.
 
@@ -102,9 +110,13 @@ EXIT STATUS
        o  101: Cargo failed to complete.
 
 EXAMPLES
-       1. Save the API token to disk:
+       1. Save the token for the default registry:
 
               cargo login
+
+       2. Save the token for a specific registry:
+
+              cargo login --registry my-registry
 
 SEE ALSO
        cargo(1), cargo-logout(1), cargo-publish(1)

--- a/src/doc/man/generated_txt/cargo-logout.txt
+++ b/src/doc/man/generated_txt/cargo-logout.txt
@@ -7,9 +7,16 @@ SYNOPSIS
        cargo logout [options]
 
 DESCRIPTION
-       This command will remove the API token from the local credential
-       storage. Credentials are stored in $CARGO_HOME/credentials.toml where
-       $CARGO_HOME defaults to .cargo in your home directory.
+       This command will run a credential provider to remove a saved token.
+
+       For the default cargo:token credential provider, credentials are stored
+       in $CARGO_HOME/credentials.toml where $CARGO_HOME defaults to .cargo in
+       your home directory.
+
+       If a registry has a credential-provider specified, it will be used.
+       Otherwise, the providers from the config value
+       registry.global-credential-providers will be attempted, starting from
+       the end of the list.
 
        If --registry is not specified, then the credentials for the default
        registry will be removed (configured by registry.default

--- a/src/doc/src/SUMMARY.md
+++ b/src/doc/src/SUMMARY.md
@@ -36,6 +36,8 @@
     * [Source Replacement](reference/source-replacement.md)
     * [External Tools](reference/external-tools.md)
     * [Registries](reference/registries.md)
+        * [Registry Authentication](reference/registry-authentication.md)
+            * [Credential Provider Protocol](reference/credential-provider-protocol.md)
         * [Running a Registry](reference/running-a-registry.md)
             * [Registry Index](reference/registry-index.md)
             * [Registry Web API](reference/registry-web-api.md)

--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -2,18 +2,25 @@
 
 ## NAME
 
-cargo-login --- Save an API token from the registry locally
+cargo-login --- Log in to a registry
 
 ## SYNOPSIS
 
-`cargo login` [_options_] [_token_]
+`cargo login` [_options_] [_token_] -- [_args_]
 
 ## DESCRIPTION
 
-This command will save the API token to disk so that commands that require
-authentication, such as [cargo-publish(1)](cargo-publish.html), will be automatically
-authenticated. The token is saved in `$CARGO_HOME/credentials.toml`. `CARGO_HOME`
-defaults to `.cargo` in your home directory.
+This command will run a credential provider to save a token so that commands
+that require authentication, such as [cargo-publish(1)](cargo-publish.html), will be
+automatically authenticated.
+
+For the default `cargo:token` credential provider, the token is saved
+in `$CARGO_HOME/credentials.toml`. `CARGO_HOME` defaults to `.cargo`
+in your home directory.
+
+If a registry has a credential-provider specified, it will be used. Otherwise,
+the providers from the config value `registry.global-credential-providers` will
+be attempted, starting from the end of the list.
 
 If the _token_ argument is not specified, it will be read from stdin.
 
@@ -122,9 +129,13 @@ details on environment variables that Cargo reads.
 
 ## EXAMPLES
 
-1. Save the API token to disk:
+1. Save the token for the default registry:
 
        cargo login
+
+2. Save the token for a specific registry:
+
+       cargo login --registry my-registry
 
 ## SEE ALSO
 [cargo(1)](cargo.html), [cargo-logout(1)](cargo-logout.html), [cargo-publish(1)](cargo-publish.html)

--- a/src/doc/src/commands/cargo-logout.md
+++ b/src/doc/src/commands/cargo-logout.md
@@ -10,9 +10,15 @@ cargo-logout --- Remove an API token from the registry locally
 
 ## DESCRIPTION
 
-This command will remove the API token from the local credential storage.
-Credentials are stored in `$CARGO_HOME/credentials.toml` where `$CARGO_HOME`
-defaults to `.cargo` in your home directory.
+This command will run a credential provider to remove a saved token.
+
+For the default `cargo:token` credential provider, credentials are stored
+in `$CARGO_HOME/credentials.toml` where `$CARGO_HOME` defaults to `.cargo`
+in your home directory.
+
+If a registry has a credential-provider specified, it will be used. Otherwise,
+the providers from the config value `registry.global-credential-providers` will
+be attempted, starting from the end of the list.
 
 If `--registry` is not specified, then the credentials for the default
 registry will be removed (configured by

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -298,7 +298,9 @@ Cargo will search `PATH` for its executable.
 
 Configuration values with sensitive information are stored in the
 `$CARGO_HOME/credentials.toml` file. This file is automatically created and updated
-by [`cargo login`] and [`cargo logout`]. It follows the same format as Cargo config files.
+by [`cargo login`] and [`cargo logout`] when using the `cargo:token` credential provider.
+
+It follows the same format as Cargo config files.
 
 ```toml
 [registry]
@@ -536,6 +538,26 @@ directory.
 #### `build.pipelining`
 
 This option is deprecated and unused. Cargo always has pipelining enabled.
+
+### `[credential-alias]`
+* Type: string or array of strings
+* Default: empty
+* Environment: `CARGO_CREDENTIAL_ALIAS_<name>`
+
+The `[credential-alias]` table defines credential provider aliases.
+These aliases can be referenced as an element of the `registry.global-credential-providers`
+array, or as a credential provider for a specific registry
+under `registries.<NAME>.credential-provider`.
+
+If specified as a string, the value will be split on spaces into path and arguments.
+
+For example, to define an alias called `my-alias`:
+
+```toml
+[credential-alias]
+my-alias = ["/usr/bin/cargo-credential-example", "--argument", "value", "--flag"]
+```
+See [Registry Authentication](registry-authentication.md) for more information.
 
 ### `[doc]`
 
@@ -947,6 +969,22 @@ commands like [`cargo publish`] that require authentication.
 
 Can be overridden with the `--token` command-line option.
 
+#### `registries.<name>.credential-provider`
+* Type: string or array of path and arguments
+* Default: none
+* Environment: `CARGO_REGISTRIES_<name>_CREDENTIAL_PROVIDER`
+
+Specifies the credential provider for the given registry. If not set, the
+providers in [`registry.global-credential-providers`](#registryglobal-credential-providers)
+will be used.
+
+If specified as a string, path and arguments will be split on spaces. For
+paths or arguments that contain spaces, use an array.
+
+If the value exists in the [`[credential-alias]`](#credential-alias) table, the alias will be used.
+
+See [Registry Authentication](registry-authentication.md) for more information.
+
 #### `registries.crates-io.protocol`
 * Type: string
 * Default: `sparse`
@@ -980,6 +1018,22 @@ by default for registry commands like [`cargo publish`].
 
 Can be overridden with the `--registry` command-line option.
 
+#### `registry.credential-provider`
+* Type: string or array of path and arguments
+* Default: none
+* Environment: `CARGO_REGISTRY_CREDENTIAL_PROVIDER`
+
+Specifies the credential provider for [crates.io]. If not set, the
+providers in [`registry.global-credential-providers`](#registryglobal-credential-providers)
+will be used.
+
+If specified as a string, path and arguments will be split on spaces. For
+paths or arguments that contain spaces, use an array.
+
+If the value exists in the `[credential-alias]` table, the alias will be used.
+
+See [Registry Authentication](registry-authentication.md) for more information.
+
 #### `registry.token`
 * Type: string
 * Default: none
@@ -990,6 +1044,21 @@ appear in the [credentials](#credentials) file. This is used for registry
 commands like [`cargo publish`] that require authentication.
 
 Can be overridden with the `--token` command-line option.
+
+#### `registry.global-credential-providers`
+* Type: array
+* Default: `["cargo:token"]`
+* Environment: `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS`
+
+Specifies the list of global credential providers. If credential provider is not set
+for a specific registry using `registries.<name>.credential-provider`, Cargo will use
+the credential providers in this list. Providers toward the end of the list have precedence.
+
+Path and arguments are split on spaces. If the path or arguments contains spaces, the credential
+provider should be defined in the [`[credential-alias]`](#credential-alias) table and
+referenced here by its alias.
+
+See [Registry Authentication](registry-authentication.md) for more information.
 
 ### `[source]`
 

--- a/src/doc/src/reference/credential-provider-protocol.md
+++ b/src/doc/src/reference/credential-provider-protocol.md
@@ -1,0 +1,237 @@
+# Credential Provider Protocol
+This document describes information for building a Cargo credential provider. For information on
+setting up or using a credential provider, see [Registry Authentication](registry-authentication.md).
+
+When using an external credential provider, Cargo communicates with the credential
+provider using stdin/stdout messages passed as single lines of JSON.
+
+Cargo will always execute the credential provider with the `--cargo-plugin` argument.
+This enables a credential provider executable to have additional functionality beyond
+what Cargo needs. Additional arguments are included in the JSON via the `args` field.
+
+## JSON messages
+The JSON messages in this document have newlines added for readability.
+Actual messages must not contain newlines.
+
+### Credential hello
+* Sent by: credential provider
+* Purpose: used to identify the supported protocols on process startup
+```javascript
+{
+    "v":[1]
+}
+```
+
+Requests sent by Cargo will include a `v` field set to one of the versions listed here.
+If Cargo does not support any of the versions offered by the credential provider, it will issue an
+error and shut down the credential process.
+
+### Registry information
+* Sent by: Cargo
+Not a message by itself. Included in all messages sent by Cargo as the `registry` field.
+```javascript
+{
+    // Index URL of the registry
+    "index-url":"https://github.com/rust-lang/crates.io-index",
+    // Name of the registry in configuration (optional)
+    "name": "crates-io",
+    // HTTP headers received from attempting to access an authenticated registry (optional)
+    "headers": ["WWW-Authenticate: cargo"]
+}
+```
+
+### Login request
+* Sent by: Cargo
+* Purpose: collect and store credentials
+```javascript
+{
+    // Protocol version
+    "v":1,
+    // Action to perform: login
+    "kind":"login",
+    // Registry information (see Registry information)
+    "registry":{"index-url":"sparse+https://registry-url/index/", "name": "my-registry"},
+    // User-specified token from stdin or command line (optional)
+    "token": "<the token value>",
+    // URL that the user could visit to get a token (optional)
+    "login-url": "http://registry-url/login",
+    // Additional command-line args (optional)
+    "args":[]
+}
+```
+
+If the `token` field is set, than the credential provider should use the token provided. If
+the `token` is not set, then the credential provider should prompt the user for a token.
+
+In addition to the arguments that may be passed to the credential provider in
+configuration, `cargo login` also supports passing additional command line args
+via `cargo login -- <additional args>`. These additional arguments will be included
+in the `args` field after any args from Cargo configuration.
+
+### Read request
+* Sent by: Cargo
+* Purpose: Get the credential for reading crate information
+```javascript
+{
+    // Protocol version
+    "v":1,
+    // Request kind: get credentials
+    "kind":"get",
+    // Action to perform: read crate information
+    "operation":"read",
+    // Registry information (see Registry information)
+    "registry":{"index-url":"sparse+https://registry-url/index/", "name": "my-registry"},
+    // Additional command-line args (optional)
+    "args":[]
+}
+```
+
+### Publish request
+* Sent by: Cargo
+* Purpose: Get the credential for publishing a crate
+```javascript
+{
+    // Protocol version
+    "v":1,
+    // Request kind: get credentials
+    "kind":"get",
+    // Action to perform: publish crate
+    "operation":"publish",
+    // Crate name
+    "name":"sample",
+    // Crate version
+    "vers":"0.1.0",
+    // Crate checksum
+    "cksum":"...",
+    // Registry information (see Registry information)
+    "registry":{"index-url":"sparse+https://registry-url/index/", "name": "my-registry"},
+    // Additional command-line args (optional)
+    "args":[]
+}
+```
+
+### Get success response
+* Sent by: credential provider
+* Purpose: Gives the credential to Cargo
+```javascript
+{"Ok":{
+    // Response kind: this was a get request
+    "kind":"get",
+    // Token to send to the registry
+    "token":"...",
+    // Cache control. Can be one of the following:
+    // * "never": do not cache
+    // * "session": cache for the current cargo session
+    // * "expires": cache for the current cargo session until expiration
+    "cache":"expires",
+    // Unix timestamp (only for "cache": "expires")
+    "expiration":1693942857,
+    // Is the token operation independent?
+    "operation_independent":true
+}}
+```
+
+The `token` will be sent to the registry as the value of the `Authorization` HTTP header.
+
+`operation_independent` indicates whether the token can be cached across different
+operations (such as publishing or fetching). In general this should be `true` unless
+the provider wants to generate tokens that are scoped to specific operations.
+
+### Login success response
+* Sent by: credential provider
+* Purpose: Indicates the login was successful
+```javascript
+{"Ok":{
+    // Response kind: this was a login request
+    "kind":"login"
+}}
+```
+
+### Logout success response
+* Sent by: credential provider
+* Purpose: Indicates the logout was successful
+```javascript
+{"Ok":{
+    // Response kind: this was a logout request
+    "kind":"logout"
+}}
+```
+
+### Failure response (URL not supported)
+* Sent by: credential provider
+* Purpose: Gives error information to Cargo
+```javascript
+{"Err":{
+    "kind":"url-not-supported"
+}}
+```
+Sent if the credential provider is designed
+to only handle specific registry URLs, and the given URL
+is not supported. Cargo will attempt another provider if
+available.
+
+### Failure response (not found)
+* Sent by: credential provider
+* Purpose: Gives error information to Cargo
+```javascript
+{"Err":{
+    // Error: The credential could not be found in the provider.
+    "kind":"not-found"
+}}
+```
+Sent if the credential could not be found. This is expected for
+`get` requests where the credential is not available, or `logout`
+requests where there is nothing found to erase.
+
+### Failure response (operation not supported)
+* Sent by: credential provider
+* Purpose: Gives error information to Cargo
+```javascript
+{"Err":{
+    // Error: The credential could not be found in the provider.
+    "kind":"operation-not-supported"
+}}
+```
+Sent if the credential provider does not support the requested operation.
+If a provider only supports `get` and a `login` is requested, the
+provider should respond with this error.
+
+### Failure response (other)
+* Sent by: credential provider
+* Purpose: Gives error information to Cargo
+```javascript
+{"Err":{
+    // Error: something else has failed
+    "kind":"other",
+    // Error message string to be displayed
+    "message": "free form string error message",
+    // Detailed cause chain for the error (optional)
+    "caused-by": ["cause 1", "cause 2"]
+}}
+```
+
+## Example communication to request a token for reading:
+1. Cargo spawns the credential process, capturing stdin and stdout.
+2. Credential process sends the Hello message to Cargo
+    ```javascript
+    { "v": [1] }
+   ```
+3. Cargo sends the CredentialRequest message to the credential process (newlines added for readability).
+    ```javascript
+    {
+        "v": 1,
+        "kind": "get",
+        "operation": "read",
+        "registry":{"index-url":"sparse+https://registry-url/index/"}
+    }
+    ```
+4. Credential process sends the CredentialResponse to Cargo (newlines added for readability).
+    ```javascript
+    {
+        "token": "...",
+        "cache": "session",
+        "operation_independent": true
+    }
+    ```
+5. Cargo closes the stdin pipe to the credential provider and it exits.
+6. Cargo uses the token for the remainder of the session (until Cargo exits) when interacting with this registry.

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -124,9 +124,12 @@ In summary, the supported environment variables are:
 * `CARGO_PROFILE_<name>_RPATH` --- The rpath linking option, see [`profile.<name>.rpath`].
 * `CARGO_PROFILE_<name>_SPLIT_DEBUGINFO` --- Controls debug file output behavior, see [`profile.<name>.split-debuginfo`].
 * `CARGO_PROFILE_<name>_STRIP` --- Controls stripping of symbols and/or debuginfos, see [`profile.<name>.strip`].
+* `CARGO_REGISTRIES_<name>_CREDENTIAL_PROVIDER` --- Credential provider for a registry, see [`registries.<name>.credential-provider`].
 * `CARGO_REGISTRIES_<name>_INDEX` --- URL of a registry index, see [`registries.<name>.index`].
 * `CARGO_REGISTRIES_<name>_TOKEN` --- Authentication token of a registry, see [`registries.<name>.token`].
+* `CARGO_REGISTRY_CREDENTIAL_PROVIDER` --- Credential provider for [crates.io], see [`registry.credential-provider`].
 * `CARGO_REGISTRY_DEFAULT` --- Default registry for the `--registry` flag, see [`registry.default`].
+* `CARGO_REGISTRY_GLOBAL_CREDENTIAL_PROVIDERS` --- Credential providers for registries that do not have a specific provider defined. See [`registry.global-credential-providers`].
 * `CARGO_REGISTRY_TOKEN` --- Authentication token for [crates.io], see [`registry.token`].
 * `CARGO_TARGET_<triple>_LINKER` --- The linker to use, see [`target.<triple>.linker`]. The triple must be [converted to uppercase and underscores](config.md#environment-variables).
 * `CARGO_TARGET_<triple>_RUNNER` --- The executable runner, see [`target.<triple>.runner`].
@@ -187,9 +190,12 @@ In summary, the supported environment variables are:
 [`profile.<name>.rpath`]: config.md#profilenamerpath
 [`profile.<name>.split-debuginfo`]: config.md#profilenamesplit-debuginfo
 [`profile.<name>.strip`]: config.md#profilenamestrip
+[`registries.<name>.credential-provider`]: config.md#registriesnamecredential-provider
 [`registries.<name>.index`]: config.md#registriesnameindex
 [`registries.<name>.token`]: config.md#registriesnametoken
+[`registry.credential-provider`]: config.md#registrycredential-provider
 [`registry.default`]: config.md#registrydefault
+[`registry.global-credential-providers`]: config.md#registryglobal-credential-providers
 [`registry.token`]: config.md#registrytoken
 [`target.<triple>.linker`]: config.md#targettriplelinker
 [`target.<triple>.runner`]: config.md#targettriplerunner

--- a/src/doc/src/reference/registries.md
+++ b/src/doc/src/reference/registries.md
@@ -11,6 +11,10 @@ support publishing new crates directly from Cargo.
 If you are implementing a registry server, see [Running a Registry] for more
 details about the protocol between Cargo and a registry.
 
+If you're using a registry that requires authentication, see [Registry Authentication].
+If you are implementing a credential provider, see [Credential Provider Protocol]
+for details.
+
 ## Using an Alternate Registry
 
 To use a registry other than [crates.io], the name and index URL of the
@@ -117,6 +121,8 @@ controlled via the [`registries.crates-io.protocol`] config key.
 
 [Source Replacement]: source-replacement.md
 [Running a Registry]: running-a-registry.md
+[Credential Provider Protocol]: credential-provider-protocol.md
+[Registry Authentication]: registry-authentication.md
 [`cargo publish`]: ../commands/cargo-publish.md
 [`cargo package`]: ../commands/cargo-package.md
 [`cargo login`]: ../commands/cargo-login.md

--- a/src/doc/src/reference/registry-authentication.md
+++ b/src/doc/src/reference/registry-authentication.md
@@ -1,0 +1,111 @@
+# Registry Authentication
+Cargo authenticates to registries with through credential providers. These
+credential providers are external executables or built-in providers that Cargo
+uses to store and retreive credentials.
+
+Using alternative registries with authentication *requires* a credential provider to be configured
+to avoid unknowningly storing unecrypted credentials on disk. For historical reasons, public
+(non-authenticated) registres do not require credential provider configuration and the `cargo:token`
+provider is used if no providers are configured.
+
+Cargo also includes platform-specific providers that use the operating system to securely store
+tokens. The `cargo:token` provider is also included which stores credentials in unencrypted plain
+text in the [credentials](config.md#credentials) file. 
+
+## Recommended configuration
+It's recommended to configure a global credential provider list in `$CARGO_HOME/config.toml`
+which defaults to:
+* Windows: `%USERPROFILE%\.cargo\config.toml`
+* Unix: `~/.cargo/config.toml`
+
+This recommended configuration uses the operating system provider, with a fallback to `cargo:token`
+to look in Cargo's [credentials](config.md#credentials) file or environment variables.
+
+Some private registries may also recommend a registry-specific credential-provider. Check your
+registry's documentation to see if this is the case.
+
+### macOS configuration
+```toml
+# ~/.cargo/config.toml
+[registry]
+global-credential-providers = ["cargo:token", "cargo:macos-keychain"]
+```
+
+### Linux (libsecret) configuration
+```toml
+# ~/.cargo/config.toml
+[registry]
+global-credential-providers = ["cargo:token", "cargo:libsecret"]
+```
+
+### Windows configuration
+```toml
+# %USERPROFILE%\.cargo\config.toml
+[registry]
+global-credential-providers = ["cargo:token", "cargo:wincred"]
+```
+
+See [`registry.global-credential-providers`](config.md#registryglobal-credential-providers)
+for more details.
+
+## Built-in providers
+Cargo includes several built-in credential providers. The available built-in providers
+may change in future Cargo releases (though there are currently no plans to do so).
+
+### `cargo:token`
+Uses Cargo's [credentials](config.md#credentials) file to store tokens unencrypted in plain text.
+When retreiving tokens, checks the `CARGO_REGISTRIES_<NAME>_TOKEN` environment variable.
+If this credential provider is not listed, then the `*_TOKEN` environment variables will not work.
+
+### `cargo:wincred`
+Uses the Windows Credential Manager to store tokens.
+
+The credentials are stored as `cargo-registry:<index-url>` in the Credential Manager
+under "Windows Credentials".
+
+### `cargo:macos-keychain`
+Uses the macOS Keychain to store tokens.
+
+The Keychain Access app can be used to view stored tokens.
+
+### `cargo:libsecret`
+Uses [libsecret](https://wiki.gnome.org/Projects/Libsecret) to store tokens.
+
+On GNOME, credentials can be viewed using [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring)
+applications.
+
+### `cargo:token-from-stdout <command> <args>`
+Launch a subprocess that returns a token on stdout. Newlines will be trimmed.
+* The process inherits the user's stdin and stderr.
+* It should exit 0 on success, and nonzero on error.
+* [`cargo login`] and [`cargo logout`] are not supported and return an error if used.
+
+The following environment variables will be provided to the executed command:
+
+* `CARGO` --- Path to the `cargo` binary executing the command.
+* `CARGO_REGISTRY_INDEX_URL` --- The URL of the registry index.
+* `CARGO_REGISTRY_NAME_OPT` --- Optional name of the registry. Should not be used as a lookup key.
+
+Arguments will be passed on to the subcommand.
+
+[`cargo login`]: ../commands/cargo-login.md
+[`cargo logout`]: ../commands/cargo-logout.md
+
+## Credential plugins
+For credential provider plugins that follow Cargo's [credential provider protocol](credential-provider-protocol.md),
+the configuration value should be a string with the path to the executable (or the executable name if on the `PATH`).
+
+For example, to install [cargo-credential-1password](https://crates.io/crates/cargo-credential-1password)
+from crates.io do the following:
+
+Install the provider with `cargo install cargo-credential-1password`
+
+In the config, add to (or create) `registry.global-credential-providers`:
+```toml
+[registry]
+global-credential-providers = ["cargo:token", "cargo-credential-1password --email you@example.com"]
+```
+
+The values in `global-credential-providers` are split on spaces to into path and command-line arguments. To
+define a global credential provider where the path or arguments contain spaces, use
+the [`[credential-alias]` table](config.md#credential-alias).

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -4,14 +4,21 @@
 .ad l
 .ss \n[.ss] 0
 .SH "NAME"
-cargo\-login \[em] Save an API token from the registry locally
+cargo\-login \[em] Log in to a registry
 .SH "SYNOPSIS"
-\fBcargo login\fR [\fIoptions\fR] [\fItoken\fR]
+\fBcargo login\fR [\fIoptions\fR] [\fItoken\fR] \[en] [\fIargs\fR]
 .SH "DESCRIPTION"
-This command will save the API token to disk so that commands that require
-authentication, such as \fBcargo\-publish\fR(1), will be automatically
-authenticated. The token is saved in \fB$CARGO_HOME/credentials.toml\fR\&. \fBCARGO_HOME\fR
-defaults to \fB\&.cargo\fR in your home directory.
+This command will run a credential provider to save a token so that commands
+that require authentication, such as \fBcargo\-publish\fR(1), will be
+automatically authenticated.
+.sp
+For the default \fBcargo:token\fR credential provider, the token is saved
+in \fB$CARGO_HOME/credentials.toml\fR\&. \fBCARGO_HOME\fR defaults to \fB\&.cargo\fR
+in your home directory.
+.sp
+If a registry has a credential\-provider specified, it will be used. Otherwise,
+the providers from the config value \fBregistry.global\-credential\-providers\fR will
+be attempted, starting from the end of the list.
 .sp
 If the \fItoken\fR argument is not specified, it will be read from stdin.
 .sp
@@ -123,11 +130,21 @@ details on environment variables that Cargo reads.
 .SH "EXAMPLES"
 .sp
 .RS 4
-\h'-04' 1.\h'+01'Save the API token to disk:
+\h'-04' 1.\h'+01'Save the token for the default registry:
 .sp
 .RS 4
 .nf
 cargo login
+.fi
+.RE
+.RE
+.sp
+.RS 4
+\h'-04' 2.\h'+01'Save the token for a specific registry:
+.sp
+.RS 4
+.nf
+cargo login \-\-registry my\-registry
 .fi
 .RE
 .RE

--- a/src/etc/man/cargo-logout.1
+++ b/src/etc/man/cargo-logout.1
@@ -8,9 +8,15 @@ cargo\-logout \[em] Remove an API token from the registry locally
 .SH "SYNOPSIS"
 \fBcargo logout\fR [\fIoptions\fR]
 .SH "DESCRIPTION"
-This command will remove the API token from the local credential storage.
-Credentials are stored in \fB$CARGO_HOME/credentials.toml\fR where \fB$CARGO_HOME\fR
-defaults to \fB\&.cargo\fR in your home directory.
+This command will run a credential provider to remove a saved token.
+.sp
+For the default \fBcargo:token\fR credential provider, credentials are stored
+in \fB$CARGO_HOME/credentials.toml\fR where \fB$CARGO_HOME\fR defaults to \fB\&.cargo\fR
+in your home directory.
+.sp
+If a registry has a credential\-provider specified, it will be used. Otherwise,
+the providers from the config value \fBregistry.global\-credential\-providers\fR will
+be attempted, starting from the end of the list.
 .sp
 If \fB\-\-registry\fR is not specified, then the credentials for the default
 registry will be removed (configured by

--- a/tests/testsuite/cargo_login/help/stdout.log
+++ b/tests/testsuite/cargo_login/help/stdout.log
@@ -4,7 +4,7 @@ Usage: cargo[EXE] login [OPTIONS] [token] [-- [args]...]
 
 Arguments:
   [token]    
-  [args]...  Arguments for the credential provider (unstable)
+  [args]...  Additional arguments for the credential provider
 
 Options:
       --registry <REGISTRY>  Registry to use

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -197,8 +197,8 @@ fn bad_asymmetric_token_args() {
         .build();
 
     // These cases are kept brief as the implementation is covered by clap, so this is only smoke testing that we have clap configured correctly.
-    cargo_process("login -Zcredential-process -Zasymmetric-token -- --key-subject")
-        .masquerade_as_nightly_cargo(&["credential-process", "asymmetric-token"])
+    cargo_process("login -Zasymmetric-token -- --key-subject")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .replace_crates_io(registry.index_url())
         .with_stderr_contains(
             "  error: a value is required for '--key-subject <SUBJECT>' but none was supplied",
@@ -228,8 +228,8 @@ fn login_with_asymmetric_token_and_subject_on_stdin() {
         .no_configure_token()
         .build();
     let credentials = credentials_toml();
-    cargo_process("login -v -Z credential-process -Z asymmetric-token -- --key-subject=foo")
-        .masquerade_as_nightly_cargo(&["credential-process"])
+    cargo_process("login -v -Z asymmetric-token -- --key-subject=foo")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .replace_crates_io(registry.index_url())
         .with_stderr_contains(
             "\
@@ -286,8 +286,8 @@ fn login_with_asymmetric_token_on_stdin() {
         .no_configure_token()
         .build();
     let credentials = credentials_toml();
-    cargo_process("login -vZ credential-process -Z asymmetric-token --registry alternative")
-        .masquerade_as_nightly_cargo(&["credential-process", "asymmetric-token"])
+    cargo_process("login -v -Z asymmetric-token --registry alternative")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .with_stderr(
             "\
 [UPDATING] [..]
@@ -308,8 +308,8 @@ fn login_with_generate_asymmetric_token() {
         .no_configure_token()
         .build();
     let credentials = credentials_toml();
-    cargo_process("login -Z credential-process -Z asymmetric-token --registry alternative")
-        .masquerade_as_nightly_cargo(&["credential-process", "asymmetric-token"])
+    cargo_process("login -Z asymmetric-token --registry alternative")
+        .masquerade_as_nightly_cargo(&["asymmetric-token"])
         .with_stderr("[UPDATING] `alternative` index\nk3.public.[..]")
         .run();
     let credentials = fs::read_to_string(&credentials).unwrap();

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -173,8 +173,7 @@ fn colored_results() {
 fn auth_required_failure() {
     let server = setup().auth_required().no_configure_token().build();
 
-    cargo_process("-Zregistry-auth search postgres")
-        .masquerade_as_nightly_cargo(&["registry-auth"])
+    cargo_process("search postgres")
         .replace_crates_io(server.index_url())
         .with_status(101)
         .with_stderr_contains("[ERROR] no token found, please run `cargo login`")
@@ -185,8 +184,7 @@ fn auth_required_failure() {
 fn auth_required() {
     let server = setup().auth_required().build();
 
-    cargo_process("-Zregistry-auth search postgres")
-        .masquerade_as_nightly_cargo(&["registry-auth"])
+    cargo_process("search postgres")
         .replace_crates_io(server.index_url())
         .with_stdout_contains(SEARCH_RESULTS)
         .run();


### PR DESCRIPTION
Stabilization PR for `registry-auth` and `credential-process`.

Tracking approval of this stabilization is done in the via the FCP in [#8933](https://github.com/rust-lang/cargo/issues/8933#issuecomment-1711990123). This PR is here to help reviewers of the FCP.

* Stabilizes `registry-auth` and `credential-process`
* Makes authenticated registries require a credential provider
* Adds stable documentation for credential providers and authenticated registries

Closes #8933
Closes #10474