### PR TITLE
libgit2 fixed upstream

### DIFF
--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -177,25 +177,8 @@ where
 
 /// Add all files in the working directory to the git index.
 pub fn add(repo: &git2::Repository) {
-    // FIXME(libgit2/libgit2#2514): apparently, `add_all` will add all submodules
-    // as well, and then fail because they're directories. As a stop-gap, we just
-    // ignore all submodules.
-    let mut s = t!(repo.submodules());
-    for submodule in s.iter_mut() {
-        t!(submodule.add_to_index(false));
-    }
     let mut index = t!(repo.index());
-    t!(index.add_all(
-        ["*"].iter(),
-        git2::IndexAddOption::DEFAULT,
-        Some(
-            &mut (|a, _b| if s.iter().any(|s| a.starts_with(s.path())) {
-                1
-            } else {
-                0
-            })
-        )
-    ));
+    t!(index.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None));
     t!(index.write());
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This "FIXME" points to https://github.com/libgit2/libgit2/issues/2514 witch has bean fixed for... 8 years. So maybe it is no longer needed.

### How should we test and review this PR?

By adding panic messages I was able to demonstrate that there were tests hitting this code path. Then I removed the "FIXME" and had the test still pass.
