### PR TITLE
Update curl-sys to pull in curl 8.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.65+curl-8.2.1"
+version = "0.4.66+curl-8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961ba061c9ef2fe34bbd12b807152d96f0badd2bebe7b90ce6c8c8b7572a0986"
+checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
 dependencies = [
  "cc",
  "libc",
@@ -766,7 +766,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ core-foundation = { version = "0.9.3", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.39.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
-curl-sys = "0.4.65"
+curl-sys = "0.4.66"
 filetime = "0.2.22"
 flate2 = { version = "1.0.27", default-features = false, features = ["zlib"] }
 fwdansi = "1.1.0"


### PR DESCRIPTION
This is a routine update to update curl to 8.3.0

There was a minor security issue, but I do not think it is an issue for cargo.

Changelog: https://curl.se/changes.html#8_3_0
Summary: https://daniel.haxx.se/blog/2023/09/13/curl-8-3-0/
