### PR TITLE
feat: inherit jobserver from env for all kinds of runner

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -257,7 +257,13 @@ impl<'cfg> Compilation<'cfg> {
         } else {
             ProcessBuilder::new(cmd)
         };
-        self.fill_env(builder, pkg, script_meta, kind, false)
+        let mut builder = self.fill_env(builder, pkg, script_meta, kind, false)?;
+
+        if let Some(client) = self.config.jobserver_from_env() {
+            builder.inherit_jobserver(client);
+        }
+
+        Ok(builder)
     }
 
     /// Prepares a new process with an appropriate environment to run against

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -192,33 +192,25 @@ test-runner:
         .env("CARGO", cargo_exe())
         .arg("run")
         .arg("-j2")
-        .with_status(2)
-        .with_stderr_contains("[..]no jobserver from env[..]")
         .run();
     p.process(make)
         .env("PATH", path)
         .env("CARGO", cargo_exe())
         .arg("run-runner")
         .arg("-j2")
-        .with_status(2)
         .with_stderr_contains("[..]this is a runner[..]")
-        .with_stderr_contains("[..]no jobserver from env[..]")
         .run();
     p.process(make)
         .env("CARGO", cargo_exe())
         .arg("test")
         .arg("-j2")
-        .with_status(2)
-        .with_stdout_contains("[..]no jobserver from env[..]")
         .run();
     p.process(make)
         .env("PATH", path)
         .env("CARGO", cargo_exe())
         .arg("test-runner")
         .arg("-j2")
-        .with_status(2)
         .with_stderr_contains("[..]this is a runner[..]")
-        .with_stdout_contains("[..]no jobserver from env[..]")
         .run();
 
     // but not from `-j` flag

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -1,18 +1,23 @@
 //! Tests for the jobserver protocol.
 
 use cargo_util::is_ci;
+use std::env;
 use std::net::TcpListener;
 use std::process::Command;
 use std::thread;
 
-use cargo_test_support::install::{assert_has_installed_exe, cargo_home};
-use cargo_test_support::{cargo_exe, project};
+use cargo_test_support::basic_bin_manifest;
+use cargo_test_support::cargo_exe;
+use cargo_test_support::install::assert_has_installed_exe;
+use cargo_test_support::install::cargo_home;
+use cargo_test_support::project;
+use cargo_test_support::rustc_host;
 
 const EXE_CONTENT: &str = r#"
 use std::env;
 
 fn main() {
-    let var = env::var("CARGO_MAKEFLAGS").unwrap();
+    let var = env::var("CARGO_MAKEFLAGS").expect("no jobserver from env");
     let arg = var.split(' ')
                  .find(|p| p.starts_with("--jobserver"))
                 .unwrap();
@@ -103,6 +108,144 @@ all:
     assert_has_installed_exe(cargo_home(), name);
 
     p.process(make).env("CARGO", cargo_exe()).arg("-j2").run();
+}
+
+#[cargo_test]
+fn runner_inherits_jobserver() {
+    let make = make_exe();
+    if Command::new(make).arg("--version").output().is_err() {
+        return;
+    }
+
+    let runner = "runner";
+    project()
+        .at(runner)
+        .file("Cargo.toml", &basic_bin_manifest(runner))
+        .file(
+            "src/main.rs",
+            r#"
+            pub fn main() {
+                eprintln!("this is a runner");
+                let args: Vec<String> = std::env::args().collect();
+                let status = std::process::Command::new(&args[1]).status().unwrap();
+                assert!(status.success());
+            }
+            "#,
+        )
+        .build()
+        .cargo("install --path .")
+        .run();
+
+    // Add .cargo/bin to PATH
+    let mut path: Vec<_> = env::split_paths(&env::var_os("PATH").unwrap_or_default()).collect();
+    path.push(cargo_home().join("bin"));
+    let path = &env::join_paths(path).unwrap();
+    assert_has_installed_exe(cargo_home(), runner);
+
+    let host = rustc_host();
+    let config_value = &format!("target.{host}.runner = \"{runner}\"");
+
+    let name = "cargo-jobserver-check";
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "{name}"
+                    version = "0.0.1"
+                "#
+            ),
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+#[test]
+fn test() {
+    _ = std::env::var("CARGO_MAKEFLAGS").expect("no jobserver from env");
+}
+        "#,
+        )
+        .file("src/main.rs", EXE_CONTENT)
+        .file(
+            "Makefile",
+            &format!(
+                "\
+run:
+\t+$(CARGO) run
+
+run-runner:
+\t+$(CARGO) run --config '{config_value}'
+
+test:
+\t+$(CARGO) test --lib
+
+test-runner:
+\t+$(CARGO) test --lib --config '{config_value}'
+",
+            ),
+        )
+        .build();
+
+    // jobserver can be inherited from env
+    p.process(make)
+        .env("CARGO", cargo_exe())
+        .arg("run")
+        .arg("-j2")
+        .with_status(2)
+        .with_stderr_contains("[..]no jobserver from env[..]")
+        .run();
+    p.process(make)
+        .env("PATH", path)
+        .env("CARGO", cargo_exe())
+        .arg("run-runner")
+        .arg("-j2")
+        .with_status(2)
+        .with_stderr_contains("[..]this is a runner[..]")
+        .with_stderr_contains("[..]no jobserver from env[..]")
+        .run();
+    p.process(make)
+        .env("CARGO", cargo_exe())
+        .arg("test")
+        .arg("-j2")
+        .with_status(2)
+        .with_stdout_contains("[..]no jobserver from env[..]")
+        .run();
+    p.process(make)
+        .env("PATH", path)
+        .env("CARGO", cargo_exe())
+        .arg("test-runner")
+        .arg("-j2")
+        .with_status(2)
+        .with_stderr_contains("[..]this is a runner[..]")
+        .with_stdout_contains("[..]no jobserver from env[..]")
+        .run();
+
+    // but not from `-j` flag
+    p.cargo("run -j2")
+        .with_status(101)
+        .with_stderr_contains("[..]no jobserver from env[..]")
+        .run();
+    p.cargo("run -j2")
+        .env("PATH", path)
+        .arg("--config")
+        .arg(config_value)
+        .with_status(101)
+        .with_stderr_contains("[..]this is a runner[..]")
+        .with_stderr_contains("[..]no jobserver from env[..]")
+        .run();
+    p.cargo("test -j2")
+        .with_status(101)
+        .with_stdout_contains("[..]no jobserver from env[..]")
+        .run();
+    p.cargo("test -j2")
+        .env("PATH", path)
+        .arg("--config")
+        .arg(config_value)
+        .with_status(101)
+        .with_stderr_contains("[..]this is a runner[..]")
+        .with_stdout_contains("[..]no jobserver from env[..]")
+        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -49,6 +49,14 @@ fn validate(_: &str) {
 }
 "#;
 
