### PR TITLE
refactor(shell): Write at once rather than in fragments

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -340,13 +340,6 @@ impl Shell {
         }
     }
 
-    /// Write a styled fragment
-    ///
-    /// Caller is responsible for deciding whether [`Shell::verbosity`] is affects output.
-    pub fn write_stdout(&mut self, fragment: impl fmt::Display, color: &Style) -> CargoResult<()> {
-        self.output.write_stdout(fragment, color)
-    }
-
     /// Prints a message to stderr and translates ANSI escape code into console colors.
     pub fn print_ansi_stderr(&mut self, message: &[u8]) -> CargoResult<()> {
         if self.needs_clear {
@@ -406,17 +399,6 @@ impl ShellOut {
             None => write!(buffer, " ")?,
         }
         self.stderr().write_all(&buffer)?;
-        Ok(())
-    }
-
-    /// Write a styled fragment
-    fn write_stdout(&mut self, fragment: impl fmt::Display, style: &Style) -> CargoResult<()> {
-        let style = style.render();
-        let reset = anstyle::Reset.render();
-
-        let mut buffer = Vec::new();
-        write!(buffer, "{style}{}{reset}", fragment)?;
-        self.stdout().write_all(&buffer)?;
         Ok(())
     }
 

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -347,13 +347,6 @@ impl Shell {
         self.output.write_stdout(fragment, color)
     }
 
-    /// Write a styled fragment
-    ///
-    /// Caller is responsible for deciding whether [`Shell::verbosity`] is affects output.
-    pub fn write_stderr(&mut self, fragment: impl fmt::Display, color: &Style) -> CargoResult<()> {
-        self.output.write_stderr(fragment, color)
-    }
-
     /// Prints a message to stderr and translates ANSI escape code into console colors.
     pub fn print_ansi_stderr(&mut self, message: &[u8]) -> CargoResult<()> {
         if self.needs_clear {
@@ -424,17 +417,6 @@ impl ShellOut {
         let mut buffer = Vec::new();
         write!(buffer, "{style}{}{reset}", fragment)?;
         self.stdout().write_all(&buffer)?;
-        Ok(())
-    }
-
-    /// Write a styled fragment
-    fn write_stderr(&mut self, fragment: impl fmt::Display, style: &Style) -> CargoResult<()> {
-        let style = style.render();
-        let reset = anstyle::Reset.render();
-
-        let mut buffer = Vec::new();
-        write!(buffer, "{style}{}{reset}", fragment)?;
-        self.stderr().write_all(&buffer)?;
         Ok(())
     }
 

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -947,12 +947,17 @@ fn print_dep_table_msg(shell: &mut Shell, dep: &DependencyUI) -> CargoResult<()>
         return Ok(());
     }
 
+    let stderr = shell.err();
+    let good = style::GOOD.render();
+    let error = style::ERROR.render();
+    let reset = anstyle::Reset.render();
+
     let (activated, deactivated) = dep.features();
     if !activated.is_empty() || !deactivated.is_empty() {
         let prefix = format!("{:>13}", " ");
         let suffix = format_features_version_suffix(&dep);
 
-        shell.write_stderr(format_args!("{prefix}Features{suffix}:\n"), &style::NOP)?;
+        writeln!(stderr, "{prefix}Features{suffix}:")?;
 
         const MAX_FEATURE_PRINTS: usize = 30;
         let total_activated = activated.len();
@@ -960,28 +965,18 @@ fn print_dep_table_msg(shell: &mut Shell, dep: &DependencyUI) -> CargoResult<()>
 
         if total_activated <= MAX_FEATURE_PRINTS {
             for feat in activated {
-                shell.write_stderr(&prefix, &style::NOP)?;
-                shell.write_stderr('+', &style::GOOD)?;
-                shell.write_stderr(format_args!(" {feat}\n"), &style::NOP)?;
+                writeln!(stderr, "{prefix}{good}+{reset} {feat}")?;
             }
         } else {
-            shell.write_stderr(
-                format_args!("{prefix}{total_activated} activated features\n"),
-                &style::NOP,
-            )?;
+            writeln!(stderr, "{prefix}{total_activated} activated features")?;
         }
 
         if total_activated + total_deactivated <= MAX_FEATURE_PRINTS {
             for feat in deactivated {
-                shell.write_stderr(&prefix, &style::NOP)?;
-                shell.write_stderr('-', &style::ERROR)?;
-                shell.write_stderr(format_args!(" {feat}\n"), &style::NOP)?;
+                writeln!(stderr, "{prefix}{error}-{reset} {feat}")?;
             }
         } else {
-            shell.write_stderr(
-                format_args!("{prefix}{total_deactivated} deactivated features\n"),
-                &style::NOP,
-            )?;
+            writeln!(stderr, "{prefix}{total_deactivated} deactivated features")?;
         }
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

For `cargo add` and `cargo search`, rather than expose `termcolor`s API, we wrote a styled fragment at a time.

This is no longer needed as of #12751 because we switched from termcolor to anstream which decorates `stdout` and `stderr` with any of the logic we need to adapt to the configured terminal. .

### How should we test and review this PR?

Ran the commands locally to verify styled output.  Tests verify unstyled output.

### Additional information

