### PR TITLE
doc/reference/manifest: Adjust `keywords` description

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -306,9 +306,9 @@ words that would help someone find this crate.
 keywords = ["gamedev", "graphics"]
 ```
 
-> **Note**: [crates.io] has a maximum of 5 keywords. Each keyword must be
-> ASCII text, start with a letter, and only contain letters, numbers, `_` or
-> `-`, and have at most 20 characters.
+> **Note**: [crates.io] allows a maximum of 5 keywords. Each keyword must be
+> ASCII text, have at most 20 characters, start with an alphanumeric character,
+> and only contain letters, numbers, `_`, `-` or `+`.
 
 ### The `categories` field
 


### PR DESCRIPTION
This adjusts the naming rules for keywords to match the implemented reality:

https://github.com/rust-lang/crates.io/blob/aab95692baa0dd2374a2ab5cb2cb2d89d7b2a2eb/src/models/keyword.rs#L56-L64

see also:

- https://github.com/rust-lang/rfcs/pull/3488#discussion_r1327466221
- https://github.com/rust-lang/rfcs/pull/3488#discussion_r1327724345