+fn make_exe() -> &'static str {
+    if cfg!(windows) {
+        "mingw32-make"
+    } else {
+        "make"
+    }
+}
+
 #[cargo_test]
 fn jobserver_exists() {
     let p = project()
@@ -64,11 +72,7 @@ fn jobserver_exists() {
 
 #[cargo_test]
 fn external_subcommand_inherits_jobserver() {
-    let make = if cfg!(windows) {
-        "mingw32-make"
-    } else {
-        "make"
-    };
+    let make = make_exe();
     if Command::new(make).arg("--version").output().is_err() {
         return;
     }
@@ -103,11 +107,7 @@ all:
 
 #[cargo_test]
 fn makes_jobserver_used() {
-    let make = if cfg!(windows) {
-        "mingw32-make"
-    } else {
-        "make"
-    };
+    let make = make_exe();
     if !is_ci() && Command::new(make).arg("--version").output().is_err() {
         return;
     }
@@ -215,11 +215,7 @@ all:
 
 #[cargo_test]
 fn jobserver_and_j() {
-    let make = if cfg!(windows) {
-        "mingw32-make"
-    } else {
-        "make"
-    };
+    let make = make_exe();
     if !is_ci() && Command::new(make).arg("--version").output().is_err() {
         return;
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?
<!-- homu-ignore:end -->

External subcommands are already able to inherit the jobserver from
env since #10511. However, users reported that they've expected
`cargo run` to behave the same as external subcommands.

A popular example "cargo-xtask" pattern is used as scripting to run
arbitrary tasks. Users may want to invoke `cargo run` from Make and
expect some parallelism. This PR provides such an ability to the
general `target.<...>.runner`, which affects `cargo test`,
`cargo bench`, and `cargo run`.

Note that this PR doesn't create any jobserver client if there is no
existing jobserver from the environment. Nor `-j`/`--jobs` would create
a new client. Reasons for this decision:

* There might be crates don't want the jobserver to pollute their
  file descriptors, although they might be rare
* Creating a jobsever driver with the new FIFO named pipe style is not
  yet supported as of `jobserver@0.1.26`. Once we can create a named
  pipe-based jobserver, it will be less risky and inheritance by
  default can be implemented.

<!-- homu-ignore:start -->
### How should we test and review this PR?

* aa6793dc93afe3ecfc1c8c2f6f59669350ef2db0 demonstrates the current behavior — `cargo run` doesn't support inheriting jobserver from env.
* baf606af53fd551e158dfa0616bac97b6b749fd1 Cargo starts supporting such case.



### Additional informations

r? ehuss

cc @petrochenkov, does this meet your needs?

fixes #12597

<!-- homu-ignore:end -->
