### PR TITLE
Print environment variables for build script executions with `-vv`

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -353,6 +353,10 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     );
     cmd.env_remove("RUSTFLAGS");
 
+    if cx.bcx.ws.config().extra_verbose() {
+        cmd.display_env_vars();
+    }
+
     // Gather the set of native dependencies that this package has along with
     // some other variables to close over.
     //

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -181,6 +181,22 @@ fn rustc_bootstrap() {
 }
 
 #[cargo_test]
+fn build_script_env_verbose() {
+    let build_rs = r#"
+        fn main() {}
+    "#;
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("verbose-build", "0.0.1"))
+        .file("src/lib.rs", "")
+        .file("build.rs", build_rs)
+        .build();
+
+    p.cargo("check -vv")
+        .with_stderr_contains("[RUNNING] `[..]CARGO=[..]build-script-build`")
+        .run();
+}
+
+#[cargo_test]
 #[cfg(target_arch = "x86_64")]
 fn build_script_sees_cfg_target_feature() {
     let build_rs = r#"


### PR DESCRIPTION
### What does this PR try to resolve?

When debugging complicated builds (I was trying to figure out how  `cargo-miri` cross-compiles compiler_builtins without needing a C cross compiler), it's useful to see all the environment variables passed to the build script.

This is also consistent with other commands.

### How should we test and review this PR?

I tested it locally by creating a small crate with an empty `build.rs` and building it. Additionally, a test is included.