### PR TITLE
fix(cli): Suggest cargo-search on bad commands

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -192,10 +192,9 @@ fn execute_external_subcommand(config: &Config, cmd: &str, args: &[&OsStr]) -> C
                 let did_you_mean = closest_msg(cmd, suggestions.keys(), |c| c);
 
                 anyhow::format_err!(
-                    "no such command: `{}`{}\n\n\t\
-                    View all installed commands with `cargo --list`",
-                    cmd,
-                    did_you_mean
+                    "no such command: `{cmd}`{did_you_mean}\n\n\t\
+                    View all installed commands with `cargo --list`\n\t\
+                    Find a package to install `{cmd}` with `cargo search cargo-{cmd}`",
                 )
             };
 

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -294,7 +294,9 @@ fn find_closest_dont_correct_nonsense() {
             "\
 [ERROR] no such command: `there-is-no-way-that-there-is-a-command-close-to-this`
 
-<tab>View all installed commands with `cargo --list`",
+<tab>View all installed commands with `cargo --list`
+<tab>Find a package to install `there-is-no-way-that-there-is-a-command-close-to-this` with `cargo search cargo-there-is-no-way-that-there-is-a-command-close-to-this`
+",
         )
         .run();
 }
@@ -307,7 +309,9 @@ fn displays_subcommand_on_error() {
             "\
 [ERROR] no such command: `invalid-command`
 
-<tab>View all installed commands with `cargo --list`",
+<tab>View all installed commands with `cargo --list`
+<tab>Find a package to install `invalid-command` with `cargo search cargo-invalid-command`
+",
         )
         .run();
 }
@@ -529,7 +533,9 @@ error: no such command: `bluid`
 
 <tab>Did you mean `build`?
 
-<tab>View all installed commands with `cargo --list`",
+<tab>View all installed commands with `cargo --list`
+<tab>Find a package to install `bluid` with `cargo search cargo-bluid`
+",
         )
         .run();
 }

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -108,6 +108,7 @@ error: no such command: `echo`
 <tab>Did you mean `bench`?
 
 <tab>View all installed commands with `cargo --list`
+<tab>Find a package to install `echo` with `cargo search cargo-echo`
 ",
         )
         .run();


### PR DESCRIPTION
This is a low-tech solution alternative to the options proposed in #4682
- Search `[[bin]]`s within all packages in the registry (which aren't tracked atm), suggesting to `cargo install` what is found
- Check if `cargo-<cmd>` is in the registry, suggesting `cargo install if it is

By suggesting `cargo search`, we are giving them a tool so they can verify if the package is what they want (a `cargo info` would help as a next step).

Is is needed?
- New users might not know of `cargo search` but they can search on crates.io
- New users might not be aware of the `cargo-<cmd>` naming pattern

Seems like this can still offer some benefit.

Fixes #4682