### PR TITLE
docs(contrib): generate redirection HTML pages in CI

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -27,8 +27,11 @@ jobs:
         echo `pwd`/mdbook >> $GITHUB_PATH
     - name: Deploy docs
       run: |
+        GENERATE_PY="$(pwd)/ci/generate.py"
+
         cd src/doc/contrib
         mdbook build
+
         # Override previous ref to avoid keeping history.
         git worktree add --orphan -B gh-pages gh-pages
         git config user.name "Deploy from CI"
@@ -36,5 +39,11 @@ jobs:
         cd gh-pages
         mv ../book contrib
         git add contrib
+
+        # Generate HTML for link redirections.
+        python3 "$GENERATE_PY"
+        git add *.html
+        git add CNAME
+
         git commit -m "Deploy $GITHUB_SHA to gh-pages"
         git push origin +gh-pages

--- a/ci/generate.py
+++ b/ci/generate.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+MAPPING = {
+    "build-script.html": "https://doc.rust-lang.org/cargo/reference/build-scripts.html",
+    "config.html": None,
+    "crates-io.html": "https://doc.rust-lang.org/cargo/reference/publishing.html",
+    "environment-variables.html": None,
+    "external-tools.html": None,
+    "faq.html": "https://doc.rust-lang.org/cargo/faq.html",
+    "guide.html": "https://doc.rust-lang.org/cargo/guide/",
+    "index.html": "https://doc.rust-lang.org/cargo/",
+    "manifest.html": None,
+    "pkgid-spec.html": None,
+    "policies.html": "https://crates.io/policies",
+    "source-replacement.html": None,
+    "specifying-dependencies.html": None,
+}
+
+TEMPLATE = """\
+<html>
+<head>
+<meta http-equiv="refresh" content="0; url={mapped}" />
+<script>
+window.location.replace("{mapped}" + window.location.hash);
+</script>
+<title>Page Moved</title>
+</head>
+<body>
+This page has moved. Click <a href="{mapped}">here</a> to go to the new page.
+</body>
+</html>
+"""
+
+def main():
+    for name in sorted(MAPPING):
+        with open(name, 'w') as f:
+            mapped = MAPPING[name]
+            if mapped is None:
+                mapped = "https://doc.rust-lang.org/cargo/reference/{}".format(name)
+            f.write(TEMPLATE.format(name=name, mapped=mapped))
+
+    with open('CNAME', 'w') as f:
+        f.write('doc.crates.io')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### What does this PR try to resolve?

#12834 wiped out the old content of all link redirections. From my understanding it relies on the existing gh-pages hosting those files.

This PR pulls out the [`generate.py`](https://github.com/rust-lang/cargo/blob/cff41259837c912b44f2eba98777d71996740fe0/generate.py) from older `gh-pages` branch, and run it during the CI deploy job.


### How to review

It succeeds on my fork <https://github.com/weihanglo/cargo/tree/gh-pages> ([CI log](https://github.com/weihanglo/cargo/actions/runs/6564128361/job/17829881499#step:4:1)).

I don't think `.lock` or [`.nojekyll`](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/) is needed. If it causes problem, we can add them back.