### PR TITLE
Better suggestion for redundant mode in build and install commands

### DIFF
--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -30,7 +30,7 @@ pub fn cli() -> Command {
         )
         .arg_features()
         .arg_release("Build artifacts in release mode, with optimizations")
-        .arg_unsupported_mode("debug", "build", "release")
+        .arg_redundant_default_mode("debug", "build", "release")
         .arg_profile("Build artifacts with the specified profile")
         .arg_parallel()
         .arg_target_triple("Build for the target triple")

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -30,6 +30,7 @@ pub fn cli() -> Command {
         )
         .arg_features()
         .arg_release("Build artifacts in release mode, with optimizations")
+        .arg_unsupported_mode("debug", "build", "release")
         .arg_profile("Build artifacts with the specified profile")
         .arg_parallel()
         .arg_target_triple("Build for the target triple")

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -83,6 +83,7 @@ pub fn cli() -> Command {
             "debug",
             "Build in debug mode (with the 'dev' profile) instead of release mode",
         ))
+        .arg_unsupported_mode("release", "install", "debug")
         .arg_profile("Install artifacts with the specified profile")
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -83,7 +83,7 @@ pub fn cli() -> Command {
             "debug",
             "Build in debug mode (with the 'dev' profile) instead of release mode",
         ))
-        .arg_unsupported_mode("release", "install", "debug")
+        .arg_redundant_default_mode("release", "install", "debug")
         .arg_profile("Install artifacts with the specified profile")
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -525,7 +525,7 @@ Run `{cmd}` to see possible targets."
 
         let name = match (
             self.maybe_flag("release"),
-            self.flag("debug"),
+            self.maybe_flag("debug"),
             specified_profile,
         ) {
             (false, false, None) => default,

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -112,17 +112,15 @@ pub trait CommandExt: Sized {
         self._arg(flag("keep-going", "").value_parser(value_parser).hide(true))
     }
 
-    fn arg_unsupported_mode(
+    fn arg_redundant_default_mode(
         self,
-        want: &'static str,
+        default_mode: &'static str,
         command: &'static str,
-        actual: &'static str,
+        supported_mode: &'static str,
     ) -> Self {
-        let msg = format!(
-            "There is no `--{want}` for `cargo {command}`. Only `--{actual}` is supported."
-        );
+        let msg = format!("`--{default_mode}` is the default for `cargo {command}`; instead `--{supported_mode}` is supported");
         let value_parser = UnknownArgumentValueParser::suggest(msg);
-        self._arg(flag(want, "").value_parser(value_parser).hide(true))
+        self._arg(flag(default_mode, "").value_parser(value_parser).hide(true))
     }
 
     fn arg_targets_all(

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -136,6 +136,27 @@ fn incremental_config() {
 }
 
 #[cargo_test]
+fn cargo_compile_with_unsupported_mode() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("build --debug")
+        .with_stderr(
+            "\
+error: unexpected argument '--debug' found
+
+Usage: cargo[EXE] build [OPTIONS]
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}
+
+#[cargo_test]
 fn cargo_compile_with_workspace_excluded() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -136,7 +136,7 @@ fn incremental_config() {
 }
 
 #[cargo_test]
-fn cargo_compile_with_unsupported_mode() {
+fn cargo_compile_with_redundant_default_mode() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
@@ -147,7 +147,7 @@ fn cargo_compile_with_unsupported_mode() {
             "\
 error: unexpected argument '--debug' found
 
-  tip: There is no `--debug` for `cargo build`. Only `--release` is supported.
+  tip: `--debug` is the default for `cargo build`; instead `--release` is supported
 
 Usage: cargo[EXE] build [OPTIONS]
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -147,6 +147,8 @@ fn cargo_compile_with_unsupported_mode() {
             "\
 error: unexpected argument '--debug' found
 
+  tip: There is no `--debug` for `cargo build`. Only `--release` is supported.
+
 Usage: cargo[EXE] build [OPTIONS]
 
 For more information, try '--help'.

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2453,9 +2453,9 @@ fn install_with_unsupported_mode() {
             "\
 error: unexpected argument '--release' found
 
-  tip: a similar argument exists: '--examples'
+  tip: There is no `--release` for `cargo install`. Only `--debug` is supported.
 
-Usage: cargo[EXE] install --examples [crate]...
+Usage: cargo[EXE] install [OPTIONS] [crate]...
 
 For more information, try '--help'.
 ",

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2445,7 +2445,7 @@ fn ambiguous_registry_vs_local_package() {
 }
 
 #[cargo_test]
-fn install_with_unsupported_mode() {
+fn install_with_redundant_default_mode() {
     pkg("foo", "0.0.1");
 
     cargo_process("install foo --release")
@@ -2453,7 +2453,7 @@ fn install_with_unsupported_mode() {
             "\
 error: unexpected argument '--release' found
 
-  tip: There is no `--release` for `cargo install`. Only `--debug` is supported.
+  tip: `--release` is the default for `cargo install`; instead `--debug` is supported
 
 Usage: cargo[EXE] install [OPTIONS] [crate]...
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2443,3 +2443,23 @@ fn ambiguous_registry_vs_local_package() {
         .run();
     assert_has_installed_exe(cargo_home(), "foo");
 }
+
+#[cargo_test]
+fn install_with_unsupported_mode() {
+    pkg("foo", "0.0.1");
+
+    cargo_process("install foo --release")
+        .with_stderr(
+            "\
+error: unexpected argument '--release' found
+
+  tip: a similar argument exists: '--examples'
+
+Usage: cargo[EXE] install --examples [crate]...
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

See: https://github.com/rust-lang/cargo/issues/11702#issuecomment-1517563353

Added better suggestions for unsupported mode in build and install commands.

### How should we test and review this PR?

Check out the unit tests.

### Additional information

r? @weihanglo 

<!-- homu-ignore:end -->
