### PR TITLE
chore(triagebot): auto label when PR review state changes

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -36,6 +36,15 @@ warn_non_default_branch = true
 [assign.owners]
 "*" = ["@ehuss", "@epage", "@weihanglo"]
 
+
+[review-submitted] 
+reviewed_label = "S-waiting-on-author" 
+review_labels = ["S-waiting-on-review"]
+
+[review-requested]
+remove_labels = ["S-waiting-on-author"]
+add_labels = ["S-waiting-on-review"]
+
 [autolabel."A-build-execution"]
 trigger_files = [
   "src/cargo/core/compiler/compilation.rs",


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Saw this <https://github.com/rust-lang/cargo/pull/12844#issuecomment-1770971174> and realized that we can configure:

* https://forge.rust-lang.org/triagebot/review-requested.html
* https://forge.rust-lang.org/triagebot/review-submitted.html

People have already [done this](https://github.com/rust-lang/rust/blob/3fbcfd2b6f7030cb70328aa759107efc1516912c/triagebot.toml#L26-L36) in rust-lang/rust.

### How should we test and review this PR?

Merge it and use it.

### Additional information
<!-- homu-ignore:end -->
