### PR TITLE
refactor: Consolidate clap/shell styles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle-termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c3d1411f1f4c8a7b177caec3c71b51290f9e8ad9f99124fd3fe9aa96e56834"
+dependencies = [
+ "anstyle",
+ "termcolor",
+]
+
+[[package]]
 name = "anstyle-wincon"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +269,7 @@ name = "cargo"
 version = "0.75.0"
 dependencies = [
  "anstyle",
+ "anstyle-termcolor",
  "anyhow",
  "base64",
  "bytesize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
 
 [[package]]
 name = "anstyle-parse"
@@ -258,6 +258,7 @@ dependencies = [
 name = "cargo"
 version = "0.75.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "base64",
  "bytesize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anstyle = "1.0.3"
+anstyle-termcolor = "1.1.0"
 anyhow = "1.0.75"
 base64 = "0.21.3"
 bytesize = "1.3"
@@ -123,6 +124,7 @@ path = "src/cargo/lib.rs"
 
 [dependencies]
 anstyle.workspace = true
+anstyle-termcolor.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 bytesize.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
+anstyle = "1.0.3"
 anyhow = "1.0.75"
 base64 = "0.21.3"
 bytesize = "1.3"
@@ -121,6 +122,7 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
+anstyle.workspace = true
 anyhow.workspace = true
 base64.workspace = true
 bytesize.workspace = true

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -14,6 +14,7 @@ use super::list_commands;
 use crate::command_prelude::*;
 use crate::util::is_rustup;
 use cargo::core::features::HIDDEN;
+use cargo::util::style;
 
 pub fn main(config: &mut LazyConfig) -> CliResult {
     let args = cli().try_get_matches()?;
@@ -519,15 +520,14 @@ pub fn cli() -> Command {
     };
 
     let styles = {
-        use clap::builder::styling::*;
-        Styles::styled()
-            .header(AnsiColor::Green.on_default() | Effects::BOLD)
-            .usage(AnsiColor::Green.on_default() | Effects::BOLD)
-            .literal(AnsiColor::Cyan.on_default() | Effects::BOLD)
-            .placeholder(AnsiColor::Cyan.on_default())
-            .error(AnsiColor::Red.on_default() | Effects::BOLD)
-            .valid(AnsiColor::Cyan.on_default() | Effects::BOLD)
-            .invalid(AnsiColor::Yellow.on_default() | Effects::BOLD)
+        clap::builder::styling::Styles::styled()
+            .header(style::HEADER)
+            .usage(style::USAGE)
+            .literal(style::LITERAL)
+            .placeholder(style::PLACEHOLDER)
+            .error(style::ERROR)
+            .valid(style::VALID)
+            .invalid(style::INVALID)
     };
 
     Command::new("cargo")

--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -8,6 +8,7 @@ use crate::core::compiler::{BuildContext, Context, TimingOutput};
 use crate::core::PackageId;
 use crate::util::cpu::State;
 use crate::util::machine_message::{self, Message};
+use crate::util::style;
 use crate::util::{CargoResult, Config};
 use anyhow::Context as _;
 use cargo_util::paths;
@@ -352,7 +353,7 @@ impl<'cfg> Timings<'cfg> {
         paths::link_or_copy(&filename, &unstamped_filename)?;
         self.config
             .shell()
-            .status_with_color("Timing", msg, termcolor::Color::Cyan)?;
+            .status_with_color("Timing", msg, &style::NOTE)?;
         Ok(())
     }
 

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -12,9 +12,6 @@ use anyhow::Context as _;
 use cargo_util::paths;
 use indexmap::IndexSet;
 use itertools::Itertools;
-use termcolor::Color::Green;
-use termcolor::Color::Red;
-use termcolor::ColorSpec;
 use toml_edit::Item as TomlItem;
 
 use crate::core::dependency::DepKind;
@@ -26,6 +23,7 @@ use crate::core::Shell;
 use crate::core::Summary;
 use crate::core::Workspace;
 use crate::sources::source::QueryKind;
+use crate::util::style;
 use crate::util::toml_mut::dependency::Dependency;
 use crate::util::toml_mut::dependency::GitSource;
 use crate::util::toml_mut::dependency::MaybeWorkspace;
@@ -968,19 +966,16 @@ fn print_dep_table_msg(shell: &mut Shell, dep: &DependencyUI) -> CargoResult<()>
         } else {
             "".to_owned()
         };
-        shell.write_stderr(
-            format_args!("{}Features{}:\n", prefix, suffix),
-            &ColorSpec::new(),
-        )?;
+        shell.write_stderr(format_args!("{}Features{}:\n", prefix, suffix), &style::NOP)?;
         for feat in activated {
-            shell.write_stderr(&prefix, &ColorSpec::new())?;
-            shell.write_stderr('+', &ColorSpec::new().set_bold(true).set_fg(Some(Green)))?;
-            shell.write_stderr(format_args!(" {}\n", feat), &ColorSpec::new())?;
+            shell.write_stderr(&prefix, &style::NOP)?;
+            shell.write_stderr('+', &style::GOOD)?;
+            shell.write_stderr(format_args!(" {}\n", feat), &style::NOP)?;
         }
         for feat in deactivated {
-            shell.write_stderr(&prefix, &ColorSpec::new())?;
-            shell.write_stderr('-', &ColorSpec::new().set_bold(true).set_fg(Some(Red)))?;
-            shell.write_stderr(format_args!(" {}\n", feat), &ColorSpec::new())?;
+            shell.write_stderr(&prefix, &style::NOP)?;
+            shell.write_stderr('-', &style::ERROR)?;
+            shell.write_stderr(format_args!(" {}\n", feat), &style::NOP)?;
         }
     }
 

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -4,9 +4,10 @@ use crate::core::{PackageId, PackageIdSpec};
 use crate::core::{Resolve, SourceId, Workspace};
 use crate::ops;
 use crate::util::config::Config;
+use crate::util::style;
 use crate::util::CargoResult;
+use anstyle::Style;
 use std::collections::{BTreeMap, HashSet};
-use termcolor::Color::{self, Cyan, Green, Red, Yellow};
 use tracing::debug;
 
 pub struct UpdateOptions<'a> {
@@ -133,7 +134,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     )?;
 
     // Summarize what is changing for the user.
