### PR TITLE
refactor(TomlManifest): fail when package_root is not a directory

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1837,6 +1837,13 @@ impl TomlManifest {
             }
         }
 
+        if !package_root.is_dir() {
+            bail!(
+                "package root '{}' is not a directory",
+                package_root.display()
+            );
+        };
+
         let mut nested_paths = vec![];
         let mut warnings = vec![];
         let mut errors = vec![];


### PR DESCRIPTION
### What does this PR try to resolve?

Currently, if you're trying to use `TomlManifest::to_real_manifest`, and
you pass in something incorrect as the `package_root`, such as the path
to the package's manifest, you will get a weird error that looks like
this:

```
can't find library `dummy_lib`, rename file to `src/lib.rs` or specify lib.path
```

This is not very helpful, so this change makes us check that
`package_root` is a directory, and reports an error early on if it
isn't.
