### PR TITLE
Add unsupported short flag suggestion for `--target` and `--exclude` flags

### DIFF
--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -232,10 +232,20 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_target_triple(self, target: &'static str) -> Self {
+        let unsupported_short_arg = {
+            let value_parser = UnknownArgumentValueParser::suggest_arg("--target");
+            Arg::new("unsupported-short-target-flag")
+                .help("")
+                .short('t')
+                .value_parser(value_parser)
+                .action(ArgAction::SetTrue)
+                .hide(true)
+        };
         self._arg(
             optional_multi_opt("target", "TRIPLE", target)
                 .help_heading(heading::COMPILATION_OPTIONS),
         )
+        ._arg(unsupported_short_arg)
     }
 
     fn arg_target_dir(self) -> Self {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -64,9 +64,19 @@ pub trait CommandExt: Sized {
         all: &'static str,
         exclude: &'static str,
     ) -> Self {
+        let unsupported_short_arg = {
+            let value_parser = UnknownArgumentValueParser::suggest_arg("--exclude");
+            Arg::new("unsupported-short-exclude-flag")
+                .help("")
+                .short('x')
+                .value_parser(value_parser)
+                .action(ArgAction::SetTrue)
+                .hide(true)
+        };
         self.arg_package_spec_simple(package)
             ._arg(flag("workspace", all).help_heading(heading::PACKAGE_SELECTION))
             ._arg(multi_opt("exclude", "SPEC", exclude).help_heading(heading::PACKAGE_SELECTION))
+            ._arg(unsupported_short_arg)
     }
 
     fn arg_package_spec_simple(self, package: &'static str) -> Self {

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4354,6 +4354,8 @@ fn cargo_build_with_unsupported_short_exclude_flag() {
             "\
 error: unexpected argument '-x' found
 
+  tip: a similar argument exists: '--exclude'
+
 Usage: cargo[EXE] build [OPTIONS]
 
 For more information, try '--help'.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4329,6 +4329,41 @@ fn build_all_exclude() {
 }
 
 #[cargo_test]
+fn cargo_build_with_unsupported_short_exclude_flag() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [workspace]
+                members = ["bar", "baz"]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .file("baz/Cargo.toml", &basic_manifest("baz", "0.1.0"))
+        .file("baz/src/lib.rs", "pub fn baz() { break_the_build(); }")
+        .build();
+
+    p.cargo("build --workspace -x baz")
+        .with_stderr(
+            "\
+error: unexpected argument '-x' found
+
+Usage: cargo[EXE] build [OPTIONS]
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}
+
+#[cargo_test]
 fn build_all_exclude_not_found() {
     let p = project()
         .file(

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4252,6 +4252,8 @@ fn cargo_build_with_unsupported_short_target_flag() {
             "\
 error: unexpected argument '-t' found
 
+  tip: a similar argument exists: '--target'
+
 Usage: cargo[EXE] build [OPTIONS]
 
 For more information, try '--help'.

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4240,6 +4240,28 @@ fn cargo_build_empty_target() {
 }
 
 #[cargo_test]
+fn cargo_build_with_unsupported_short_target_flag() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build -t")
+        .arg("")
+        .with_stderr(
+            "\
+error: unexpected argument '-t' found
+
+Usage: cargo[EXE] build [OPTIONS]
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}
+
+#[cargo_test]
 fn build_all_workspace() {
     let p = project()
         .file(


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

ref https://github.com/rust-lang/cargo/issues/11702

[Added unsupported short flag suggestion for --target flag](https://github.com/rust-lang/cargo/pull/12805/commits/819a836e9a7d38d255cf2184281d75c8362d1b41)

[Added unsupported short flag suggestion for --exclude flag](https://github.com/rust-lang/cargo/pull/12805/commits/b514ca5e246c82999c9db7a220f9987aa4f5412a)

### How should we test and review this PR?

Check out the unit tests.

### Additional information

r? @weihanglo 
<!-- homu-ignore:end -->
