### PR TITLE
feat: Add `Edition2024`

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -205,20 +205,22 @@ pub enum Edition {
     Edition2018,
     /// The 2021 edition
     Edition2021,
+    /// The 2024 edition
+    Edition2024,
 }
 
 impl Edition {
     /// The latest edition that is unstable.
     ///
     /// This is `None` if there is no next unstable edition.
-    pub const LATEST_UNSTABLE: Option<Edition> = None;
+    pub const LATEST_UNSTABLE: Option<Edition> = Some(Edition::Edition2024);
     /// The latest stable edition.
     pub const LATEST_STABLE: Edition = Edition::Edition2021;
     /// Possible values allowed for the `--edition` CLI flag.
     ///
     /// This requires a static value due to the way clap works, otherwise I
     /// would have built this dynamically.
-    pub const CLI_VALUES: [&'static str; 3] = ["2015", "2018", "2021"];
+    pub const CLI_VALUES: [&'static str; 4] = ["2015", "2018", "2021", "2024"];
 
     /// Returns the first version that a particular edition was released on
     /// stable.
@@ -228,6 +230,7 @@ impl Edition {
             Edition2015 => None,
             Edition2018 => Some(semver::Version::new(1, 31, 0)),
             Edition2021 => Some(semver::Version::new(1, 56, 0)),
+            Edition2024 => None,
         }
     }
 
@@ -238,6 +241,7 @@ impl Edition {
             Edition2015 => true,
             Edition2018 => true,
             Edition2021 => true,
+            Edition2024 => false,
         }
     }
 
@@ -250,6 +254,7 @@ impl Edition {
             Edition2015 => None,
             Edition2018 => Some(Edition2015),
             Edition2021 => Some(Edition2018),
+            Edition2024 => Some(Edition2021),
         }
     }
 
@@ -260,7 +265,8 @@ impl Edition {
         match self {
             Edition2015 => Edition2018,
             Edition2018 => Edition2021,
-            Edition2021 => Edition2021,
+            Edition2021 => Edition2024,
+            Edition2024 => Edition2024,
         }
     }
 
@@ -286,6 +292,7 @@ impl Edition {
             Edition2015 => false,
             Edition2018 => true,
             Edition2021 => true,
+            Edition2024 => false,
         }
     }
 
@@ -298,6 +305,7 @@ impl Edition {
             Edition2015 => false,
             Edition2018 => true,
             Edition2021 => false,
+            Edition2024 => false,
         }
     }
 
@@ -316,6 +324,7 @@ impl fmt::Display for Edition {
             Edition::Edition2015 => f.write_str("2015"),
             Edition::Edition2018 => f.write_str("2018"),
             Edition::Edition2021 => f.write_str("2021"),
+            Edition::Edition2024 => f.write_str("2024"),
         }
     }
 }
