### PR TITLE
chore(ci): Update Renovate schema

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,7 +8,7 @@
   ignorePaths: [
     "**/tests/**",
   ],
-  regexManagers: [
+  customManagers: [
     {
       customType: 'regex',
       fileMatch: [


### PR DESCRIPTION
We have `configMigration` enabled, so in theory a PR should show up at any time, but it will drop comments because they don't support format-preserving edits.

I did this based on clap-rs/clap#5142