-    let print_change = |status: &str, msg: String, color: Color| {
+    let print_change = |status: &str, msg: String, color: &Style| {
         opts.config.shell().status_with_color(status, msg, color)
     };
     for (removed, added) in compare_dependency_graphs(&previous_resolve, &resolve) {
@@ -149,16 +150,16 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             };
 
             if removed[0].version() > added[0].version() {
-                print_change("Downgrading", msg, Yellow)?;
+                print_change("Downgrading", msg, &style::WARN)?;
             } else {
-                print_change("Updating", msg, Green)?;
+                print_change("Updating", msg, &style::GOOD)?;
             }
         } else {
             for package in removed.iter() {
-                print_change("Removing", format!("{}", package), Red)?;
+                print_change("Removing", format!("{}", package), &style::ERROR)?;
             }
             for package in added.iter() {
-                print_change("Adding", format!("{}", package), Cyan)?;
+                print_change("Adding", format!("{}", package), &style::NOTE)?;
             }
         }
     }

--- a/src/cargo/ops/registry/search.rs
+++ b/src/cargo/ops/registry/search.rs
@@ -6,10 +6,9 @@ use std::cmp;
 use std::iter::repeat;
 
 use anyhow::Context as _;
-use termcolor::Color;
-use termcolor::ColorSpec;
 use url::Url;
 
+use crate::util::style;
 use crate::util::truncate_with_ellipsis;
 use crate::CargoResult;
 use crate::Config;
