### PR TITLE
Remove outdated option to `-Zcheck-cfg` warnings

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -803,7 +803,7 @@ impl BuildOutput {
                     if extra_check_cfg {
                         check_cfgs.push(value.to_string());
                     } else {
-                        warnings.push(format!("cargo:{} requires -Zcheck-cfg=output flag", key));
+                        warnings.push(format!("cargo:{} requires -Zcheck-cfg flag", key));
                     }
                 }
                 "rustc-env" => {

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -208,7 +208,7 @@ fn parse_links_overrides(
                         output.check_cfgs.extend(list.iter().map(|v| v.0.clone()));
                     } else {
                         config.shell().warn(format!(
-                            "target config `{}.{}` requires -Zcheck-cfg=output flag",
+                            "target config `{}.{}` requires -Zcheck-cfg flag",
                             target_key, key
                         ))?;
                     }


### PR DESCRIPTION
Forgot to remove those in https://github.com/rust-lang/cargo/pull/12845.

Note: Would it make sense to have feature-gate tests for those? and if so what would be the recommended way?