### PR TITLE
refactor: move cached crates.io SourceID to config module

### DIFF
--- a/src/cargo/core/source_id.rs
+++ b/src/cargo/core/source_id.rs
@@ -253,11 +253,7 @@ impl SourceId {
     /// This is the main cargo registry by default, but it can be overridden in
     /// a `.cargo/config.toml`.
     pub fn crates_io(config: &Config) -> CargoResult<SourceId> {
-        config.crates_io_source_id(|| {
-            config.check_registry_index_not_set()?;
-            let url = CRATES_IO_INDEX.into_url().unwrap();
-            SourceId::new(SourceKind::Registry, url, Some(CRATES_IO_REGISTRY))
-        })
+        config.crates_io_source_id()
     }
 
     /// Returns the `SourceId` corresponding to the main repository, using the


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

`SourceId` should know nothing about `config` caching.

This factors out `Config` from some core types like `SourceId` step-by-step.

### How should we test and review this PR?

Shouldn't have any behavior change.
<!-- homu-ignore:end -->
