### PR TITLE
doc(cargo-login): mention args after `--` in manpage

### DIFF
--- a/src/doc/man/cargo-login.md
+++ b/src/doc/man/cargo-login.md
@@ -6,13 +6,15 @@ cargo-login --- Log in to a registry
 
 ## SYNOPSIS
 
-`cargo login` [_options_] [_token_] -- [_args_]
+`cargo login` [_options_] [_token_] [`--` _args_]
 
 ## DESCRIPTION
 
 This command will run a credential provider to save a token so that commands
 that require authentication, such as {{man "cargo-publish" 1}}, will be
 automatically authenticated.
+
+All the arguments following the two dashes (`--`) are passed to the credential provider.
 
 For the default `cargo:token` credential provider, the token is saved
 in `$CARGO_HOME/credentials.toml`. `CARGO_HOME` defaults to `.cargo`

--- a/src/doc/man/generated_txt/cargo-login.txt
+++ b/src/doc/man/generated_txt/cargo-login.txt
@@ -4,12 +4,15 @@ NAME
        cargo-login — Log in to a registry
 
 SYNOPSIS
-       cargo login [options] [token] – [args]
+       cargo login [options] [token] [-- args]
 
 DESCRIPTION
        This command will run a credential provider to save a token so that
        commands that require authentication, such as cargo-publish(1), will be
        automatically authenticated.
+
+       All the arguments following the two dashes (--) are passed to the
+       credential provider.
 
        For the default cargo:token credential provider, the token is saved in
        $CARGO_HOME/credentials.toml. CARGO_HOME defaults to .cargo in your home

--- a/src/doc/src/commands/cargo-login.md
+++ b/src/doc/src/commands/cargo-login.md
@@ -6,13 +6,15 @@ cargo-login --- Log in to a registry
 
 ## SYNOPSIS
 
-`cargo login` [_options_] [_token_] -- [_args_]
+`cargo login` [_options_] [_token_] [`--` _args_]
 
 ## DESCRIPTION
 
 This command will run a credential provider to save a token so that commands
 that require authentication, such as [cargo-publish(1)](cargo-publish.html), will be
 automatically authenticated.
+
+All the arguments following the two dashes (`--`) are passed to the credential provider.
 
 For the default `cargo:token` credential provider, the token is saved
 in `$CARGO_HOME/credentials.toml`. `CARGO_HOME` defaults to `.cargo`

--- a/src/etc/man/cargo-login.1
+++ b/src/etc/man/cargo-login.1
@@ -6,11 +6,13 @@
 .SH "NAME"
 cargo\-login \[em] Log in to a registry
 .SH "SYNOPSIS"
-\fBcargo login\fR [\fIoptions\fR] [\fItoken\fR] \[en] [\fIargs\fR]
+\fBcargo login\fR [\fIoptions\fR] [\fItoken\fR] [\fB\-\-\fR \fIargs\fR]
 .SH "DESCRIPTION"
 This command will run a credential provider to save a token so that commands
 that require authentication, such as \fBcargo\-publish\fR(1), will be
 automatically authenticated.
+.sp
+All the arguments following the two dashes (\fB\-\-\fR) are passed to the credential provider.
 .sp
 For the default \fBcargo:token\fR credential provider, the token is saved
 in \fB$CARGO_HOME/credentials.toml\fR\&. \fBCARGO_HOME\fR defaults to \fB\&.cargo\fR


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

We failed to mention `-- args` in manpage. Also `--` should be quoted with backticks.
<!-- homu-ignore:end -->
