### PR TITLE
publish.py: Remove obsolete `sleep()` calls

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -11,7 +11,6 @@
 import os
 import re
 import subprocess
-import time
 import urllib.request
 from urllib.error import HTTPError
 
@@ -52,13 +51,9 @@ def maybe_publish(path):
 
 def main():
     print('Starting publish...')
-    for i, path in enumerate(TO_PUBLISH):
-        if maybe_publish(path):
-            if i < len(TO_PUBLISH)-1:
-                # Sleep to allow the index to update. This should probably
-                # check that the index is updated, or use a retry loop
-                # instead.
-                time.sleep(5)
+    for path in TO_PUBLISH:
+        maybe_publish(path)
+
     print('Publish complete!')
 
 


### PR DESCRIPTION
`cargo` waits for the package to appear in the index by default these days, so these obsolete extra `sleep()` calls are just making the publish process slower now without any advantages.

see https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/publish.2Epy
