### PR TITLE
docs(cargo-bench): `--bench` is passed in unconditionally to bench harnesses

### DIFF
--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -34,7 +34,7 @@ Benchmarks are built with the `--test` option to `rustc` which creates a
 special executable by linking your code with libtest. The executable
 automatically runs all functions annotated with the `#[bench]` attribute.
 Cargo passes the `--bench` flag to the test harness to tell it to run
-only benchmarks.
+only benchmarks, regardless of whether the harness is libtest or a custom harness.
 
 The libtest harness may be disabled by setting `harness = false` in the target
 manifest settings, in which case your code will need to provide its own `main`

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -27,7 +27,8 @@ DESCRIPTION
        special executable by linking your code with libtest. The executable
        automatically runs all functions annotated with the #[bench] attribute.
        Cargo passes the --bench flag to the test harness to tell it to run only
-       benchmarks.
+       benchmarks, regardless of whether the harness is libtest or a custom
+       harness.
 
        The libtest harness may be disabled by setting harness = false in the
        target manifest settings, in which case your code will need to provide

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -30,7 +30,7 @@ Benchmarks are built with the `--test` option to `rustc` which creates a
 special executable by linking your code with libtest. The executable
 automatically runs all functions annotated with the `#[bench]` attribute.
 Cargo passes the `--bench` flag to the test harness to tell it to run
-only benchmarks.
+only benchmarks, regardless of whether the harness is libtest or a custom harness.
 
 The libtest harness may be disabled by setting `harness = false` in the target
 manifest settings, in which case your code will need to provide its own `main`

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -32,7 +32,7 @@ Benchmarks are built with the \fB\-\-test\fR option to \fBrustc\fR which creates
 special executable by linking your code with libtest. The executable
 automatically runs all functions annotated with the \fB#[bench]\fR attribute.
 Cargo passes the \fB\-\-bench\fR flag to the test harness to tell it to run
-only benchmarks.
+only benchmarks, regardless of whether the harness is libtest or a custom harness.
 .sp
 The libtest harness may be disabled by setting \fBharness = false\fR in the target
 manifest settings, in which case your code will need to provide its own \fBmain\fR


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #3027

This PR makes it clear that custom benchmark harnesses would also received `--bench` CLI option.

### How should we test and review this PR?

Read the doc.

### Additional information
<!-- homu-ignore:end -->
