### PR TITLE
add message when compile starts for crate

### DIFF
--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -111,3 +111,14 @@ impl Message for BuildFinished {
         "build-finished"
     }
 }
+
+#[derive(Serialize)]
+pub struct CompileStarted {
+    pub package_id: PackageId,
+}
+
+impl Message for CompileStarted {
+    fn reason(&self) -> &str {
+        "compile-started"
+    }
+}

--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -244,7 +244,7 @@ The "build-finished" message is emitted at the end of the build.
     /* Whether or not the build finished successfully. */
     "success": true,
 }
-````
+```
 
 This message can be helpful for tools to know when to stop reading JSON
 messages. Commands such as `cargo test` or `cargo run` can produce additional
@@ -256,6 +256,19 @@ executed by `cargo run`).
 > Note: There is experimental nightly-only support for JSON output for tests,
 > so additional test-specific JSON messages may begin arriving after the
 > "build-finished" message if that is enabled.
+
+### Compile started
+
+The "compile-started" message is emitted when a crate begins compiling.
+This corresponds to the ui's "Compiling <crate>" message.
+
+```javascript
+{
+    "reason": "compile-started",
+    /* The package getting compiled */
+    "package-id": "cargo 0.74.0"
+}
+```
 
 ## Custom subcommands
 

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1644,6 +1644,8 @@ fn json_artifact_includes_executable_for_benchmark() {
     p.cargo("bench --no-run --message-format=json")
         .with_json(
             r#"
+                {"reason":"compile-started","package_id":"foo 0.0.1 [..]"}
+
                 {
                     "executable": "[..]/foo/target/release/deps/benchmark-[..][EXE]",
                     "features": [],

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -278,6 +278,8 @@ fn check_msg_format_json() {
         .build();
 
     let output = r#"
+{"reason":"compile-started","package_id":"foo 0.0.1 [..]"}
+
 {
     "reason": "compiler-artifact",
     "package_id": "foo 0.0.1 [..]",

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -103,6 +103,8 @@ fn simple_with_message_format() {
         )
         .with_json(
             r#"
+            {"reason":"compile-started","package_id":"foo 0.0.1 [..]"}
+
             {
                 "reason": "compiler-artifact",
                 "package_id": "foo 0.0.1 ([..])",

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -3881,6 +3881,8 @@ fn json_artifact_includes_test_flag() {
     p.cargo("test --lib -v --message-format=json")
         .with_json(
             r#"
+                {"reason":"compile-started","package_id":"foo 0.0.1 [..]"}
+
                 {
                     "reason":"compiler-artifact",
                     "profile": {
@@ -3924,6 +3926,8 @@ fn json_artifact_includes_executable_for_library_tests() {
     p.cargo("test --lib -v --no-run --message-format=json")
         .with_json(
             r#"
+                {"reason":"compile-started","package_id":"foo 0.0.1 [..]"}
+
                 {
                     "executable": "[..]/foo/target/debug/deps/foo-[..][EXE]",
                     "features": [],
@@ -3963,6 +3967,8 @@ fn json_artifact_includes_executable_for_integration_tests() {
     p.cargo("test -v --no-run --message-format=json --test integration_test")
         .with_json(
             r#"
+                {"reason":"compile-started","package_id":"foo 0.0.1 [..]"}
+
                 {
                     "executable": "[..]/foo/target/debug/deps/integration_test-[..][EXE]",
                     "features": [],


### PR DESCRIPTION
<!-- homu-ignore:start -->

fixes #12864

adds json output such as:
```json
{"reason":"compile-started","package_id":"foo 0.0.1"}
```

### How should we test and review this PR?

- `git clone --depth 1 https://github.com/rust-lang/cargo cargo1`
- `git clone --depth 1 https://github.com/bend-n/cargo cargo2`
- `cd cargo2`
- `cargo build`
- `cd ../cargo1`
- `../cargo2/target/debug build --message-format json`

or just `cargo test -- json`

### Notes

should the message have more information?

<!-- homu-ignore:end -->
