### PR TITLE
Set the `TARGET` env variable when running rustc

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -247,6 +247,9 @@ corresponding environment variable is set to the empty string, `""`.
 * `OUT_DIR` --- If the package has a build script, this is set to the folder where the build
               script should place its output. See below for more information.
               (Only set during compilation.)
+* `TARGET` --- the target triple that is being compiled for. Native code should be
+             compiled for this triple. See the [Target Triple] description
+             for more information. (Only set during compilation.)
 * `CARGO_BIN_EXE_<name>` --- The absolute path to a binary target's executable.
   This is only set when building an [integration test] or benchmark. This may
   be used with the [`env` macro] to find the executable to run for testing

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -5101,6 +5101,7 @@ fn duplicate_script_with_extra_env() {
                     compile_error!{"expected mycfg set"}
                     // Compile-time assertion.
                     assert_eq!(env!("CRATE_TARGET"), "{target}");
+                    assert_eq!(env!("TARGET"), "{target}");
                     // Run-time assertion.
                     assert_eq!(std::env::var("CRATE_TARGET").unwrap(), "{target}");
                 }

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -30,7 +30,7 @@ fn simple_cross() {
                         assert_eq!(std::env::var("TARGET").unwrap(), "{}");
                     }}
                 "#,
-                cross_compile::alternate()
+                cross_compile::alternate(),
             ),
         )
         .file(
@@ -40,9 +40,11 @@ fn simple_cross() {
                     use std::env;
                     fn main() {{
                         assert_eq!(env::consts::ARCH, "{}");
+                        assert_eq!(env!("TARGET"), "{}");
                     }}
                 "#,
-                cross_compile::alternate_arch()
+                cross_compile::alternate_arch(),
+                cross_compile::alternate()
             ),
         )
         .build();
@@ -101,9 +103,11 @@ fn simple_cross_config() {
                     use std::env;
                     fn main() {{
                         assert_eq!(env::consts::ARCH, "{}");
+                        assert_eq!(env!("TARGET"), "{}");
                     }}
                 "#,
-                cross_compile::alternate_arch()
+                cross_compile::alternate_arch(),
+                cross_compile::alternate()
             ),
         )
         .build();


### PR DESCRIPTION
### What does this PR try to resolve?

The goal is to be able to do things differently in a proc macro depending on the target platform. It is already defined for build script and it would help to have it for macros as well.

Closes: #10714

### Additional information

I understand that the discussion in #10714 asks for a more structured way to get the target. But this change is really easy to make like this and is consistent with the way to do it in build.rs  (I always get confused as to what env variable is defined where, and consistency helps here.) So I thought I'd make a PR anyway.