### PR TITLE
Ensure package IDs are unique when cleaning.

### DIFF
--- a/src/cargo/ops/cargo_clean.rs
+++ b/src/cargo/ops/cargo_clean.rs
@@ -8,6 +8,7 @@ use crate::util::interning::InternedString;
 use crate::util::{human_readable_bytes, Config, Progress, ProgressStyle};
 use anyhow::bail;
 use cargo_util::paths;
+use indexmap::IndexSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -129,7 +130,7 @@ fn clean_specs(
     // Doc tests produce no output.
 
     // Get Packages for the specified specs.
-    let mut pkg_ids = Vec::new();
+    let mut pkg_ids = IndexSet::new();
     for spec_str in spec.iter() {
         // Translate the spec to a Package.
         let spec = PackageIdSpec::parse(spec_str)?;


### PR DESCRIPTION
get_many will panic if there are duplicate IDs.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

when cleaning, package IDs are accumulated in a Vec, which may contain duplicates. Duplicates will cause get_many to panic, which was observed when running "cargo geiger" on a Cargo.toml with several hundred dependencies:

```
$ RUST_BACKTRACE=1 cargo geiger
thread 'main' panicked at 'assertion failed: self.pending_ids.insert(id)', /usr/local/google/home/jamesfarrell/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-0.69.1/src/cargo/core/package.rs:708:9
stack backtrace:
   0: rust_begin_unwind
             at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:67:14
   2: core::panicking::panic
             at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:117:5
   3: cargo::core::package::Downloads::start
   4: cargo::core::package::PackageSet::get_many
   5: cargo::ops::cargo_clean::clean
   6: cargo_geiger::scan::rs_file::resolve_rs_file_deps
   7: cargo_geiger::scan::default::scan
   8: cargo_geiger::scan::default::table::scan_to_table
   9: cargo_geiger::scan::default::scan_unsafe
  10: cargo_geiger::scan::scan
  11: cargo_geiger::main
```

### How should we test and review this PR?

I tested it by building cargo-geiger with the change and observing it no longer panicked. Since this is a very small change, I would expect that existing CI and tests are sufficient.

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
