### PR TITLE
[stable 1.73] Update serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,9 +2887,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -2906,9 +2906,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
This updates serde on the stable branch from 1.0.171 to 1.0.188. This fixes a problem preventing cargo from being published. The problem is that I published `cargo-credential 0.3.0` from the master branch after serde had been updated, causing it to depend on `1.0.180`. That breaks with cargo 1.73's lock file which is locked to 1.0.171.
