### PR TITLE
refactor: centralize logic of getting max resolve version

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -88,6 +88,17 @@ pub enum ResolveVersion {
     V4,
 }
 
+impl ResolveVersion {
+    /// The maximum version of lockfile made into the stable channel.
+    ///
+    /// Any version larger than this needs `-Znext-lockfile-bump` to enable.
+    ///
+    /// Update this when you're going to stabilize a new lockfile format.
+    pub fn max_stable() -> ResolveVersion {
+        ResolveVersion::V3
+    }
+}
+
 impl Resolve {
     pub fn new(
         graph: Graph<PackageId, HashSet<Dependency>>,


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Centralize the logic of getting the maximum version of `ResolveVersion`.

This was requested from <https://github.com/rust-lang/cargo/pull/12852#discussion_r1365599557>

### How should we test and review this PR?

### Additional information

<!-- homu-ignore:end -->
