### PR TITLE
crates-io: Add doc comment for `NewCrate` struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,7 +582,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "curl",
  "percent-encoding",

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.39.0"
+version = "0.39.1"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -38,6 +38,10 @@ pub struct Crate {
     pub max_version: String,
 }
 
+/// This struct is serialized as JSON and sent as metadata ahead of the crate
+/// tarball when publishing crates to a crate registry like crates.io.
+///
+/// see <https://doc.rust-lang.org/cargo/reference/registry-web-api.html#publish>
 #[derive(Serialize, Deserialize)]
 pub struct NewCrate {
     pub name: String,


### PR DESCRIPTION
This PR adds a small doc comment to the `NewCrate` struct in the `crates-io` package, linking to https://doc.rust-lang.org/cargo/reference/registry-web-api.html#publish to give additional context.

I saw other links to https://doc.rust-lang.org in some of the doc comments, so I'm hoping this is correct vs. linking directly to the file with a relative path?