### PR TITLE
Clarify flag behavior in `cargo remove --help`

### DIFF
--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -34,19 +34,19 @@ pub fn cli() -> clap::Command {
                 .conflicts_with("build")
                 .action(clap::ArgAction::SetTrue)
                 .group("section")
-                .help("Remove as development dependency"),
+                .help("Remove from dev-dependencies"),
             clap::Arg::new("build")
                 .long("build")
                 .conflicts_with("dev")
                 .action(clap::ArgAction::SetTrue)
                 .group("section")
-                .help("Remove as build dependency"),
+                .help("Remove from build-dependencies"),
             clap::Arg::new("target")
                 .long("target")
                 .num_args(1)
                 .value_name("TARGET")
                 .value_parser(clap::builder::NonEmptyStringValueParser::new())
-                .help("Remove as dependency from the given target platform"),
+                .help("Remove from target-dependencies"),
         ])
         .arg_package("Package to remove from")
         .arg_manifest_path()

--- a/tests/testsuite/cargo_remove/help/stdout.log
+++ b/tests/testsuite/cargo_remove/help/stdout.log
@@ -15,9 +15,9 @@ Options:
   -h, --help                Print help
 
 Section:
-      --dev              Remove as development dependency
-      --build            Remove as build dependency
-      --target <TARGET>  Remove as dependency from the given target platform
+      --dev              Remove from dev-dependencies
+      --build            Remove from build-dependencies
+      --target <TARGET>  Remove from target-dependencies
 
 Package Selection:
   -p, --package [<SPEC>]  Package to remove from


### PR DESCRIPTION
### What does this PR try to resolve?

I noticed what I believe are typos in `cargo rm --help`:

```
Section:
      --dev              Remove as development dependency
      --build            Remove as build dependency
      --target <TARGET>  Remove as dependency from the given target platform
```

This change updates that section with a more appropriate description of those flags.

### How should we test and review this PR?

I've updated the relevant test for that help output.

### Additional information

Sorry for not opening an issue about this. I believe it's easy enough to approve it if my assumption is correct.