### PR TITLE
Fix typos: `informations` -> `information`

### DIFF
--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -123,7 +123,7 @@ impl<'cfg> GitSource<'cfg> {
     }
 
     /// Returns the packages discovered by this source. It may fetch the Git
-    /// repository as well as walk the filesystem if package informations
+    /// repository as well as walk the filesystem if package information
     /// haven't yet updated.
     pub fn read_packages(&mut self) -> CargoResult<Vec<Package>> {
         if self.path_source.is_none() {

--- a/src/cargo/sources/mod.rs
+++ b/src/cargo/sources/mod.rs
@@ -1,9 +1,9 @@
 //! The trait for sources of Cargo packages and its built-in implemetations.
 //!
 //! A source is a provider that contains source files and metadata of packages.
-//! It provides a number of methods to fetch those package informations, for
+//! It provides a number of methods to fetch those package information, for
 //! example, querying metadata or downloading files for a package. These
-//! informations then can be used as dependencies for other Cargo packages.
+//! information then can be used as dependencies for other Cargo packages.
 //!
 //! This module provides [`Source`][source::Source] trait as an abstraction of different sources,
 //! as well as [`SourceMap`][source::SourceMap] struct as a map of all available sources.

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -30,7 +30,7 @@ pub struct PathSource<'cfg> {
     source_id: SourceId,
     /// The root path of this source.
     path: PathBuf,
-    /// Whether this source has updated all package informations it may contain.
+    /// Whether this source has updated all package information it may contain.
     updated: bool,
     /// Packages that this sources has discovered.
     packages: Vec<Package>,
@@ -97,7 +97,7 @@ impl<'cfg> PathSource<'cfg> {
     }
 
     /// Returns the packages discovered by this source. It may walk the
-    /// filesystem if package informations haven't yet updated.
+    /// filesystem if package information haven't yet updated.
     pub fn read_packages(&self) -> CargoResult<Vec<Package>> {
         if self.updated {
             Ok(self.packages.clone())

--- a/src/cargo/sources/registry/local.rs
+++ b/src/cargo/sources/registry/local.rs
@@ -63,7 +63,7 @@ pub struct LocalRegistry<'cfg> {
     /// Path where this local registry extract `.crate` tarballs to.
     src_path: Filesystem,
     config: &'cfg Config,
-    /// Whether this source has updated all package informations it may contain.
+    /// Whether this source has updated all package information it may contain.
     updated: bool,
     /// Disables status messages.
     quiet: bool,

--- a/src/cargo/sources/registry/remote.rs
+++ b/src/cargo/sources/registry/remote.rs
@@ -70,7 +70,7 @@ pub struct RemoteRegistry<'cfg> {
     head: Cell<Option<git2::Oid>>,
     /// This stores sha value of the current HEAD commit for convenience.
     current_sha: Cell<Option<InternedString>>,
-    /// Whether this registry needs to update package informations.
+    /// Whether this registry needs to update package information.
     ///
     /// See [`RemoteRegistry::mark_updated`] on how to make sure a registry
     /// index is updated only once per session.

--- a/src/cargo/sources/source.rs
+++ b/src/cargo/sources/source.rs
@@ -47,7 +47,7 @@ pub trait Source {
     /// Attempts to find the packages that match a dependency request.
     ///
     /// Usually you should call [`Source::block_until_ready`] somewhere and
-    /// wait until package informations become available. Otherwise any query
+    /// wait until package information become available. Otherwise any query
     /// may return a [`Poll::Pending`].
     ///
     /// The `f` argument is expected to get called when any [`Summary`] becomes available.


### PR DESCRIPTION
We do not use information in the plural form.