### PR TITLE
Better suggestion for unsupported `--path` flag 

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -77,7 +77,7 @@ Example uses:
                 "Ignore `rust-version` specification in packages (unstable)"
             ),
         ])
-        .arg_manifest_path()
+        .arg_manifest_path_without_unsupported_path_tip()
         .arg_package("Package to modify")
         .arg_dry_run("Don't actually write the manifest")
         .arg_quiet()

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -267,6 +267,20 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_manifest_path(self) -> Self {
+        // We use `--manifest-path` instead of `--path`.
+        let unsupported_path_arg = {
+            let value_parser = UnknownArgumentValueParser::suggest_arg("--manifest-path");
+            flag("unsupported-path-flag", "")
+                .long("path")
+                .value_parser(value_parser)
+                .hide(true)
+        };
+        self.arg_manifest_path_without_unsupported_path_tip()
+            ._arg(unsupported_path_arg)
+    }
+
+    // `cargo add` has a `--path` flag to install a crate from a local path.
+    fn arg_manifest_path_without_unsupported_path_tip(self) -> Self {
         self._arg(
             opt("manifest-path", "Path to Cargo.toml")
                 .value_name("PATH")

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -372,7 +372,7 @@ pub trait CommandExt: Sized {
                 .value_parser(value_parser)
                 .hide(true)
         };
-        self._arg(flag("quiet", "Do not print cargo log messages").short('q'))
+        self.arg_quiet_without_unknown_silent_arg_tip()
             ._arg(unsupported_silent_arg)
     }
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -206,6 +206,28 @@ fn cargo_compile_manifest_path() {
 }
 
 #[cargo_test]
+fn cargo_compile_with_wrong_manifest_path_flag() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/foo.rs", &main_file(r#""i am foo""#, &[]))
+        .build();
+
+    p.cargo("build --path foo/Cargo.toml")
+        .cwd(p.root().parent().unwrap())
+        .with_stderr(
+            "\
+error: unexpected argument '--path' found
+
+Usage: cargo[EXE] build [OPTIONS]
+
+For more information, try '--help'.
+",
+        )
+        .with_status(1)
+        .run();
+}
+
+#[cargo_test]
 fn chdir_gated() {
     let p = project()
         .file("Cargo.toml", &basic_bin_manifest("foo"))

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -218,6 +218,8 @@ fn cargo_compile_with_wrong_manifest_path_flag() {
             "\
 error: unexpected argument '--path' found
 
+  tip: a similar argument exists: '--manifest-path'
+
 Usage: cargo[EXE] build [OPTIONS]
 
 For more information, try '--help'.


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/11702

Added a better suggestion for the unsupported `--path` flag.


### How should we test and review this PR?

Check out the unit tests.

### Additional information

r? @weihanglo 

<!-- homu-ignore:end -->
