### PR TITLE
chore: set `publish=false` for built-in credential providers

### DIFF
--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens in a 1password vault."
+publish = false
 
 [dependencies]
 cargo-credential.workspace = true

--- a/credential/cargo-credential-libsecret/Cargo.toml
+++ b/credential/cargo-credential-libsecret/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with GNOME libsecret."
+publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 repository = "https://github.com/rust-lang/cargo"
 description = "A Cargo credential process that stores tokens with Windows Credential Manager."
+publish = false
 
 [dependencies]
 cargo-credential.workspace = true


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

I could be wrong, but these packages no longer need to be published, right?

r? arlosi 

<!-- homu-ignore:end -->
