### PR TITLE
fix(metadata): Stabilize id format as PackageIDSpec 

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -22,7 +22,7 @@ use crate::core::compiler::{CompileKind, RustcTargetData};
 use crate::core::dependency::DepKind;
 use crate::core::resolver::features::ForceAllTargets;
 use crate::core::resolver::{HasDevUnits, Resolve};
-use crate::core::{Dependency, Manifest, PackageId, SourceId, Target};
+use crate::core::{Dependency, Manifest, PackageId, PackageIdSpec, SourceId, Target};
 use crate::core::{Summary, Workspace};
 use crate::sources::source::{MaybePackage, SourceMap};
 use crate::util::cache_lock::{CacheLock, CacheLockMode};
@@ -82,7 +82,7 @@ impl PartialOrd for Package {
 pub struct SerializedPackage {
     name: InternedString,
     version: Version,
-    id: PackageId,
+    id: PackageIdSpec,
     license: Option<String>,
     license_file: Option<String>,
     description: Option<String>,
@@ -239,7 +239,7 @@ impl Package {
         SerializedPackage {
             name: package_id.name(),
             version: package_id.version().clone(),
-            id: package_id,
+            id: package_id.to_spec(),
             license: manmeta.license.clone(),
             license_file: manmeta.license_file.clone(),
             description: manmeta.description.clone(),

--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -56,7 +56,7 @@ The JSON output has the following format:
             /* The Package ID, an opaque and unique identifier for referring to the
                package. See "Compatibility" above for the stability guarantee.
             */
-            "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+            "id": "file:///path/to/my-package#0.1.0",
             /* The license value from the manifest, or null. */
             "license": "MIT/Apache-2.0",
             /* The license-file value from the manifest, or null. */
@@ -242,13 +242,13 @@ The JSON output has the following format:
        Each entry is the Package ID for the package.
     */
     "workspace_members": [
-        "my-package 0.1.0 (path+file:///path/to/my-package)",
+        "file:///path/to/my-package#0.1.0",
     ],
     /* Array of default members of the workspace.
        Each entry is the Package ID for the package.
     */
     "workspace_default_members": [
-        "my-package 0.1.0 (path+file:///path/to/my-package)",
+        "file:///path/to/my-package#0.1.0",
     ],
     // The resolved dependency graph for the entire workspace. The enabled
     // features are based on the enabled features for the "current" package.
@@ -266,10 +266,10 @@ The JSON output has the following format:
         "nodes": [
             {
                 /* The Package ID of this node. */
-                "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+                "id": "file:///path/to/my-package#0.1.0",
                 /* The dependencies of this package, an array of Package IDs. */
                 "dependencies": [
-                    "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "https://github.com/rust-lang/crates.io-index#bitflags@1.0.4"
                 ],
                 /* The dependencies of this package. This is an alternative to
                    "dependencies" which contains additional information. In
@@ -283,7 +283,7 @@ The JSON output has the following format:
                         */
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
-                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "pkg": "https://github.com/rust-lang/crates.io-index#bitflags@1.0.4"
                         /* Array of dependency kinds. Added in Cargo 1.40. */
                         "dep_kinds": [
                             {
@@ -309,7 +309,7 @@ The JSON output has the following format:
            This is null if this is a virtual workspace. Otherwise it is
            the Package ID of the root package.
         */
-        "root": "my-package 0.1.0 (path+file:///path/to/my-package)"
+        "root": "file:///path/to/my-package#0.1.0",
     },
     /* The absolute path to the build directory where Cargo places its output. */
     "target_directory": "/path/to/my-package/target",

--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -34,8 +34,8 @@ considersed as incompatible:
 * **Adding new values for enum-like fields** — Same as adding new fields. It
   keeps metadata evolving without stagnation.
 * **Changing opaque representations** — The inner representations of some
-  fields are implementation details. For example, fields related to "Package ID"
-  or "Source ID" are treated as opaque identifiers to differentiate packages or
+  fields are implementation details. For example, fields related to
+  "Source ID" are treated as opaque identifiers to differentiate packages or
   sources. Consumers shouldn't rely on those representations unless specified.
 
 ### JSON format
@@ -53,8 +53,8 @@ The JSON output has the following format:
             "name": "my-package",
             /* The version of the package. */
             "version": "0.1.0",
-            /* The Package ID, an opaque and unique identifier for referring to the
-               package. See "Compatibility" above for the stability guarantee.
+            /* The Package ID for referring to the
+               package within the document and as the `--package` argument to many commands
             */
             "id": "file:///path/to/my-package#0.1.0",
             /* The license value from the manifest, or null. */
@@ -330,6 +330,11 @@ The JSON output has the following format:
     }
 }
 ````
+
+Notes:
+- For `"id"` field syntax, see [Package ID Specifications] in the reference.
+
+[Package ID Specifications]: ../reference/pkgid-spec.html
 
 ## OPTIONS
 

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -32,9 +32,9 @@ OUTPUT FORMAT
 
        o  Changing opaque representations — The inner representations of some
           fields are implementation details. For example, fields related to
-          “Package ID” or “Source ID” are treated as opaque identifiers
-          to differentiate packages or sources. Consumers shouldn’t rely on
-          those representations unless specified.
+          “Source ID” are treated as opaque identifiers to differentiate
+          packages or sources. Consumers shouldn’t rely on those
+          representations unless specified.
 
    JSON format
        The JSON output has the following format:
@@ -49,8 +49,8 @@ OUTPUT FORMAT
                        "name": "my-package",
                        /* The version of the package. */
                        "version": "0.1.0",
-                       /* The Package ID, an opaque and unique identifier for referring to the
-                          package. See "Compatibility" above for the stability guarantee.
+                       /* The Package ID for referring to the
+                          package within the document and as the `--package` argument to many commands
                        */
                        "id": "file:///path/to/my-package#0.1.0",
                        /* The license value from the manifest, or null. */
@@ -325,6 +325,12 @@ OUTPUT FORMAT
                    }
                }
            }
+
+       Notes:
+
+       o  For "id" field syntax, see Package ID Specifications
+          <https://doc.rust-lang.org/cargo/reference/pkgid-spec.html> in the
+          reference.
 
 OPTIONS
    Output Options

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -52,7 +52,7 @@ OUTPUT FORMAT
                        /* The Package ID, an opaque and unique identifier for referring to the
                           package. See "Compatibility" above for the stability guarantee.
                        */
-                       "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+                       "id": "file:///path/to/my-package#0.1.0",
                        /* The license value from the manifest, or null. */
                        "license": "MIT/Apache-2.0",
                        /* The license-file value from the manifest, or null. */
@@ -238,13 +238,13 @@ OUTPUT FORMAT
                   Each entry is the Package ID for the package.
                */
                "workspace_members": [
-                   "my-package 0.1.0 (path+file:///path/to/my-package)",
+                   "file:///path/to/my-package#0.1.0",
                ],
                /* Array of default members of the workspace.
                   Each entry is the Package ID for the package.
                */
                "workspace_default_members": [
-                   "my-package 0.1.0 (path+file:///path/to/my-package)",
+                   "file:///path/to/my-package#0.1.0",
                ],
                // The resolved dependency graph for the entire workspace. The enabled
                // features are based on the enabled features for the "current" package.
@@ -262,10 +262,10 @@ OUTPUT FORMAT
                    "nodes": [
                        {
                            /* The Package ID of this node. */
-                           "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+                           "id": "file:///path/to/my-package#0.1.0",
                            /* The dependencies of this package, an array of Package IDs. */
                            "dependencies": [
-                               "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                               "https://github.com/rust-lang/crates.io-index#bitflags@1.0.4"
                            ],
                            /* The dependencies of this package. This is an alternative to
                               "dependencies" which contains additional information. In
@@ -279,7 +279,7 @@ OUTPUT FORMAT
                                    */
                                    "name": "bitflags",
                                    /* The Package ID of the dependency. */
-                                   "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                                   "pkg": "https://github.com/rust-lang/crates.io-index#bitflags@1.0.4"
                                    /* Array of dependency kinds. Added in Cargo 1.40. */
                                    "dep_kinds": [
                                        {
@@ -305,7 +305,7 @@ OUTPUT FORMAT
                       This is null if this is a virtual workspace. Otherwise it is
                       the Package ID of the root package.
                    */
-                   "root": "my-package 0.1.0 (path+file:///path/to/my-package)"
+                   "root": "file:///path/to/my-package#0.1.0",
                },
                /* The absolute path to the build directory where Cargo places its output. */
                "target_directory": "/path/to/my-package/target",

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -56,7 +56,7 @@ The JSON output has the following format:
             /* The Package ID, an opaque and unique identifier for referring to the
                package. See "Compatibility" above for the stability guarantee.
             */
-            "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+            "id": "file:///path/to/my-package#0.1.0",
             /* The license value from the manifest, or null. */
             "license": "MIT/Apache-2.0",
             /* The license-file value from the manifest, or null. */
@@ -242,13 +242,13 @@ The JSON output has the following format:
        Each entry is the Package ID for the package.
     */
     "workspace_members": [
-        "my-package 0.1.0 (path+file:///path/to/my-package)",
+        "file:///path/to/my-package#0.1.0",
     ],
     /* Array of default members of the workspace.
        Each entry is the Package ID for the package.
     */
     "workspace_default_members": [
-        "my-package 0.1.0 (path+file:///path/to/my-package)",
+        "file:///path/to/my-package#0.1.0",
     ],
     // The resolved dependency graph for the entire workspace. The enabled
     // features are based on the enabled features for the "current" package.
@@ -266,10 +266,10 @@ The JSON output has the following format:
         "nodes": [
             {
                 /* The Package ID of this node. */
-                "id": "my-package 0.1.0 (path+file:///path/to/my-package)",
+                "id": "file:///path/to/my-package#0.1.0",
                 /* The dependencies of this package, an array of Package IDs. */
                 "dependencies": [
-                    "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "https://github.com/rust-lang/crates.io-index#bitflags@1.0.4"
                 ],
                 /* The dependencies of this package. This is an alternative to
                    "dependencies" which contains additional information. In
@@ -283,7 +283,7 @@ The JSON output has the following format:
                         */
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
-                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "pkg": "https://github.com/rust-lang/crates.io-index#bitflags@1.0.4"
                         /* Array of dependency kinds. Added in Cargo 1.40. */
                         "dep_kinds": [
                             {
@@ -309,7 +309,7 @@ The JSON output has the following format:
            This is null if this is a virtual workspace. Otherwise it is
            the Package ID of the root package.
         */
-        "root": "my-package 0.1.0 (path+file:///path/to/my-package)"
+        "root": "file:///path/to/my-package#0.1.0",
     },
     /* The absolute path to the build directory where Cargo places its output. */
     "target_directory": "/path/to/my-package/target",

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -34,8 +34,8 @@ considersed as incompatible:
 * **Adding new values for enum-like fields** — Same as adding new fields. It
   keeps metadata evolving without stagnation.
 * **Changing opaque representations** — The inner representations of some
-  fields are implementation details. For example, fields related to "Package ID"
-  or "Source ID" are treated as opaque identifiers to differentiate packages or
+  fields are implementation details. For example, fields related to
+  "Source ID" are treated as opaque identifiers to differentiate packages or
   sources. Consumers shouldn't rely on those representations unless specified.
 
 ### JSON format
@@ -53,8 +53,8 @@ The JSON output has the following format:
             "name": "my-package",
             /* The version of the package. */
             "version": "0.1.0",
-            /* The Package ID, an opaque and unique identifier for referring to the
-               package. See "Compatibility" above for the stability guarantee.
+            /* The Package ID for referring to the
+               package within the document and as the `--package` argument to many commands
             */
             "id": "file:///path/to/my-package#0.1.0",
             /* The license value from the manifest, or null. */
@@ -330,6 +330,11 @@ The JSON output has the following format:
     }
 }
 ````
+
+Notes:
+- For `"id"` field syntax, see [Package ID Specifications] in the reference.
+
+[Package ID Specifications]: ../reference/pkgid-spec.html
 
 ## OPTIONS
 

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -36,8 +36,8 @@ keeps metadata evolving without stagnation.
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBChanging opaque representations\fR \[em] The inner representations of some
-fields are implementation details. For example, fields related to \[lq]Package ID\[rq]
-or \[lq]Source ID\[rq] are treated as opaque identifiers to differentiate packages or
+fields are implementation details. For example, fields related to
+\[lq]Source ID\[rq] are treated as opaque identifiers to differentiate packages or
 sources. Consumers shouldn\[cq]t rely on those representations unless specified.
 .RE
 .SS "JSON format"
@@ -332,6 +332,12 @@ The JSON output has the following format:
     }
 }
 .fi
+.RE
+.sp
+Notes:
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'For \fB"id"\fR field syntax, see \fIPackage ID Specifications\fR <https://doc.rust\-lang.org/cargo/reference/pkgid\-spec.html> in the reference.
 .RE
 .SH "OPTIONS"
 .SS "Output Options"

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -58,7 +58,7 @@ The JSON output has the following format:
             /* The Package ID, an opaque and unique identifier for referring to the
                package. See "Compatibility" above for the stability guarantee.
             */
-            "id": "my\-package 0.1.0 (path+file:///path/to/my\-package)",
+            "id": "file:///path/to/my\-package#0.1.0",
             /* The license value from the manifest, or null. */
             "license": "MIT/Apache\-2.0",
             /* The license\-file value from the manifest, or null. */
@@ -244,13 +244,13 @@ The JSON output has the following format:
        Each entry is the Package ID for the package.
     */
     "workspace_members": [
-        "my\-package 0.1.0 (path+file:///path/to/my\-package)",
+        "file:///path/to/my\-package#0.1.0",
     ],
     /* Array of default members of the workspace.
        Each entry is the Package ID for the package.
     */
     "workspace_default_members": [
-        "my\-package 0.1.0 (path+file:///path/to/my\-package)",
+        "file:///path/to/my\-package#0.1.0",
     ],
     // The resolved dependency graph for the entire workspace. The enabled
     // features are based on the enabled features for the "current" package.
@@ -268,10 +268,10 @@ The JSON output has the following format:
         "nodes": [
             {
                 /* The Package ID of this node. */
-                "id": "my\-package 0.1.0 (path+file:///path/to/my\-package)",
+                "id": "file:///path/to/my\-package#0.1.0",
                 /* The dependencies of this package, an array of Package IDs. */
                 "dependencies": [
-                    "bitflags 1.0.4 (registry+https://github.com/rust\-lang/crates.io\-index)"
+                    "https://github.com/rust\-lang/crates.io\-index#bitflags@1.0.4"
                 ],
                 /* The dependencies of this package. This is an alternative to
                    "dependencies" which contains additional information. In
@@ -285,7 +285,7 @@ The JSON output has the following format:
                         */
                         "name": "bitflags",
                         /* The Package ID of the dependency. */
-                        "pkg": "bitflags 1.0.4 (registry+https://github.com/rust\-lang/crates.io\-index)",
+                        "pkg": "https://github.com/rust\-lang/crates.io\-index#bitflags@1.0.4"
                         /* Array of dependency kinds. Added in Cargo 1.40. */
                         "dep_kinds": [
                             {
@@ -311,7 +311,7 @@ The JSON output has the following format:
            This is null if this is a virtual workspace. Otherwise it is
            the Package ID of the root package.
         */
-        "root": "my\-package 0.1.0 (path+file:///path/to/my\-package)"
+        "root": "file:///path/to/my\-package#0.1.0",
     },
     /* The absolute path to the build directory where Cargo places its output. */
     "target_directory": "/path/to/my\-package/target",

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -857,7 +857,7 @@ fn alt_reg_metadata() {
                     {
                         "name": "foo",
                         "version": "0.0.1",
-                        "id": "foo 0.0.1 (path+file:[..]/foo)",
+                        "id": "path+file:[..]/foo#0.0.1",
                         "license": null,
                         "license_file": null,
                         "description": null,
@@ -907,10 +907,10 @@ fn alt_reg_metadata() {
                     }
                 ],
                 "workspace_members": [
-                    "foo 0.0.1 (path+file:[..]/foo)"
+                    "path+file:[..]/foo#0.0.1"
                 ],
                 "workspace_default_members": [
-                    "foo 0.0.1 (path+file:[..]/foo)"
+                    "path+file:[..]/foo#0.0.1"
                 ],
                 "resolve": null,
                 "target_directory": "[..]/foo/target",
@@ -930,7 +930,7 @@ fn alt_reg_metadata() {
                     {
                         "name": "altdep",
                         "version": "0.0.1",
-                        "id": "altdep 0.0.1 (registry+file:[..]/alternative-registry)",
+                        "id": "registry+file:[..]/alternative-registry#altdep@0.0.1",
                         "license": null,
                         "license_file": null,
                         "description": null,
@@ -969,7 +969,7 @@ fn alt_reg_metadata() {
                     {
                         "name": "altdep2",
                         "version": "0.0.1",
-                        "id": "altdep2 0.0.1 (registry+file:[..]/alternative-registry)",
+                        "id": "registry+file:[..]/alternative-registry#altdep2@0.0.1",
                         "license": null,
                         "license_file": null,
                         "description": null,
@@ -995,7 +995,7 @@ fn alt_reg_metadata() {
                     {
                         "name": "bar",
                         "version": "0.0.1",
-                        "id": "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
                         "license": null,
                         "license_file": null,
                         "description": null,
@@ -1021,7 +1021,7 @@ fn alt_reg_metadata() {
                     {
                         "name": "foo",
                         "version": "0.0.1",
-                        "id": "foo 0.0.1 (path+file:[..]/foo)",
+                        "id": "path+file:[..]/foo#0.0.1",
                         "license": null,
                         "license_file": null,
                         "description": null,
@@ -1072,7 +1072,7 @@ fn alt_reg_metadata() {
                     {
                         "name": "iodep",
                         "version": "0.0.1",
-                        "id": "iodep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                        "id": "registry+https://github.com/rust-lang/crates.io-index#iodep@0.0.1",
                         "license": null,
                         "license_file": null,
                         "description": null,
@@ -1110,10 +1110,10 @@ fn alt_reg_metadata() {
                     }
                 ],
                 "workspace_members": [
-                    "foo 0.0.1 (path+file:[..]/foo)"
+                    "path+file:[..]/foo#0.0.1"
                 ],
                 "workspace_default_members": [
-                    "foo 0.0.1 (path+file:[..]/foo)"
+                    "path+file:[..]/foo#0.0.1"
                 ],
                 "resolve": "{...}",
                 "target_directory": "[..]/foo/target",
@@ -1173,7 +1173,7 @@ fn unknown_registry() {
                 {
                   "name": "bar",
                   "version": "0.0.1",
-                  "id": "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                  "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
                   "license": null,
                   "license_file": null,
                   "description": null,
@@ -1212,7 +1212,7 @@ fn unknown_registry() {
                 {
                   "name": "baz",
                   "version": "0.0.1",
-                  "id": "baz 0.0.1 (registry+file://[..]/alternative-registry)",
+                  "id": "registry+file://[..]/alternative-registry#baz@0.0.1",
                   "license": null,
                   "license_file": null,
                   "description": null,
@@ -1238,7 +1238,7 @@ fn unknown_registry() {
                 {
                   "name": "foo",
                   "version": "0.0.1",
-                  "id": "foo 0.0.1 (path+file://[..]/foo)",
+                  "id": "path+file://[..]/foo#0.0.1",
                   "license": null,
                   "license_file": null,
                   "description": null,
@@ -1276,10 +1276,10 @@ fn unknown_registry() {
                 }
               ],
               "workspace_members": [
-                "foo 0.0.1 (path+file://[..]/foo)"
+                "path+file://[..]/foo#0.0.1"
               ],
               "workspace_default_members": [
-                "foo 0.0.1 (path+file://[..]/foo)"
+                "path+file://[..]/foo#0.0.1"
               ],
               "resolve": "{...}",
               "target_directory": "[..]/foo/target",

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -586,7 +586,7 @@ fn json_exposed() {
                     {
                       "name": "foo",
                       "version": "0.1.0",
-                      "id": "foo 0.1.0 [..]",
+                      "id": "[..]foo#0.1.0",
                       "license": null,
                       "license_file": null,
                       "description": null,

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -3275,7 +3275,7 @@ fn metadata_master_consistency() {
                 {
                   "name": "bar",
                   "version": "1.0.0",
-                  "id": "bar 1.0.0 (__BAR_SOURCE__#__BAR_HASH__)",
+                  "id": "__BAR_SOURCE__#1.0.0",
                   "license": null,
                   "license_file": null,
                   "description": null,
@@ -3301,7 +3301,7 @@ fn metadata_master_consistency() {
                 {
                   "name": "foo",
                   "version": "0.1.0",
-                  "id": "foo 0.1.0 [..]",
+                  "id": "[..]foo#0.1.0",
                   "license": null,
                   "license_file": null,
                   "description": null,
@@ -3339,28 +3339,28 @@ fn metadata_master_consistency() {
                 }
               ],
               "workspace_members": [
-                "foo 0.1.0 [..]"
+                "[..]foo#0.1.0"
               ],
               "workspace_default_members": [
-                "foo 0.1.0 [..]"
+                "[..]foo#0.1.0"
               ],
               "resolve": {
                 "nodes": [
                   {
-                    "id": "bar 1.0.0 (__BAR_SOURCE__#__BAR_HASH__)",
+                    "id": "__BAR_SOURCE__#1.0.0",
                     "dependencies": [],
                     "deps": [],
                     "features": []
                   },
                   {
-                    "id": "foo 0.1.0 [..]",
+                    "id": "[..]foo#0.1.0",
                     "dependencies": [
-                      "bar 1.0.0 (__BAR_SOURCE__#__BAR_HASH__)"
+                      "__BAR_SOURCE__#1.0.0"
                     ],
                     "deps": [
                       {
                         "name": "bar",
-                        "pkg": "bar 1.0.0 (__BAR_SOURCE__#__BAR_HASH__)",
+                        "pkg": "__BAR_SOURCE__#1.0.0",
                         "dep_kinds": [
                           {
                             "kind": null,
@@ -3372,7 +3372,7 @@ fn metadata_master_consistency() {
                     "features": []
                   }
                 ],
-                "root": "foo 0.1.0 [..]"
+                "root": "[..]foo#0.1.0"
               },
               "target_directory": "[..]",
               "version": 1,

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -26,7 +26,7 @@ fn cargo_metadata_simple() {
                 "default_run": null,
                 "name": "foo",
                 "version": "0.5.0",
-                "id": "foo[..]",
+                "id": "[..]foo#0.5.0",
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
@@ -64,18 +64,18 @@ fn cargo_metadata_simple() {
                 "publish": null
             }
         ],
-        "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
-        "workspace_default_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "workspace_members": ["path+file:[..]foo#0.5.0"],
+        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
         "resolve": {
             "nodes": [
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "foo 0.5.0 (path+file:[..]foo)"
+                    "id": "path+file:[..]foo#0.5.0"
                 }
             ],
-            "root": "foo 0.5.0 (path+file:[..]foo)"
+            "root": "path+file:[..]foo#0.5.0"
         },
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -131,7 +131,7 @@ crate-type = ["lib", "staticlib"]
                 "documentation": null,
                 "version": "0.5.0",
                 "rust_version": null,
-                "id": "foo[..]",
+                "id": "[..]foo#0.5.0",
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
@@ -164,18 +164,18 @@ crate-type = ["lib", "staticlib"]
                 "publish": null
             }
         ],
-        "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
-        "workspace_default_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "workspace_members": ["path+file:[..]foo#0.5.0"],
+        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
         "resolve": {
             "nodes": [
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "foo 0.5.0 (path+file:[..]foo)"
+                    "id": "path+file:[..]foo#0.5.0"
                 }
             ],
-            "root": "foo 0.5.0 (path+file:[..]foo)"
+            "root": "path+file:[..]foo#0.5.0"
         },
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -221,7 +221,7 @@ optional_feat = []
                 "homepage": null,
                 "documentation": null,
                 "version": "0.5.0",
-                "id": "foo[..]",
+                "id": "[..]foo#0.5.0",
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
@@ -258,8 +258,8 @@ optional_feat = []
                 "publish": null
             }
         ],
-        "workspace_members": ["foo 0.5.0 (path+file:[..]foo)"],
-        "workspace_default_members": ["foo 0.5.0 (path+file:[..]foo)"],
+        "workspace_members": ["path+file:[..]foo#0.5.0"],
+        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
         "resolve": {
             "nodes": [
                 {
@@ -269,10 +269,10 @@ optional_feat = []
                       "default",
                       "default_feat"
                     ],
-                    "id": "foo 0.5.0 (path+file:[..]foo)"
+                    "id": "path+file:[..]foo#0.5.0"
                 }
             ],
-            "root": "foo 0.5.0 (path+file:[..]foo)"
+            "root": "path+file:[..]foo#0.5.0"
         },
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -337,7 +337,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "description": null,
                 "edition": "2015",
                 "features": {},
-                "id": "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
                 "keywords": [],
                 "license": null,
                 "license_file": null,
@@ -378,7 +378,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "description": null,
                 "edition": "2015",
                 "features": {},
-                "id": "baz 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "id": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1",
                 "keywords": [],
                 "license": null,
                 "license_file": null,
@@ -444,7 +444,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "description": "foo",
                 "edition": "2015",
                 "features": {},
-                "id": "foo 0.5.0 (path+file:[..]foo)",
+                "id": "path+file:[..]foo#0.5.0",
                 "keywords": [],
                 "license": "MIT",
                 "license_file": null,
@@ -485,7 +485,7 @@ fn cargo_metadata_with_deps_and_version() {
                 "description": null,
                 "edition": "2015",
                 "features": {},
-                "id": "foobar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+                "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1",
                 "keywords": [],
                 "license": null,
                 "license_file": null,
@@ -523,7 +523,7 @@ fn cargo_metadata_with_deps_and_version() {
             "nodes": [
                 {
                     "dependencies": [
-                        "baz 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
                     ],
                     "deps": [
                         {
@@ -534,22 +534,22 @@ fn cargo_metadata_with_deps_and_version() {
                               }
                             ],
                             "name": "baz",
-                            "pkg": "baz 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                            "pkg": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
                         }
                     ],
                     "features": [],
-                    "id": "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
                 },
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "baz 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "id": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
                 },
                 {
                     "dependencies": [
-                        "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-                        "foobar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
+                        "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
                     ],
                     "deps": [
                         {
@@ -560,7 +560,7 @@ fn cargo_metadata_with_deps_and_version() {
                               }
                             ],
                             "name": "bar",
-                            "pkg": "bar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
                         },
                         {
                             "dep_kinds": [
@@ -570,28 +570,28 @@ fn cargo_metadata_with_deps_and_version() {
                               }
                             ],
                             "name": "foobar",
-                            "pkg": "foobar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                            "pkg": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
                         }
                     ],
                     "features": [],
-                    "id": "foo 0.5.0 (path+file:[..]foo)"
+                    "id": "path+file:[..]foo#0.5.0"
                 },
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "foobar 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
                 }
             ],
-            "root": "foo 0.5.0 (path+file:[..]foo)"
+            "root": "path+file:[..]foo#0.5.0"
         },
         "target_directory": "[..]foo/target",
         "version": 1,
         "workspace_members": [
-            "foo 0.5.0 (path+file:[..]foo)"
+            "path+file:[..]foo#0.5.0"
         ],
         "workspace_default_members": [
-            "foo 0.5.0 (path+file:[..]foo)"
+            "path+file:[..]foo#0.5.0"
         ],
         "workspace_root": "[..]/foo",
         "metadata": null
@@ -634,7 +634,7 @@ name = "ex"
                 "homepage": null,
                 "documentation": null,
                 "version": "0.1.0",
-                "id": "foo[..]",
+                "id": "[..]foo#0.1.0",
                 "keywords": [],
                 "license": null,
                 "license_file": null,
@@ -672,16 +672,16 @@ name = "ex"
             }
         ],
         "workspace_members": [
-            "foo 0.1.0 (path+file:[..]foo)"
+            "path+file:[..]foo#0.1.0"
         ],
         "workspace_default_members": [
-            "foo 0.1.0 (path+file:[..]foo)"
+            "path+file:[..]foo#0.1.0"
         ],
         "resolve": {
-            "root": "foo 0.1.0 (path+file://[..]foo)",
+            "root": "path+file://[..]foo#0.1.0",
             "nodes": [
                 {
-                    "id": "foo 0.1.0 (path+file:[..]foo)",
+                    "id": "path+file:[..]foo#0.1.0",
                     "features": [],
                     "dependencies": [],
                     "deps": []
@@ -732,7 +732,7 @@ crate-type = ["rlib", "dylib"]
                 "homepage": null,
                 "documentation": null,
                 "version": "0.1.0",
-                "id": "foo[..]",
+                "id": "[..]foo#0.1.0",
                 "keywords": [],
                 "license": null,
                 "license_file": null,
@@ -770,16 +770,16 @@ crate-type = ["rlib", "dylib"]
             }
         ],
         "workspace_members": [
-            "foo 0.1.0 (path+file:[..]foo)"
+            "path+file:[..]foo#0.1.0"
         ],
          "workspace_default_members": [
-            "foo 0.1.0 (path+file:[..]foo)"
+            "path+file:[..]foo#0.1.0"
         ],
         "resolve": {
-            "root": "foo 0.1.0 (path+file://[..]foo)",
+            "root": "path+file://[..]foo#0.1.0",
             "nodes": [
                 {
-                    "id": "foo 0.1.0 (path+file:[..]foo)",
+                    "id": "path+file:[..]foo#0.1.0",
                     "features": [],
                     "dependencies": [],
                     "deps": []
@@ -832,7 +832,7 @@ fn workspace_metadata() {
                 "default_run": null,
                 "name": "bar",
                 "version": "0.5.0",
-                "id": "bar[..]",
+                "id": "[..]bar#0.5.0",
                 "readme": null,
                 "repository": null,
                 "rust_version": null,
@@ -876,7 +876,7 @@ fn workspace_metadata() {
                 "homepage": null,
                 "documentation": null,
                 "version": "0.5.0",
-                "id": "baz[..]",
+                "id": "[..]baz#0.5.0",
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
@@ -903,21 +903,27 @@ fn workspace_metadata() {
                 "publish": null
             }
         ],
-        "workspace_members": ["bar 0.5.0 (path+file:[..]bar)", "baz 0.5.0 (path+file:[..]baz)"],
-        "workspace_default_members": ["bar 0.5.0 (path+file:[..]bar)", "baz 0.5.0 (path+file:[..]baz)"],
+        "workspace_members": [
+            "path+file:[..]bar#0.5.0",
+            "path+file:[..]baz#0.5.0"
+        ],
+        "workspace_default_members": [
+            "path+file:[..]bar#0.5.0",
+            "path+file:[..]baz#0.5.0"
+        ],
         "resolve": {
             "nodes": [
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "bar 0.5.0 (path+file:[..]bar)"
+                    "id": "path+file:[..]bar#0.5.0"
                 },
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "baz 0.5.0 (path+file:[..]baz)"
+                    "id": "path+file:[..]baz#0.5.0"
                 }
             ],
             "root": null
@@ -988,7 +994,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
                 "homepage": null,
                 "documentation": null,
                 "version": "0.5.0",
-                "id": "bar[..]",
+                "id": "[..]bar#0.5.0",
                 "keywords": [],
                 "source": null,
                 "license": null,
@@ -1060,7 +1066,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
               "edition": "2015",
               "features": {},
               "homepage": null,
-              "id": "artifact 0.5.0 (path+file:[..]/foo/artifact)",
+              "id": "path+file:[..]/foo/artifact#0.5.0",
               "keywords": [],
               "license": null,
               "license_file": null,
@@ -1104,7 +1110,7 @@ fn workspace_metadata_with_dependencies_no_deps() {
                 "homepage": null,
                 "documentation": null,
                 "version": "0.5.0",
-                "id": "baz[..]",
+                "id": "[..]baz#0.5.0",
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
@@ -1132,14 +1138,14 @@ fn workspace_metadata_with_dependencies_no_deps() {
             }
         ],
         "workspace_members": [
-            "bar 0.5.0 (path+file:[..]bar)",
-            "artifact 0.5.0 (path+file:[..]/foo/artifact)",
-            "baz 0.5.0 (path+file:[..]baz)"
+            "path+file:[..]bar#0.5.0",
+            "path+file:[..]/foo/artifact#0.5.0",
+            "path+file:[..]baz#0.5.0"
         ],
         "workspace_default_members": [
-            "bar 0.5.0 (path+file:[..]bar)",
-            "artifact 0.5.0 (path+file:[..]/foo/artifact)",
-            "baz 0.5.0 (path+file:[..]baz)"
+            "path+file:[..]bar#0.5.0",
+            "path+file:[..]/foo/artifact#0.5.0",
+            "path+file:[..]baz#0.5.0"
         ],
         "resolve": null,
         "target_directory": "[..]foo/target",
@@ -1254,7 +1260,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "artifact 0.5.0 (path+file://[..]/foo/artifact)",
+                  "id": "path+file://[..]/foo/artifact#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -1482,7 +1488,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "bar 0.5.0 (path+file://[..]/foo/bar)",
+                  "id": "path+file://[..]/foo/bar#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -1537,7 +1543,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)",
+                  "id": "path+file://[..]/foo/bin-only-artifact#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -1592,7 +1598,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)",
+                  "id": "path+file://[..]/foo/non-artifact#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -1630,13 +1636,13 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "artifact 0.5.0 (path+file://[..]/foo/artifact)"
+                    "id": "path+file://[..]/foo/artifact#0.5.0"
                   },
                   {
                     "dependencies": [
-                      "artifact 0.5.0 (path+file://[..]/foo/artifact)",
-                      "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)",
-                      "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
+                      "path+file://[..]/foo/artifact#0.5.0",
+                      "path+file://[..]/foo/bin-only-artifact#0.5.0",
+                      "path+file://[..]/foo/non-artifact#0.5.0"
                     ],
                     "deps": [
                       {
@@ -1690,7 +1696,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                           }
                         ],
                         "name": "artifact",
-                        "pkg": "artifact 0.5.0 (path+file://[..]/foo/artifact)"
+                        "pkg": "path+file://[..]/foo/artifact#0.5.0"
                       },
                       {
                         "dep_kinds": [
@@ -1726,7 +1732,7 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                           }
                         ],
                         "name": "",
-                        "pkg": "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)"
+                        "pkg": "path+file://[..]/foo/bin-only-artifact#0.5.0"
                       },
                       {
                         "dep_kinds": [
@@ -1744,23 +1750,23 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                           }
                         ],
                         "name": "non_artifact",
-                        "pkg": "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
+                        "pkg": "path+file://[..]/foo/non-artifact#0.5.0"
                       }
                     ],
                     "features": [],
-                    "id": "bar 0.5.0 (path+file://[..]/foo/bar)"
+                    "id": "path+file://[..]/foo/bar#0.5.0"
                   },
                   {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)"
+                    "id": "path+file://[..]/foo/bin-only-artifact#0.5.0"
                   },
                   {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
+                    "id": "path+file://[..]/foo/non-artifact#0.5.0"
                   }
                 ],
                 "root": null
@@ -1768,16 +1774,16 @@ fn workspace_metadata_with_dependencies_and_resolve() {
               "target_directory": "[..]/foo/target",
               "version": 1,
               "workspace_members": [
-                "bar 0.5.0 (path+file://[..]/foo/bar)",
-                "artifact 0.5.0 (path+file://[..]/foo/artifact)",
-                "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)",
-                "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
+                "path+file://[..]/foo/bar#0.5.0",
+                "path+file://[..]/foo/artifact#0.5.0",
+                "path+file://[..]/foo/bin-only-artifact#0.5.0",
+                "path+file://[..]/foo/non-artifact#0.5.0"
               ],
               "workspace_default_members": [
-                "bar 0.5.0 (path+file://[..]/foo/bar)",
-                "artifact 0.5.0 (path+file://[..]/foo/artifact)",
-                "bin-only-artifact 0.5.0 (path+file://[..]/foo/bin-only-artifact)",
-                "non-artifact 0.5.0 (path+file://[..]/foo/non-artifact)"
+                "path+file://[..]/foo/bar#0.5.0",
+                "path+file://[..]/foo/artifact#0.5.0",
+                "path+file://[..]/foo/bin-only-artifact#0.5.0",
+                "path+file://[..]/foo/non-artifact#0.5.0"
               ],
               "workspace_root": "[..]/foo"
             }
@@ -1956,7 +1962,7 @@ const MANIFEST_OUTPUT: &str = r#"
         "default_run": null,
         "name":"foo",
         "version":"0.5.0",
-        "id":"foo[..]0.5.0[..](path+file://[..]/foo)",
+        "id":"path+file://[..]/foo#0.5.0",
         "source":null,
         "dependencies":[],
         "keywords": [],
@@ -1985,8 +1991,8 @@ const MANIFEST_OUTPUT: &str = r#"
         "homepage": null,
         "documentation": null
     }],
-    "workspace_members": [ "foo 0.5.0 (path+file:[..]foo)" ],
-    "workspace_default_members": [ "foo 0.5.0 (path+file:[..]foo)" ],
+    "workspace_members": [ "path+file:[..]foo#0.5.0" ],
+    "workspace_default_members": [ "path+file:[..]foo#0.5.0" ],
     "resolve": null,
     "target_directory": "[..]foo/target",
     "version": 1,
@@ -2149,7 +2155,7 @@ fn package_metadata() {
                 "homepage": "https://rust-lang.org",
                 "documentation": "https://doc.rust-lang.org/stable/std/",
                 "version": "0.1.0",
-                "id": "foo[..]",
+                "id": "[..]foo#0.1.0",
                 "keywords": ["database"],
                 "source": null,
                 "dependencies": [],
@@ -2180,8 +2186,8 @@ fn package_metadata() {
                 "publish": null
             }
         ],
-        "workspace_members": ["foo[..]"],
-        "workspace_default_members": ["foo[..]"],
+        "workspace_members": ["[..]foo#0.1.0"],
+        "workspace_default_members": ["[..]foo#0.1.0"],
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -2229,7 +2235,7 @@ fn package_publish() {
                 "homepage": null,
                 "documentation": null,
                 "version": "0.1.0",
-                "id": "foo[..]",
+                "id": "[..]foo#0.1.0",
                 "keywords": ["database"],
                 "source": null,
                 "dependencies": [],
@@ -2256,8 +2262,8 @@ fn package_publish() {
                 "publish": ["my-registry"]
             }
         ],
-        "workspace_members": ["foo[..]"],
-        "workspace_default_members": ["foo[..]"],
+        "workspace_members": ["[..]foo#0.1.0"],
+        "workspace_default_members": ["[..]foo#0.1.0"],
         "resolve": null,
         "target_directory": "[..]foo/target",
         "version": 1,
@@ -2303,7 +2309,7 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                     "description": null,
                     "edition": "2015",
                     "features": {},
-                    "id": "bar 0.5.0 ([..])",
+                    "id": "[..]#bar@0.5.0",
                     "keywords": [],
                     "license": null,
                     "license_file": null,
@@ -2343,18 +2349,18 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                         "dependencies": [],
                         "deps": [],
                         "features": [],
-                        "id": "bar 0.5.0 ([..])"
+                        "id": "[..]#bar@0.5.0"
                     }
                     ],
-                    "root": "bar 0.5.0 (path+file:[..])"
+                    "root": "path+file:[..]#bar@0.5.0"
                 },
                 "target_directory": "[..]",
                 "version": 1,
                 "workspace_members": [
-                    "bar 0.5.0 (path+file:[..])"
+                    "path+file:[..]#bar@0.5.0"
                 ],
                 "workspace_default_members": [
-                    "bar 0.5.0 (path+file:[..])"
+                    "path+file:[..]#bar@0.5.0"
                 ],
                 "workspace_root": "[..]",
                 "metadata": null
@@ -2394,7 +2400,7 @@ fn package_edition_2018() {
                         "description": null,
                         "edition": "2018",
                         "features": {},
-                        "id": "foo 0.1.0 (path+file:[..])",
+                        "id": "path+file:[..]#0.1.0",
                         "keywords": [],
                         "license": null,
                         "license_file": null,
@@ -2434,18 +2440,18 @@ fn package_edition_2018() {
                             "dependencies": [],
                             "deps": [],
                             "features": [],
-                            "id": "foo 0.1.0 (path+file:[..])"
+                            "id": "path+file:[..]#0.1.0"
                         }
                     ],
-                    "root": "foo 0.1.0 (path+file:[..])"
+                    "root": "path+file:[..]#0.1.0"
                 },
                 "target_directory": "[..]",
                 "version": 1,
                 "workspace_members": [
-                    "foo 0.1.0 (path+file:[..])"
+                    "path+file:[..]#0.1.0"
                 ],
                 "workspace_default_members": [
-                    "foo 0.1.0 (path+file:[..])"
+                    "path+file:[..]#0.1.0"
                 ],
                 "workspace_root": "[..]",
                 "metadata": null
@@ -2531,7 +2537,7 @@ fn target_edition_2018() {
                         "description": null,
                         "edition": "2015",
                         "features": {},
-                        "id": "foo 0.1.0 (path+file:[..])",
+                        "id": "path+file:[..]#0.1.0",
                         "keywords": [],
                         "license": null,
                         "license_file": null,
@@ -2585,18 +2591,18 @@ fn target_edition_2018() {
                             "dependencies": [],
                             "deps": [],
                             "features": [],
-                            "id": "foo 0.1.0 (path+file:[..])"
+                            "id": "path+file:[..]#0.1.0"
                         }
                     ],
-                    "root": "foo 0.1.0 (path+file:[..])"
+                    "root": "path+file:[..]#0.1.0"
                 },
                 "target_directory": "[..]",
                 "version": 1,
                 "workspace_members": [
-                    "foo 0.1.0 (path+file:[..])"
+                    "path+file:[..]#0.1.0"
                 ],
                 "workspace_default_members": [
-                    "foo 0.1.0 (path+file:[..])"
+                    "path+file:[..]#0.1.0"
                 ],
                 "workspace_root": "[..]",
                 "metadata": null
@@ -2641,7 +2647,7 @@ fn rename_dependency() {
             "description": null,
             "edition": "2015",
             "features": {},
-            "id": "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -2682,7 +2688,7 @@ fn rename_dependency() {
             "description": null,
             "edition": "2015",
             "features": {},
-            "id": "bar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+            "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -2748,7 +2754,7 @@ fn rename_dependency() {
             "description": null,
             "edition": "2015",
             "features": {},
-            "id": "foo 0.0.1[..]",
+            "id": "[..]foo#0.0.1",
             "keywords": [],
             "license": null,
             "license_file": null,
@@ -2788,18 +2794,18 @@ fn rename_dependency() {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
             },
             {
                 "dependencies": [],
                 "deps": [],
                 "features": [],
-                "id": "bar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
             },
             {
                 "dependencies": [
-                    "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-                    "bar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                    "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
+                    "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
                 ],
                 "deps": [
                     {
@@ -2810,7 +2816,7 @@ fn rename_dependency() {
                           }
                         ],
                         "name": "bar",
-                        "pkg": "bar 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
                     },
                     {
                         "dep_kinds": [
@@ -2820,22 +2826,22 @@ fn rename_dependency() {
                           }
                         ],
                         "name": "baz",
-                        "pkg": "bar 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
                     }
                 ],
                 "features": [],
-                "id": "foo 0.0.1[..]"
+                "id": "[..]foo#0.0.1"
             }
         ],
-        "root": "foo 0.0.1[..]"
+        "root": "[..]foo#0.0.1"
     },
     "target_directory": "[..]",
     "version": 1,
     "workspace_members": [
-        "foo 0.0.1[..]"
+        "[..]foo#0.0.1"
     ],
     "workspace_default_members": [
-        "foo 0.0.1[..]"
+        "[..]foo#0.0.1"
     ],
     "workspace_root": "[..]",
     "metadata": null
@@ -2873,7 +2879,7 @@ fn metadata_links() {
                   "description": null,
                   "edition": "2015",
                   "features": {},
-                  "id": "foo 0.5.0 [..]",
+                  "id": "[..]foo#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -2927,18 +2933,18 @@ fn metadata_links() {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "foo 0.5.0 [..]"
+                    "id": "[..]foo#0.5.0"
                   }
                 ],
-                "root": "foo 0.5.0 [..]"
+                "root": "[..]foo#0.5.0"
               },
               "target_directory": "[..]/foo/target",
               "version": 1,
               "workspace_members": [
-                "foo 0.5.0 [..]"
+                "[..]foo#0.5.0"
               ],
               "workspace_default_members": [
-                "foo 0.5.0 [..]"
+                "[..]foo#0.5.0"
               ],
               "workspace_root": "[..]/foo",
               "metadata": null
@@ -2974,7 +2980,7 @@ fn deps_with_bin_only() {
                 {
                   "name": "foo",
                   "version": "0.1.0",
-                  "id": "foo 0.1.0 ([..])",
+                  "id": "[..]foo#0.1.0",
                   "license": null,
                   "license_file": null,
                   "description": null,
@@ -3028,21 +3034,21 @@ fn deps_with_bin_only() {
                 }
               ],
               "workspace_members": [
-                "foo 0.1.0 ([..])"
+                "[..]foo#0.1.0"
               ],
               "workspace_default_members": [
-                "foo 0.1.0 ([..])"
+                "[..]foo#0.1.0"
               ],
               "resolve": {
                 "nodes": [
                   {
-                    "id": "foo 0.1.0 ([..])",
+                    "id": "[..]foo#0.1.0",
                     "dependencies": [],
                     "deps": [],
                     "features": []
                   }
                 ],
-                "root": "foo 0.1.0 ([..])"
+                "root": "[..]foo#0.1.0"
               },
               "target_directory": "[..]/foo/target",
               "version": 1,
@@ -3096,7 +3102,7 @@ fn filter_platform() {
     {
       "name": "alt-dep",
       "version": "0.0.1",
-      "id": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+      "id": "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
       "license": null,
       "license_file": null,
       "description": null,
@@ -3140,7 +3146,7 @@ fn filter_platform() {
     {
       "name": "cfg-dep",
       "version": "0.0.1",
-      "id": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+      "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
       "license": null,
       "license_file": null,
       "description": null,
@@ -3184,7 +3190,7 @@ fn filter_platform() {
     {
       "name": "host-dep",
       "version": "0.0.1",
-      "id": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+      "id": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
       "license": null,
       "license_file": null,
       "description": null,
@@ -3228,7 +3234,7 @@ fn filter_platform() {
     {
       "name": "normal-dep",
       "version": "0.0.1",
-      "id": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+      "id": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
       "license": null,
       "license_file": null,
       "description": null,
@@ -3334,7 +3340,7 @@ fn filter_platform() {
     {
       "name": "foo",
       "version": "0.1.0",
-      "id": "foo 0.1.0 (path+file:[..]foo)",
+      "id": "path+file:[..]foo#0.1.0",
       "license": null,
       "license_file": null,
       "description": null,
@@ -3410,37 +3416,37 @@ fn filter_platform() {
     $NORMAL_DEP
   ],
   "workspace_members": [
-    "foo 0.1.0 (path+file:[..]foo)"
+    "path+file:[..]foo#0.1.0"
   ],
   "workspace_default_members": [
-    "foo 0.1.0 (path+file:[..]foo)"
+    "path+file:[..]foo#0.1.0"
   ],
   "resolve": {
     "nodes": [
       {
-        "id": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "foo 0.1.0 (path+file:[..]foo)",
+        "id": "path+file:[..]foo#0.1.0",
         "dependencies": [
-          "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+          "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1"
         ],
         "deps": [
           {
             "name": "alt_dep",
-            "pkg": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3450,7 +3456,7 @@ fn filter_platform() {
           },
           {
             "name": "cfg_dep",
-            "pkg": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3460,7 +3466,7 @@ fn filter_platform() {
           },
           {
             "name": "host_dep",
-            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3470,7 +3476,7 @@ fn filter_platform() {
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3482,19 +3488,19 @@ fn filter_platform() {
         "features": []
       },
       {
-        "id": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       }
     ],
-    "root": "foo 0.1.0 (path+file:[..]foo)"
+    "root": "path+file:[..]foo#0.1.0"
   },
   "target_directory": "[..]/foo/target",
   "version": 1,
@@ -3538,21 +3544,21 @@ fn filter_platform() {
   "resolve": {
     "nodes": [
       {
-        "id": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "foo 0.1.0 (path+file:[..]foo)",
+        "id": "path+file:[..]foo#0.1.0",
         "dependencies": [
-          "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+          "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1"
         ],
         "deps": [
           {
             "name": "alt_dep",
-            "pkg": "alt-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#alt-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3562,7 +3568,7 @@ fn filter_platform() {
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3574,13 +3580,13 @@ fn filter_platform() {
         "features": []
       },
       {
-        "id": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       }
     ],
-    "root": "foo 0.1.0 (path+file:[..]foo)"
+    "root": "path+file:[..]foo#0.1.0"
   },
   "target_directory": "[..]foo/target",
   "version": 1,
@@ -3620,15 +3626,15 @@ fn filter_platform() {
   "resolve": {
     "nodes": [
       {
-        "id": "foo 0.1.0 (path+file:[..]foo)",
+        "id": "path+file:[..]foo#0.1.0",
         "dependencies": [
-          "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+          "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1"
         ],
         "deps": [
           {
             "name": "host_dep",
-            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3638,7 +3644,7 @@ fn filter_platform() {
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3650,19 +3656,19 @@ fn filter_platform() {
         "features": []
       },
       {
-        "id": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       }
     ],
-    "root": "foo 0.1.0 (path+file:[..]foo)"
+    "root": "path+file:[..]foo#0.1.0"
   },
   "target_directory": "[..]foo/target",
   "version": 1,
@@ -3705,22 +3711,22 @@ fn filter_platform() {
   "resolve": {
     "nodes": [
       {
-        "id": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "foo 0.1.0 (path+file:[..]/foo)",
+        "id": "path+file:[..]/foo#0.1.0",
         "dependencies": [
-          "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
-          "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)"
+          "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1"
         ],
         "deps": [
           {
             "name": "cfg_dep",
-            "pkg": "cfg-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#cfg-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3730,7 +3736,7 @@ fn filter_platform() {
           },
           {
             "name": "host_dep",
-            "pkg": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3740,7 +3746,7 @@ fn filter_platform() {
           },
           {
             "name": "normal_dep",
-            "pkg": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -3752,19 +3758,19 @@ fn filter_platform() {
         "features": []
       },
       {
-        "id": "host-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#host-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       },
       {
-        "id": "normal-dep 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+        "id": "registry+https://github.com/rust-lang/crates.io-index#normal-dep@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []
       }
     ],
-    "root": "foo 0.1.0 (path+file:[..]/foo)"
+    "root": "path+file:[..]/foo#0.1.0"
   },
   "target_directory": "[..]/foo/target",
   "version": 1,
@@ -3824,21 +3830,21 @@ fn dep_kinds() {
               "resolve": {
                 "nodes": [
                   {
-                    "id": "bar 0.1.0 [..]",
+                    "id": "[..]#bar@0.1.0",
                     "dependencies": [],
                     "deps": [],
                     "features": []
                   },
                   {
-                    "id": "foo 0.1.0 [..]",
+                    "id": "[..]foo#0.1.0",
                     "dependencies": [
-                      "bar 0.1.0 [..]",
-                      "winapi 0.1.0 [..]"
+                      "[..]#bar@0.1.0",
+                      "[..]#winapi@0.1.0"
                     ],
                     "deps": [
                       {
                         "name": "bar",
-                        "pkg": "bar 0.1.0 [..]",
+                        "pkg": "[..]#bar@0.1.0",
                         "dep_kinds": [
                           {
                             "kind": null,
@@ -3856,7 +3862,7 @@ fn dep_kinds() {
                       },
                       {
                         "name": "winapi",
-                        "pkg": "winapi 0.1.0 [..]",
+                        "pkg": "[..]#winapi@0.1.0",
                         "dep_kinds": [
                           {
                             "kind": null,
@@ -3868,13 +3874,13 @@ fn dep_kinds() {
                     "features": []
                   },
                   {
-                    "id": "winapi 0.1.0 [..]",
+                    "id": "[..]#winapi@0.1.0",
                     "dependencies": [],
                     "deps": [],
                     "features": []
                   }
                 ],
-                "root": "foo 0.1.0 [..]"
+                "root": "[..]foo#0.1.0"
               }
             }
             "#,
@@ -3940,14 +3946,14 @@ fn dep_kinds_workspace() {
               "resolve": {
                 "nodes": [
                   {
-                    "id": "bar 0.1.0 (path+file://[..]/foo/bar)",
+                    "id": "path+file://[..]/foo/bar#0.1.0",
                     "dependencies": [
-                      "foo 0.1.0 (path+file://[..]/foo)"
+                      "path+file://[..]/foo#0.1.0"
                     ],
                     "deps": [
                       {
                         "name": "foo",
-                        "pkg": "foo 0.1.0 (path+file://[..]/foo)",
+                        "pkg": "path+file://[..]/foo#0.1.0",
                         "dep_kinds": [
                           {
                             "kind": null,
@@ -3959,20 +3965,20 @@ fn dep_kinds_workspace() {
                     "features": []
                   },
                   {
-                    "id": "dep 0.5.0 (path+file://[..]/foo/dep)",
+                    "id": "path+file://[..]/foo/dep#0.5.0",
                     "dependencies": [],
                     "deps": [],
                     "features": []
                   },
                   {
-                    "id": "foo 0.1.0 (path+file://[..]/foo)",
+                    "id": "path+file://[..]/foo#0.1.0",
                     "dependencies": [
-                      "dep 0.5.0 (path+file://[..]/foo/dep)"
+                      "path+file://[..]/foo/dep#0.5.0"
                     ],
                     "deps": [
                       {
                         "name": "dep",
-                        "pkg": "dep 0.5.0 (path+file://[..]/foo/dep)",
+                        "pkg": "path+file://[..]/foo/dep#0.5.0",
                         "dep_kinds": [
                           {
                             "kind": null,
@@ -3986,7 +3992,7 @@ fn dep_kinds_workspace() {
                     ]
                   }
                 ],
-                "root": "foo 0.1.0 (path+file://[..]/foo)"
+                "root": "path+file://[..]/foo#0.1.0"
               }
             }
             "#,
@@ -4120,7 +4126,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "bar 0.5.0 (path+file://[..]/foo/bar)",
+                  "id": "path+file://[..]/foo/bar#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -4163,7 +4169,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "artifact 0.5.0 (path+file://[..]/foo/artifact)",
+                  "id": "path+file://[..]/foo/artifact#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -4206,7 +4212,7 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                   "edition": "2015",
                   "features": {},
                   "homepage": null,
-                  "id": "baz 0.5.0 (path+file://[..]/foo/baz)",
+                  "id": "path+file://[..]/foo/baz#0.5.0",
                   "keywords": [],
                   "license": null,
                   "license_file": null,
@@ -4242,14 +4248,14 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
               "target_directory": "[..]/foo/target",
               "version": 1,
               "workspace_members": [
-                "bar 0.5.0 (path+file://[..]/foo/bar)",
-                "artifact 0.5.0 (path+file://[..]/foo/artifact)",
-                "baz 0.5.0 (path+file://[..]/foo/baz)"
+                "path+file://[..]/foo/bar#0.5.0",
+                "path+file://[..]/foo/artifact#0.5.0",
+                "path+file://[..]/foo/baz#0.5.0"
               ],
               "workspace_default_members": [
-                "bar 0.5.0 (path+file://[..]/foo/bar)",
-                "artifact 0.5.0 (path+file://[..]/foo/artifact)",
-                "baz 0.5.0 (path+file://[..]/foo/baz)"
+                "path+file://[..]/foo/bar#0.5.0",
+                "path+file://[..]/foo/artifact#0.5.0",
+                "path+file://[..]/foo/baz#0.5.0"
               ],
               "workspace_root": "[..]/foo"
             }
@@ -4302,7 +4308,7 @@ fn versionless_packages() {
     {
       "name": "bar",
       "version": "0.0.0",
-      "id": "bar 0.0.0 [..]",
+      "id": "[..]bar#0.0.0",
       "license": null,
       "license_file": null,
       "description": null,
@@ -4369,7 +4375,7 @@ fn versionless_packages() {
     {
       "name": "baz",
       "version": "0.0.0",
-      "id": "baz 0.0.0 [..]",
+      "id": "[..]baz#0.0.0",
       "license": null,
       "license_file": null,
       "description": null,
@@ -4423,7 +4429,7 @@ fn versionless_packages() {
     {
       "name": "foobar",
       "version": "0.0.1",
-      "id": "foobar 0.0.1 [..]",
+      "id": "[..]#foobar@0.0.1",
       "license": null,
       "license_file": null,
       "description": null,
@@ -4463,25 +4469,25 @@ fn versionless_packages() {
     }
   ],
   "workspace_members": [
-    "bar 0.0.0 [..]",
-    "baz 0.0.0 [..]"
+    "[..]bar#0.0.0",
+    "[..]baz#0.0.0"
   ],
   "workspace_default_members": [
-    "bar 0.0.0 [..]",
-    "baz 0.0.0 [..]"
+    "[..]bar#0.0.0",
+    "[..]baz#0.0.0"
   ],
   "resolve": {
     "nodes": [
       {
-        "id": "bar 0.0.0 [..]",
+        "id": "[..]bar#0.0.0",
         "dependencies": [
-          "baz 0.0.0 [..]",
-          "foobar 0.0.1 [..]"
+          "[..]baz#0.0.0",
+          "[..]#foobar@0.0.1"
         ],
         "deps": [
           {
             "name": "baz",
-            "pkg": "baz 0.0.0 [..]",
+            "pkg": "[..]baz#0.0.0",
             "dep_kinds": [
               {
                 "kind": null,
@@ -4491,7 +4497,7 @@ fn versionless_packages() {
           },
           {
             "name": "foobar",
-            "pkg": "foobar 0.0.1 [..]",
+            "pkg": "[..]#foobar@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -4503,14 +4509,14 @@ fn versionless_packages() {
         "features": []
       },
       {
-        "id": "baz 0.0.0 [..]",
+        "id": "[..]baz#0.0.0",
         "dependencies": [
-          "foobar 0.0.1 [..]"
+          "[..]#foobar@0.0.1"
         ],
         "deps": [
           {
             "name": "foobar",
-            "pkg": "foobar 0.0.1 [..]",
+            "pkg": "[..]#foobar@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
@@ -4522,7 +4528,7 @@ fn versionless_packages() {
         "features": []
       },
       {
-        "id": "foobar 0.0.1 [..]",
+        "id": "[..]#foobar@0.0.1",
         "dependencies": [],
         "deps": [],
         "features": []

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -18,7 +18,7 @@ fn manifest_output(readme_value: &str) -> String {
     "repository": null,
     "rust_version": null,
     "version":"0.5.0",
-    "id":"foo[..]0.5.0[..](path+file://[..]/foo)",
+    "id":"path+file://[..]/foo#0.5.0",
     "keywords": [],
     "license": null,
     "license_file": null,

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1024,7 +1024,7 @@ fn cmd_metadata_with_embedded() {
                 "default_run": null,
                 "name": "script",
                 "version": "0.0.0",
-                "id": "script[..]",
+                "id": "path+file:[..]foo#script@0.0.0",
                 "keywords": [],
                 "source": null,
                 "dependencies": [],
@@ -1062,18 +1062,18 @@ fn cmd_metadata_with_embedded() {
                 "publish": []
             }
         ],
-        "workspace_members": ["script 0.0.0 (path+file:[..]foo)"],
-        "workspace_default_members": ["script 0.0.0 (path+file:[..]foo)"],
+        "workspace_members": ["path+file:[..]foo#script@0.0.0"],
+        "workspace_default_members": ["path+file:[..]foo#script@0.0.0"],
         "resolve": {
             "nodes": [
                 {
                     "dependencies": [],
                     "deps": [],
                     "features": [],
-                    "id": "script 0.0.0 (path+file:[..]foo)"
+                    "id": "path+file:[..]foo#script@0.0.0"
                 }
             ],
-            "root": "script 0.0.0 (path+file:[..]foo)"
+            "root": "path+file:[..]foo#script@0.0.0"
         },
         "target_directory": "[ROOT]/home/.cargo/target/[..]",
         "version": 1,
@@ -1112,7 +1112,7 @@ fn cmd_read_manifest_with_embedded() {
     "repository": null,
     "rust_version": null,
     "version":"0.0.0",
-    "id":"script[..]0.0.0[..](path+file://[..]/foo)",
+    "id":"path+file://[..]/foo#script@0.0.0",
     "keywords": [],
     "license": null,
     "license_file": null,

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -700,7 +700,7 @@ fn update_precise_first_run() {
       "edition": "2015",
       "features": {},
       "homepage": null,
-      "id": "bar 0.0.1 (path+file://[..]/foo)",
+      "id": "path+file://[..]/foo#bar@0.0.1",
       "keywords": [],
       "license": null,
       "license_file": null,
@@ -741,7 +741,7 @@ fn update_precise_first_run() {
       "edition": "2015",
       "features": {},
       "homepage": null,
-      "id": "serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+      "id": "registry+https://github.com/rust-lang/crates.io-index#serde@0.2.0",
       "keywords": [],
       "license": null,
       "license_file": null,
@@ -777,7 +777,7 @@ fn update_precise_first_run() {
     "nodes": [
       {
         "dependencies": [
-          "serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+          "registry+https://github.com/rust-lang/crates.io-index#serde@0.2.0"
         ],
         "deps": [
           {
@@ -788,28 +788,28 @@ fn update_precise_first_run() {
               }
             ],
             "name": "serde",
-            "pkg": "serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#serde@0.2.0"
           }
         ],
         "features": [],
-        "id": "bar 0.0.1 (path+file://[..]/foo)"
+        "id": "path+file://[..]/foo#bar@0.0.1"
       },
       {
         "dependencies": [],
         "deps": [],
         "features": [],
-        "id": "serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)"
+        "id": "registry+https://github.com/rust-lang/crates.io-index#serde@0.2.0"
       }
     ],
-    "root": "bar 0.0.1 (path+file://[..]/foo)"
+    "root": "path+file://[..]/foo#bar@0.0.1"
   },
   "target_directory": "[..]/foo/target",
   "version": 1,
   "workspace_members": [
-    "bar 0.0.1 (path+file://[..]/foo)"
+    "path+file://[..]/foo#bar@0.0.1"
   ],
   "workspace_default_members": [
-    "bar 0.0.1 (path+file://[..]/foo)"
+    "path+file://[..]/foo#bar@0.0.1"
   ],
   "workspace_root": "[..]/foo",
   "metadata": null


### PR DESCRIPTION
### What does this PR try to resolve?

For tools integrating with cargo, `cargo metadata` is the primary interface.  Limitations include:
-  There isn't an unambiguous way to map a package entry from `cargo metadata`  to a parameter to pass to other `cargo` commands.  An `id` field exists but it is documented as an opaque string, useful only for comparisons with other `id`s within the document.
- There isn't an unambiguous way of taking user parameters (`--package`) and mapping them to `cargo metadata` entries.  `cargo pkgid` could help but it returns a `PackageIdSpec` which doesn't exist within the `cargo metadata` output.

This attempts to solve these problems by switching the `id` field from `PackageId` to `PackageIdSpec` which is a [publicly documented format](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html), can be generated by `cargo pkgid`, and is accepted by most commands via the `--package` flag.

As the `"id"` field is documented as opaque, this technically isn't a breaking change though people could be parsing it.

For `cargo_metadata` they do [use a new type that documents it as opaque but publicly expose the inner `String`](https://docs.rs/cargo_metadata/latest/cargo_metadata/struct.PackageId.html).  The `String` wasn't publicly exposed due to a request by users but instead their `PackageId` type replaced using `String`s in the API in oli-obk/cargo_metadata#59 with no indication given as to why the `String` was still exposed.  However, you'll note that before that PR, they had `WorkspaceMember` that parsed `PackageId`.  This was introduced in oli-obk/cargo_metadata#26 without a motivation given.

**Note that `PackageIdSpec` has multiple representation that might uniquely identify a package and we can return any one of them.**

Fixes #7267

### How should we test and review this PR?

### Additional information

cc @oli-obk 