### PR TITLE
feat(toml): Allow version-less manifests

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -103,7 +103,7 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         if allowed_registries.is_empty() {
             bail!(
                 "`{}` cannot be published.\n\
-                 `package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.",
+                 `package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.",
                 pkg.name(),
             );
         } else if !allowed_registries.contains(&reg_name) {

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -6,7 +6,6 @@ use crate::Config;
 
 const DEFAULT_EDITION: crate::core::features::Edition =
     crate::core::features::Edition::LATEST_STABLE;
-const DEFAULT_VERSION: &str = "0.0.0";
 const DEFAULT_PUBLISH: bool = false;
 const AUTO_FIELDS: &[&str] = &["autobins", "autoexamples", "autotests", "autobenches"];
 
@@ -123,9 +122,6 @@ fn expand_manifest_(
     package
         .entry("name".to_owned())
         .or_insert(toml::Value::String(name));
-    package
-        .entry("version".to_owned())
-        .or_insert_with(|| toml::Value::String(DEFAULT_VERSION.to_owned()));
     package.entry("edition".to_owned()).or_insert_with(|| {
         let _ = config.shell().warn(format_args!(
             "`package.edition` is unspecified, defaulting to `{}`",
@@ -622,7 +618,6 @@ build = false
 edition = "2021"
 name = "test-"
 publish = false
-version = "0.0.0"
 
 [profile.release]
 strip = true
@@ -652,7 +647,6 @@ build = false
 edition = "2021"
 name = "test-"
 publish = false
-version = "0.0.0"
 
 [profile.release]
 strip = true

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -6,7 +6,6 @@ use crate::Config;
 
 const DEFAULT_EDITION: crate::core::features::Edition =
     crate::core::features::Edition::LATEST_STABLE;
-const DEFAULT_PUBLISH: bool = false;
 const AUTO_FIELDS: &[&str] = &["autobins", "autoexamples", "autotests", "autobenches"];
 
 pub fn expand_manifest(
@@ -132,9 +131,6 @@ fn expand_manifest_(
     package
         .entry("build".to_owned())
         .or_insert_with(|| toml::Value::Boolean(false));
-    package
-        .entry("publish".to_owned())
-        .or_insert_with(|| toml::Value::Boolean(DEFAULT_PUBLISH));
     for field in AUTO_FIELDS {
         package
             .entry(field.to_owned())
@@ -617,7 +613,6 @@ autotests = false
 build = false
 edition = "2021"
 name = "test-"
-publish = false
 
 [profile.release]
 strip = true
@@ -646,7 +641,6 @@ autotests = false
 build = false
 edition = "2021"
 name = "test-"
-publish = false
 
 [profile.release]
 strip = true

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1012,7 +1012,8 @@ impl TomlManifest {
         let publish = match publish {
             Some(VecStringOrBool::VecString(ref vecstring)) => Some(vecstring.clone()),
             Some(VecStringOrBool::Bool(false)) => Some(vec![]),
-            None | Some(VecStringOrBool::Bool(true)) => None,
+            Some(VecStringOrBool::Bool(true)) => None,
+            None => version.is_none().then_some(vec![]),
         };
 
         if version.is_none() && publish != Some(vec![]) {

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -109,6 +109,8 @@ resolve dependencies, and for guidelines on setting your own version. See the
 [SemVer compatibility] chapter for more details on exactly what constitutes a
 breaking change.
 
+This field is optional and defaults to `0.0.0`.
+
 [Resolver]: resolver.md
 [SemVer compatibility]: semver.md
 

--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -109,7 +109,7 @@ resolve dependencies, and for guidelines on setting your own version. See the
 [SemVer compatibility] chapter for more details on exactly what constitutes a
 breaking change.
 
-This field is optional and defaults to `0.0.0`.
+This field is optional and defaults to `0.0.0`.  The field is required for publishing packages.
 
 [Resolver]: resolver.md
 [SemVer compatibility]: semver.md
@@ -472,23 +472,22 @@ if any of those files change.
 
 ### The `publish` field
 
-The `publish` field can be used to prevent a package from being published to a
-package registry (like *crates.io*) by mistake, for instance to keep a package
-private in a company.
-
-```toml
-[package]
-# ...
-publish = false
-```
-
-The value may also be an array of strings which are registry names that are
-allowed to be published to.
-
+The `publish` field can be used to control which registries names the package
+may be published to:
 ```toml
 [package]
 # ...
 publish = ["some-registry-name"]
+```
+
+To prevent a package from being published to a registry (like crates.io) by mistake,
+for instance to keep a package private in a company,
+you can omit the [`version`](#the-version-field) field.
+If you'd like to be more explicit, you can disable publishing:
+```toml
+[package]
+# ...
+publish = false
 ```
 
 If publish array contains a single registry, `cargo publish` command will use

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1221,7 +1221,6 @@ at the start of the infostring at the top of the file.
 
 Inferred / defaulted manifest fields:
 - `package.name = <slugified file stem>`
-- `package.version = "0.0.0"` to [call attention to this crate being used in unexpected places](https://matklad.github.io/2021/08/22/large-rust-workspaces.html#Smaller-Tips)
 - `package.publish = false` to avoid accidental publishes, particularly if we
   later add support for including them in a workspace.
 - `package.edition = <current>` to avoid always having to add an embedded

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1221,8 +1221,6 @@ at the start of the infostring at the top of the file.
 
 Inferred / defaulted manifest fields:
 - `package.name = <slugified file stem>`
-- `package.publish = false` to avoid accidental publishes, particularly if we
-  later add support for including them in a workspace.
 - `package.edition = <current>` to avoid always having to add an embedded
   manifest at the cost of potentially breaking scripts on rust upgrades
   - Warn when `edition` is unspecified to raise awareness of this

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1506,7 +1506,6 @@ fn versionless_package() {
                 [package]
                 name = "foo"
                 description = "foo"
-                publish = false
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1496,3 +1496,32 @@ fn check_unused_manifest_keys() {
         )
         .run();
 }
+
+#[cargo_test]
+fn versionless_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                description = "foo"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+    p.cargo("check")
+        .with_stderr(
+            r#"error: failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  TOML parse error at line 2, column 17
+    |
+  2 |                 [package]
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+  missing field `version`
+"#,
+        )
+        .with_status(101)
+        .run();
+}

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1506,22 +1506,17 @@ fn versionless_package() {
                 [package]
                 name = "foo"
                 description = "foo"
+                publish = false
             "#,
         )
         .file("src/lib.rs", "")
         .build();
     p.cargo("check")
         .with_stderr(
-            r#"error: failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 2, column 17
-    |
-  2 |                 [package]
-    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-  missing field `version`
-"#,
+            "\
+[CHECKING] foo v0.0.0 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+",
         )
-        .with_status(101)
         .run();
 }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4273,6 +4273,7 @@ fn versionless_packages() {
             r#"
                 [package]
                 name = "bar"
+                publish = false
 
                 [dependencies]
                 foobar = "0.0.1"
@@ -4285,6 +4286,7 @@ fn versionless_packages() {
             r#"
                 [package]
                 name = "baz"
+                publish = false
 
                 [dependencies]
                 foobar = "0.0.1"
@@ -4295,20 +4297,247 @@ fn versionless_packages() {
     Package::new("foobar", "0.0.1").publish();
 
     p.cargo("metadata -q --format-version 1")
-        .with_stderr(
-            r#"error: failed to load manifest for workspace member `[CWD]/bar`
-
-Caused by:
-  failed to parse manifest at `[CWD]/bar/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 2, column 17
-    |
-  2 |                 [package]
-    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-  missing field `version`
+        .with_json(
+            r#"
+{
+  "packages": [
+    {
+      "name": "bar",
+      "version": "0.0.0",
+      "id": "bar 0.0.0 [..]",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "baz",
+          "source": null,
+          "req": "*",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null,
+          "path": "[..]/baz"
+        },
+        {
+          "name": "foobar",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.0.1",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[..]/bar/src/lib.rs",
+          "edition": "2015",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "[..]/bar/Cargo.toml",
+      "metadata": null,
+      "publish": [],
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2015",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "baz",
+      "version": "0.0.0",
+      "id": "baz 0.0.0 [..]",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": null,
+      "dependencies": [
+        {
+          "name": "foobar",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "req": "^0.0.1",
+          "kind": null,
+          "rename": null,
+          "optional": false,
+          "uses_default_features": true,
+          "features": [],
+          "target": null,
+          "registry": null
+        }
+      ],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "baz",
+          "src_path": "[..]/baz/src/lib.rs",
+          "edition": "2015",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "[..]/baz/Cargo.toml",
+      "metadata": null,
+      "publish": [],
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2015",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    },
+    {
+      "name": "foobar",
+      "version": "0.0.1",
+      "id": "foobar 0.0.1 [..]",
+      "license": null,
+      "license_file": null,
+      "description": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "dependencies": [],
+      "targets": [
+        {
+          "kind": [
+            "lib"
+          ],
+          "crate_types": [
+            "lib"
+          ],
+          "name": "foobar",
+          "src_path": "[..]/foobar-0.0.1/src/lib.rs",
+          "edition": "2015",
+          "doc": true,
+          "doctest": true,
+          "test": true
+        }
+      ],
+      "features": {},
+      "manifest_path": "[..]/foobar-0.0.1/Cargo.toml",
+      "metadata": null,
+      "publish": null,
+      "authors": [],
+      "categories": [],
+      "keywords": [],
+      "readme": null,
+      "repository": null,
+      "homepage": null,
+      "documentation": null,
+      "edition": "2015",
+      "links": null,
+      "default_run": null,
+      "rust_version": null
+    }
+  ],
+  "workspace_members": [
+    "bar 0.0.0 [..]",
+    "baz 0.0.0 [..]"
+  ],
+  "workspace_default_members": [
+    "bar 0.0.0 [..]",
+    "baz 0.0.0 [..]"
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "id": "bar 0.0.0 [..]",
+        "dependencies": [
+          "baz 0.0.0 [..]",
+          "foobar 0.0.1 [..]"
+        ],
+        "deps": [
+          {
+            "name": "baz",
+            "pkg": "baz 0.0.0 [..]",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          },
+          {
+            "name": "foobar",
+            "pkg": "foobar 0.0.1 [..]",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          }
+        ],
+        "features": []
+      },
+      {
+        "id": "baz 0.0.0 [..]",
+        "dependencies": [
+          "foobar 0.0.1 [..]"
+        ],
+        "deps": [
+          {
+            "name": "foobar",
+            "pkg": "foobar 0.0.1 [..]",
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ]
+          }
+        ],
+        "features": []
+      },
+      {
+        "id": "foobar 0.0.1 [..]",
+        "dependencies": [],
+        "deps": [],
+        "features": []
+      }
+    ],
+    "root": null
+  },
+  "target_directory": "[..]/foo/target",
+  "version": 1,
+  "workspace_root": "[..]",
+  "metadata": null
+}
 "#,
         )
