### PR TITLE
fix(install): Suggest an alternative version on MSRV failure 

### DIFF
--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -90,6 +90,7 @@ fn uninstall_cwd(root: &Filesystem, bins: &[String], config: &Config) -> CargoRe
         None,
         |path: &mut PathSource<'_>| path.read_packages(),
         config,
+        None,
     )?;
     let pkgid = pkg.package_id();
     uninstall_pkgid(root, tracker, pkgid, bins, config)

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2479,6 +2479,7 @@ fn install_incompat_msrv() {
         .with_stderr("\
 [UPDATING] `dummy-registry` index
 [ERROR] cannot install package `foo 0.2.0`, it requires rustc 1.9876.0 or newer, while the currently active rustc version is [..]
+`foo 0.1.0` supports rustc 1.30
 ")
         .with_status(101).run();
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2478,15 +2478,7 @@ fn install_incompat_msrv() {
     cargo_process("install foo")
         .with_stderr("\
 [UPDATING] `dummy-registry` index
-[DOWNLOADING] crates ...
-[DOWNLOADED] foo v0.2.0 (registry `[..]`)
-[INSTALLING] foo v0.2.0
-[ERROR] failed to compile `foo v0.2.0`, intermediate artifacts can be found at `[..]`.
-To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
-
-Caused by:
-  package `foo v0.2.0` cannot be built because it requires rustc 1.9876.0 or newer, while the currently active rustc version is [..]
-  Try re-running cargo install with `--locked`
+[ERROR] cannot install package `foo 0.2.0`, it requires rustc 1.9876.0 or newer, while the currently active rustc version is [..]
 ")
         .with_status(101).run();
 }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2463,3 +2463,30 @@ For more information, try '--help'.
         .with_status(1)
         .run();
 }
+
+#[cargo_test]
+fn install_incompat_msrv() {
+    Package::new("foo", "0.1.0")
+        .file("src/main.rs", "fn main() {}")
+        .rust_version("1.30")
+        .publish();
+    Package::new("foo", "0.2.0")
+        .file("src/main.rs", "fn main() {}")
+        .rust_version("1.9876.0")
+        .publish();
+
+    cargo_process("install foo")
+        .with_stderr("\
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.2.0 (registry `[..]`)
+[INSTALLING] foo v0.2.0
+[ERROR] failed to compile `foo v0.2.0`, intermediate artifacts can be found at `[..]`.
+To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
+
+Caused by:
+  package `foo v0.2.0` cannot be built because it requires rustc 1.9876.0 or newer, while the currently active rustc version is [..]
+  Try re-running cargo install with `--locked`
+")
+        .with_status(101).run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

Moves users from a bad error message, suggesting `--locked` which won't do anything, to suggesting a version of a package to use instead.

The side benefit is errors get reported sooner
- Before downloading the `.crate`
- When installing multiple packages, before building the first

This comes at the cost of an extra `rustc` invocation.

### How should we test and review this PR?

Per-commit this builds it up, from tests to the final design.

### Additional information

This is also written in a way to align fairly well with how we'd likely implement #10903.
This improved error message will still be useful after that issue is resolved when the MSRV compatible version is outside of the version req.