### PR TITLE
fix: use channel-specific link for registry auth error

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -530,15 +530,9 @@ impl Features {
         }
 
         let see_docs = || {
-            let url_channel = match channel().as_str() {
-                "dev" | "nightly" => "nightly/",
-                "beta" => "beta/",
-                _ => "",
-            };
             format!(
-                "See https://doc.rust-lang.org/{}cargo/{} for more information \
-                about using this feature.",
-                url_channel, feature.docs
+                "See {} for more information about using this feature.",
+                cargo_docs_link(feature.docs)
             )
         };
 
@@ -1230,4 +1224,15 @@ pub fn channel() -> String {
 #[allow(clippy::disallowed_methods)]
 fn cargo_use_gitoxide_instead_of_git2() -> bool {
     std::env::var_os("__CARGO_USE_GITOXIDE_INSTEAD_OF_GIT2").map_or(false, |value| value == "1")
+}
+
+/// Generate a link to Cargo documentation for the current release channel
+/// `path` is the URL component after `https://doc.rust-lang.org/{channel}/cargo/`
+pub fn cargo_docs_link(path: &str) -> String {
+    let url_channel = match channel().as_str() {
+        "dev" | "nightly" => "nightly/",
+        "beta" => "beta/",
+        _ => "",
+    };
+    format!("https://doc.rust-lang.org/{url_channel}cargo/{path}")
 }

--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -1,6 +1,7 @@
 //! Registry authentication support.
 
 use crate::{
+    core::features::cargo_docs_link,
     sources::CRATES_IO_REGISTRY,
     util::{config::ConfigKey, CanonicalUrl, CargoResult, Config, IntoUrl},
 };
@@ -219,7 +220,8 @@ fn credential_provider(
     if !global_provider_defined && require_cred_provider_config {
         bail!(
             "authenticated registries require a credential-provider to be configured\n\
-        see https://doc.rust-lang.org/cargo/reference/registry-authentication.html for details"
+        see {} for details",
+            cargo_docs_link("reference/registry-authentication.html")
         );
     }
     Ok(global_providers)


### PR DESCRIPTION
The current error message for attempting to use a private registry without a credential provider will be a dead link until it's stabilized in 1.74. This makes the URL dependent on the channel.

r? @ehuss