### PR TITLE
docs: remove review capacity notice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,14 +8,12 @@ Contributing documentation has moved to the **[Cargo Contributor Guide]**.
 
 We encourage people to discuss their design before hacking on code. Typically,
 you [file an issue] or start a thread on the [internals forum] before submitting
-a pull request. Please read [the process] of how features and bugs are managed
-in Cargo.
+a pull request.
 
-**NOTICE: Due to limited review capacity, the Cargo team is not accepting new
-features or major changes at this time. Please consult with the team before
-opening a new PR. Only issues that have been explicitly marked as accepted
-will be reviewed.**
+Please read [the process] of how features and bugs are managed in Cargo.
+**Only issues that have been explicitly marked as [accepted] will be reviewed.**
 
 [internals forum]: https://internals.rust-lang.org/c/tools-and-infrastructure/cargo
 [file an issue]: https://github.com/rust-lang/cargo/issues
 [the process]: https://doc.crates.io/contrib/process/index.html
+[accepted]: https://github.com/rust-lang/cargo/issues?q=is%3Aissue+is%3Aopen+label%3AS-accepted

--- a/src/doc/contrib/src/process/index.md
+++ b/src/doc/contrib/src/process/index.md
@@ -8,11 +8,6 @@ process.
 
 Please read the guidelines below before working on an issue or new feature.
 
-**Due to limited review capacity, the Cargo team is not accepting new features
-or major changes at this time. Please consult with the team before opening a
-new PR. Only issues that have been explicitly marked as accepted will be
-reviewed.**
-
 [Working on Cargo]: working-on-cargo.md
 
 ## Mentorship

--- a/src/doc/contrib/src/process/working-on-cargo.md
+++ b/src/doc/contrib/src/process/working-on-cargo.md
@@ -17,8 +17,10 @@ We encourage people to discuss their design before hacking on code. This gives
 the Cargo team a chance to know your idea more. Sometimes after a discussion,
 we even find a way to solve the problem without coding! Typically, you
 [file an issue] or start a thread on the [internals forum] before submitting a
-pull request. Please read [the process] of how features and bugs are managed in
-Cargo.
+pull request.
+
+Please read [the process] of how features and bugs are managed in Cargo.
+**Only issues that have been explicitly marked as [accepted] will be reviewed.**
 
 ## Checkout the source
 
@@ -170,3 +172,4 @@ more information on how Cargo releases are made.
 [internals forum]: https://internals.rust-lang.org/c/tools-and-infrastructure/cargo
 [file an issue]: https://github.com/rust-lang/cargo/issues
 [the process]: index.md
+[accepted]: https://github.com/rust-lang/cargo/issues?q=is%3Aissue+is%3Aopen+label%3AS-accepted


### PR DESCRIPTION
The Cargo project is in a better state than it was when maintainers added this notice. I believe it's time to take it down, as maintainers have got more time on it, and more people are willing to contribute to the project constantly.

Note that this doesn't mean Cargo start accepting arbitrary pull requests or features. The reviewers are still a small handful of people. The guideline never change — issue, discuss, then pull request.