### PR TITLE
Update curl-sys to pull in curl 8.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.66+curl-8.3.0"
+version = "0.4.68+curl-8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
+checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ core-foundation = { version = "0.9.3", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.39.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
-curl-sys = "0.4.66"
+curl-sys = "0.4.68"
 filetime = "0.2.22"
 flate2 = { version = "1.0.27", default-features = false, features = ["zlib"] }
 git2 = "0.18.1"


### PR DESCRIPTION
This updates curl-sys from 0.4.66 to 0.4.68 to pull in curl 8.4.0. This fixes two CVEs:

* CVE-2023-38546 — https://curl.se/docs/CVE-2023-38546.html
* CVE-2023-38545 — https://curl.se/docs/CVE-2023-38545.html

This also pulls in a change to fix compiling on macOS Sonoma.
