### PR TITLE
cargo/targets: fix error-message typo

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -309,7 +309,7 @@ fn clean_bins(
         if restricted_names::is_conflicting_artifact_name(&name) {
             anyhow::bail!(
                 "the binary target name `{}` is forbidden, \
-                 it conflicts with with cargo's build directory names",
+                 it conflicts with cargo's build directory names",
                 name
             )
         }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -465,7 +465,7 @@ fn cargo_compile_with_forbidden_bin_target_name() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  the binary target name `build` is forbidden, it conflicts with with cargo's build directory names
+  the binary target name `build` is forbidden, it conflicts with cargo's build directory names
 ",
         )
         .run();


### PR DESCRIPTION
Fix typo: "with with" -> "with"