### PR TITLE
Fix unused_imports warning

### DIFF
--- a/src/cargo/core/resolver/context.rs
+++ b/src/cargo/core/resolver/context.rs
@@ -10,10 +10,6 @@ use std::collections::HashMap;
 use std::num::NonZeroU64;
 use tracing::debug;
 
-pub use super::encode::Metadata;
-pub use super::encode::{EncodableDependency, EncodablePackageId, EncodableResolve};
-pub use super::resolve::Resolve;
-
 // A `Context` is basically a bunch of local resolution information which is
 // kept around for all `BacktrackFrame` instances. As a result, this runs the
 // risk of being cloned *a lot* so we want to make this as cheap to clone as


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/116033 recently improved the fidelity of the unused_imports warning, causing this code to surface as something that is not being used (because the `context` module is not publicly exported, and nothing was referencing these imports). This fixes the warning by removing the unused imports.

