### PR TITLE
Add new package cache lock modes

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -236,6 +236,7 @@ fn substitute_macros(input: &str) -> String {
         ("[SKIPPING]", "    Skipping"),
         ("[WAITING]", "     Waiting"),
         ("[PUBLISHED]", "   Published"),
+        ("[BLOCKING]", "    Blocking"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -22,6 +22,7 @@ use cargo::core::Registry;
 use cargo::core::SourceId;
 use cargo::core::Workspace;
 use cargo::sources::source::QueryKind;
+use cargo::util::cache_lock::CacheLockMode;
 use cargo::util::command_prelude::*;
 use cargo::util::ToSemver;
 use cargo::CargoResult;
@@ -361,7 +362,7 @@ fn check_crates_io<'a>(
 ) -> CargoResult<()> {
     let source_id = SourceId::crates_io(config)?;
     let mut registry = PackageRegistry::new(config)?;
-    let _lock = config.acquire_package_cache_lock()?;
+    let _lock = config.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
     registry.lock_patches();
     config.shell().status(
         STATUS,

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -37,6 +37,7 @@ use crate::core::compiler::BuildContext;
 use crate::core::{Dependency, PackageId, Workspace};
 use crate::sources::source::QueryKind;
 use crate::sources::SourceConfigMap;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::{iter_join, CargoResult};
 use anyhow::{bail, format_err, Context};
 use serde::{Deserialize, Serialize};
@@ -297,7 +298,10 @@ fn render_report(per_package_reports: &[FutureIncompatReportPackage]) -> BTreeMa
 /// This is best-effort - if an error occurs, `None` will be returned.
 fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<String> {
     // This in general ignores all errors since this is opportunistic.
-    let _lock = ws.config().acquire_package_cache_lock().ok()?;
+    let _lock = ws
+        .config()
+        .acquire_package_cache_lock(CacheLockMode::DownloadExclusive)
+        .ok()?;
     // Create a set of updated registry sources.
     let map = SourceConfigMap::new(ws.config()).ok()?;
     let mut package_ids: BTreeSet<_> = package_ids

--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -167,7 +167,7 @@ impl OnDiskReports {
         let on_disk = serde_json::to_vec(&self).unwrap();
         if let Err(e) = ws
             .target_dir()
-            .open_rw(
+            .open_rw_exclusive_create(
                 FUTURE_INCOMPAT_FILE,
                 ws.config(),
                 "Future incompatibility report",
@@ -191,7 +191,7 @@ impl OnDiskReports {
 
     /// Loads the on-disk reports.
     pub fn load(ws: &Workspace<'_>) -> CargoResult<OnDiskReports> {
-        let report_file = match ws.target_dir().open_ro(
+        let report_file = match ws.target_dir().open_ro_shared(
             FUTURE_INCOMPAT_FILE,
             ws.config(),
             "Future incompatible report",

--- a/src/cargo/core/compiler/layout.rs
+++ b/src/cargo/core/compiler/layout.rs
@@ -166,7 +166,7 @@ impl Layout {
         // For now we don't do any more finer-grained locking on the artifact
         // directory, so just lock the entire thing for the duration of this
         // compile.
-        let lock = dest.open_rw(".cargo-lock", ws.config(), "build directory")?;
+        let lock = dest.open_rw_exclusive_create(".cargo-lock", ws.config(), "build directory")?;
         let root = root.into_path_unlocked();
         let dest = dest.into_path_unlocked();
         let deps = dest.join("deps");

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -23,6 +23,7 @@ use crate::core::Shell;
 use crate::core::Summary;
 use crate::core::Workspace;
 use crate::sources::source::QueryKind;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::style;
 use crate::util::toml_mut::dependency::Dependency;
 use crate::util::toml_mut::dependency::GitSource;
@@ -77,7 +78,9 @@ pub fn add(workspace: &Workspace<'_>, options: &AddOptions<'_>) -> CargoResult<(
     let mut registry = PackageRegistry::new(options.config)?;
 
     let deps = {
-        let _lock = options.config.acquire_package_cache_lock()?;
+        let _lock = options
+            .config
+            .acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
         registry.lock_patches();
         options
             .dependencies

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -3,6 +3,7 @@ use crate::core::resolver::features::{CliFeatures, HasDevUnits};
 use crate::core::{PackageId, PackageIdSpec};
 use crate::core::{Resolve, SourceId, Workspace};
 use crate::ops;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::config::Config;
 use crate::util::style;
 use crate::util::CargoResult;
@@ -48,7 +49,9 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
 
     // Updates often require a lot of modifications to the registry, so ensure
     // that we're synchronized against other Cargos.
-    let _lock = ws.config().acquire_package_cache_lock()?;
+    let _lock = ws
+        .config()
+        .acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
 
     let max_rust_version = ws.rust_version();
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -133,7 +133,7 @@ pub fn package_one(
     let dir = ws.target_dir().join("package");
     let mut dst = {
         let tmp = format!(".{}", filename);
-        dir.open_rw(&tmp, config, "package scratch space")?
+        dir.open_rw_exclusive_create(&tmp, config, "package scratch space")?
     };
 
     // Package up and test a temporary tarball and only move it to the final

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -13,6 +13,7 @@ use crate::core::{registry::PackageRegistry, resolver::HasDevUnits};
 use crate::core::{Feature, Shell, Verbosity, Workspace};
 use crate::core::{Package, PackageId, PackageSet, Resolve, SourceId};
 use crate::sources::PathSource;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::config::JobsConfig;
 use crate::util::errors::CargoResult;
 use crate::util::toml::TomlManifest;
@@ -806,7 +807,7 @@ pub fn check_yanked(
 ) -> CargoResult<()> {
     // Checking the yanked status involves taking a look at the registry and
     // maybe updating files, so be sure to lock it here.
-    let _lock = config.acquire_package_cache_lock()?;
+    let _lock = config.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
 
     let mut sources = pkg_set.sources_mut();
     let mut pending: Vec<PackageId> = resolve.iter().collect();

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -17,6 +17,7 @@ use crate::ops::{self, CompileFilter, CompileOptions};
 use crate::sources::source::QueryKind;
 use crate::sources::source::Source;
 use crate::sources::PathSource;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::CargoResult;
 use crate::util::Config;
 use crate::util::{FileLock, Filesystem};
@@ -536,7 +537,7 @@ where
     // This operation may involve updating some sources or making a few queries
     // which may involve frobbing caches, as a result make sure we synchronize
     // with other global Cargos
-    let _lock = config.acquire_package_cache_lock()?;
+    let _lock = config.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
 
     if needs_update {
         source.invalidate_cache();
@@ -604,7 +605,7 @@ where
     // This operation may involve updating some sources or making a few queries
     // which may involve frobbing caches, as a result make sure we synchronize
     // with other global Cargos
-    let _lock = config.acquire_package_cache_lock()?;
+    let _lock = config.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
 
     source.invalidate_cache();
 

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -98,8 +98,10 @@ pub struct CrateListingV1 {
 impl InstallTracker {
     /// Create an InstallTracker from information on disk.
     pub fn load(config: &Config, root: &Filesystem) -> CargoResult<InstallTracker> {
-        let v1_lock = root.open_rw(Path::new(".crates.toml"), config, "crate metadata")?;
-        let v2_lock = root.open_rw(Path::new(".crates2.json"), config, "crate metadata")?;
+        let v1_lock =
+            root.open_rw_exclusive_create(Path::new(".crates.toml"), config, "crate metadata")?;
+        let v2_lock =
+            root.open_rw_exclusive_create(Path::new(".crates2.json"), config, "crate metadata")?;
 
         let v1 = (|| -> CargoResult<_> {
             let mut contents = String::new();

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -12,7 +12,7 @@ pub fn load_pkg_lockfile(ws: &Workspace<'_>) -> CargoResult<Option<Resolve>> {
         return Ok(None);
     }
 
-    let mut f = lock_root.open_ro("Cargo.lock", ws.config(), "Cargo.lock file")?;
+    let mut f = lock_root.open_ro_shared("Cargo.lock", ws.config(), "Cargo.lock file")?;
 
     let mut s = String::new();
     f.read_to_string(&mut s)
@@ -79,7 +79,7 @@ pub fn write_pkg_lockfile(ws: &Workspace<'_>, resolve: &mut Resolve) -> CargoRes
 
     // Ok, if that didn't work just write it out
     lock_root
-        .open_rw("Cargo.lock", ws.config(), "Cargo.lock file")
+        .open_rw_exclusive_create("Cargo.lock", ws.config(), "Cargo.lock file")
         .and_then(|mut f| {
             f.file().set_len(0)?;
             f.write_all(out.as_bytes())?;
@@ -100,7 +100,7 @@ fn resolve_to_string_orig(
 ) -> (Option<String>, String, Filesystem) {
     // Load the original lock file if it exists.
     let lock_root = lock_root(ws);
-    let orig = lock_root.open_ro("Cargo.lock", ws.config(), "Cargo.lock file");
+    let orig = lock_root.open_ro_shared("Cargo.lock", ws.config(), "Cargo.lock file");
     let orig = orig.and_then(|mut f| {
         let mut s = String::new();
         f.read_to_string(&mut s)?;

--- a/src/cargo/ops/registry/mod.rs
+++ b/src/cargo/ops/registry/mod.rs
@@ -22,6 +22,7 @@ use crate::core::SourceId;
 use crate::sources::source::Source;
 use crate::sources::{RegistrySource, SourceConfigMap};
 use crate::util::auth;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::config::{Config, PathAndArgs};
 use crate::util::errors::CargoResult;
 use crate::util::network::http::http_handle;
@@ -131,7 +132,7 @@ fn registry(
     }
 
     let cfg = {
-        let _lock = config.acquire_package_cache_lock()?;
+        let _lock = config.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
         let mut src = RegistrySource::remote(source_ids.replacement, &HashSet::new(), config)?;
         // Only update the index if `force_update` is set.
         if force_update {

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -30,6 +30,7 @@ use crate::sources::source::QueryKind;
 use crate::sources::SourceConfigMap;
 use crate::sources::CRATES_IO_REGISTRY;
 use crate::util::auth;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::config::JobsConfig;
 use crate::util::Progress;
 use crate::util::ProgressStyle;
@@ -233,7 +234,7 @@ fn wait_for_publish(
     progress.tick_now(0, max, "")?;
     let is_available = loop {
         {
-            let _lock = config.acquire_package_cache_lock()?;
+            let _lock = config.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
             // Force re-fetching the source
             //
             // As pulling from a git source is expensive, we track when we've done it within the

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -68,6 +68,7 @@ use crate::core::Feature;
 use crate::core::{GitReference, PackageId, PackageIdSpec, PackageSet, SourceId, Workspace};
 use crate::ops;
 use crate::sources::PathSource;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::CargoResult;
 use crate::util::RustVersion;
 use crate::util::{profile, CanonicalUrl};
@@ -289,7 +290,9 @@ pub fn resolve_with_previous<'cfg>(
 ) -> CargoResult<Resolve> {
     // We only want one Cargo at a time resolving a crate graph since this can
     // involve a lot of frobbing of the global caches.
-    let _lock = ws.config().acquire_package_cache_lock()?;
+    let _lock = ws
+        .config()
+        .acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
 
     // Here we place an artificial limitation that all non-registry sources
     // cannot be locked at more than one revision. This means that if a Git

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -8,6 +8,7 @@ use crate::sources::source::MaybePackage;
 use crate::sources::source::QueryKind;
 use crate::sources::source::Source;
 use crate::sources::PathSource;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::CargoResult;
 use crate::util::hex::short_hash;
 use crate::util::Config;
@@ -212,7 +213,9 @@ impl<'cfg> Source for GitSource<'cfg> {
         // Ignore errors creating it, in case this is a read-only filesystem:
         // perhaps the later operations can succeed anyhow.
         let _ = git_fs.create_dir();
-        let git_path = self.config.assert_package_cache_locked(&git_fs);
+        let git_path = self
+            .config
+            .assert_package_cache_locked(CacheLockMode::DownloadExclusive, &git_fs);
 
         // Before getting a checkout, make sure that `<cargo_home>/git` is
         // marked as excluded from indexing and backups. Older versions of Cargo

--- a/src/cargo/sources/registry/http_remote.rs
+++ b/src/cargo/sources/registry/http_remote.rs
@@ -4,6 +4,7 @@ use crate::core::{PackageId, SourceId};
 use crate::sources::registry::download;
 use crate::sources::registry::MaybeLock;
 use crate::sources::registry::{LoadResponse, RegistryConfig, RegistryData};
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::errors::{CargoResult, HttpNotSuccessful};
 use crate::util::network::http::http_handle;
 use crate::util::network::retry::{Retry, RetryResult};
@@ -461,7 +462,8 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
     }
 
     fn assert_index_locked<'a>(&self, path: &'a Filesystem) -> &'a Path {
-        self.config.assert_package_cache_locked(path)
+        self.config
+            .assert_package_cache_locked(CacheLockMode::DownloadExclusive, path)
     }
 
     fn is_updated(&self) -> bool {
@@ -744,6 +746,7 @@ impl<'cfg> RegistryData for HttpRegistry<'cfg> {
                 Poll::Ready(cfg) => break cfg.to_owned(),
             }
         };
+
         download::download(
             &self.cache_path,
             &self.config,

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -89,6 +89,7 @@ use crate::core::dependency::{Artifact, DepKind};
 use crate::core::Dependency;
 use crate::core::{PackageId, SourceId, Summary};
 use crate::sources::registry::{LoadResponse, RegistryData};
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::interning::InternedString;
 use crate::util::IntoUrl;
 use crate::util::{internal, CargoResult, Config, Filesystem, OptVersionReq, RustVersion};
@@ -823,7 +824,7 @@ impl Summaries {
                     // something in case of error.
                     if paths::create_dir_all(cache_path.parent().unwrap()).is_ok() {
                         let path = Filesystem::new(cache_path.clone());
-                        config.assert_package_cache_locked(&path);
+                        config.assert_package_cache_locked(CacheLockMode::DownloadExclusive, &path);
                         if let Err(e) = fs::write(cache_path, &cache_bytes) {
                             tracing::info!("failed to write cache: {}", e);
                         }

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -206,6 +206,7 @@ use crate::sources::source::MaybePackage;
 use crate::sources::source::QueryKind;
 use crate::sources::source::Source;
 use crate::sources::PathSource;
+use crate::util::cache_lock::CacheLockMode;
 use crate::util::hex;
 use crate::util::interning::InternedString;
 use crate::util::network::PollExt;
@@ -581,7 +582,9 @@ impl<'cfg> RegistrySource<'cfg> {
         let package_dir = format!("{}-{}", pkg.name(), pkg.version());
         let dst = self.src_path.join(&package_dir);
         let path = dst.join(PACKAGE_SOURCE_LOCK);
-        let path = self.config.assert_package_cache_locked(&path);
+        let path = self
+            .config
+            .assert_package_cache_locked(CacheLockMode::DownloadExclusive, &path);
         let unpack_dir = path.parent().unwrap();
         match fs::read_to_string(path) {
             Ok(ok) => match serde_json::from_str::<LockMetadata>(&ok) {

--- a/src/cargo/util/cache_lock.rs
+++ b/src/cargo/util/cache_lock.rs
@@ -1,0 +1,463 @@
+//! Support for locking the package and index caches.
+//!
+//! This implements locking on the package and index caches (source files,
+//! `.crate` files, and index caches) to coordinate when multiple cargos are
+//! running at the same time. There are three styles of locks:
+//!
+//! * [`CacheLockMode::DownloadExclusive`] -- This is an exclusive lock
+//!   acquired while downloading packages and doing resolution.
+//! * [`CacheLockMode::Shared`] -- This is a shared lock acquired while a
+//!   build is running. In other words, whenever cargo just needs to read from
+//!   the cache, it should hold this lock. This is here to ensure that no
+//!   cargos are trying to read the source caches when cache garbage
+//!   collection runs.
+//! * [`CacheLockMode::MutateExclusive`] -- This is an exclusive lock acquired
+//!   whenever needing to modify existing source files (for example, with
+//!   cache garbage collection). This is acquired to make sure that no other
+//!   cargo is reading from the cache.
+//!
+//! Importantly, a `DownloadExclusive` lock does *not* interfere with a
+//! `Shared` lock. The download process generally does not modify source
+//! files, so other cargos should be able to safely proceed in reading source
+//! files[^1].
+//!
+//! This is implemented by two separate lock files, the "download" one and the
+//! "mutate" one. The `MutateExclusive` lock acquired both the "mutate" and
+//! "download" locks. The `Shared` lock acquires the "mutate" lock in share
+//! mode.
+//!
+//! An important rule is that `MutateExclusive` acquires the locks in the
+//! order "mutate" first and then the "download". That helps prevent
+//! deadlocks. It is not allowed for a cargo to first acquire a
+//! `DownloadExclusive` lock and then a `Shared` lock because that would open
+//! it up for deadlock.
+//!
+//! Another rule is that there should be only one [`CacheLocker`] per process
+//! to uphold the ordering rules. You could in theory have multiple if you
+//! could ensure that other threads would make progress and drop a lock, but
+//! cargo is not architected that way.
+//!
+//! It is safe to recursively acquire a lock as many times as you want.
+//!
+//! ## Interaction with older cargos
+//!
+//! Before version 1.74, cargo only acquired the `DownloadExclusive` lock when
+//! downloading and doing resolution. Newer cargos that acquire
+//! `MutateExclusive` should still correctly block when an old cargo is
+//! downloading (because it also acquires `DownloadExclusive`), but they do
+//! not properly coordinate when an old cargo is in the build phase (because
+//! it holds no locks). This isn't expected to be much of a problem because
+//! the intended use of mutating the cache is only to delete old contents
+//! which aren't currently being used. It is possible for there to be a
+//! conflict, particularly if the user manually deletes the entire cache, but
+//! it is not expected for this scenario to happen too often, and the only
+//! consequence is that one side or the other encounters an error and needs to
+//! retry.
+//!
+//! [^1]: A minor caveat is that downloads will delete an existing `src`
+//!   directory if it was extracted via an old cargo. See
+//!   [`crate::sources::registry::RegistrySource::unpack_package`]. This
+//!   should probably be fixed, but is unlikely to be a problem if the user is
+//!   only using versions of cargo with the same deletion logic.
+
+use super::FileLock;
+use crate::CargoResult;
+use crate::Config;
+use anyhow::Context;
+use std::cell::RefCell;
+use std::io;
+
+/// The style of lock to acquire.
+#[derive(Copy, Clone, Debug)]
+pub enum CacheLockMode {
+    /// A `Shared` lock allows multiple cargos to read from the source files.
+    ///
+    /// If another cargo has a `MutateExclusive` lock, then an attempt to get
+    /// a `Shared` will block.
+    ///
+    /// If another cargo has a `DownloadExclusive` lock, then the both can
+    /// operate concurrently under the assumption that downloading does not
+    /// modify existing source files.
+    Shared,
+    /// A `DownloadExclusive` lock ensures that only one cargo is downloading
+    /// new packages.
+    ///
+    /// If another cargo has a `MutateExclusive` lock, then an attempt to get
+    /// a `DownloadExclusive` lock will block.
+    ///
+    /// If another cargo has a `Shared` lock, then both can operate
+    /// concurrently.
+    DownloadExclusive,
+    /// A `MutateExclusive` lock ensures no other cargo is reading or writing
+    /// from the package caches.
+    ///
+    /// This is used for things like garbage collection to avoid modifying
+    /// caches while other cargos are running.
+    MutateExclusive,
+}
+
+/// A locker that can be used to acquire locks.
+#[derive(Debug)]
+pub struct CacheLocker {
+    state: RefCell<CacheState>,
+}
+
+/// The state of the [`CacheLocker`].
+///
+/// [`CacheLocker`] uses interior mutability because it is stuffed inside the
+/// global `Config`, which does not allow mutation.
+///
+/// An important note is that locks can be `None` even when they are held.
+/// This can happen on things like old NFS mounts where locking isn't
+/// supported. We otherwise pretend we have a lock via the lock counts. See
+/// [`FileLock`] for more detail on that.
+#[derive(Debug, Default)]
+struct CacheState {
+    cache_lock: Option<FileLock>,
+    cache_lock_count: u32,
+    mutate_lock: Option<FileLock>,
+    mutate_lock_count: u32,
+    /// Indicator of whether or not `mutate_lock` is currently a shared lock
+    /// or an exclusive one.
+    mutate_is_exclusive: bool,
+}
+
+/// A held lock guard.
+///
+/// When this is dropped, the lock will be released.
+#[must_use]
+pub struct CacheLock<'lock> {
+    mode: CacheLockMode,
+    locker: &'lock CacheLocker,
+}
+
+/// The filename for the [`CacheLockMode::DownloadExclusive`] lock.
+const CACHE_LOCK_NAME: &str = ".package-cache";
+/// The filename for the [`CacheLockMode::MutateExclusive`] and
+/// [`CacheLockMode::Shared`] lock.
+const MUTATE_NAME: &str = ".package-cache-mutate";
+
+// Descriptions that are displayed in the "Blocking" message shown to the user.
+const SHARED_DESCR: &str = "shared package cache";
+const DOWNLOAD_EXCLUSIVE_DESCR: &str = "package cache";
+const MUTATE_EXCLUSIVE_DESCR: &str = "package cache mutation";
+
+/// Macro to unlock a previously acquired lock.
+macro_rules! decrement {
+    ($state:expr, $count:ident, $lock:ident) => {
+        let new_cnt = $state.$count.checked_sub(1).unwrap();
+        $state.$count = new_cnt;
+        if new_cnt == 0 {
+            // This will drop, releasing the lock.
+            $state.$lock = None;
+        }
+    };
+}
+
+/// Macro for acquiring a shared lock (can block).
+macro_rules! do_shared_lock {
+    ($self: ident, $config: expr, $to_set: ident, $lock_name: expr, $descr: expr) => {
+        $self.$to_set = match $config
+            .home()
+            .open_shared_create($lock_name, $config, $descr)
+        {
+            Ok(lock) => Some(lock),
+            Err(e) => {
+                // There is no error here because locking is mostly a
+                // best-effort attempt. If cargo home is read-only, we don't
+                // want to fail just because we couldn't create the lock file.
+                tracing::warn!("failed to acquire cache lock {}: {e:?}", $lock_name);
+                None
+            }
+        };
+    };
+}
+
+/// Macro for acquiring a shared lock without blocking.
+macro_rules! do_try_shared_lock {
+    ($self: ident, $config: expr, $to_set: ident, $lock_name: expr, $unused: expr) => {
+        $self.$to_set = match $config.home().try_open_shared_create($lock_name) {
+            Ok(Some(lock)) => Some(lock),
+            Ok(None) => {
+                return Ok(false);
+            }
+            Err(e) => {
+                tracing::warn!("failed to acquire cache lock {}: {e:?}", $lock_name);
+                None
+            }
+        };
+    };
+}
+
+/// Macro for acquiring an exclusive lock (can block).
+macro_rules! do_exclusive_lock {
+    ($self: ident, $config: expr, $to_set: ident, $lock_name: expr, $descr: expr) => {
+        match $config.home().open_rw($lock_name, $config, $descr) {
+            Ok(lock) => {
+                $self.$to_set = Some(lock);
+                Ok(())
+            }
+            Err(e) => {
+                if maybe_readonly(&e) {
+                    // This is a best-effort attempt to at least try to
+                    // acquire some sort of lock. This can help in the
+                    // situation where this cargo only has read-only access,
+                    // but maybe some other cargo has read-write. This will at
+                    // least attempt to coordinate with it.
+                    //
+                    // We don't want to fail on a read-only mount because
+                    // cargo grabs an exclusive lock in situations where it
+                    // may only be reading from the package cache. In that
+                    // case, cargo isn't writing anything, and we don't want
+                    // to fail on that.
+                    do_shared_lock!($self, $config, $to_set, $lock_name, $descr);
+                    Ok(())
+                } else {
+                    Err(e).with_context(|| "failed to acquire package cache lock")
+                }
+            }
+        }
+    };
+}
+
+/// Macro for acquiring an exclusive lock without blocking.
+macro_rules! do_try_exclusive_lock {
+    ($self: ident, $config: expr, $to_set: ident, $lock_name: expr, $unused: expr) => {
+        match $config.home().try_open_rw($lock_name) {
+            Ok(Some(lock)) => {
+                $self.$to_set = Some(lock);
+                Ok(())
+            }
+            Ok(None) => return Ok(false),
+            Err(e) => {
+                if maybe_readonly(&e) {
+                    do_try_shared_lock!($self, $config, $to_set, $lock_name, $unused);
+                    Ok(())
+                } else {
+                    Err(e).with_context(|| "failed to acquire package cache lock")
+                }
+            }
+        }
+    };
+}
+
+/// Macro to help with acquiring a lock.
+///
+/// `shared` and `exclusive` are inputs to the macro so that either the
+/// blocking or non-blocking implementations can be called based on what the
+/// caller wants.
+macro_rules! do_lock {
+    ($self: ident, $config: expr, $mode: expr, $shared: ident, $exclusive: ident) => {
+        use CacheLockMode::*;
+        match (
+            $mode,
+            &$self.cache_lock_count,
+            &$self.mutate_lock_count,
+            $self.mutate_is_exclusive,
+        ) {
+            (Shared, 0, 0, _) => {
+                // Shared lock, no locks currently held.
+                $shared!($self, $config, mutate_lock, MUTATE_NAME, SHARED_DESCR);
+                $self.mutate_lock_count += 1;
+                $self.mutate_is_exclusive = false;
+            }
+            (DownloadExclusive, 0, _, _) => {
+                // DownloadExclusive lock, no DownloadExclusive lock currently held.
+                $exclusive!(
+                    $self,
+                    $config,
+                    cache_lock,
+                    CACHE_LOCK_NAME,
+                    DOWNLOAD_EXCLUSIVE_DESCR
+                )?;
+                $self.cache_lock_count += 1;
+            }
+            (MutateExclusive, 0, 0, _) => {
+                // MutateExclusive lock, no locks currently held.
+                $exclusive!(
+                    $self,
+                    $config,
+                    mutate_lock,
+                    MUTATE_NAME,
+                    MUTATE_EXCLUSIVE_DESCR
+                )?;
+                $self.mutate_lock_count += 1;
+                $self.mutate_is_exclusive = true;
+
+                // Part of the contract of MutateExclusive is that it doesn't
+                // allow any processes to have a lock on the package cache, so
+                // this acquires both locks.
+                if let Err(e) = $exclusive!(
+                    $self,
+                    $config,
+                    cache_lock,
+                    CACHE_LOCK_NAME,
+                    DOWNLOAD_EXCLUSIVE_DESCR
+                ) {
+                    decrement!($self, mutate_lock_count, mutate_lock);
+                    return Err(e);
+                }
+                $self.cache_lock_count += 1;
+            }
+            (Shared, 1.., 0, _) => {
+                // Shared lock, when a DownloadExclusive is held.
+                //
+                // This isn't supported because it could cause a deadlock. If
+                // one cargo is attempting to acquire a MutateExclusive lock,
+                // and acquires the mutate lock, but is blocked on the
+                // download lock, and the cargo that holds the download lock
+                // attempts to get a shared lock, they would end up blocking
+                // each other.
+                panic!("shared lock while holding download lock is not allowed");
+            }
+            (MutateExclusive, _, 1.., false) => {
+                // MutateExclusive lock, when a Shared lock is held.
+                //
+                // Lock upgrades are dicey. It might be possible to support
+                // this but would take a bit of work, and so far it isn't
+                // needed.
+                panic!("lock upgrade from Shared to MutateExclusive not supported");
+            }
+            (Shared, _, 1.., _) => {
+                // Shared lock, when a Shared or MutateExclusive lock is held.
+                //
+                // MutateExclusive is more restrictive than Shared, so no need
+                // to do anything.
+                $self.mutate_lock_count = $self.mutate_lock_count.checked_add(1).unwrap();
+            }
+            (DownloadExclusive, 1.., _, _) => {
+                // DownloadExclusive lock, when another DownloadExclusive is held.
+                $self.cache_lock_count = $self.cache_lock_count.checked_add(1).unwrap();
+            }
+            (MutateExclusive, _, 1.., true) => {
+                // MutateExclusive lock, when another MutateExclusive is held.
+                $self.cache_lock_count += 1;
+                $self.mutate_lock_count += 1;
+            }
+            (MutateExclusive, 1.., 0, _) => {
+                // MutateExclusive lock, when only a DownloadExclusive is held.
+                $exclusive!(
+                    $self,
+                    $config,
+                    mutate_lock,
+                    MUTATE_NAME,
+                    MUTATE_EXCLUSIVE_DESCR
+                )?;
+                // Both of these need to be incremented to match the behavior
+                // in the drop impl.
+                $self.cache_lock_count += 1;
+                $self.mutate_lock_count += 1;
+                $self.mutate_is_exclusive = true;
+            }
+        }
+    };
+}
+
+impl CacheLocker {
+    /// Creates a new `CacheLocker`.
+    pub fn new() -> CacheLocker {
+        CacheLocker {
+            state: RefCell::new(CacheState::default()),
+        }
+    }
+
+    /// Acquires a lock with the given mode, possibly blocking if another
+    /// cargo is holding the lock.
+    pub fn lock(&self, config: &Config, mode: CacheLockMode) -> CargoResult<CacheLock<'_>> {
+        let mut state = self.state.borrow_mut();
+        state.lock(config, mode)?;
+        Ok(CacheLock { mode, locker: self })
+    }
+
+    /// Acquires a lock with the given mode, returning `None` if another cargo
+    /// is holding the lock.
+    pub fn try_lock(
+        &self,
+        config: &Config,
+        mode: CacheLockMode,
+    ) -> CargoResult<Option<CacheLock<'_>>> {
+        let mut state = self.state.borrow_mut();
+        if state.try_lock(config, mode)? {
+            Ok(Some(CacheLock { mode, locker: self }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns whether or not a lock is held for the given mode in this locker.
+    ///
+    /// This does not tell you whether or not it is locked in some other
+    /// locker (such as in another process).
+    ///
+    /// Note that `Shared` will return true if a `MutateExclusive` lock is
+    /// held, since `MutateExclusive` is just an upgraded `Shared`. Likewise,
+    /// `DownlaodExclusive` will return true if a `MutateExclusive` lock is
+    /// held since they overlap.
+    pub fn is_locked(&self, mode: CacheLockMode) -> bool {
+        let state = self.state.borrow();
+        match (
+            mode,
+            state.cache_lock_count,
+            state.mutate_lock_count,
+            state.mutate_is_exclusive,
+        ) {
+            (CacheLockMode::Shared, _, 1.., _) => true,
+            (CacheLockMode::MutateExclusive, _, 1.., true) => true,
+            (CacheLockMode::DownloadExclusive, 1.., _, _) => true,
+            _ => false,
+        }
+    }
+}
+
+impl CacheState {
+    fn lock(&mut self, config: &Config, mode: CacheLockMode) -> CargoResult<()> {
+        do_lock!(self, config, mode, do_shared_lock, do_exclusive_lock);
+        Ok(())
+    }
+
+    fn try_lock(&mut self, config: &Config, mode: CacheLockMode) -> CargoResult<bool> {
+        do_lock!(
+            self,
+            config,
+            mode,
+            do_try_shared_lock,
+            do_try_exclusive_lock
+        );
+        Ok(true)
+    }
+}
+
+/// Returns whether or not the error appears to be from a read-only filesystem.
+fn maybe_readonly(err: &anyhow::Error) -> bool {
+    err.chain().any(|err| {
+        if let Some(io) = err.downcast_ref::<io::Error>() {
+            if io.kind() == io::ErrorKind::PermissionDenied {
+                return true;
+            }
+
+            #[cfg(unix)]
+            return io.raw_os_error() == Some(libc::EROFS);
+        }
+
+        false
+    })
+}
+
+impl Drop for CacheLock<'_> {
+    fn drop(&mut self) {
+        use CacheLockMode::*;
+        let mut state = self.locker.state.borrow_mut();
+        match self.mode {
+            Shared => {
+                decrement!(state, mutate_lock_count, mutate_lock);
+            }
+            DownloadExclusive => {
+                decrement!(state, cache_lock_count, cache_lock);
+            }
+            MutateExclusive => {
+                decrement!(state, cache_lock_count, cache_lock);
+                decrement!(state, mutate_lock_count, mutate_lock);
+            }
+        }
+    }
+}

--- a/src/cargo/util/cache_lock.rs
+++ b/src/cargo/util/cache_lock.rs
@@ -70,15 +70,6 @@ use std::io;
 /// The style of lock to acquire.
 #[derive(Copy, Clone, Debug)]
 pub enum CacheLockMode {
-    /// A `Shared` lock allows multiple cargos to read from the source files.
-    ///
-    /// If another cargo has a `MutateExclusive` lock, then an attempt to get
-    /// a `Shared` will block.
-    ///
-    /// If another cargo has a `DownloadExclusive` lock, then the both can
-    /// operate concurrently under the assumption that downloading does not
-    /// modify existing source files.
-    Shared,
     /// A `DownloadExclusive` lock ensures that only one cargo is downloading
     /// new packages.
     ///
@@ -88,6 +79,15 @@ pub enum CacheLockMode {
     /// If another cargo has a `Shared` lock, then both can operate
     /// concurrently.
     DownloadExclusive,
+    /// A `Shared` lock allows multiple cargos to read from the source files.
+    ///
+    /// If another cargo has a `MutateExclusive` lock, then an attempt to get
+    /// a `Shared` will block.
+    ///
+    /// If another cargo has a `DownloadExclusive` lock, then the both can
+    /// operate concurrently under the assumption that downloading does not
+    /// modify existing source files.
+    Shared,
     /// A `MutateExclusive` lock ensures no other cargo is reading or writing
     /// from the package caches.
     ///

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2235,7 +2235,7 @@ pub fn save_credentials(
     let mut file = {
         cfg.home_path.create_dir()?;
         cfg.home_path
-            .open_rw(filename, cfg, "credentials' config file")?
+            .open_rw_exclusive_create(filename, cfg, "credentials' config file")?
     };
 
     let mut contents = String::new();

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -49,6 +49,7 @@
 //! translate from `ConfigValue` and environment variables to the caller's
 //! desired type.
 
+use crate::util::cache_lock::{CacheLock, CacheLockMode, CacheLocker};
 use std::borrow::Cow;
 use std::cell::{RefCell, RefMut};
 use std::collections::hash_map::Entry::{Occupied, Vacant};
@@ -58,7 +59,7 @@ use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs::{self, File};
 use std::io::prelude::*;
-use std::io::{self, SeekFrom};
+use std::io::SeekFrom;
 use std::mem;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -78,7 +79,7 @@ use crate::util::network::http::http_handle;
 use crate::util::toml as cargo_toml;
 use crate::util::{internal, CanonicalUrl};
 use crate::util::{try_canonicalize, validate_package_name};
-use crate::util::{FileLock, Filesystem, IntoUrl, IntoUrlWithBase, Rustc};
+use crate::util::{Filesystem, IntoUrl, IntoUrlWithBase, Rustc};
 use anyhow::{anyhow, bail, format_err, Context as _};
 use cargo_credential::Secret;
 use cargo_util::paths;
@@ -215,9 +216,8 @@ pub struct Config {
     credential_cache: LazyCell<RefCell<HashMap<CanonicalUrl, CredentialCacheValue>>>,
     /// Cache of registry config from from the `[registries]` table.
     registry_config: LazyCell<RefCell<HashMap<SourceId, Option<RegistryConfig>>>>,
-    /// Lock, if held, of the global package cache along with the number of
-    /// acquisitions so far.
-    package_cache_lock: RefCell<Option<(Option<FileLock>, usize)>>,
+    /// Locks on the package and index caches.
+    package_cache_lock: CacheLocker,
     /// Cached configuration parsed by Cargo
     http_config: LazyCell<CargoHttpConfig>,
     future_incompat_config: LazyCell<CargoFutureIncompatConfig>,
@@ -307,7 +307,7 @@ impl Config {
             updated_sources: LazyCell::new(),
             credential_cache: LazyCell::new(),
             registry_config: LazyCell::new(),
-            package_cache_lock: RefCell::new(None),
+            package_cache_lock: CacheLocker::new(),
             http_config: LazyCell::new(),
             future_incompat_config: LazyCell::new(),
             net_config: LazyCell::new(),
@@ -1876,10 +1876,20 @@ impl Config {
         T::deserialize(d).map_err(|e| e.into())
     }
 
-    pub fn assert_package_cache_locked<'a>(&self, f: &'a Filesystem) -> &'a Path {
+    /// Obtain a [`Path`] from a [`Filesystem`], verifying that the
+    /// appropriate lock is already currently held.
+    ///
+    /// Locks are usually acquired via [`Config::acquire_package_cache_lock`]
+    /// or [`Config::try_acquire_package_cache_lock`].
+    #[track_caller]
+    pub fn assert_package_cache_locked<'a>(
+        &self,
+        mode: CacheLockMode,
+        f: &'a Filesystem,
+    ) -> &'a Path {
         let ret = f.as_path_unlocked();
         assert!(
-            self.package_cache_lock.borrow().is_some(),
+            self.package_cache_lock.is_locked(mode),
             "package cache lock is not currently held, Cargo forgot to call \
              `acquire_package_cache_lock` before we got to this stack frame",
         );
@@ -1887,72 +1897,26 @@ impl Config {
         ret
     }
 
-    /// Acquires an exclusive lock on the global "package cache"
+    /// Acquires a lock on the global "package cache", blocking if another
+    /// cargo holds the lock.
     ///
-    /// This lock is global per-process and can be acquired recursively. An RAII
-    /// structure is returned to release the lock, and if this process
-    /// abnormally terminates the lock is also released.
-    pub fn acquire_package_cache_lock(&self) -> CargoResult<PackageCacheLock<'_>> {
-        let mut slot = self.package_cache_lock.borrow_mut();
-        match *slot {
-            // We've already acquired the lock in this process, so simply bump
-            // the count and continue.
-            Some((_, ref mut cnt)) => {
-                *cnt += 1;
-            }
-            None => {
-                let path = ".package-cache";
-                let desc = "package cache";
-
-                // First, attempt to open an exclusive lock which is in general
-                // the purpose of this lock!
-                //
-                // If that fails because of a readonly filesystem or a
-                // permission error, though, then we don't really want to fail
-                // just because of this. All files that this lock protects are
-                // in subfolders, so they're assumed by Cargo to also be
-                // readonly or have invalid permissions for us to write to. If
-                // that's the case, then we don't really need to grab a lock in
-                // the first place here.
-                //
-                // Despite this we attempt to grab a readonly lock. This means
-                // that if our read-only folder is shared read-write with
-                // someone else on the system we should synchronize with them,
-                // but if we can't even do that then we did our best and we just
-                // keep on chugging elsewhere.
-                match self.home_path.open_rw(path, self, desc) {
-                    Ok(lock) => *slot = Some((Some(lock), 1)),
-                    Err(e) => {
-                        if maybe_readonly(&e) {
-                            let lock = self.home_path.open_ro(path, self, desc).ok();
-                            *slot = Some((lock, 1));
-                            return Ok(PackageCacheLock(self));
-                        }
-
-                        Err(e).with_context(|| "failed to acquire package cache lock")?;
-                    }
-                }
-            }
-        }
-        return Ok(PackageCacheLock(self));
-
-        fn maybe_readonly(err: &anyhow::Error) -> bool {
-            err.chain().any(|err| {
-                if let Some(io) = err.downcast_ref::<io::Error>() {
-                    if io.kind() == io::ErrorKind::PermissionDenied {
-                        return true;
-                    }
-
-                    #[cfg(unix)]
-                    return io.raw_os_error() == Some(libc::EROFS);
-                }
-
-                false
-            })
-        }
+    /// See [`crate::util::cache_lock`] for an in-depth discussion of locking
+    /// and lock modes.
+    pub fn acquire_package_cache_lock(&self, mode: CacheLockMode) -> CargoResult<CacheLock<'_>> {
+        self.package_cache_lock.lock(self, mode)
     }
 
-    pub fn release_package_cache_lock(&self) {}
+    /// Acquires a lock on the global "package cache", returning `None` if
+    /// another cargo holds the lock.
+    ///
+    /// See [`crate::util::cache_lock`] for an in-depth discussion of locking
+    /// and lock modes.
+    pub fn try_acquire_package_cache_lock(
+        &self,
+        mode: CacheLockMode,
+    ) -> CargoResult<Option<CacheLock<'_>>> {
+        self.package_cache_lock.try_lock(self, mode)
+    }
 }
 
 /// Internal error for serde errors.
@@ -2387,19 +2351,6 @@ pub fn save_credentials(
     #[allow(unused)]
     fn set_permissions(file: &File, mode: u32) -> CargoResult<()> {
         Ok(())
-    }
-}
-
-pub struct PackageCacheLock<'a>(&'a Config);
-
-impl Drop for PackageCacheLock<'_> {
-    fn drop(&mut self) {
-        let mut slot = self.0.package_cache_lock.borrow_mut();
-        let (_, cnt) = slot.as_mut().unwrap();
-        *cnt -= 1;
-        if *cnt == 0 {
-            *slot = None;
-        }
     }
 }
 

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -31,6 +31,7 @@ pub use self::workspace::{
 };
 
 pub mod auth;
+pub mod cache_lock;
 mod canonical_url;
 pub mod command_prelude;
 pub mod config;

--- a/tests/testsuite/cache_lock.rs
+++ b/tests/testsuite/cache_lock.rs
@@ -145,7 +145,7 @@ fn download_then_shared() {
 }
 
 #[cargo_test]
-#[should_panic(expected = "Shared to MutateExclusive not supported")]
+#[should_panic(expected = "lock upgrade from shared to exclusive not supported")]
 fn shared_then_mutate() {
     // This sequence is not supported.
     a_b_nested(CacheLockMode::Shared, CacheLockMode::MutateExclusive);
@@ -204,7 +204,9 @@ fn readonly() {
         CacheLockMode::DownloadExclusive,
         CacheLockMode::MutateExclusive,
     ] {
-        let _lock = locker.lock(&config, mode).unwrap();
+        let _lock1 = locker.lock(&config, mode).unwrap();
+        // Make sure it can recursively acquire the lock, too.
+        let _lock2 = locker.lock(&config, mode).unwrap();
     }
 }
 

--- a/tests/testsuite/cache_lock.rs
+++ b/tests/testsuite/cache_lock.rs
@@ -1,0 +1,302 @@
+//! Tests for `CacheLock`.
+
+use crate::config::ConfigBuilder;
+use cargo::util::cache_lock::{CacheLockMode, CacheLocker};
+use cargo_test_support::paths::{self, CargoPathExt};
+use cargo_test_support::{retry, thread_wait_timeout, threaded_timeout};
+use std::thread::JoinHandle;
+
+/// Helper to verify that it is OK to acquire the given lock (it shouldn't block).
+fn verify_lock_is_ok(mode: CacheLockMode) {
+    let root = paths::root();
+    threaded_timeout(10, move || {
+        let config = ConfigBuilder::new().root(root).build();
+        let locker = CacheLocker::new();
+        // This would block if it is held.
+        let _lock = locker.lock(&config, mode).unwrap();
+        assert!(locker.is_locked(mode));
+    });
+}
+
+/// Helper to acquire two locks from the same locker.
+fn a_b_nested(a: CacheLockMode, b: CacheLockMode) {
+    let config = ConfigBuilder::new().build();
+    let locker = CacheLocker::new();
+    let lock1 = locker.lock(&config, a).unwrap();
+    assert!(locker.is_locked(a));
+    let lock2 = locker.lock(&config, b).unwrap();
+    assert!(locker.is_locked(b));
+    drop(lock2);
+    drop(lock1);
+    // Verify locks were unlocked.
+    verify_lock_is_ok(CacheLockMode::Shared);
+    verify_lock_is_ok(CacheLockMode::DownloadExclusive);
+    verify_lock_is_ok(CacheLockMode::MutateExclusive);
+}
+
+/// Helper to acquire two locks from separate lockers, verifying that they
+/// don't block each other.
+fn a_then_b_separate_not_blocked(a: CacheLockMode, b: CacheLockMode, verify: CacheLockMode) {
+    let config = ConfigBuilder::new().build();
+    let locker1 = CacheLocker::new();
+    let lock1 = locker1.lock(&config, a).unwrap();
+    assert!(locker1.is_locked(a));
+    let locker2 = CacheLocker::new();
+    let lock2 = locker2.lock(&config, b).unwrap();
+    assert!(locker2.is_locked(b));
+    let thread = verify_lock_would_block(verify);
+    // Unblock the thread.
+    drop(lock1);
+    drop(lock2);
+    // Verify the thread is unblocked.
+    thread_wait_timeout::<()>(100, thread);
+}
+
+/// Helper to acquire two locks from separate lockers, verifying that the
+/// second one blocks.
+fn a_then_b_separate_blocked(a: CacheLockMode, b: CacheLockMode) {
+    let config = ConfigBuilder::new().build();
+    let locker = CacheLocker::new();
+    let lock = locker.lock(&config, a).unwrap();
+    assert!(locker.is_locked(a));
+    let thread = verify_lock_would_block(b);
+    // Unblock the thread.
+    drop(lock);
+    // Verify the thread is unblocked.
+    thread_wait_timeout::<()>(100, thread);
+}
+
+/// Helper to verify that acquiring the given mode would block.
+///
+/// Always call `thread_wait_timeout` on the result.
+#[must_use]
+fn verify_lock_would_block(mode: CacheLockMode) -> JoinHandle<()> {
+    let root = paths::root();
+    // Spawn a thread that will block on the lock.
+    let thread = std::thread::spawn(move || {
+        let config = ConfigBuilder::new().root(root).build();
+        let locker2 = CacheLocker::new();
+        let lock2 = locker2.lock(&config, mode).unwrap();
+        assert!(locker2.is_locked(mode));
+        drop(lock2);
+    });
+    // Verify that it blocked.
+    retry(100, || {
+        if let Ok(s) = std::fs::read_to_string(paths::root().join("shell.out")) {
+            if s.trim().starts_with("Blocking waiting for file lock on") {
+                return Some(());
+            } else {
+                eprintln!("unexpected output: {s}");
+                // Try again, it might have been partially written.
+            }
+        }
+        None
+    });
+    thread
+}
+
+#[test]
+fn new_is_unlocked() {
+    let locker = CacheLocker::new();
+    assert!(!locker.is_locked(CacheLockMode::Shared));
+    assert!(!locker.is_locked(CacheLockMode::DownloadExclusive));
+    assert!(!locker.is_locked(CacheLockMode::MutateExclusive));
+}
+
+#[cargo_test]
+fn multiple_shared() {
+    // Test that two nested shared locks from the same locker are safe to acquire.
+    a_b_nested(CacheLockMode::Shared, CacheLockMode::Shared);
+}
+
+#[cargo_test]
+fn multiple_shared_separate() {
+    // Test that two independent shared locks are safe to acquire at the same time.
+    a_then_b_separate_not_blocked(
+        CacheLockMode::Shared,
+        CacheLockMode::Shared,
+        CacheLockMode::MutateExclusive,
+    );
+}
+
+#[cargo_test]
+fn multiple_download() {
+    // That that two nested download locks from the same locker are safe to acquire.
+    a_b_nested(
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::DownloadExclusive,
+    );
+}
+
+#[cargo_test]
+fn multiple_mutate() {
+    // That that two nested mutate locks from the same locker are safe to acquire.
+    a_b_nested(
+        CacheLockMode::MutateExclusive,
+        CacheLockMode::MutateExclusive,
+    );
+}
+
+#[cargo_test]
+#[should_panic(expected = "lock is not allowed")]
+fn download_then_shared() {
+    // This sequence is not supported.
+    a_b_nested(CacheLockMode::DownloadExclusive, CacheLockMode::Shared);
+}
+
+#[cargo_test]
+#[should_panic(expected = "Shared to MutateExclusive not supported")]
+fn shared_then_mutate() {
+    // This sequence is not supported.
+    a_b_nested(CacheLockMode::Shared, CacheLockMode::MutateExclusive);
+}
+
+#[cargo_test]
+fn shared_then_download() {
+    a_b_nested(CacheLockMode::Shared, CacheLockMode::DownloadExclusive);
+    // Verify drop actually unlocked.
+    verify_lock_is_ok(CacheLockMode::DownloadExclusive);
+    verify_lock_is_ok(CacheLockMode::MutateExclusive);
+}
+
+#[cargo_test]
+fn mutate_then_shared() {
+    a_b_nested(CacheLockMode::MutateExclusive, CacheLockMode::Shared);
+    // Verify drop actually unlocked.
+    verify_lock_is_ok(CacheLockMode::MutateExclusive);
+}
+
+#[cargo_test]
+fn download_then_mutate() {
+    a_b_nested(
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::MutateExclusive,
+    );
+    // Verify drop actually unlocked.
+    verify_lock_is_ok(CacheLockMode::DownloadExclusive);
+    verify_lock_is_ok(CacheLockMode::MutateExclusive);
+}
+
+#[cargo_test]
+fn mutate_then_download() {
+    a_b_nested(
+        CacheLockMode::MutateExclusive,
+        CacheLockMode::DownloadExclusive,
+    );
+    // Verify drop actually unlocked.
+    verify_lock_is_ok(CacheLockMode::MutateExclusive);
+    verify_lock_is_ok(CacheLockMode::DownloadExclusive);
+}
+
+#[cargo_test]
+fn readonly() {
+    // In a permission denied situation, it should still allow a lock. It just
+    // silently behaves as-if it was locked.
+    let cargo_home = paths::home().join(".cargo");
+    std::fs::create_dir_all(&cargo_home).unwrap();
+    let mut perms = std::fs::metadata(&cargo_home).unwrap().permissions();
+    perms.set_readonly(true);
+    std::fs::set_permissions(&cargo_home, perms).unwrap();
+    let config = ConfigBuilder::new().build();
+    let locker = CacheLocker::new();
+    for mode in [
+        CacheLockMode::Shared,
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::MutateExclusive,
+    ] {
+        let _lock = locker.lock(&config, mode).unwrap();
+    }
+}
+
+#[cargo_test]
+fn download_then_shared_separate() {
+    a_then_b_separate_not_blocked(
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::Shared,
+        CacheLockMode::MutateExclusive,
+    );
+}
+
+#[cargo_test]
+fn shared_then_download_separate() {
+    a_then_b_separate_not_blocked(
+        CacheLockMode::Shared,
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::MutateExclusive,
+    );
+}
+
+#[cargo_test]
+fn multiple_download_separate() {
+    // Test that with two independent download locks, the second blocks until
+    // the first is released.
+    a_then_b_separate_blocked(
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::DownloadExclusive,
+    );
+}
+
+#[cargo_test]
+fn multiple_mutate_separate() {
+    // Test that with two independent mutate locks, the second blocks until
+    // the first is released.
+    a_then_b_separate_blocked(
+        CacheLockMode::MutateExclusive,
+        CacheLockMode::MutateExclusive,
+    );
+}
+
+#[cargo_test]
+fn shared_then_mutate_separate() {
+    a_then_b_separate_blocked(CacheLockMode::Shared, CacheLockMode::MutateExclusive);
+}
+
+#[cargo_test]
+fn download_then_mutate_separate() {
+    a_then_b_separate_blocked(
+        CacheLockMode::DownloadExclusive,
+        CacheLockMode::MutateExclusive,
+    );
+}
+
+#[cargo_test]
+fn mutate_then_download_separate() {
+    a_then_b_separate_blocked(
+        CacheLockMode::MutateExclusive,
+        CacheLockMode::DownloadExclusive,
+    );
+}
+
+#[cargo_test]
+fn mutate_then_shared_separate() {
+    a_then_b_separate_blocked(CacheLockMode::MutateExclusive, CacheLockMode::Shared);
+}
+
+#[cargo_test(ignore_windows = "no method to prevent creating or locking a file")]
+fn mutate_err_is_atomic() {
+    // Verifies that when getting a mutate lock, that if the first lock
+    // succeeds, but the second one fails, that the first lock is released.
+    let config = ConfigBuilder::new().build();
+    let locker = CacheLocker::new();
+    let cargo_home = config.home().as_path_unlocked();
+    let cache_path = cargo_home.join(".package-cache");
+    // This is a hacky way to force an error acquiring the download lock. By
+    // making it a directory, it is unable to open it.
+    // TODO: Unfortunately this doesn't work on Windows. I don't have any
+    // ideas on how to simulate an error on Windows.
+    cache_path.mkdir_p();
+    match locker.lock(&config, CacheLockMode::MutateExclusive) {
+        Ok(_) => panic!("did not expect lock to succeed"),
+        Err(e) => {
+            let msg = format!("{e:?}");
+            assert!(msg.contains("failed to open:"), "{msg}");
+        }
+    }
+    assert!(!locker.is_locked(CacheLockMode::MutateExclusive));
+    assert!(!locker.is_locked(CacheLockMode::DownloadExclusive));
+    assert!(!locker.is_locked(CacheLockMode::Shared));
+    cache_path.rm_rf();
+    verify_lock_is_ok(CacheLockMode::DownloadExclusive);
+    verify_lock_is_ok(CacheLockMode::Shared);
+    verify_lock_is_ok(CacheLockMode::MutateExclusive);
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -17,6 +17,7 @@ mod build_plan;
 mod build_script;
 mod build_script_env;
 mod build_script_extra_link_arg;
+mod cache_lock;
 mod cache_messages;
 mod cargo;
 mod cargo_add;

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -1,5 +1,6 @@
 //! Tests for the `cargo search` command.
 
+use cargo::util::cache_lock::CacheLockMode;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths;
 use cargo_test_support::registry::{RegistryBuilder, Response};
@@ -100,7 +101,9 @@ fn not_update() {
         paths::root(),
         paths::home().join(".cargo"),
     );
-    let lock = cfg.acquire_package_cache_lock().unwrap();
+    let lock = cfg
+        .acquire_package_cache_lock(CacheLockMode::DownloadExclusive)
+        .unwrap();
     let mut regsrc = RegistrySource::remote(sid, &HashSet::new(), &cfg).unwrap();
     regsrc.invalidate_cache();
     regsrc.block_until_ready().unwrap();


### PR DESCRIPTION
The way locking worked before this PR is that only one cargo could write to the package cache at once (otherwise it could cause corruption). However, it allowed cargo's to read from the package cache while running a build under the assumption that writers are append-only and won't affect reading. This allows multiple builds to run concurrently, only blocking on the part where it is not possible to run concurrently (downloading to the cache).

This introduces a new package cache locking strategy to support the ability to safely modify existing cache entries while other cargos are potentially reading from the cache. It has different locking modes:

- `MutateExclusive` (new) — Held when cargo wants to modify existing cache entries (such as being introduced for garbage collection in #12634), and ensures only one cargo has access to the cache during that time.
- `DownloadExclusive`  (renamed) — This is a more specialized name for the lock that was before this PR.   A caller should acquire this when downloading into the cache and doing resolution.  It ensures that only one cargo can append to the cache, but allows other cargos to concurrently read from the cache.
- `Shared` (new) — This is to preserve the old concurrent build behavior by allowing multiple concurrent cargos to hold this while a build is running when it is reading from the cache

**Reviewing suggestions:**
There are a few commits needed to help with testing which are first. The main commit has the following:
- `src/cargo/util/cache_lock.rs` is an abstraction around package cache locks, and is the heart of the change. It should have comments and notes which should guide what it is doing. The `CacheLocker` is stored in `Config` along with all our other global stuff.
- Every call to `config.acquire_package_cache_lock()` has been changed to explicitly state which lock mode it wants to lock the package cache in.
- `Context::compile` is the key point where the `Shared` lock is acquired, ensuring that no mutation is done while the cache is being read.
- `MutateExclusive` is not used in this PR, but is being added in preparation for #12634.
- The non-blocking `try_acquire_package_cache_lock` API is not used in this PR, but is being added in preparation for #12634 to allow automatic gc to skip running if another cargo is already running (to avoid unnecessary blocking).
- `src/cargo/util/flock.rs` has been updated with some code cleanup (removing unused stuff), adds support for non-blocking locks, and renames some functions to make their operation clearer.
- `tests/testsuite/cache_lock.rs` contains tests for all the different permutations of ways of acquiring locks.
