### PR TITLE
fix: merge `trim-paths` from different profiles 

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -3007,6 +3007,10 @@ impl TomlProfile {
         if let Some(v) = &profile.strip {
             self.strip = Some(v.clone());
         }
+
+        if let Some(v) = &profile.trim_paths {
+            self.trim_paths = Some(v.clone())
+        }
     }
 }
 

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -192,7 +192,7 @@ fn profile_merge_works() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
-    -Zremap-path-scope=macro \
+    -Zremap-path-scope=diagnostics \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
     --remap-path-prefix=[CWD]= [..]
 [FINISHED] custom [..]",


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

In https://github.com/rust-lang/cargo/commit/4d29af1d81c7460fd97a07ff894eeec1c4357082 we forgot to add trim-paths to `fn merge()`.
This PR follows how `-Zprofile-rustflags` works --- overriding instead of merging array.

### How should we test and review this PR?

The first commit demonstrate the bad behavior with a new test.
The second fixes the bug and the test.

### Additional information

_None_
<!-- homu-ignore:end -->
