### PR TITLE
Add test for unsupported short config flag

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -618,7 +618,7 @@ See '<cyan,bold>cargo help</> <cyan><<command>></>' for more information on a sp
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )
-        .arg(multi_opt("config", "KEY=VALUE", "Override a configuration value").global(true))
+        .arg_config()
         .arg(
             Arg::new("unstable-features")
                 .help("Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details")

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -378,6 +378,21 @@ pub trait CommandExt: Sized {
         )
         ._arg(unsupported_short_arg)
     }
+
+    fn arg_config(self) -> Self {
+        let unsupported_short_arg = {
+            let value_parser = UnknownArgumentValueParser::suggest_arg("--config");
+            Arg::new("unsupported-short-config-flag")
+                .help("")
+                .short('c')
+                .value_parser(value_parser)
+                .action(ArgAction::SetTrue)
+                .global(true)
+                .hide(true)
+        };
+        self._arg(unsupported_short_arg)
+            ._arg(multi_opt("config", "KEY=VALUE", "Override a configuration value").global(true))
+    }
 }
 
 impl CommandExt for Command {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -170,6 +170,8 @@ fn cargo_compile_with_unsupported_short_config_flag() {
             "\
 error: unexpected argument '-c' found
 
+  tip: a similar argument exists: '--config'
+
 Usage: cargo[EXE] build [OPTIONS]
 
 For more information, try '--help'.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -159,6 +159,27 @@ For more information, try '--help'.
 }
 
 #[cargo_test]
+fn cargo_compile_with_unsupported_short_config_flag() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("build -c net.git-fetch-with-cli=true")
+        .with_stderr(
+            "\
+error: unexpected argument '-c' found
+
+Usage: cargo[EXE] build [OPTIONS]
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}
+
+#[cargo_test]
 fn cargo_compile_with_workspace_excluded() {
     let p = project().file("src/main.rs", "fn main() {}").build();
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/11702

Added unsupported short alias suggestion for --config flag.


### How should we test and review this PR?

Check out the unit tests.

### Additional information
<!-- homu-ignore:end -->
