### PR TITLE
vendor: Add --include-path-deps to include path dependencies

### DIFF
--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -32,6 +32,7 @@ pub fn cli() -> Command {
             "versioned-dirs",
             "Always include version in subdir name",
         ))
+        .arg(flag("include-path-deps", "Include path dependencies"))
         .arg(unsupported("no-merge-sources"))
         .arg(unsupported("relative-path"))
         .arg(unsupported("only-git-deps"))
@@ -75,6 +76,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
             no_delete: args.flag("no-delete"),
             destination: &path,
             versioned_dirs: args.flag("versioned-dirs"),
+            include_path_deps: args.flag("include-path-deps"),
             extra: args
                 .get_many::<PathBuf>("tomls")
                 .unwrap_or_default()

--- a/tests/testsuite/cargo_vendor/help/stdout.log
+++ b/tests/testsuite/cargo_vendor/help/stdout.log
@@ -10,6 +10,7 @@ Options:
   -s, --sync <TOML>            Additional `Cargo.toml` to sync and vendor
       --respect-source-config  Respect `[source]` config in `.cargo/config`
       --versioned-dirs         Always include version in subdir name
+      --include-path-deps      Include path dependencies
   -q, --quiet                  Do not print cargo log messages
   -v, --verbose...             Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>           Coloring: auto, always, never

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -1025,6 +1025,40 @@ fn git_crlf_preservation() {
 }
 
 #[cargo_test]
+fn path_deps() {
+    let p = project()
+        .file(
+            "bar/Cargo.toml",
+            r#"
+                [package]
+                name = "bar"
+                version = "0.1.0"
+			"#,
+        )
+        .file("bar/src/lib.rs", "")
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+
+                [dependencies]
+                bar = { path = "bar" }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("vendor --respect-source-config").run();
+    assert!(!p.root().join("vendor/bar").is_dir());
+
+    p.cargo("vendor --respect-source-config --include-path-deps")
+        .run();
+    assert!(p.root().join("vendor/bar").is_dir());
+}
+
+#[cargo_test]
 #[cfg(unix)]
 fn vendor_preserves_permissions() {
     use std::os::unix::fs::MetadataExt;


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/9172, https://github.com/rust-lang/cargo/issues/10134.
Replacement of https://github.com/rust-lang/cargo/pull/10135.

I would just like to say that I personally think it's incorrect that path dependencies are skipped by default (especially without this being documented explicitly anywhere). I think #10135 is a more correct fix for this behavior that I consider a bug. However, since it seems that #10135 is not considered a bugfix by the cargo devs, I would like to propose this alternative solution to make a flag that explicitly includes path dependencies.

This means that using the flag will break with existing behavior, but using the flag will also fix the current documented behavior.