### PR TITLE
cargo: prevent dashes in lib.name

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -207,6 +207,8 @@ pub struct Target {
 struct TargetInner {
     kind: TargetKind,
     name: String,
+    // Whether the name was inferred by Cargo, or explicitly given.
+    name_inferred: bool,
     // Note that `bin_name` is used for the cargo-feature `different_binary_name`
     bin_name: Option<String>,
     // Note that the `src_path` here is excluded from the `Hash` implementation
@@ -366,6 +368,7 @@ compact_debug! {
             [debug_the_fields(
                 kind
                 name
+                name_inferred
                 bin_name
                 src_path
                 required_features
@@ -657,6 +660,7 @@ impl Target {
             inner: Arc::new(TargetInner {
                 kind: TargetKind::Bin,
                 name: String::new(),
+                name_inferred: false,
                 bin_name: None,
                 src_path,
                 required_features: None,
@@ -789,6 +793,9 @@ impl Target {
 
     pub fn name(&self) -> &str {
         &self.inner.name
+    }
+    pub fn name_inferred(&self) -> bool {
+        self.inner.name_inferred
     }
     pub fn crate_name(&self) -> String {
         self.name().replace("-", "_")
@@ -962,6 +969,10 @@ impl Target {
     }
     pub fn set_name(&mut self, name: &str) -> &mut Target {
         Arc::make_mut(&mut self.inner).name = name.to_string();
+        self
+    }
+    pub fn set_name_inferred(&mut self, inferred: bool) -> &mut Target {
+        Arc::make_mut(&mut self.inner).name_inferred = inferred;
         self
     }
     pub fn set_binary_name(&mut self, bin_name: Option<String>) -> &mut Target {

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -247,6 +247,7 @@ fn clean_lib(
 
     let mut target = Target::lib_target(&lib.name(), crate_types, path, edition);
     configure(lib, &mut target)?;
+    target.set_name_inferred(toml_lib.map_or(true, |v| v.name.is_none()));
     Ok(Some(target))
 }
 

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -154,18 +154,20 @@ fn clean_lib(
     let lib = match toml_lib {
         Some(lib) => {
             if let Some(ref name) = lib.name {
-                // XXX: other code paths dodge this validation
                 if name.contains('-') {
                     anyhow::bail!("library target names cannot contain hyphens: {}", name)
                 }
             }
             Some(TomlTarget {
-                name: lib.name.clone().or_else(|| Some(package_name.to_owned())),
+                name: lib
+                    .name
+                    .clone()
+                    .or_else(|| Some(package_name.replace("-", "_"))),
                 ..lib.clone()
             })
         }
         None => inferred.as_ref().map(|lib| TomlTarget {
-            name: Some(package_name.to_string()),
+            name: Some(package_name.replace("-", "_")),
             path: Some(PathValue(lib.clone())),
             ..TomlTarget::new()
         }),

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -817,8 +817,10 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
                 let _b = include_bytes!(env!("CARGO_BIN_FILE_BAR_BAZ_baz-suffix"));
                 let _b = include_bytes!(env!("CARGO_STATICLIB_FILE_BAR_BAZ"));
                 let _b = include_bytes!(env!("CARGO_STATICLIB_FILE_BAR_BAZ_bar-baz"));
+                let _b = include_bytes!(env!("CARGO_STATICLIB_FILE_BAR_BAZ_bar_baz"));
                 let _b = include_bytes!(env!("CARGO_CDYLIB_FILE_BAR_BAZ"));
                 let _b = include_bytes!(env!("CARGO_CDYLIB_FILE_BAR_BAZ_bar-baz"));
+                let _b = include_bytes!(env!("CARGO_CDYLIB_FILE_BAR_BAZ_bar_baz"));
             }
         "#,
         )

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -534,7 +534,7 @@ fn collision_with_root() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo-macro v1.0.0 [..]
 warning: output filename collision.
-The lib target `foo-macro` in package `foo-macro v1.0.0` has the same output filename as the lib target `foo-macro` in package `foo-macro v1.0.0 [..]`.
+The lib target `foo_macro` in package `foo-macro v1.0.0` has the same output filename as the lib target `foo_macro` in package `foo-macro v1.0.0 [..]`.
 Colliding filename is: [CWD]/target/doc/foo_macro/index.html
 The targets should have unique names.
 This is a known bug where multiple crates with the same name use

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2089,7 +2089,7 @@ fn doc_test_in_workspace() {
         )
         .build();
     p.cargo("test --doc -vv")
-        .with_stderr_contains("[DOCTEST] crate-a")
+        .with_stderr_contains("[DOCTEST] crate_a")
         .with_stdout_contains(
             "
 running 1 test
@@ -2098,7 +2098,7 @@ test crate-a/src/lib.rs - (line 1) ... ok
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]
 ",
         )
-        .with_stderr_contains("[DOCTEST] crate-b")
+        .with_stderr_contains("[DOCTEST] crate_b")
         .with_stdout_contains(
             "
 running 1 test

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1616,7 +1616,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                       "kind": [
                         "lib"
                       ],
-                      "name": "non-artifact",
+                      "name": "non_artifact",
                       "src_path": "[..]/foo/non-artifact/src/lib.rs",
                       "test": true
                     }
@@ -3110,7 +3110,7 @@ fn filter_platform() {
           "crate_types": [
             "lib"
           ],
-          "name": "alt-dep",
+          "name": "alt_dep",
           "src_path": "[..]/alt-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
@@ -3154,7 +3154,7 @@ fn filter_platform() {
           "crate_types": [
             "lib"
           ],
-          "name": "cfg-dep",
+          "name": "cfg_dep",
           "src_path": "[..]/cfg-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
@@ -3198,7 +3198,7 @@ fn filter_platform() {
           "crate_types": [
             "lib"
           ],
-          "name": "host-dep",
+          "name": "host_dep",
           "src_path": "[..]/host-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,
@@ -3242,7 +3242,7 @@ fn filter_platform() {
           "crate_types": [
             "lib"
           ],
-          "name": "normal-dep",
+          "name": "normal_dep",
           "src_path": "[..]/normal-dep-0.0.1/src/lib.rs",
           "edition": "2015",
           "test": true,

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4671,9 +4671,9 @@ fn test_workspaces_cwd() {
         .build();
 
     p.cargo("test --workspace --all")
-        .with_stderr_contains("[DOCTEST] root-crate")
-        .with_stderr_contains("[DOCTEST] nested-crate")
-        .with_stderr_contains("[DOCTEST] deep-crate")
+        .with_stderr_contains("[DOCTEST] root_crate")
+        .with_stderr_contains("[DOCTEST] nested_crate")
+        .with_stderr_contains("[DOCTEST] deep_crate")
         .with_stdout_contains("test test_unit_root_cwd ... ok")
         .with_stdout_contains("test test_unit_nested_cwd ... ok")
         .with_stdout_contains("test test_unit_deep_cwd ... ok")
@@ -4683,33 +4683,33 @@ fn test_workspaces_cwd() {
         .run();
 
     p.cargo("test -p root-crate --all")
-        .with_stderr_contains("[DOCTEST] root-crate")
+        .with_stderr_contains("[DOCTEST] root_crate")
         .with_stdout_contains("test test_unit_root_cwd ... ok")
         .with_stdout_contains("test test_integration_root_cwd ... ok")
         .run();
 
     p.cargo("test -p nested-crate --all")
-        .with_stderr_contains("[DOCTEST] nested-crate")
+        .with_stderr_contains("[DOCTEST] nested_crate")
         .with_stdout_contains("test test_unit_nested_cwd ... ok")
         .with_stdout_contains("test test_integration_nested_cwd ... ok")
         .run();
 
     p.cargo("test -p deep-crate --all")
-        .with_stderr_contains("[DOCTEST] deep-crate")
+        .with_stderr_contains("[DOCTEST] deep_crate")
         .with_stdout_contains("test test_unit_deep_cwd ... ok")
         .with_stdout_contains("test test_integration_deep_cwd ... ok")
         .run();
 
     p.cargo("test --all")
         .cwd("nested-crate")
-        .with_stderr_contains("[DOCTEST] nested-crate")
+        .with_stderr_contains("[DOCTEST] nested_crate")
         .with_stdout_contains("test test_unit_nested_cwd ... ok")
         .with_stdout_contains("test test_integration_nested_cwd ... ok")
         .run();
 
     p.cargo("test --all")
         .cwd("very/deeply/nested/deep-crate")
-        .with_stderr_contains("[DOCTEST] deep-crate")
+        .with_stderr_contains("[DOCTEST] deep_crate")
         .with_stdout_contains("test test_unit_deep_cwd ... ok")
         .with_stdout_contains("test test_integration_deep_cwd ... ok")
         .run();


### PR DESCRIPTION
The TOML parser of Cargo currently refuses `lib.name` entries that contain dashes. Unfortunately, it uses the package-name as default if no explicit `lib.name` entry is specified. This package-name, however, can contain dashes.

Cargo documentation states that the package name is converted first, yet this was never implemented by the code-base.

Fix this inconsistency and convert the package name to a suitable crate-name first.

This fixes #12780. It is an alternative to #12640.