### PR TITLE
rustdoc: remove the word "Version" from test cases

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2004,7 +2004,7 @@ fn crate_versions() {
     let output_path = p.root().join("target/doc/foo/index.html");
     let output_documentation = fs::read_to_string(&output_path).unwrap();
 
-    assert!(output_documentation.contains("Version 1.2.4"));
+    assert!(output_documentation.contains("1.2.4"));
 }
 
 #[cargo_test]
@@ -2028,7 +2028,7 @@ fn crate_versions_flag_is_overridden() {
     };
     let asserts = |html: String| {
         assert!(!html.contains("1.2.4"));
-        assert!(html.contains("Version 2.0.3"));
+        assert!(html.contains("2.0.3"));
     };
 
     p.cargo("doc")

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -110,17 +110,19 @@ fn whitespace() {
         .with_status(101)
         .run();
 
-    const SPACED_VERSION: &str = "a\nb\tc\u{00a0}d";
     p.cargo("doc")
         .env_remove("__CARGO_TEST_FORCE_ARGFILE") // Not applicable for argfile.
         .env(
             "RUSTDOCFLAGS",
-            format!("--crate-version {}", SPACED_VERSION),
+            "--crate-version 1111\n2222\t3333\u{00a0}4444",
         )
         .run();
 
     let contents = p.read_file("target/doc/foo/index.html");
-    assert!(contents.contains(SPACED_VERSION));
+    assert!(contents.contains("1111"));
+    assert!(contents.contains("2222"));
+    assert!(contents.contains("3333"));
+    assert!(contents.contains("4444"));
 }
 
 #[cargo_test]


### PR DESCRIPTION
Needed for https://github.com/rust-lang/rust/pull/115948 to merge.

That PR gets rid of the word "Version" in rustdoc's HTML output, and it splits spaced versions on their first space, to fit in the tight horizontal spacing. This causes Cargo's test suite to fail, because it look for the word "Version", even though things are working as they should.

These tests work on both current nightly and on that pull request.