### PR TITLE
Disable custom_target::custom_bin_target on windows-gnu

### DIFF
--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -116,6 +116,8 @@ fn custom_target_dependency() {
 }
 
 #[cargo_test(nightly, reason = "requires features no_core, lang_items")]
+// This is randomly crashing in lld. See https://github.com/rust-lang/rust/issues/115985
+#[cfg_attr(all(windows, target_env = "gnu"), ignore = "windows-gnu lld crashing")]
 fn custom_bin_target() {
     let p = project()
         .file(


### PR DESCRIPTION
The `custom_target::custom_bin_target` test has been crashing frequently in CI on the x86_64-pc-windows-gnu target since the last LLVM 17 update. This disables the test to reduce the disruption in CI. The issue is being tracked in https://github.com/rust-lang/rust/issues/115985.
