### PR TITLE
Set and verify all MSRVs in CI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,6 +22,19 @@
       packageNameTemplate: 'rust-lang/rust',
       datasourceTemplate: 'github-releases',
     },
+    {
+      customType: 'regex',
+      fileMatch: [
+        'Cargo.toml$',
+      ],
+      matchStrings: [
+        '\bMSRV:3\b.*?(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
+        '(?<currentValue>\\d+\\.\\d+(\\.\\d+)?).*?\bMSRV:3\b',
+      ],
+      depNameTemplate: 'MSRV:3',  // Support 3 versions of rustc
+      packageNameTemplate: 'rust-lang/rust',
+      datasourceTemplate: 'github-releases',
+    },
   ],
   packageRules: [
     {
@@ -32,10 +45,26 @@
       matchPackageNames: [
         'MSRV:1',
       ],
+      schedule: [
+        '* * * * *',
+      ],
+      groupName: 'msrv',
+    },
+    {
+      commitMessageTopic: 'MSRV (3 versions)',
+      matchManagers: [
+        'regex',
+      ],
+      matchPackageNames: [
+        'MSRV:3',
+      ],
       "extractVersion": "^(?<version>\\d+\\.\\d+)",  // Drop the patch version
       schedule: [
         '* * * * *',
       ],
+      minimumReleaseAge: '85 days',  // 2 releases back * 6 weeks per release * 7 days per week + 1
+      internalChecksFilter: 'strict',
+      groupName: 'msrv',
     },
     // Goals:
     // - Rollup safe upgrades to reduce CI runner load

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,24 +12,25 @@
     {
       customType: 'regex',
       fileMatch: [
-        '^Cargo.toml$',
+        'Cargo.toml$',
       ],
       matchStrings: [
-        'rust-version.*?(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
+        '\bMSRV:1\b.*?(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)',
+        '(?<currentValue>\\d+\\.\\d+(\\.\\d+)?).*?\bMSRV:1\b',
       ],
-      depNameTemplate: 'latest-msrv',
+      depNameTemplate: 'MSRV:1',  // Support 1 version of rustc
       packageNameTemplate: 'rust-lang/rust',
       datasourceTemplate: 'github-releases',
     },
   ],
   packageRules: [
     {
-      commitMessageTopic: 'Latest MSRV',
+      commitMessageTopic: 'MSRV (1 version)',
       matchManagers: [
         'regex',
       ],
       matchPackageNames: [
-        'latest-msrv',
+        'MSRV:1',
       ],
       "extractVersion": "^(?<version>\\d+\\.\\d+)",  // Drop the patch version
       schedule: [

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     needs:
     - build_std
     - clippy
-    - credential_msrv
+    - msrv
     - docs
     - lockfile
     - resolver
@@ -38,7 +38,7 @@ jobs:
     needs:
     - build_std
     - clippy
-    - credential_msrv
+    - msrv
     - docs
     - lockfile
     - resolver
@@ -249,9 +249,9 @@ jobs:
         curl -sSLO https://raw.githubusercontent.com/rust-lang/rust/master/src/tools/linkchecker/linkcheck.sh
         sh linkcheck.sh --all --path ../src/doc cargo
 
-  credential_msrv:
+  msrv:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@cargo-hack
-    - run: cargo hack check --all-targets --rust-version -p cargo-credential
+    - run: cargo hack check --all-targets --rust-version --workspace --ignore-private

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
  "cargo-credential-libsecret",
  "cargo-credential-macos-keychain",
  "cargo-credential-wincred",
- "cargo-platform 0.1.5",
+ "cargo-platform 0.1.6",
  "cargo-test-macro",
  "cargo-test-support",
  "cargo-util",
@@ -305,7 +305,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-1password"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "cargo-credential",
  "serde",
@@ -328,7 +328,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "cargo-credential",
  "windows-sys",
@@ -362,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ name = "cargo"
 version = "0.76.0"
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 homepage = "https://crates.io"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-rust-version = "1.73"
+rust-version = "1.73"  # MSRV:1
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/crates/cargo-platform/Cargo.toml
+++ b/crates/cargo-platform/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cargo-platform"
-version = "0.1.5"
+version = "0.1.6"
 edition.workspace = true
 license.workspace = true
+rust-version = "1.70.0"  # MSRV:3
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 documentation = "https://docs.rs/cargo-platform"

--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -2,6 +2,7 @@
 name = "home"
 version = "0.5.8"
 authors = ["Brian Anderson <andersrb@gmail.com>"]
+rust-version = "1.70.0"  # MSRV:3
 documentation = "https://docs.rs/home"
 edition.workspace = true
 include = [

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cargo-credential-1password"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
+rust-version = "1.70.0"  # MSRV:3
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a 1password vault."
 

--- a/credential/cargo-credential-libsecret/Cargo.toml
+++ b/credential/cargo-credential-libsecret/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cargo-credential-libsecret"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with GNOME libsecret."
 

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cargo-credential-macos-keychain"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a macOS keychain."
 

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cargo-credential-wincred"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 license.workspace = true
+rust-version.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with Windows Credential Manager."
 

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-credential"
 version = "0.4.0"
 edition.workspace = true
 license.workspace = true
-rust-version = "1.70.0"
+rust-version = "1.70.0"  # MSRV:3
 repository = "https://github.com/rust-lang/cargo"
 description = "A library to assist writing Cargo credential helpers."
 

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.70.0"  # MSRV:3


### PR DESCRIPTION
### What does this PR try to resolve?

Allow us to advertise an MSRV for all public packages, unblocking #12432.

Packages are broken down into two MSRV policies
- Internal packages: `rust-version=stable`
- Public packages: `rust-version=stable-2`

To support this
- RenovateBot will automatically update all MSRVs
- CI will verify all packages build according to their MSRV

Since this takes the "single workspace" approach, the downside is that common dependencies are subject to each package's MSRV.  We also can't rely on `-Zmsrv-policy` to help us generate a lockfile because it breaks down when trying to support multiple MSRVs in a workspace

### How should we test and review this PR?

Per commit

### Additional information

#12381 skipped setting some MSRVs because we weren't sure how to handle it.  For `cargo-credential`, we needed to do something and did one-off verification (#12623).  `cargo-hack` recently gained the ability to automatically select MSRVs for each package allowing us to scale this up to the entire workspace.

I don't know if we consciously chose an MSRV policy for `cargo-credential` but it looked like N-2 so that is what I stuck with and propagated out.
- Without an aggressive sliding MSRV, we discourage people from using newer features because they will feel like they need permission which means it needs to be justified
- Without an aggressive sliding MSRV, if the MSRV at one point in time works for someone, they tend to assume it will always work, leading to frustration at unmet expectations.

I switched the MSRV check to `cargo check` from `cargo test` because I didn't want to deal with the out-of-diskspace issues and `check` will catch 99% of MSRV issues.

Potential future improvements to `cargo-hack`
- Allow `--version-range ..stable` so we can verify all MSRVs that aren't stable which would bypass the diskspace issues and allow us to more easily use `cargo test` again
- Verify on a `cargo package` version of a crate (taiki-e/cargo-hack#216)