### PR TITLE
Fix spurious errors with networking tests.

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -781,6 +781,7 @@ impl HttpServer {
             let buf = buf.get_mut();
             write!(buf, "HTTP/1.1 {}\r\n", response.code).unwrap();
             write!(buf, "Content-Length: {}\r\n", response.body.len()).unwrap();
+            write!(buf, "Connection: close\r\n").unwrap();
             for header in response.headers {
                 write!(buf, "{}\r\n", header).unwrap();
             }

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1965,6 +1965,7 @@ Caused by:
   headers:
   <tab>HTTP/1.1 400
   <tab>Content-Length: 7
+  <tab>Connection: close
   <tab>
   body:
   go away


### PR DESCRIPTION
This fixes an issue where some networking tests could behave erratically. In particular, the `registry_auth::token_not_logged` has been failing somewhat often (see https://github.com/rust-lang/cargo/issues/12639). The issue is that curl can behave inconsistently based on whether or not it immediately detects that the connection has closed or not, which is not done consistently. HTTP 1.1 defaults to `Connection: open`, so this mini HTTP server was essentially not standards compliant. `Connection: close` tells curl to expect the connection to close ([ref](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection)).