### PR TITLE
Remove duplicate binaries during install

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -9,6 +9,7 @@ use cargo::util::IntoUrl;
 use cargo::util::ToSemver;
 use cargo::util::VersionReqExt;
 use cargo::CargoResult;
+use itertools::Itertools;
 use semver::VersionReq;
 
 use cargo_util::paths;
@@ -119,6 +120,7 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
         .get_many::<CrateVersion>("crate")
         .unwrap_or_default()
         .cloned()
+        .dedup_by(|x, y| x == y)
         .map(|(krate, local_version)| resolve_crate(krate, local_version, version))
         .collect::<crate::CargoResult<Vec<_>>>()?;
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -58,6 +58,34 @@ fn simple() {
 }
 
 #[cargo_test]
+fn install_the_same_version_twice() {
+    pkg("foo", "0.0.1");
+
+    cargo_process("install foo foo")
+        .with_stderr(
+            "\
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] foo v0.0.1 (registry [..])
+[INSTALLING] foo v0.0.1
+[COMPILING] foo v0.0.1
+[FINISHED] release [optimized] target(s) in [..]
+[INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
+[INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
+[INSTALLING] foo v0.0.1
+[COMPILING] foo v0.0.1
+[FINISHED] release [optimized] target(s) in [..]
+[REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
+[REPLACED] package `foo v0.0.1` with `foo v0.0.1` (executable `foo[EXE]`)
+     Summary Successfully installed foo, foo!
+[WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
+",
+        )
+        .run();
+    assert_has_installed_exe(cargo_home(), "foo");
+}
+
+#[cargo_test]
 fn toolchain() {
     pkg("foo", "0.0.1");
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -72,12 +72,6 @@ fn install_the_same_version_twice() {
 [FINISHED] release [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
-[INSTALLING] foo v0.0.1
-[COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
-[REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
-[REPLACED] package `foo v0.0.1` with `foo v0.0.1` (executable `foo[EXE]`)
-     Summary Successfully installed foo, foo!
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
 ",
         )


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/12866

Deduped the binaries by name.

### How should we test and review this PR?

See the unit test changes.

### Additional information

Should we pick up a bigger version here? For example: `cargo install foo@1 foo@2` Should we pick the last one here?
<!-- homu-ignore:end -->
