### PR TITLE
Add missing `strip` entries in `dev` and `release` profiles.

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -233,6 +233,7 @@ The default settings for the `dev` profile are:
 opt-level = 0
 debug = true
 split-debuginfo = '...'  # Platform-specific.
+strip = false
 debug-assertions = true
 overflow-checks = true
 lto = false
@@ -255,6 +256,7 @@ The default settings for the `release` profile are:
 opt-level = 3
 debug = false
 split-debuginfo = '...'  # Platform-specific.
+strip = false
 debug-assertions = false
 overflow-checks = false
 lto = false


### PR DESCRIPTION
The docs for the `dev` and `release` profiles mention 10 of the 11 possible profile settings. This commit adds the missing `strip` entries.