@@ -58,15 +57,12 @@ pub fn search(
         };
         let mut fragments = line.split(query).peekable();
         while let Some(fragment) = fragments.next() {
-            let _ = config.shell().write_stdout(fragment, &ColorSpec::new());
+            let _ = config.shell().write_stdout(fragment, &style::NOP);
             if fragments.peek().is_some() {
-                let _ = config.shell().write_stdout(
-                    query,
-                    &ColorSpec::new().set_bold(true).set_fg(Some(Color::Green)),
-                );
+                let _ = config.shell().write_stdout(query, &style::GOOD);
             }
         }
-        let _ = config.shell().write_stdout("\n", &ColorSpec::new());
+        let _ = config.shell().write_stdout("\n", &style::NOP);
     }
 
     let search_max_limit = 100;
@@ -76,7 +72,7 @@ pub fn search(
                 "... and {} crates more (use --limit N to see more)\n",
                 total_crates - limit
             ),
-            &ColorSpec::new(),
+            &style::NOP,
         );
     } else if total_crates > limit && limit >= search_max_limit {
         let extra = if source_ids.original.is_crates_io() {
@@ -87,7 +83,7 @@ pub fn search(
         };
         let _ = config.shell().write_stdout(
             format_args!("... and {} crates more{}\n", total_crates - limit, extra),
-            &ColorSpec::new(),
+            &style::NOP,
         );
     }
 

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -4,11 +4,11 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Display, Path, PathBuf};
 
 use crate::util::errors::CargoResult;
+use crate::util::style;
 use crate::util::Config;
 use anyhow::Context as _;
 use cargo_util::paths;
 use sys::*;
-use termcolor::Color::Cyan;
 
 #[derive(Debug)]
 pub struct FileLock {
@@ -312,7 +312,9 @@ fn acquire(
         }
     }
     let msg = format!("waiting for file lock on {}", msg);
-    config.shell().status_with_color("Blocking", &msg, Cyan)?;
+    config
+        .shell()
+        .status_with_color("Blocking", &msg, &style::NOTE)?;
 
     lock_block().with_context(|| format!("failed to lock file: {}", path.display()))?;
     return Ok(());

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -60,6 +60,7 @@ mod queue;
 pub mod restricted_names;
 pub mod rustc;
 mod semver_ext;
+pub mod style;
 pub mod to_semver;
 pub mod toml;
 pub mod toml_mut;

--- a/src/cargo/util/style.rs
+++ b/src/cargo/util/style.rs
@@ -1,0 +1,9 @@
+use anstyle::*;
+
+pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+pub const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
+pub const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
+pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
+pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);

--- a/src/cargo/util/style.rs
+++ b/src/cargo/util/style.rs
@@ -1,9 +1,13 @@
 use anstyle::*;
 
+pub const NOP: Style = Style::new();
 pub const HEADER: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const USAGE: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const LITERAL: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const PLACEHOLDER: Style = AnsiColor::Cyan.on_default();
 pub const ERROR: Style = AnsiColor::Red.on_default().effects(Effects::BOLD);
+pub const WARN: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);
+pub const NOTE: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
+pub const GOOD: Style = AnsiColor::Green.on_default().effects(Effects::BOLD);
 pub const VALID: Style = AnsiColor::Cyan.on_default().effects(Effects::BOLD);
 pub const INVALID: Style = AnsiColor::Yellow.on_default().effects(Effects::BOLD);


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #12578 to reduce duplication of terminal styling.

This still leaves styling in `color_print::cstr!`.

This is also prep for copy/pasting into `clap-cargo` for others to use.  Another step might be to extract `cargo::util::style` into its own crate.

### How should we test and review this PR?

We have no styling tests so this can only be verified by inspection or running the commands

### Additional information

I chose `anstyle` for expressing these as its an API designed specifically for stable style definitions to put in public APIs.