### PR TITLE
Add option to error when warnings are emitted, or ignore warnings

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -140,6 +140,7 @@ use crate::core::compiler::future_incompat::{
 };
 use crate::core::resolver::ResolveBehavior;
 use crate::core::{PackageId, Shell, TargetKind};
+use crate::util::config::WarningHandling;
 use crate::util::diagnostic_server::{self, DiagnosticPrinter};
 use crate::util::errors::AlreadyPrintedError;
 use crate::util::machine_message::{self, Message as _};
@@ -314,8 +315,10 @@ impl<'cfg> DiagDedupe<'cfg> {
             return Ok(false);
         }
         let mut shell = self.config.shell();
-        shell.print_ansi_stderr(diag.as_bytes())?;
-        shell.err().write_all(b"\n")?;
+        if shell.warnings() != WarningHandling::Ignore {
+            shell.print_ansi_stderr(diag.as_bytes())?;
+            shell.err().write_all(b"\n")?;
+        }
         Ok(true)
     }
 }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -158,6 +158,16 @@ pub struct CredentialCacheValue {
     pub operation_independent: bool,
 }
 
+/// Whether warnings should warn, be ignored, or cause an error.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum WarningHandling {
+    #[default]
+    Warn,
+    Ignore,
+    Error,
+}
+
 /// Configuration information for cargo. This is not specific to a build, it is information
 /// relating to cargo itself.
 #[derive(Debug)]
