### PR TITLE
test(build): generalize test assertion for non-rustup env

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -261,8 +261,8 @@ error: unexpected argument '-z' found
 
   tip: a similar argument exists: '-Z'
 
-Usage: cargo [+toolchain] [OPTIONS] [COMMAND]
-       cargo [+toolchain] [OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
+Usage: cargo [..][OPTIONS] [COMMAND]
+       cargo [..][OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
 
 For more information, try '--help'.
 ",


### PR DESCRIPTION
<!-- homu-ignore:start -->
This was found during syncing cargo to rust-lang/rust repo.

See also <https://github.com/rust-lang/cargo/pull/12416>.
<!-- homu-ignore:end -->
