### PR TITLE
fix: copy PDBs for EFI targets

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -465,7 +465,7 @@ impl TargetInfo {
                     // the names to match.
                     should_replace_hyphens: false,
                 })
-            } else if target_triple.ends_with("-msvc") {
+            } else if target_triple.ends_with("-msvc") || target_triple.ends_with("-uefi") {
                 ret.push(FileType {
                     suffix: ".pdb".to_string(),
                     prefix: prefix.clone(),


### PR DESCRIPTION

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them. -->

### What does this PR try to resolve?

EFI also uses the PE format with .pdb files, and rustc generates them, but Cargo does not copy them out of target/*/deps as it does on Windows. This is an oversight, so this PR fixes it.


### How should we test and review this PR?

See the test below; you can copy it into a new project and run `cargo build --target x86_64-unknown-uefi` and verify that the pdb is properly copied.

### Additional information

Related: https://github.com/rust-osdev/uefi-rs/issues/289
Related (originally adding the pdb stuff for windows): https://github.com/rust-lang/cargo/pull/5179

<!-- homu-ignore:end -->
