### PR TITLE
fix(test): Add back in newlines to diffs

### DIFF
--- a/crates/cargo-test-support/src/diff.rs
+++ b/crates/cargo-test-support/src/diff.rs
@@ -132,7 +132,7 @@ pub fn render_colored_changes<T: fmt::Display>(changes: &[Change<T>]) -> String 
             Change::Remove(i, s) => (format!("{:<4}     ", i), '-', red, s),
             Change::Keep(x, y, s) => (format!("{:<4}{:<4} ", x, y), ' ', dim, s),
         };
-        write!(
+        writeln!(
             buffer,
             "{dim}{nums}{reset}{bold}{sign}{reset}{color}{text}{reset}"
         )


### PR DESCRIPTION
Errors like this aren't too helpful
```
error: stderr did not match:
1   1     error: failed to parse manifest at `[..]`2   2     3   3     Caused by:4   4       TOML parse error at line 3, column 275   5         |6   6       3 |                 version = 17
  7         |                           ^8        -  invalid type: integer `1`, expected SemVer version    8    +  invalid type: integer `1`, expected a string or workspace
```

This was broken in #12751

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
