### PR TITLE
refactor: use `RegistryOrIndex` enum to replace two booleans

### DIFF
--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -7,7 +7,7 @@ pub fn cli() -> Command {
         .about("Create a new cargo package in an existing directory")
         .arg(Arg::new("path").action(ArgAction::Set).default_value("."))
         .arg_new_opts()
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_registry("Registry to use")
         .arg_quiet()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help init</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -154,10 +154,11 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     } else if krates.is_empty() {
         from_cwd = true;
         SourceId::for_path(config.cwd())?
-    } else if let Some(index) = args.get_one::<String>("index") {
-        SourceId::for_registry(&index.into_url()?)?
-    } else if let Some(registry) = args.registry(config)? {
-        SourceId::alt_registry(config, &registry)?
+    } else if let Some(reg_or_index) = args.registry_or_index(config)? {
+        match reg_or_index {
+            ops::RegistryOrIndex::Registry(r) => SourceId::alt_registry(config, &r)?,
+            ops::RegistryOrIndex::Index(url) => SourceId::for_registry(&url)?,
+        }
     } else {
         SourceId::crates_io(config)?
     };

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -1,6 +1,7 @@
-use crate::command_prelude::*;
-
 use cargo::ops;
+use cargo::ops::RegistryOrIndex;
+
+use crate::command_prelude::*;
 
 pub fn cli() -> Command {
     subcommand("login")
@@ -20,7 +21,12 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
-    let registry = args.registry(config)?;
+    let reg = args.registry_or_index(config)?;
+    assert!(
+        !matches!(reg, Some(RegistryOrIndex::Index(..))),
+        "must not be index URL"
+    );
+
     let extra_args = args
         .get_many::<String>("args")
         .unwrap_or_default()
@@ -29,7 +35,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     ops::registry_login(
         config,
         args.get_one::<String>("token").map(|s| s.as_str().into()),
-        registry.as_deref(),
+        reg.as_ref(),
         &extra_args,
     )?;
     Ok(())

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -6,7 +6,7 @@ pub fn cli() -> Command {
     subcommand("login")
         .about("Log in to a registry.")
         .arg(Arg::new("token").action(ArgAction::Set))
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_registry("Registry to use")
         .arg(
             Arg::new("args")
                 .help("Arguments for the credential provider (unstable)")

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -1,5 +1,7 @@
-use crate::command_prelude::*;
 use cargo::ops;
+use cargo::ops::RegistryOrIndex;
+
+use crate::command_prelude::*;
 
 pub fn cli() -> Command {
     subcommand("logout")
@@ -12,7 +14,12 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
-    let registry = args.registry(config)?;
-    ops::registry_logout(config, registry.as_deref())?;
+    let reg = args.registry_or_index(config)?;
+    assert!(
+        !matches!(reg, Some(RegistryOrIndex::Index(..))),
+        "must not be index URL"
+    );
+
+    ops::registry_logout(config, reg)?;
     Ok(())
 }

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -4,7 +4,7 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("logout")
         .about("Remove an API token from the registry locally")
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_registry("Registry to use")
         .arg_quiet()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help logout</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -7,7 +7,7 @@ pub fn cli() -> Command {
         .about("Create a new cargo package at <path>")
         .arg(Arg::new("path").action(ArgAction::Set).required(true))
         .arg_new_opts()
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_registry("Registry to use")
         .arg_quiet()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help new</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -34,11 +34,10 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
-    let registry = args.registry(config)?;
     let opts = OwnersOptions {
         krate: args.get_one::<String>("crate").cloned(),
         token: args.get_one::<String>("token").cloned().map(Secret::from),
-        index: args.get_one::<String>("index").cloned(),
+        reg_or_index: args.registry_or_index(config)?,
         to_add: args
             .get_many::<String>("add")
             .map(|xs| xs.cloned().collect()),
@@ -46,7 +45,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             .get_many::<String>("remove")
             .map(|xs| xs.cloned().collect()),
         list: args.flag("list"),
-        registry,
     };
     ops::modify_owners(config, &opts)?;
     Ok(())

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -24,9 +24,9 @@ pub fn cli() -> Command {
             .short('r'),
         )
         .arg(flag("list", "List owners of a crate").short('l'))
-        .arg(opt("index", "Registry index to modify owners for").value_name("INDEX"))
+        .arg_index("Registry index URL to modify owners for")
+        .arg_registry("Registry to modify owners for")
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
         .arg_quiet()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help owner</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -30,7 +30,7 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
-    let registry = args.registry(config)?;
+    let reg_or_index = args.registry_or_index(config)?;
     let ws = args.workspace(config)?;
     if ws.root_maybe().is_embedded() {
         return Err(anyhow::format_err!(
@@ -39,7 +39,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         )
         .into());
     }
-    let index = args.index()?;
 
     ops::publish(
         &ws,
@@ -48,7 +47,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             token: args
                 .get_one::<String>("token")
                 .map(|s| s.to_string().into()),
-            index,
+            reg_or_index,
             verify: !args.flag("no-verify"),
             allow_dirty: args.flag("allow-dirty"),
             to_publish: args.packages_from_flags()?,
@@ -56,7 +55,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             jobs: args.jobs()?,
             keep_going: args.keep_going(),
             dry_run: args.dry_run(),
-            registry,
             cli_features: args.cli_features()?,
         },
     )?;

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -6,8 +6,8 @@ pub fn cli() -> Command {
     subcommand("publish")
         .about("Upload a package to the registry")
         .arg_dry_run("Perform all checks without uploading")
-        .arg_index()
-        .arg(opt("registry", "Registry to publish to").value_name("REGISTRY"))
+        .arg_index("Registry index URL to upload the package to")
+        .arg_registry("Registry to upload the package to")
         .arg(opt("token", "Token to use when uploading").value_name("TOKEN"))
         .arg(flag(
             "no-verify",

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -15,8 +15,8 @@ pub fn cli() -> Command {
             )
             .value_name("LIMIT"),
         )
-        .arg_index()
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_index("Registry index URL to search packages in")
+        .arg_registry("Registry to search packages in")
         .arg_quiet()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help search</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -24,8 +24,7 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
-    let registry = args.registry(config)?;
-    let index = args.index()?;
+    let reg_or_index = args.registry_or_index(config)?;
     let limit = args.value_of_u32("limit")?;
     let limit = min(100, limit.unwrap_or(10));
     let query: Vec<&str> = args
@@ -34,6 +33,6 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         .map(String::as_str)
         .collect();
     let query: String = query.join("+");
-    ops::search(&query, config, index, limit, registry)?;
+    ops::search(&query, config, reg_or_index, limit)?;
     Ok(())
 }

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -16,8 +16,8 @@ pub fn cli() -> Command {
             "undo",
             "Undo a yank, putting a version back into the index",
         ))
-        .arg(opt("index", "Registry index to yank from").value_name("INDEX"))
-        .arg(opt("registry", "Registry to use").value_name("REGISTRY"))
+        .arg_index("Registry index URL to yank from")
+        .arg_registry("Registry to yank from")
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
         .arg_quiet()
         .after_help(color_print::cstr!(

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -26,8 +26,6 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
-    let registry = args.registry(config)?;
-
     let (krate, version) = resolve_crate(
         args.get_one::<String>("crate").map(String::as_str),
         args.get_one::<String>("version").map(String::as_str),
@@ -41,9 +39,8 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         krate.map(|s| s.to_string()),
         version.map(|s| s.to_string()),
         args.get_one::<String>("token").cloned().map(Secret::from),
-        args.get_one::<String>("index").cloned(),
+        args.registry_or_index(config)?,
         args.flag("undo"),
-        registry,
     )?;
     Ok(())
 }

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -30,6 +30,7 @@ pub use self::registry::yank;
 pub use self::registry::OwnersOptions;
 pub use self::registry::PublishOpts;
 pub use self::registry::RegistryCredentialConfig;
+pub use self::registry::RegistryOrIndex;
 pub use self::resolve::{
     add_overrides, get_resolved_packages, resolve_with_previous, resolve_ws, resolve_ws_with_opts,
     WorkspaceResolve,

--- a/src/cargo/ops/registry/login.rs
+++ b/src/cargo/ops/registry/login.rs
@@ -16,16 +16,23 @@ use cargo_credential::Secret;
 
 use super::get_source_id;
 use super::registry;
+use super::RegistryOrIndex;
 
 pub fn registry_login(
     config: &Config,
     token_from_cmdline: Option<Secret<&str>>,
-    reg: Option<&str>,
+    reg_or_index: Option<&RegistryOrIndex>,
     args: &[&str],
 ) -> CargoResult<()> {
-    let source_ids = get_source_id(config, None, reg)?;
+    let source_ids = get_source_id(config, reg_or_index)?;
 
-    let login_url = match registry(config, token_from_cmdline.clone(), None, reg, false, None) {
+    let login_url = match registry(
+        config,
+        token_from_cmdline.clone(),
+        reg_or_index,
+        false,
+        None,
+    ) {
         Ok((registry, _)) => Some(format!("{}/me", registry.host())),
         Err(e) if e.is::<AuthorizationError>() => e
             .downcast::<AuthorizationError>()

--- a/src/cargo/ops/registry/logout.rs
+++ b/src/cargo/ops/registry/logout.rs
@@ -8,9 +8,10 @@ use crate::CargoResult;
 use crate::Config;
 
 use super::get_source_id;
+use super::RegistryOrIndex;
 
-pub fn registry_logout(config: &Config, reg: Option<&str>) -> CargoResult<()> {
-    let source_ids = get_source_id(config, None, reg)?;
+pub fn registry_logout(config: &Config, reg_or_index: Option<RegistryOrIndex>) -> CargoResult<()> {
+    let source_ids = get_source_id(config, reg_or_index.as_ref())?;
     auth::logout(config, &source_ids.original)?;
     Ok(())
 }

--- a/src/cargo/ops/registry/owner.rs
+++ b/src/cargo/ops/registry/owner.rs
@@ -13,14 +13,15 @@ use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::CargoResult;
 use crate::Config;
 
+use super::RegistryOrIndex;
+
 pub struct OwnersOptions {
     pub krate: Option<String>,
     pub token: Option<Secret<String>>,
-    pub index: Option<String>,
+    pub reg_or_index: Option<RegistryOrIndex>,
     pub to_add: Option<Vec<String>>,
     pub to_remove: Option<Vec<String>>,
     pub list: bool,
-    pub registry: Option<String>,
 }
 
 pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
@@ -38,8 +39,7 @@ pub fn modify_owners(config: &Config, opts: &OwnersOptions) -> CargoResult<()> {
     let (mut registry, _) = super::registry(
         config,
         opts.token.as_ref().map(Secret::as_deref),
-        opts.index.as_deref(),
-        opts.registry.as_deref(),
+        opts.reg_or_index.as_ref(),
         true,
         Some(operation),
     )?;

--- a/src/cargo/ops/registry/search.rs
+++ b/src/cargo/ops/registry/search.rs
@@ -13,15 +13,16 @@ use crate::util::truncate_with_ellipsis;
 use crate::CargoResult;
 use crate::Config;
 
+use super::RegistryOrIndex;
+
 pub fn search(
     query: &str,
     config: &Config,
-    index: Option<String>,
+    reg_or_index: Option<RegistryOrIndex>,
     limit: u32,
-    reg: Option<String>,
 ) -> CargoResult<()> {
     let (mut registry, source_ids) =
-        super::registry(config, None, index.as_deref(), reg.as_deref(), false, None)?;
+        super::registry(config, None, reg_or_index.as_ref(), false, None)?;
     let (crates, total_crates) = registry.search(query, limit).with_context(|| {
         format!(
             "failed to retrieve search results from the registry at {}",

--- a/src/cargo/ops/registry/yank.rs
+++ b/src/cargo/ops/registry/yank.rs
@@ -13,14 +13,15 @@ use crate::util::config::Config;
 use crate::util::errors::CargoResult;
 use crate::util::important_paths::find_root_manifest_for_wd;
 
+use super::RegistryOrIndex;
+
 pub fn yank(
     config: &Config,
     krate: Option<String>,
     version: Option<String>,
     token: Option<Secret<String>>,
-    index: Option<String>,
+    reg_or_index: Option<RegistryOrIndex>,
     undo: bool,
-    reg: Option<String>,
 ) -> CargoResult<()> {
     let name = match krate {
         Some(name) => name,
@@ -49,8 +50,7 @@ pub fn yank(
     let (mut registry, _) = super::registry(
         config,
         token.as_ref().map(Secret::as_deref),
-        index.as_deref(),
-        reg.as_deref(),
+        reg_or_index.as_ref(),
         true,
         Some(message),
     )?;

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -291,7 +291,12 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_index(self, help: &'static str) -> Self {
-        self._arg(opt("index", help).value_name("INDEX"))
+        // Always conflicts with `--registry`.
+        self._arg(
+            opt("index", help)
+                .value_name("INDEX")
+                .conflicts_with("registry"),
+        )
     }
 
     fn arg_dry_run(self, dry_run: &'static str) -> Self {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -286,8 +286,12 @@ pub trait CommandExt: Sized {
         )
     }
 
-    fn arg_index(self) -> Self {
-        self._arg(opt("index", "Registry index URL to upload the package to").value_name("INDEX"))
+    fn arg_registry(self, help: &'static str) -> Self {
+        self._arg(opt("registry", help).value_name("REGISTRY"))
+    }
+
+    fn arg_index(self, help: &'static str) -> Self {
+        self._arg(opt("index", help).value_name("INDEX"))
     }
 
     fn arg_dry_run(self, dry_run: &'static str) -> Self {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -1,6 +1,7 @@
 use crate::core::compiler::{BuildConfig, MessageFormat, TimingOutput};
 use crate::core::resolver::CliFeatures;
 use crate::core::{Edition, Workspace};
+use crate::ops::registry::RegistryOrIndex;
 use crate::ops::{CompileFilter, CompileOptions, NewOptions, Packages, VersionControl};
 use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::interning::InternedString;
@@ -27,6 +28,7 @@ pub use clap::{value_parser, Arg, ArgAction, ArgMatches};
 pub use clap::Command;
 
 use super::config::JobsConfig;
+use super::IntoUrl;
 
 pub mod heading {
     pub const PACKAGE_SELECTION: &str = "Package Selection";
@@ -744,29 +746,32 @@ Run `{cmd}` to see possible targets."
         )
     }
 
-    fn registry(&self, config: &Config) -> CargoResult<Option<String>> {
+    fn registry_or_index(&self, config: &Config) -> CargoResult<Option<RegistryOrIndex>> {
         let registry = self._value_of("registry");
         let index = self._value_of("index");
         let result = match (registry, index) {
-            (None, None) => config.default_registry()?,
-            (None, Some(_)) => {
-                // If --index is set, then do not look at registry.default.
-                None
-            }
+            (None, None) => config.default_registry()?.map(RegistryOrIndex::Registry),
+            (None, Some(i)) => Some(RegistryOrIndex::Index(i.into_url()?)),
             (Some(r), None) => {
                 validate_package_name(r, "registry name", "")?;
-                Some(r.to_string())
+                Some(RegistryOrIndex::Registry(r.to_string()))
             }
             (Some(_), Some(_)) => {
-                bail!("both `--index` and `--registry` should not be set at the same time")
+                // Should be guarded by clap
+                unreachable!("both `--index` and `--registry` should not be set at the same time")
             }
         };
         Ok(result)
     }
 
-    fn index(&self) -> CargoResult<Option<String>> {
-        let index = self._value_of("index").map(|s| s.to_string());
-        Ok(index)
+    fn registry(&self, config: &Config) -> CargoResult<Option<String>> {
+        match self._value_of("registry").map(|s| s.to_string()) {
+            None => config.default_registry(),
+            Some(registry) => {
+                validate_package_name(&registry, "registry name", "")?;
+                Ok(Some(registry))
+            }
+        }
     }
 
     fn check_optional_opts(

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1389,10 +1389,9 @@ fn both_index_and_registry() {
         p.cargo(cmd)
             .arg("--registry=foo")
             .arg("--index=foo")
-            .with_status(101)
-            .with_stderr(
-                "[ERROR] both `--index` and `--registry` \
-                should not be set at the same time",
+            .with_status(1)
+            .with_stderr_contains(
+                "error: the argument '--registry <REGISTRY>' cannot be used with '--index <INDEX>'",
             )
             .run();
     }

--- a/tests/testsuite/cargo_owner/help/stdout.log
+++ b/tests/testsuite/cargo_owner/help/stdout.log
@@ -9,9 +9,9 @@ Options:
   -a, --add <LOGIN>          Name of a user or team to invite as an owner
   -r, --remove <LOGIN>       Name of a user or team to remove as an owner
   -l, --list                 List owners of a crate
-      --index <INDEX>        Registry index to modify owners for
+      --index <INDEX>        Registry index URL to modify owners for
+      --registry <REGISTRY>  Registry to modify owners for
       --token <TOKEN>        API token to use when authenticating
-      --registry <REGISTRY>  Registry to use
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never

--- a/tests/testsuite/cargo_publish/help/stdout.log
+++ b/tests/testsuite/cargo_publish/help/stdout.log
@@ -5,7 +5,7 @@ Usage: cargo[EXE] publish [OPTIONS]
 Options:
       --dry-run              Perform all checks without uploading
       --index <INDEX>        Registry index URL to upload the package to
-      --registry <REGISTRY>  Registry to publish to
+      --registry <REGISTRY>  Registry to upload the package to
       --token <TOKEN>        Token to use when uploading
       --no-verify            Don't verify the contents by building them
       --allow-dirty          Allow dirty working directories to be packaged

--- a/tests/testsuite/cargo_search/help/stdout.log
+++ b/tests/testsuite/cargo_search/help/stdout.log
@@ -7,8 +7,8 @@ Arguments:
 
 Options:
       --limit <LIMIT>        Limit the number of results (default: 10, max: 100)
-      --index <INDEX>        Registry index URL to upload the package to
-      --registry <REGISTRY>  Registry to use
+      --index <INDEX>        Registry index URL to search packages in
+      --registry <REGISTRY>  Registry to search packages in
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never

--- a/tests/testsuite/cargo_yank/help/stdout.log
+++ b/tests/testsuite/cargo_yank/help/stdout.log
@@ -8,8 +8,8 @@ Arguments:
 Options:
       --version <VERSION>    The version to yank or un-yank
       --undo                 Undo a yank, putting a version back into the index
-      --index <INDEX>        Registry index to yank from
-      --registry <REGISTRY>  Registry to use
+      --index <INDEX>        Registry index URL to yank from
+      --registry <REGISTRY>  Registry to yank from
       --token <TOKEN>        API token to use when authenticating
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -922,6 +922,48 @@ You may press ctrl-c [..]
 }
 
 #[cargo_test]
+fn publish_failed_with_index_and_only_allowed_registry() {
+    let registry = RegistryBuilder::new()
+        .http_api()
+        .http_index()
+        .alternative()
+        .build();
+
+    let p = project().build();
+
+    let _ = repo(&paths::root().join("foo"))
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+                documentation = "foo"
+                homepage = "foo"
+                repository = "foo"
+                publish = ["alternative"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("publish")
+        .arg("--index")
+        .arg(registry.index_url().as_str())
+        .with_status(101)
+        .with_stderr(
+            "\
+[NOTE] Found `alternative` as only allowed registry. Publishing to it automatically.
+[ERROR] command-line argument --index requires --token to be specified
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn publish_fail_with_no_registry_specified() {
     let p = project().build();
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

`fn registry()` has two booleans representing `--index` and `--registry` respectively. However, they are inherently mutually exclusive and better to use a single sum type `RegistryOrIndex` to model them.

### How should we test and review this PR?

This PR is expected not to bring any behavior change. The only change is that the cli arg conflict detection is now moved to command line parsing phase (clap).

A new test `publish_failed_with_index_and_only_allowed_registry` demonstrates a quirky message was emitted when 

* `package.publish = […]` contains the only one registry that trigger an implicit publish
* `--index` arg was provided and took precedence over the implicit registry publish

This behavior should be fixed IMO but let's leave it to another PR.

### Additional information


<!-- homu-ignore:end -->
