### PR TITLE
add detailed message when target folder path is invalid

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -694,7 +694,8 @@ pub fn create_dir_all_excluded_from_backups_atomic(p: impl AsRef<Path>) -> Resul
     // we can infer from it's another cargo process doing work.
     if let Err(e) = fs::rename(tempdir.path(), path) {
         if !path.exists() {
-            return Err(anyhow::Error::from(e));
+            return Err(anyhow::Error::from(e))
+                .with_context(|| format!("failed to create directory `{}`", path.display()));
         }
     }
     Ok(())


### PR DESCRIPTION
# What does this PR try to resolve?
close https://github.com/rust-lang/cargo/issues/12789

add more detailed message when target folder path is invalid

# How should we test and review this PR?

Before this PR, if the target folder refer to broken symbolic link like /a/b/c, then run cargo build, the output is:

```
error: Not a directory (os error 20)
```
the detailed error message is missing.


This PR will add the error context for it, the finall output will be
```
cargo build
error: failed to create directory `/root/workspace/playground/target`

Caused by:
  Not a directory (os error 20)
```