-        .with_status(101)
         .run();
 }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -4273,7 +4273,6 @@ fn versionless_packages() {
             r#"
                 [package]
                 name = "bar"
-                publish = false
 
                 [dependencies]
                 foobar = "0.0.1"
@@ -4286,7 +4285,6 @@ fn versionless_packages() {
             r#"
                 [package]
                 name = "baz"
-                publish = false
 
                 [dependencies]
                 foobar = "0.0.1"

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3095,3 +3095,33 @@ src/main.rs
         &[],
     );
 }
+
+#[cargo_test]
+fn versionless_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                description = "foo"
+            "#,
+        )
+        .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .build();
+
+    p.cargo("package")
+        .with_stderr(
+            r#"error: failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  TOML parse error at line 2, column 17
+    |
+  2 |                 [package]
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+  missing field `version`
+"#,
+        )
+        .with_status(101)
+        .run();
+}

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3105,7 +3105,6 @@ fn versionless_package() {
                 [package]
                 name = "foo"
                 description = "foo"
-                publish = false
             "#,
         )
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3004,3 +3004,33 @@ Caused by:
         .with_status(101)
         .run();
 }
+
+#[cargo_test]
+fn versionless_package() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                description = "foo"
+            "#,
+        )
+        .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+        .build();
+
+    p.cargo("publish")
+        .with_stderr(
+            r#"error: failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  TOML parse error at line 2, column 17
+    |
+  2 |                 [package]
+    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
+  missing field `version`
+"#,
+        )
+        .with_status(101)
+        .run();
+}

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3007,6 +3007,9 @@ Caused by:
 
 #[cargo_test]
 fn versionless_package() {
+    // Use local registry for faster test times since no publish will occur
+    let registry = registry::init();
+
     let p = project()
         .file(
             "Cargo.toml",
@@ -3020,17 +3023,15 @@ fn versionless_package() {
         .build();
 
     p.cargo("publish")
+        .replace_crates_io(registry.index_url())
+        .with_status(101)
         .with_stderr(
-            r#"error: failed to parse manifest at `[CWD]/Cargo.toml`
+            "\
+error: failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
-  TOML parse error at line 2, column 17
-    |
-  2 |                 [package]
-    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
-  missing field `version`
-"#,
+  `package.publish` requires `package.version` be specified
+",
         )
-        .with_status(101)
         .run();
 }

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -420,7 +420,7 @@ fn unpublishable_crate() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
 ",
         )
         .run();
@@ -794,7 +794,7 @@ fn publish_empty_list() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
 ",
         )
         .run();
