### PR TITLE
ci: big ⚠️ to ensure the CNAME file is always there

### DIFF
--- a/.github/workflows/contrib.yml
+++ b/.github/workflows/contrib.yml
@@ -43,6 +43,9 @@ jobs:
         # Generate HTML for link redirections.
         python3 "$GENERATE_PY"
         git add *.html
+        # WARN: The CNAME file is for GitHub to redirect requests to the custom domain.
+        # Missing this may entail security hazard and domain takeover.
+        # See <https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#securing-your-custom-domain>
         git add CNAME
 
         git commit -m "Deploy $GITHUB_SHA to gh-pages"

--- a/ci/generate.py
+++ b/ci/generate.py
@@ -39,6 +39,9 @@ def main():
                 mapped = "https://doc.rust-lang.org/cargo/reference/{}".format(name)
             f.write(TEMPLATE.format(name=name, mapped=mapped))
 
+    # WARN: The CNAME file is for GitHub to redirect requests to the custom domain.
+    # Missing this may entail security hazard and domain takeover.
+    # See <https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#securing-your-custom-domain>
     with open('CNAME', 'w') as f:
         f.write('doc.crates.io')
 


### PR DESCRIPTION
### What does this PR try to resolve?

A request from <https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/doc.2Ecrates.2Eio.20CNAME.20missing>

The CNAME file is for GitHub to redirect requests to the custom domain.
Missing this may entail security hazard and domain takeover.
See <https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#securing-your-custom-domain>

