### PR TITLE
docs: clarify config to use vendored source is printed to stdout

### DIFF
--- a/src/doc/man/cargo-vendor.md
+++ b/src/doc/man/cargo-vendor.md
@@ -16,8 +16,10 @@ the vendor directory specified by `<path>` will contain all remote sources from
 dependencies specified. Additional manifests beyond the default one can be
 specified with the `-s` option.
 
-The `cargo vendor` command will also print out the configuration necessary
-to use the vendored sources, which you will need to add to `.cargo/config.toml`.
+The configuration necessary to use the vendored sources would be printed to
+stdout after `cargo vendor` completes the vendoring process.
+You will need to add or redirect it to your Cargo configuration file,
+which is usually `.cargo/config.toml` locally for the current package.
 
 ## OPTIONS
 
@@ -87,6 +89,10 @@ only a subset of the packages have changed.
 3. Vendor the current workspace as well as another to "vendor"
 
        cargo vendor -s ../path/to/Cargo.toml
+
+4. Vendor and redirect the necessary vendor configs to a config file.
+
+       cargo vendor > path/to/my/cargo/config.toml
 
 ## SEE ALSO
 {{man "cargo" 1}}

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -13,9 +13,10 @@ DESCRIPTION
        remote sources from dependencies specified. Additional manifests beyond
        the default one can be specified with the -s option.
 
-       The cargo vendor command will also print out the configuration necessary
-       to use the vendored sources, which you will need to add to
-       .cargo/config.toml.
+       The configuration necessary to use the vendored sources would be printed
+       to stdout after cargo vendor completes the vendoring process. You will
+       need to add or redirect it to your Cargo configuration file, which is
+       usually .cargo/config.toml locally for the current package.
 
 OPTIONS
    Vendor Options
@@ -156,6 +157,10 @@ EXAMPLES
        3. Vendor the current workspace as well as another to “vendor”
 
               cargo vendor -s ../path/to/Cargo.toml
+
+       4. Vendor and redirect the necessary vendor configs to a config file.
+
+              cargo vendor > path/to/my/cargo/config.toml
 
 SEE ALSO
        cargo(1)

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -16,8 +16,10 @@ the vendor directory specified by `<path>` will contain all remote sources from
 dependencies specified. Additional manifests beyond the default one can be
 specified with the `-s` option.
 
-The `cargo vendor` command will also print out the configuration necessary
-to use the vendored sources, which you will need to add to `.cargo/config.toml`.
+The configuration necessary to use the vendored sources would be printed to
+stdout after `cargo vendor` completes the vendoring process.
+You will need to add or redirect it to your Cargo configuration file,
+which is usually `.cargo/config.toml` locally for the current package.
 
 ## OPTIONS
 
@@ -188,6 +190,10 @@ details on environment variables that Cargo reads.
 3. Vendor the current workspace as well as another to "vendor"
 
        cargo vendor -s ../path/to/Cargo.toml
+
+4. Vendor and redirect the necessary vendor configs to a config file.
+
+       cargo vendor > path/to/my/cargo/config.toml
 
 ## SEE ALSO
 [cargo(1)](cargo.html)

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -14,8 +14,10 @@ the vendor directory specified by \fB<path>\fR will contain all remote sources f
 dependencies specified. Additional manifests beyond the default one can be
 specified with the \fB\-s\fR option.
 .sp
-The \fBcargo vendor\fR command will also print out the configuration necessary
-to use the vendored sources, which you will need to add to \fB\&.cargo/config.toml\fR\&.
+The configuration necessary to use the vendored sources would be printed to
+stdout after \fBcargo vendor\fR completes the vendoring process.
+You will need to add or redirect it to your Cargo configuration file,
+which is usually \fB\&.cargo/config.toml\fR locally for the current package.
 .SH "OPTIONS"
 .SS "Vendor Options"
 .sp
@@ -202,6 +204,16 @@ cargo vendor third\-party/vendor
 .RS 4
 .nf
 cargo vendor \-s ../path/to/Cargo.toml
+.fi
+.RE
+.RE
+.sp
+.RS 4
+\h'-04' 4.\h'+01'Vendor and redirect the necessary vendor configs to a config file.
+.sp
+.RS 4
+.nf
+cargo vendor > path/to/my/cargo/config.toml
 .fi
 .RE
 .RE


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

#7280 states out it not clear how to get the necessary config for `cargo vendor`.
This PR improves the documentation a bit but hasn't yet resolved the issue that `--quiet` makes `cargo vendor` stdout really quiet.

### How should we test and review this PR?

`mdbook serve src/doc` and read the doc.

### Additional information
<!-- homu-ignore:end -->