@@ -1020,7 +1020,7 @@ fn block_publish_no_registry() {
         .with_stderr(
             "\
 [ERROR] `foo` cannot be published.
-`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
 ",
         )
         .run();
@@ -3027,10 +3027,8 @@ fn versionless_package() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  `package.publish` requires `package.version` be specified
+error: `foo` cannot be published.
+`package.publish` must be set to `true` or a non-empty list in Cargo.toml to publish.
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Expected behavior with this PR:
- `package.version` defaults to `0.0.0`
- `package.publish` is defaulted to `version.is_some()`

This also updates "cargo script" to rely on this new behavior.

My motivation is to find ways to close the gap between "cargo script" and `Cargo.toml`.  With "cargo script", we want to allow people to only write however much of a manifest is directly needed for the work they are doing (which includes having no manifest).  Each difference between "cargo script" and `Cargo.toml` is a cost we have to pay in our documentation and a hurdle in a users understanding of what is happening.

There has been other interest in this which I also find of interest (from #9829):
- Lower boilerplate, whether for [cargo xtasks](https://github.com/matklad/cargo-xtask), nested packages (rust-lang/rfcs#3452), etc
- Unmet expectations from users because this field is primarily targeted at registry operations when they want it for their marketing version (#6583).
- Make "unpublished" packages stand out

This then unblocks unifying `package.publish` by making the field's default based on the presence of a version as inspired by the proposal in #9829.  Without this change, we were trading one form of boilerplate (`version = "0.0.0"`) for another (`publish = false`).

Fixes #9829
Fixes #12690
See also #6153

### How should we test and review this PR?

The initial commit has test cases I thought would be relevant for this change and you can see how each commit affects those or existing test cases.  Would definitely be interested in hearing of other troubling cases to test

Implementation wise, I made `MaybeWorkspaceVersion` deserializer trim spaces so I could more easily handle the field being an `Option`.  This is in its own commit.

### Additional information

Alternatives considered
- Making the default version "stand out more" with it being something like `0.0.0+HEAD`.  The extra noise didn't seem worth it and people would contend over what the metadata field *should be*
- Make the default version the lowest version possible (`0.0.0-0`?).  Unsure if this will ever really matter especially since you can't publish
- Defer defaulting `package.publish` and instead error
  - Further unifying more fields made this too compelling for me :)
- Put this behind `-Zscript` and make it a part of rust-lang/rfcs#3502
  - Having an affect outside of that RFC, I wanted to make sure this got the attention it deserved rather than getting lost in the noise of a large RFC.
- Don't just default the version but make packages versionless
  - I extended the concept of versionless to `PackageId`'s internals and saw no observable difference
  - I then started to examine the idea of version being optional everywhere (via `PackageId`s API) and ... things got messy especially when starting to look at the resolver.  This would have also added a lot of error checks / asserts for "the version must be set here".  Overall, the gains seemed questionable and the cost high, so I held off.