### PR TITLE
doc: differentiate defaults for split-debuginfo

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -96,6 +96,10 @@ split-debuginfo` flag] and is platform-specific. Some options are only
 available on the [nightly channel]. The Cargo default may change in the future
 once more testing has been performed, and support for DWARF is stabilized.
 
+Be aware that Cargo and rustc have different defaults for this option. This
+option exists to allow Cargo to experiment on different combinations of flags
+thus providing better debugging and developer experience.
+
 [nightly channel]: ../../book/appendix-07-nightly-rust.html
 [`-C split-debuginfo` flag]: ../../rustc/codegen-options/index.html#split-debuginfo
 


### PR DESCRIPTION
### What does this PR try to resolve?

Documentation of different values for same named option in two different tools.
could fix #12243 

### How should we test and review this PR?

Editor review.
