### PR TITLE
If there's a version in the lock file only use that exact version

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -116,7 +116,7 @@ enum Kind {
 /// directive that we found in a lockfile, if present.
 pub struct LockedPatchDependency {
     /// The original `Dependency` directive, except "locked" so it's version
-    /// requirement is `=foo` and its `SourceId` has a "precise" listed.
+    /// requirement is Locked to `foo` and its `SourceId` has a "precise" listed.
     pub dependency: Dependency,
     /// The `PackageId` that was previously found in a lock file which
     /// `dependency` matches.

--- a/src/cargo/sources/registry/index.rs
+++ b/src/cargo/sources/registry/index.rs
@@ -439,11 +439,9 @@ impl<'cfg> RegistryIndex<'cfg> {
     /// checking the integrity of a downloaded package matching the checksum in
     /// the index file, aka [`IndexSummary`].
     pub fn hash(&mut self, pkg: PackageId, load: &mut dyn RegistryData) -> Poll<CargoResult<&str>> {
-        let req = OptVersionReq::exact(pkg.version());
+        let req = OptVersionReq::lock_to_exact(pkg.version());
         let summary = self.summaries(pkg.name(), &req, load)?;
-        let summary = ready!(summary)
-            .filter(|s| s.package_id().version() == pkg.version())
-            .next();
+        let summary = ready!(summary).next();
         Poll::Ready(Ok(summary
             .ok_or_else(|| internal(format!("no hash listed for {}", pkg)))?
             .as_summary()
@@ -697,10 +695,8 @@ impl<'cfg> RegistryIndex<'cfg> {
         pkg: PackageId,
         load: &mut dyn RegistryData,
     ) -> Poll<CargoResult<bool>> {
-        let req = OptVersionReq::exact(pkg.version());
-        let found = ready!(self.summaries(pkg.name(), &req, load))?
-            .filter(|s| s.package_id().version() == pkg.version())
-            .any(|s| s.is_yanked());
+        let req = OptVersionReq::lock_to_exact(pkg.version());
+        let found = ready!(self.summaries(pkg.name(), &req, load))?.any(|s| s.is_yanked());
         Poll::Ready(Ok(found))
     }
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1274,8 +1274,7 @@ impl TomlManifest {
                 replacement.unused_keys(),
                 &mut cx.warnings,
             );
-            dep.set_version_req(OptVersionReq::exact(&version))
-                .lock_version(&version);
+            dep.set_version_req(OptVersionReq::exact(&version));
             replace.push((spec, dep));
         }
         Ok(replace)


### PR DESCRIPTION
### What does this PR try to resolve?

Generally, cargo is of the opinion that semver metadata should be ignored.
It's is relevant to dependency resolution as any other description of the version, just like the description field in cargo.toml.
If your registry has two versions that only differing metadata you get the bugs you deserve.
We implement functionality to make it easier for our users or for us to maintain.

~~So let's use `==` because it's less code to write and test.~~

We also believe that lock files should ensure reproducibility
 and protect against mutations from the registry.
 In this circumstance these two goals are in conflict, and this PR picks reproducibility.
 If the lock file tells us that there is a version called `1.0.0+bar` then
 we should not silently use `1.0.0+foo` even though they have the same version.

This is one of the alternatives/follow-ups discussed in #11447.
It was separated from #12749, to allow for separate discussion and because I was being too clever by half.

### How should we test and review this PR?

All tests still pass except for the ones that were removed. The removed tests were only added to verify the on intuitive behavior of the older implementation in #9847.