### PR TITLE
feat(doc): Print the generated docs links

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -237,6 +237,7 @@ fn substitute_macros(input: &str) -> String {
         ("[WAITING]", "     Waiting"),
         ("[PUBLISHED]", "   Published"),
         ("[BLOCKING]", "    Blocking"),
+        ("[GENERATED]", "   Generated"),
     ];
     let mut result = input.to_owned();
     for &(pat, subst) in &macros {

--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -34,10 +34,22 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
                 let cfg: Option<PathAndArgs> = ws.config().get("doc.browser")?;
                 cfg.map(|path_args| (path_args.path.resolve_program(ws.config()), path_args.args))
             };
-
             let mut shell = ws.config().shell();
             shell.status("Opening", path.display())?;
             open_docs(&path, &mut shell, config_browser, ws.config())?;
+        }
+    } else {
+        for name in &compilation.root_crate_names {
+            for kind in &options.compile_opts.build_config.requested_kinds {
+                let path = compilation.root_output[&kind]
+                    .with_file_name("doc")
+                    .join(&name)
+                    .join("index.html");
+                if path.exists() {
+                    let mut shell = ws.config().shell();
+                    shell.status("Generated", path.display())?;
+                }
+            }
         }
     }
 

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2152,6 +2152,7 @@ fn doc_lib_true() {
 [DOCUMENTING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -2227,6 +2228,7 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1471,6 +1471,7 @@ fn testing_and_such() {
 [DOCUMENTING] foo v0.5.0 ([CWD])
 [RUNNING] `rustdoc [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -312,7 +312,9 @@ fn build_script_doc() {
 [RUNNING] `[..]/build-script-build`
 [DOCUMENTING] foo [..]
 [RUNNING] `rustdoc [..] src/main.rs [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
         )
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .run();

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -202,6 +202,7 @@ fn collision_doc_multiple_versions() {
 [DOCUMENTING] bar v2.0.0
 [FINISHED] [..]
 [DOCUMENTING] foo v0.1.0 [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -384,6 +385,7 @@ fn collision_doc_profile_split() {
 [DOCUMENTING] pm v0.1.0 [..]
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -430,6 +432,7 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] bar v1.0.0
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -478,6 +481,7 @@ fn collision_doc_target() {
 [CHECKING] bar v1.0.0
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/[..]/doc/foo/index.html
 ",
         )
         .run();
@@ -545,6 +549,8 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [DOCUMENTING] foo-macro v1.0.0 [..]
 [DOCUMENTING] abc v1.0.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/abc/index.html
+[GENERATED] [CWD]/target/doc/foo_macro/index.html
 ")
         .run();
 }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -31,6 +31,7 @@ fn simple() {
 [..] foo v0.0.1 ([CWD])
 [..] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -69,6 +70,7 @@ fn doc_twice() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -103,6 +105,7 @@ fn doc_deps() {
 [..] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -151,6 +154,7 @@ fn doc_no_deps() {
 [CHECKING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -284,6 +288,8 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo/foo)
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo_lib/index.html
+[GENERATED] [CWD]/target/doc/foo_lib/index.html
 ",
         )
         .run();
@@ -398,6 +404,7 @@ fn doc_lib_bin_same_name_documents_lib() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -433,6 +440,7 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -478,6 +486,7 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -523,6 +532,7 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -567,7 +577,9 @@ fn doc_lib_bin_example_same_name_documents_named_example_when_requested() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/ex1/index.html
+",
         )
         .run();
 
@@ -620,7 +632,10 @@ fn doc_lib_bin_example_same_name_documents_examples_when_requested() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/ex1/index.html
+[GENERATED] [CWD]/target/doc/ex2/index.html
+",
         )
         .run();
 
@@ -677,6 +692,7 @@ fn doc_dash_p() {
 [..] b v0.0.1 ([CWD]/b)
 [DOCUMENTING] a v0.0.1 ([CWD]/a)
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/a/index.html
 ",
         )
         .run();
@@ -704,6 +720,7 @@ fn doc_all_exclude() {
             "\
 [DOCUMENTING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
         .run();
@@ -731,6 +748,7 @@ fn doc_all_exclude_glob() {
             "\
 [DOCUMENTING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
         .run();
@@ -918,6 +936,7 @@ fn doc_release() {
 [DOCUMENTING] foo v0.0.1 ([..])
 [RUNNING] `rustdoc [..] src/lib.rs [..]`
 [FINISHED] release [optimized] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1006,6 +1025,7 @@ fn features() {
 [DOCUMENTING] bar v0.0.1 [..]
 [DOCUMENTING] foo v0.0.1 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1020,6 +1040,7 @@ fn features() {
 [DOCUMENTING] bar v0.0.1 [..]
 [DOCUMENTING] foo v0.0.1 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1032,6 +1053,7 @@ fn features() {
 [DOCUMENTING] bar v0.0.1 [..]
 [DOCUMENTING] foo v0.0.1 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1202,6 +1224,7 @@ fn doc_virtual_manifest_one_project() {
             "\
 [DOCUMENTING] bar v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
         .run();
@@ -1229,6 +1252,7 @@ fn doc_virtual_manifest_glob() {
             "\
 [DOCUMENTING] baz v0.1.0 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/baz/index.html
 ",
         )
         .run();
@@ -1277,6 +1301,7 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] bar v0.1.0
 [DOCUMENTING] bar v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
         .run();
@@ -1639,6 +1664,7 @@ fn doc_cap_lints() {
 [CHECKING] a v0.5.0 ([..])
 [DOCUMENTING] foo v0.0.1 ([..])
 [FINISHED] dev [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1903,6 +1929,7 @@ fn bin_private_items() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1963,6 +1990,7 @@ fn bin_private_items_deps() {
 [CHECKING] bar v0.0.1 ([..])
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -1997,6 +2025,7 @@ fn crate_versions() {
 [DOCUMENTING] foo v1.2.4 [..]
 [RUNNING] `rustdoc --crate-type lib --crate-name foo src/lib.rs [..]--crate-version 1.2.4`
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -2406,7 +2435,8 @@ fn doc_fingerprint_unusual_behavior() {
     p.cargo("doc")
         .with_stderr(
             "[DOCUMENTING] foo [..]\n\
-             [FINISHED] [..]",
+             [FINISHED] [..]\n\
+             [GENERATED] [CWD]/target/doc/foo/index.html",
         )
         .run();
     // This will delete somefile, but not .hidden.
@@ -2425,7 +2455,8 @@ fn doc_fingerprint_unusual_behavior() {
         .masquerade_as_nightly_cargo(&["skip-rustdoc-fingerprint"])
         .with_stderr(
             "[DOCUMENTING] foo [..]\n\
-             [FINISHED] [..]",
+             [FINISHED] [..]\n\
+             [GENERATED] [CWD]/target/doc/foo/index.html",
         )
         .run();
     // Should not have deleted anything.
@@ -2467,6 +2498,8 @@ fn lib_before_bin() {
 [RUNNING] `rustdoc --crate-type lib --crate-name foo src/lib.rs [..]
 [RUNNING] `rustdoc --crate-type bin --crate-name somebin src/bin/somebin.rs [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+[GENERATED] [CWD]/target/doc/somebin/index.html
 ",
         )
         .run();
@@ -2517,6 +2550,7 @@ fn doc_lib_false() {
 [CHECKING] foo v0.1.0 [..]
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/some_bin/index.html
 ",
         )
         .run();
@@ -2563,6 +2597,7 @@ fn doc_lib_false_dep() {
 [CHECKING] bar v0.1.0 [..]
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -2587,7 +2622,8 @@ fn link_to_private_item() {
     p.cargo("doc")
         .with_stderr(
             "[DOCUMENTING] foo [..]\n\
-             [FINISHED] [..]",
+             [FINISHED] [..]\n\
+             [GENERATED] [CWD]/target/doc/foo/index.html",
         )
         .run();
 }

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -26,13 +26,18 @@ fn basic() {
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
 
     p.cargo("doc -Zunstable-options -Z rustdoc-scrape-examples")
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
-        .with_stderr("[FINISHED] [..]")
+        .with_stderr(
+            "[FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
+        )
         .run();
 
     let doc_html = p.read_file("target/doc/foo/fn.foo.html");
@@ -311,6 +316,7 @@ fn cache() {
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -320,6 +326,7 @@ fn cache() {
         .with_stderr(
             "\
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -361,7 +368,9 @@ warning: failed to scan example \"ex2\" in package `foo` for example code usage
     If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex2\") generated 1 warning
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
     )
         .run();
 }
@@ -425,7 +434,9 @@ warning: failed to scan example \"ex1\" in package `foo` for example code usage
     If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex1\") generated 1 warning
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
         )
         .run();
 
@@ -448,7 +459,9 @@ error: expected one of `!` or `::`, found `NOT`
   |      ^^^ expected one of `!` or `::`
 
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
         )
         .run();
 
@@ -499,7 +512,9 @@ warning: Rustdoc did not scrape the following examples because they require dev-
     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
     to the [[example]] target configuration of at least one example.
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
         )
         .run();
 
@@ -513,7 +528,9 @@ warning: Rustdoc did not scrape the following examples because they require dev-
 [DOCUMENTING] a v0.0.1 ([CWD]/a)
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/ex/index.html
+",
         )
         .run();
 }
@@ -560,7 +577,9 @@ fn use_dev_deps_if_explicitly_enabled() {
 [CHECKING] a v0.0.1 ([CWD]/a)
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
         )
         .run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1955,6 +1955,7 @@ fn doc_optional() {
 [CHECKING] bar v1.0.0
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -137,6 +137,7 @@ fn doc_bin() {
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name bin1 [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bin1/index.html
 ",
         )
         .run();
@@ -407,6 +408,7 @@ fn rustdoc_example() {
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name example1 [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/example1/index.html
 ",
         )
         .run();
@@ -421,6 +423,7 @@ fn rustdoc_bin() {
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name bin1 [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bin1/index.html
 ",
         )
         .run();
@@ -435,6 +438,7 @@ fn rustdoc_bench() {
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name bench1 [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bench1/index.html
 ",
         )
         .run();
@@ -449,6 +453,7 @@ fn rustdoc_test() {
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name test1 [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/test1/index.html
 ",
         )
         .run();

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -111,6 +111,34 @@ fn simple_doc() {
 }
 
 #[cargo_test]
+fn simple_doc_open() {
+    if cross_compile::disabled() {
+        return;
+    }
+    let t1 = cross_compile::alternate();
+    let t2 = rustc_host();
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "1.0.0"))
+        .file("src/lib.rs", "//! empty lib")
+        .build();
+
+    p.cargo("doc")
+        .arg("--open")
+        .arg("--target")
+        .arg(&t1)
+        .arg("--target")
+        .arg(&t2)
+        .with_stderr(
+            "\
+[DOCUMENTING] foo v1.0.0 ([..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[ERROR] only one `--target` argument is supported",
+        )
+        .with_status(101)
+        .run();
+}
+
+#[cargo_test]
 fn simple_check() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -667,5 +667,6 @@ fn profile_selection_doc() {
 [DOCUMENTING] foo [..]
 [RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]
 [FINISHED] dev [unoptimized + debuginfo] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ").run();
 }

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -15,6 +15,7 @@ fn rustdoc_simple() {
         [..] \
         -L dependency=[CWD]/target/debug/deps [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -35,6 +36,7 @@ fn rustdoc_args() {
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -88,6 +90,7 @@ fn rustdoc_foo_with_bar_dependency() {
         -L dependency=[CWD]/target/debug/deps \
         --extern [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -127,6 +130,7 @@ fn rustdoc_only_bar_dependency() {
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
         .run();
@@ -150,6 +154,7 @@ fn rustdoc_same_name_documents_lib() {
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps [..]`
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();
@@ -225,7 +230,8 @@ fn rustdoc_target() {
     [..] \
     -L dependency=[CWD]/target/{target}/debug/deps \
     -L dependency=[CWD]/target/debug/deps[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/[..]/doc/foo/index.html",
             target = cross_compile::alternate()
         ))
         .run();

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -48,7 +48,10 @@ fn rerun() {
     p.cargo("doc").env("RUSTDOCFLAGS", "--cfg=foo").run();
     p.cargo("doc")
         .env("RUSTDOCFLAGS", "--cfg=foo")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr(
+            "[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html",
+        )
         .run();
     p.cargo("doc")
         .env("RUSTDOCFLAGS", "--cfg=bar")
@@ -56,6 +59,7 @@ fn rerun() {
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
         .run();


### PR DESCRIPTION
I've wanted something like this myself.  I dislike using `--open` because I tend to move up to re-run my `cargo doc` run but then have to edit it to remove `--open`.
Also makes it annoying when opening docs when `cargo doc` is wrapped by a tool like `make`.

This was previously attempted in #5592:
- Unlike the request in #5562, this aligns with #5592 in always printing rather than using a flag as this seems generally useful
- Unlike #5592, this prints as an alternative to "Opening" to keep things light
- Unlike #5592, this prints afterwards as the link is only valid then

Fixes #5562

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