@@ -971,6 +981,7 @@ impl Config {
         &mut self,
         verbose: u32,
         quiet: bool,
+        warnings: Option<WarningHandling>,
         color: Option<&str>,
         frozen: bool,
         locked: bool,
@@ -1032,6 +1043,8 @@ impl Config {
 
         self.shell().set_verbosity(verbosity);
         self.shell().set_color_choice(color)?;
+        self.shell()
+            .set_warnings(warnings.or_else(|| term.warnings).unwrap_or_default());
         self.progress_config = term.progress.unwrap_or_default();
         self.extra_verbose = extra_verbose;
         self.frozen = frozen;
@@ -2563,6 +2576,7 @@ struct TermConfig {
     #[serde(default)]
     #[serde(deserialize_with = "progress_or_string")]
     progress: Option<ProgressConfig>,
+    warnings: Option<WarningHandling>,
 }
 
 #[derive(Debug, Default, Deserialize)]

--- a/src/doc/man/includes/options-display.md
+++ b/src/doc/man/includes/options-display.md
@@ -22,3 +22,14 @@ Control when colored output is used. Valid values:
 May also be specified with the `term.color`
 [config value](../reference/config.html).
 {{/option}}
+
+{{#option "`--warnings`"}}
+Overrides how warnings are handled. Valid values:
+
+* `warn` (default): warnings are displayed and do not fail the operation.
+* `error`: if any warnings are encountered an error will be emitted at the of the operation.
+* `ignore`: warnings will be silently ignored.
+
+May also be specified with the `term.warnings`
+[config value](../reference/config.html).
+{{/option}}

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -1257,6 +1257,19 @@ Controls whether or not extra detailed messages are displayed by Cargo.
 Specifying the `--quiet` flag will override and disable verbose output.
 Specifying the `--verbose` flag will override and force verbose output.
 
+#### `term.warnings`
+* Type: string
+* Default: "warn"
+* Environment: `CARGO_TERM_WARNINGS`
+
+Overrides how warnings are handled, including warnings that come from `rustc`.
+
+The `--warnings=` CLI option overrides this configuration value.
+
+* `warn` (default): warnings are displayed and do not fail the operation.
+* `error`: if any warnings are encountered an error will be emitted at the of the operation.
+* `ignore`: warnings will be silently ignored.
+
 #### `term.color`
 * Type: string
 * Default: "auto"

--- a/tests/testsuite/cargo/help/stdout.log
+++ b/tests/testsuite/cargo/help/stdout.log
@@ -4,19 +4,20 @@ Usage: cargo [..][OPTIONS] [COMMAND]
        cargo [..][OPTIONS] -Zscript <MANIFEST_RS> [ARGS]...
 
 Options:
-  -V, --version             Print version info and exit
-      --list                List installed commands
-      --explain <CODE>      Provide a detailed explanation of a rustc error message
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-  -q, --quiet               Do not print cargo log messages
-      --color <WHEN>        Coloring: auto, always, never
-  -C <DIRECTORY>            Change to DIRECTORY before doing anything (nightly-only)
-      --frozen              Require Cargo.lock and cache are up to date
-      --locked              Require Cargo.lock is up to date
-      --offline             Run without accessing the network
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -V, --version              Print version info and exit
+      --list                 List installed commands
+      --explain <CODE>       Provide a detailed explanation of a rustc error message
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+  -C <DIRECTORY>             Change to DIRECTORY before doing anything (nightly-only)
+      --frozen               Require Cargo.lock and cache are up to date
+      --locked               Require Cargo.lock is up to date
+      --offline              Run without accessing the network
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Commands:
     build, b    Compile the current package

--- a/tests/testsuite/cargo_add/help/stdout.log
+++ b/tests/testsuite/cargo_add/help/stdout.log
@@ -54,6 +54,11 @@ Options:
       --color <WHEN>
           Coloring: auto, always, never
 
+      --warnings <warnings>
+          Warning behavior
+          
+          [possible values: error, warn, ignore]
+
       --config <KEY=VALUE>
           Override a configuration value
 

--- a/tests/testsuite/cargo_bench/help/stdout.log
+++ b/tests/testsuite/cargo_bench/help/stdout.log
@@ -14,6 +14,7 @@ Options:
   -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
+      --warnings <warnings>   Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details

--- a/tests/testsuite/cargo_build/help/stdout.log
+++ b/tests/testsuite/cargo_build/help/stdout.log
@@ -9,6 +9,7 @@ Options:
   -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
+      --warnings <warnings>     Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details

--- a/tests/testsuite/cargo_check/help/stdout.log
+++ b/tests/testsuite/cargo_check/help/stdout.log
@@ -9,6 +9,7 @@ Options:
   -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
+      --warnings <warnings>     Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details

--- a/tests/testsuite/cargo_clean/help/stdout.log
+++ b/tests/testsuite/cargo_clean/help/stdout.log
@@ -3,14 +3,15 @@ Remove artifacts that cargo has generated in the past
 Usage: cargo[EXE] clean [OPTIONS]
 
 Options:
-      --doc                 Whether or not to clean just the documentation directory
-  -q, --quiet               Do not print cargo log messages
-  -n, --dry-run             Display what would be deleted without deleting anything
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+      --doc                  Whether or not to clean just the documentation directory
+  -q, --quiet                Do not print cargo log messages
+  -n, --dry-run              Display what would be deleted without deleting anything
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Package Selection:
   -p, --package [<SPEC>]  Package to clean artifacts for

--- a/tests/testsuite/cargo_config/help/stdout.log
+++ b/tests/testsuite/cargo_config/help/stdout.log
@@ -6,11 +6,12 @@ Commands:
   get  
 
 Options:
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --frozen   Require Cargo.lock and cache are up to date

--- a/tests/testsuite/cargo_doc/help/stdout.log
+++ b/tests/testsuite/cargo_doc/help/stdout.log
@@ -11,6 +11,7 @@ Options:
   -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
+      --warnings <warnings>     Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details

--- a/tests/testsuite/cargo_fetch/help/stdout.log
+++ b/tests/testsuite/cargo_fetch/help/stdout.log
@@ -3,12 +3,13 @@ Fetch dependencies of a package from the network
 Usage: cargo[EXE] fetch [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Compilation Options:
       --target [<TRIPLE>]  Fetch dependencies for the target triple

--- a/tests/testsuite/cargo_fix/help/stdout.log
+++ b/tests/testsuite/cargo_fix/help/stdout.log
@@ -14,6 +14,7 @@ Options:
   -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
+      --warnings <warnings>   Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.log
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.log
@@ -3,12 +3,13 @@ Generate the lockfile for a package
 Usage: cargo[EXE] generate-lockfile [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml

--- a/tests/testsuite/cargo_help/help/stdout.log
+++ b/tests/testsuite/cargo_help/help/stdout.log
@@ -6,11 +6,12 @@ Arguments:
   [COMMAND]  
 
 Options:
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --frozen   Require Cargo.lock and cache are up to date

--- a/tests/testsuite/cargo_init/help/stdout.log
+++ b/tests/testsuite/cargo_init/help/stdout.log
@@ -18,6 +18,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_install/help/stdout.log
+++ b/tests/testsuite/cargo_install/help/stdout.log
@@ -24,6 +24,7 @@ Options:
       --debug                 Build in debug mode (with the 'dev' profile) instead of release mode
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
+      --warnings <warnings>   Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details

--- a/tests/testsuite/cargo_locate_project/help/stdout.log
+++ b/tests/testsuite/cargo_locate_project/help/stdout.log
@@ -8,6 +8,7 @@ Options:
   -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
+      --warnings <warnings>   Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details

--- a/tests/testsuite/cargo_login/help/stdout.log
+++ b/tests/testsuite/cargo_login/help/stdout.log
@@ -11,6 +11,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_logout/help/stdout.log
+++ b/tests/testsuite/cargo_logout/help/stdout.log
@@ -7,6 +7,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_metadata/help/stdout.log
+++ b/tests/testsuite/cargo_metadata/help/stdout.log
@@ -11,6 +11,7 @@ Options:
   -q, --quiet                     Do not print cargo log messages
   -v, --verbose...                Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>              Coloring: auto, always, never
+      --warnings <warnings>       Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>        Override a configuration value
   -Z <FLAG>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                   details

--- a/tests/testsuite/cargo_new/help/stdout.log
+++ b/tests/testsuite/cargo_new/help/stdout.log
@@ -18,6 +18,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_owner/help/stdout.log
+++ b/tests/testsuite/cargo_owner/help/stdout.log
@@ -15,6 +15,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_package/help/stdout.log
+++ b/tests/testsuite/cargo_package/help/stdout.log
@@ -3,16 +3,17 @@ Assemble the local package into a distributable tarball
 Usage: cargo[EXE] package [OPTIONS]
 
 Options:
-  -l, --list                Print files included in a package without making one
-      --no-verify           Don't verify the contents by building them
-      --no-metadata         Ignore warnings about a lack of human-usable metadata
-      --allow-dirty         Allow dirty working directories to be packaged
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -l, --list                 Print files included in a package without making one
+      --no-verify            Don't verify the contents by building them
+      --no-metadata          Ignore warnings about a lack of human-usable metadata
+      --allow-dirty          Allow dirty working directories to be packaged
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Package Selection:
   -p, --package [<SPEC>]  Package(s) to assemble

--- a/tests/testsuite/cargo_pkgid/help/stdout.log
+++ b/tests/testsuite/cargo_pkgid/help/stdout.log
@@ -6,12 +6,13 @@ Arguments:
   [SPEC]  
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Package Selection:
   -p, --package [<SPEC>]  Argument to get the package ID specifier for

--- a/tests/testsuite/cargo_publish/help/stdout.log
+++ b/tests/testsuite/cargo_publish/help/stdout.log
@@ -12,6 +12,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_read_manifest/help/stdout.log
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.log
@@ -5,12 +5,13 @@ Deprecated, use `cargo metadata --no-deps` instead.
 Usage: cargo[EXE] read-manifest [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml

--- a/tests/testsuite/cargo_remove/help/stdout.log
+++ b/tests/testsuite/cargo_remove/help/stdout.log
@@ -6,13 +6,14 @@ Arguments:
   <DEP_ID>...  Dependencies to be removed
 
 Options:
-  -n, --dry-run             Don't actually write the manifest
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -n, --dry-run              Don't actually write the manifest
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Section:
       --dev              Remove from dev-dependencies

--- a/tests/testsuite/cargo_report/help/stdout.log
+++ b/tests/testsuite/cargo_report/help/stdout.log
@@ -6,11 +6,12 @@ Commands:
   future-incompatibilities  Reports any crates which will eventually stop compiling
 
 Options:
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --frozen   Require Cargo.lock and cache are up to date

--- a/tests/testsuite/cargo_run/help/stdout.log
+++ b/tests/testsuite/cargo_run/help/stdout.log
@@ -11,6 +11,7 @@ Options:
   -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
+      --warnings <warnings>   Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details

--- a/tests/testsuite/cargo_rustc/help/stdout.log
+++ b/tests/testsuite/cargo_rustc/help/stdout.log
@@ -14,6 +14,7 @@ Options:
   -q, --quiet                    Do not print cargo log messages
   -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>             Coloring: auto, always, never
+      --warnings <warnings>      Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>       Override a configuration value
   -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                  details

--- a/tests/testsuite/cargo_rustdoc/help/stdout.log
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.log
@@ -12,6 +12,7 @@ Options:
   -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>          Coloring: auto, always, never
+      --warnings <warnings>   Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                               details

--- a/tests/testsuite/cargo_search/help/stdout.log
+++ b/tests/testsuite/cargo_search/help/stdout.log
@@ -12,6 +12,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/cargo_test/help/stdout.log
+++ b/tests/testsuite/cargo_test/help/stdout.log
@@ -16,6 +16,7 @@ Options:
   -q, --quiet                   Display one character per test instead of one line
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>            Coloring: auto, always, never
+      --warnings <warnings>     Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                 details

--- a/tests/testsuite/cargo_tree/help/stdout.log
+++ b/tests/testsuite/cargo_tree/help/stdout.log
@@ -3,24 +3,25 @@ Display a tree visualization of a dependency graph
 Usage: cargo[EXE] tree [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -e, --edges <KINDS>       The kinds of dependencies to display (features, normal, build, dev, all,
-                            no-normal, no-build, no-dev, no-proc-macro)
-  -i, --invert [<SPEC>]     Invert the tree direction and focus on the given package
-      --prune <SPEC>        Prune the given package from the display of the dependency tree
-      --depth <DEPTH>       Maximum display depth of the dependency tree
-      --prefix <PREFIX>     Change the prefix (indentation) of how each entry is displayed [default:
-                            indent] [possible values: depth, indent, none]
-      --no-dedupe           Do not de-duplicate (repeats all shared dependencies)
-  -d, --duplicates          Show only dependencies which come in multiple versions (implies -i)
-      --charset <CHARSET>   Character set to use in output [default: utf8] [possible values: utf8,
-                            ascii]
-  -f, --format <FORMAT>     Format string used for printing dependencies [default: {p}]
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -e, --edges <KINDS>        The kinds of dependencies to display (features, normal, build, dev,
+                             all, no-normal, no-build, no-dev, no-proc-macro)
+  -i, --invert [<SPEC>]      Invert the tree direction and focus on the given package
+      --prune <SPEC>         Prune the given package from the display of the dependency tree
+      --depth <DEPTH>        Maximum display depth of the dependency tree
+      --prefix <PREFIX>      Change the prefix (indentation) of how each entry is displayed
+                             [default: indent] [possible values: depth, indent, none]
+      --no-dedupe            Do not de-duplicate (repeats all shared dependencies)
+  -d, --duplicates           Show only dependencies which come in multiple versions (implies -i)
+      --charset <CHARSET>    Character set to use in output [default: utf8] [possible values: utf8,
+                             ascii]
+  -f, --format <FORMAT>      Format string used for printing dependencies [default: {p}]
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Package Selection:
   -p, --package [<SPEC>]  Package to be used as the root of the tree

--- a/tests/testsuite/cargo_uninstall/help/stdout.log
+++ b/tests/testsuite/cargo_uninstall/help/stdout.log
@@ -6,13 +6,14 @@ Arguments:
   [SPEC]...  
 
 Options:
-      --root <DIR>          Directory to uninstall packages from
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+      --root <DIR>           Directory to uninstall packages from
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Package Selection:
   -p, --package [<SPEC>]  Package to uninstall

--- a/tests/testsuite/cargo_update/help/stdout.log
+++ b/tests/testsuite/cargo_update/help/stdout.log
@@ -3,15 +3,16 @@ Update dependencies as recorded in the local lock file
 Usage: cargo[EXE] update [OPTIONS] [SPEC]...
 
 Options:
-  -n, --dry-run             Don't actually write the lockfile
-      --recursive           Force updating all dependencies of [SPEC]... as well
-      --precise <PRECISE>   Update [SPEC] to exactly PRECISE
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -n, --dry-run              Don't actually write the lockfile
+      --recursive            Force updating all dependencies of [SPEC]... as well
+      --precise <PRECISE>    Update [SPEC] to exactly PRECISE
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Package Selection:
   -w, --workspace  Only update the workspace packages

--- a/tests/testsuite/cargo_vendor/help/stdout.log
+++ b/tests/testsuite/cargo_vendor/help/stdout.log
@@ -13,6 +13,7 @@ Options:
   -q, --quiet                  Do not print cargo log messages
   -v, --verbose...             Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>           Coloring: auto, always, never
+      --warnings <warnings>    Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>     Override a configuration value
   -Z <FLAG>                    Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
                                details

--- a/tests/testsuite/cargo_verify_project/help/stdout.log
+++ b/tests/testsuite/cargo_verify_project/help/stdout.log
@@ -3,12 +3,13 @@ Check correctness of crate manifest
 Usage: cargo[EXE] verify-project [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --manifest-path <PATH>  Path to Cargo.toml

--- a/tests/testsuite/cargo_version/help/stdout.log
+++ b/tests/testsuite/cargo_version/help/stdout.log
@@ -3,12 +3,13 @@ Show version information
 Usage: cargo[EXE] version [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
-  -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
-      --color <WHEN>        Coloring: auto, always, never
-      --config <KEY=VALUE>  Override a configuration value
-  -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
-  -h, --help                Print help
+  -q, --quiet                Do not print cargo log messages
+  -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+      --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
+      --config <KEY=VALUE>   Override a configuration value
+  -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                 Print help
 
 Manifest Options:
       --frozen   Require Cargo.lock and cache are up to date

--- a/tests/testsuite/cargo_yank/help/stdout.log
+++ b/tests/testsuite/cargo_yank/help/stdout.log
@@ -14,6 +14,7 @@ Options:
   -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>         Coloring: auto, always, never
+      --warnings <warnings>  Warning behavior [possible values: error, warn, ignore]
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
   -h, --help                 Print help

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -107,6 +107,7 @@ impl ConfigBuilder {
             0,
             false,
             None,
+            None,
             false,
             false,
             false,

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -175,6 +175,7 @@ mod vendor;
 mod verify_project;
 mod version;
 mod warn_on_failure;
+mod warning_override;
 mod weak_dep_features;
 mod workspaces;
 mod yank;

--- a/tests/testsuite/warning_override.rs
+++ b/tests/testsuite/warning_override.rs
@@ -1,0 +1,85 @@
+//! Tests for overriding warning behavior using `--warnings=` on the CLI or `term.warnings` config option.
+
+use cargo_test_support::{project, Project};
+
+const WARNING1: &'static str = "[WARNING] unused variable: `x`";
+const WARNING2: &'static str = "[WARNING] unused config key `build.xyz` in `[..]`";
+
+fn make_project(main_src: &str) -> Project {
+    project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+            "#,
+        )
+        .file("src/main.rs", &format!("fn main() {{ {} }}", main_src))
+        .build()
+}
+
+#[cargo_test]
+fn rustc_warnings() {
+    let p = make_project("let x = 3;");
+    p.cargo("check --warnings=warn")
+        .with_stderr_contains(WARNING1)
+        .run();
+
+    p.cargo("check --warnings=error")
+        .with_stderr_contains(WARNING1)
+        .with_stderr_contains(
+            "[ERROR] warnings detected and warnings are disallowed by configuration",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo("check --warnings=ignore")
+        .with_stderr_does_not_contain(WARNING1)
+        .run();
+}
+
+#[cargo_test]
+fn config() {
+    let p = make_project("let x = 3;");
+    p.cargo("check")
+        .env("CARGO_TERM_WARNINGS", "error")
+        .with_stderr_contains(WARNING1)
+        .with_stderr_contains(
+            "[ERROR] warnings detected and warnings are disallowed by configuration",
+        )
+        .with_status(101)
+        .run();
+
+    // CLI has precedence over config
+    p.cargo("check --warnings=ignore")
+        .env("CARGO_TERM_WARNINGS", "error")
+        .with_stderr_does_not_contain(WARNING1)
+        .run();
+
+    p.cargo("check")
+        .env("CARGO_TERM_WARNINGS", "ignore")
+        .with_stderr_does_not_contain(WARNING1)
+        .run();
+}
+
+#[cargo_test]
+/// Warnings that come from cargo rather than rustc
+fn cargo_warnings() {
+    let p = make_project("");
+    p.change_file(".cargo/config.toml", "[build]\nxyz = false");
+    p.cargo("check").with_stderr_contains(WARNING2).run();
+
+    p.cargo("check --warnings=error")
+        .with_stderr_contains(WARNING2)
+        .with_stderr_contains(
+            "[ERROR] warnings detected and warnings are disallowed by configuration",
+        )
+        .with_status(101)
+        .run();
+
+    p.cargo("check --warnings=ignore")
+        .with_stderr_does_not_contain(WARNING2)
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

Users want a way to deny all warnings, particularly in CI.

* Adds `--warnings error|warn|ignore` CLI flag
* Adds `term.warnings` config option.

The options mean:
- `error` emits an error if any warnings were emitted during the Cargo operation
- `warn` is the existing behavior
- `ignore` hides the warnings

### Open Questions:

* Should this be unstable initially via `-Zunstable-options`?
* Should it only apply to `rustc` warnings (not Cargo warnings) until cargo has better control over diagnostics system (#12235)?
  * This could be confusing if users want to deny all warnings and set this flag, only to see some warnings still allowed.
* Where should the config option go?
  * I used `term.warnings`, since that also where `verbose` and `quiet` live. However, it's not really a terminal setting.
  * `[build]` is another option, but this applies to all warnings, not just build warnings.
* Since we have `--config "term.warnings='error'"` do we need the `--warnings` CLI option?
  * The CLI option is easier to discover and use than `--config` but adds 1 more option to every command's help.

Fixes #8424

### How should we test and review this PR?
Tests are included in the PR. Resolving the open questions is the majority of the review work.

