### PR TITLE
[stable 1.73] backport publish script fixes

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -11,7 +11,6 @@
 import os
 import re
 import subprocess
-import time
 import urllib.request
 from urllib.error import HTTPError
 
@@ -52,13 +51,9 @@ def maybe_publish(path):
 
 def main():
     print('Starting publish...')
-    for i, path in enumerate(TO_PUBLISH):
-        if maybe_publish(path):
-            if i < len(TO_PUBLISH)-1:
-                # Sleep to allow the index to update. This should probably
-                # check that the index is updated, or use a retry loop
-                # instead.
-                time.sleep(5)
+    for path in TO_PUBLISH:
+        maybe_publish(path)
+
     print('Publish complete!')
 
 

--- a/publish.py
+++ b/publish.py
@@ -17,6 +17,11 @@ from urllib.error import HTTPError
 
 
 TO_PUBLISH = [
+    'credential/cargo-credential',
+    'credential/cargo-credential-libsecret',
+    'credential/cargo-credential-wincred',
+    'credential/cargo-credential-1password',
+    'credential/cargo-credential-macos-keychain',
     'crates/cargo-platform',
     'crates/cargo-util',
     'crates/crates-io',


### PR DESCRIPTION
Backports:

* Add credential crates from [12649](https://github.com/rust-lang/cargo/pull/12649). I didn't realize that these crates were added as unstable dependencies in 1.73, and thus were required for publishing. @Mark-Simulacrum has already published the missing versions, but I am updating this just to be thorough.
* Remove sleep from https://github.com/rust-lang/cargo/pull/12686. This is just so the publish doesn't take forever.