@@ -326,13 +335,14 @@ impl FromStr for Edition {
             "2015" => Ok(Edition::Edition2015),
             "2018" => Ok(Edition::Edition2018),
             "2021" => Ok(Edition::Edition2021),
-            s if s.parse().map_or(false, |y: u16| y > 2021 && y < 2050) => bail!(
+            "2024" => Ok(Edition::Edition2024),
+            s if s.parse().map_or(false, |y: u16| y > 2024 && y < 2050) => bail!(
                 "this version of Cargo is older than the `{}` edition, \
-                 and only supports `2015`, `2018`, and `2021` editions.",
+                 and only supports `2015`, `2018`, `2021`, and `2024` editions.",
                 s
             ),
             s => bail!(
-                "supported edition values are `2015`, `2018`, or `2021`, \
+                "supported edition values are `2015`, `2018`, `2021`, or `2024`, \
                  but `{}` is unknown",
                 s
             ),
@@ -483,6 +493,9 @@ features! {
 
     // Allow specifying rustflags directly in a profile
     (stable, workspace_inheritance, "1.64", "reference/unstable.html#workspace-inheritance"),
+
+     // Support for 2024 edition.
+    (unstable, edition2024, "", "reference/unstable.html#edition-2024"),
 }
 
 pub struct Feature {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -569,10 +569,12 @@ impl TomlManifest {
         // Add these lines if start a new unstable edition.
         // ```
         // if edition == Edition::Edition20xx {
-        //     features.require(Feature::edition20xx))?;
+        //     features.require(Feature::edition20xx())?;
         // }
         // ```
-        if !edition.is_stable() {
+        if edition == Edition::Edition2024 {
+            features.require(Feature::edition2024())?;
+        } else if !edition.is_stable() {
             // Guard in case someone forgets to add .require()
             return Err(util::errors::internal(format!(
                 "edition {} should be gated",

--- a/src/doc/man/generated_txt/cargo-init.txt
+++ b/src/doc/man/generated_txt/cargo-init.txt
@@ -31,7 +31,7 @@ OPTIONS
 
        --edition edition
            Specify the Rust edition to use. Default is 2021. Possible values:
-           2015, 2018, 2021
+           2015, 2018, 2021, 2024
 
        --name name
            Set the package name. Defaults to the directory name.

--- a/src/doc/man/generated_txt/cargo-new.txt
+++ b/src/doc/man/generated_txt/cargo-new.txt
@@ -26,7 +26,7 @@ OPTIONS
 
        --edition edition
            Specify the Rust edition to use. Default is 2021. Possible values:
-           2015, 2018, 2021
+           2015, 2018, 2021, 2024
 
        --name name
            Set the package name. Defaults to the directory name.

--- a/src/doc/man/includes/options-new.md
+++ b/src/doc/man/includes/options-new.md
@@ -11,7 +11,7 @@ Create a package with a library target (`src/lib.rs`).
 
 {{#option "`--edition` _edition_" }}
 Specify the Rust edition to use. Default is 2021.
-Possible values: 2015, 2018, 2021
+Possible values: 2015, 2018, 2021, 2024
 {{/option}}
 
 {{#option "`--name` _name_" }}

--- a/src/doc/src/commands/cargo-init.md
+++ b/src/doc/src/commands/cargo-init.md
@@ -40,7 +40,7 @@ This is the default behavior.</dd>
 
 <dt class="option-term" id="option-cargo-init---edition"><a class="option-anchor" href="#option-cargo-init---edition"></a><code>--edition</code> <em>edition</em></dt>
 <dd class="option-desc">Specify the Rust edition to use. Default is 2021.
-Possible values: 2015, 2018, 2021</dd>
+Possible values: 2015, 2018, 2021, 2024</dd>
 
 
 <dt class="option-term" id="option-cargo-init---name"><a class="option-anchor" href="#option-cargo-init---name"></a><code>--name</code> <em>name</em></dt>

--- a/src/doc/src/commands/cargo-new.md
+++ b/src/doc/src/commands/cargo-new.md
@@ -35,7 +35,7 @@ This is the default behavior.</dd>
 
 <dt class="option-term" id="option-cargo-new---edition"><a class="option-anchor" href="#option-cargo-new---edition"></a><code>--edition</code> <em>edition</em></dt>
 <dd class="option-desc">Specify the Rust edition to use. Default is 2021.
-Possible values: 2015, 2018, 2021</dd>
+Possible values: 2015, 2018, 2021, 2024</dd>
 
 
 <dt class="option-term" id="option-cargo-new---name"><a class="option-anchor" href="#option-cargo-new---name"></a><code>--name</code> <em>name</em></dt>

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -93,6 +93,7 @@ For the latest nightly, see the [nightly version] of this page.
     * [codegen-backend](#codegen-backend) --- Select the codegen backend used by rustc.
     * [per-package-target](#per-package-target) --- Sets the `--target` to use for each individual package.
     * [artifact dependencies](#artifact-dependencies) --- Allow build artifacts to be included into other build artifacts and build them for different targets.
+    * [Edition 2024](#edition-2024) — Adds support for the 2024 Edition.
 * Information and metadata
     * [Build-plan](#build-plan) --- Emits JSON information on which commands will be run.
     * [unit-graph](#unit-graph) --- Emits JSON for Cargo's internal graph structure.
@@ -1270,6 +1271,32 @@ Differences between `cargo run --manifest-path <path>` and `cargo <path>`
 - `cargo <path>` is at a verbosity level below the normal default.  Pass `-v` to get normal output.
 
 ### Documentation Updates
+
+## Edition 2024
+* Tracking Issue: (none created yet)
+* RFC: [rust-lang/rfcs#3501](https://github.com/rust-lang/rfcs/pull/3501)
+
+Support for the 2024 [edition] can be enabled by adding the `edition2024`
+unstable feature to the top of `Cargo.toml`:
+
+```toml
+cargo-features = ["edition2024"]
+
+[package]
+name = "my-package"
+version = "0.1.0"
+edition = "2024"
+```
+
+If you want to transition an existing project from a previous edition, then
+`cargo fix --edition` can be used on the nightly channel. After running `cargo
+fix`, you can switch the edition to 2024 as illustrated above.
+
+This feature is very unstable, and is only intended for early testing and
+experimentation. Future nightly releases may introduce changes for the 2024
+edition that may break your build.
+
+[edition]: ../../edition-guide/index.html
 
 # Stabilized and removed features
 

--- a/src/etc/man/cargo-init.1
+++ b/src/etc/man/cargo-init.1
@@ -37,7 +37,7 @@ Create a package with a library target (\fBsrc/lib.rs\fR).
 \fB\-\-edition\fR \fIedition\fR
 .RS 4
 Specify the Rust edition to use. Default is 2021.
-Possible values: 2015, 2018, 2021
+Possible values: 2015, 2018, 2021, 2024
 .RE
 .sp
 \fB\-\-name\fR \fIname\fR

--- a/src/etc/man/cargo-new.1
+++ b/src/etc/man/cargo-new.1
@@ -32,7 +32,7 @@ Create a package with a library target (\fBsrc/lib.rs\fR).
 \fB\-\-edition\fR \fIedition\fR
 .RS 4
 Specify the Rust edition to use. Default is 2021.
-Possible values: 2015, 2018, 2021
+Possible values: 2015, 2018, 2021, 2024
 .RE
 .sp
 \fB\-\-name\fR \fIname\fR

--- a/tests/testsuite/cargo_init/help/stdout.log
+++ b/tests/testsuite/cargo_init/help/stdout.log
@@ -12,7 +12,7 @@ Options:
       --bin                  Use a binary (application) template [default]
       --lib                  Use a library template
       --edition <YEAR>       Edition to set for the crate generated [possible values: 2015, 2018,
-                             2021]
+                             2021, 2024]
       --name <NAME>          Set the resulting package name, defaults to the directory name
       --registry <REGISTRY>  Registry to use
   -q, --quiet                Do not print cargo log messages

--- a/tests/testsuite/cargo_new/help/stdout.log
+++ b/tests/testsuite/cargo_new/help/stdout.log
@@ -12,7 +12,7 @@ Options:
       --bin                  Use a binary (application) template [default]
       --lib                  Use a library template
       --edition <YEAR>       Edition to set for the crate generated [possible values: 2015, 2018,
-                             2021]
+                             2021, 2024]
       --name <NAME>          Set the resulting package name, defaults to the directory name
       --registry <REGISTRY>  Registry to use
   -q, --quiet                Do not print cargo log messages

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1359,7 +1359,7 @@ Caused by:
   failed to parse the `edition` key
 
 Caused by:
-  supported edition values are `2015`, `2018`, or `2021`, but `chicken` is unknown
+  supported edition values are `2015`, `2018`, `2021`, or `2024`, but `chicken` is unknown
 "
             .to_string(),
         )
@@ -1391,7 +1391,7 @@ Caused by:
   failed to parse the `edition` key
 
 Caused by:
-  this version of Cargo is older than the `2038` edition, and only supports `2015`, `2018`, and `2021` editions.
+  this version of Cargo is older than the `2038` edition, and only supports `2015`, `2018`, `2021`, and `2024` editions.
 "
             .to_string(),
         )


### PR DESCRIPTION
[RFC for `Edition2024`](https://github.com/rust-lang/rfcs/pull/3501).  While the RFC is not yet merged, this follows rustc which added the 2024 edition previously in rust-lang/rust#94461

This PR adds `Edition2024` as a possible value for `edition = "xxxx"`. I did this by following the [guide here](https://github.com/rust-lang/cargo/blob/ed0a7873107f48079a424da2920f7d434fd22fdc/src/cargo/core/features.rs#L163-L174). 
