### PR TITLE
Add more missing `strip` info to docs.

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -933,21 +933,21 @@ See [opt-level](profiles.md#opt-level).
 
 #### `profile.<name>.panic`
 * Type: string
-* default: See profile docs.
+* Default: See profile docs.
 * Environment: `CARGO_PROFILE_<name>_PANIC`
 
 See [panic](profiles.md#panic).
 
 #### `profile.<name>.rpath`
 * Type: boolean
-* default: See profile docs.
+* Default: See profile docs.
 * Environment: `CARGO_PROFILE_<name>_RPATH`
 
 See [rpath](profiles.md#rpath).
 
 #### `profile.<name>.strip`
 * Type: string
-* default: See profile docs.
+* Default: See profile docs.
 * Environment: `CARGO_PROFILE_<name>_STRIP`
 
 See [strip](profiles.md#strip).

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -126,6 +126,7 @@ inherits = "dev"         # Inherits settings from [profile.dev].
 opt-level = 0            # Optimization level.
 debug = true             # Include debug info.
 split-debuginfo = '...'  # Debug info splitting behavior.
+strip = "none"           # Removes symbols or debuginfo.
 debug-assertions = true  # Enables debug assertions.
 overflow-checks = true   # Enables runtime integer overflow checks.
 lto = false              # Sets link-time optimization.
@@ -133,7 +134,6 @@ panic = 'unwind'         # The panic strategy.
 incremental = true       # Incremental compilation.
 codegen-units = 16       # Number of code generation units.
 rpath = false            # Sets the rpath linking option.
-strip = "none"           # Removes symbols or debuginfo.
 [profile.<name>.build-override]  # Overrides build-script settings.
 # Same keys for a normal profile.
 [profile.<name>.package.<name>]  # Override profile for a package.
@@ -888,6 +888,13 @@ See [debug](profiles.md#debug).
 * Environment: `CARGO_PROFILE_<name>_SPLIT_DEBUGINFO`
 
 See [split-debuginfo](profiles.md#split-debuginfo).
+
+#### `profile.<name>.strip`
+* Type: string or boolean
+* Default: See profile docs.
+* Environment: `CARGO_PROFILE_<name>_STRIP`
+
+See [strip](profiles.md#strip).
 
 #### `profile.<name>.debug-assertions`
 * Type: boolean

--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -270,7 +270,7 @@ The default settings for the `dev` profile are:
 opt-level = 0
 debug = true
 split-debuginfo = '...'  # Platform-specific.
-strip = false
+strip = "none"
 debug-assertions = true
 overflow-checks = true
 lto = false
@@ -293,7 +293,7 @@ The default settings for the `release` profile are:
 opt-level = 3
 debug = false
 split-debuginfo = '...'  # Platform-specific.
-strip = false
+strip = "none"
 debug-assertions = false
 overflow-checks = false
 lto = false


### PR DESCRIPTION
This is a follow-up to #12748.