### PR TITLE
ci/contrib: do not fail on missing gh-pages

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -25,14 +25,12 @@ jobs:
       run: |
         cd src/doc/contrib
         mdbook build
-        git worktree add gh-pages gh-pages
+        # Override previous ref to avoid keeping history.
+        git worktree add --orphan -B gh-pages gh-pages
         git config user.name "Deploy from CI"
         git config user.email ""
         cd gh-pages
-        # Delete the ref to avoid keeping history.
-        git update-ref -d refs/heads/gh-pages
-        rm -rf contrib
         mv ../book contrib
         git add contrib
         git commit -m "Deploy $GITHUB_SHA to gh-pages"
-        git push --force
+        git push origin +gh-pages


### PR DESCRIPTION
The current contrib deploy-hook fails if there is no `gh-pages` branch. Change the CI order to disregard the old `gh-pages` branch first.

The `contrib` deploy-hook always creates a fresh `gh-pages` commit and pushes it out. However, currently it relies on the old `gh-pages` branch to exist, since it does not ignore errors when pruning it. Fortunately, the code always creates a new orphan branch, since it does not want to keep history for deployments. Therefore, we can simply use:

    `git worktree --orphan -B <branch> <path>`

This will ensure to always create an orphan branch named `<branch>`, and override an existing branch if it exists (see `-b` vs `-B`). Hence, there is no need for us to prune the old branch, anymore.

Since we will recreate the branch on every push, we have to explicitly specify the remote to push to. We no longer set up branch tracking.

Note that running github-actions in a private fork is quite useful to avoid constantly pushing changes to a PR and triggering notifications. Unfortunately, private forks on github do not automatically clone the gh-pages branch. This PR fixes annoying CI failures when updating the master branch on private forks, since github does not automatically clone the gh-pages branch.