### PR TITLE
Add unsupported short suggestion for --out-dir flag

### DIFF
--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -35,14 +35,7 @@ pub fn cli() -> Command {
         .arg_parallel()
         .arg_target_triple("Build for the target triple")
         .arg_target_dir()
-        .arg(
-            opt(
-                "out-dir",
-                "Copy final artifacts to this directory (unstable)",
-            )
-            .value_name("PATH")
-            .help_heading(heading::COMPILATION_OPTIONS),
-        )
+        .arg_out_dir()
         .arg_build_plan()
         .arg_unit_graph()
         .arg_timings()

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -357,6 +357,27 @@ pub trait CommandExt: Sized {
             .help_heading(heading::COMPILATION_OPTIONS),
         )
     }
+
+    fn arg_out_dir(self) -> Self {
+        let unsupported_short_arg = {
+            let value_parser = UnknownArgumentValueParser::suggest_arg("--out-dir");
+            Arg::new("unsupported-short-out-dir-flag")
+                .help("")
+                .short('O')
+                .value_parser(value_parser)
+                .action(ArgAction::SetTrue)
+                .hide(true)
+        };
+        self._arg(
+            opt(
+                "out-dir",
+                "Copy final artifacts to this directory (unstable)",
+            )
+            .value_name("PATH")
+            .help_heading(heading::COMPILATION_OPTIONS),
+        )
+        ._arg(unsupported_short_arg)
+    }
 }
 
 impl CommandExt for Command {

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -293,6 +293,8 @@ fn unsupported_short_out_dir_flag() {
             "\
 error: unexpected argument '-O' found
 
+  tip: a similar argument exists: '--out-dir'
+
 Usage: cargo[EXE] build [OPTIONS]
 
 For more information, try '--help'.

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -281,6 +281,27 @@ fn cargo_build_out_dir() {
     );
 }
 
+#[cargo_test]
+fn unsupported_short_out_dir_flag() {
+    let p = project()
+        .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
+        .build();
+
+    p.cargo("build -Z unstable-options -O")
+        .masquerade_as_nightly_cargo(&["out-dir"])
+        .with_stderr(
+            "\
+error: unexpected argument '-O' found
+
+Usage: cargo[EXE] build [OPTIONS]
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}
+
 fn check_dir_contents(
     out_dir: &Path,
     expected_linux: &[&str],


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/11702

Added unsupported short alias suggestion for `--out-dir` flag.

### How should we test and review this PR?

See the unit test.

### Additional information

~~I am not sure if `error: unexpected argument '--unsupported-short-out-dir-flag' found` makes sense.~~

~~I don't know how to make it show `error: unexpected argument '-O'`~~
<!-- homu-ignore:end -->
