### PR TITLE
fix(cli): Clarify --test is for targets, not test functions

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -37,9 +37,9 @@ pub fn cli() -> Command {
             "Benchmark only the specified example",
             "Benchmark all examples",
             "Benchmark only the specified test target",
-            "Benchmark all tests",
+            "Benchmark all test targets",
             "Benchmark only the specified bench target",
-            "Benchmark all benches",
+            "Benchmark all bench targets",
             "Benchmark all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -23,9 +23,9 @@ pub fn cli() -> Command {
             "Build only the specified example",
             "Build all examples",
             "Build only the specified test target",
-            "Build all tests",
+            "Build all test targets",
             "Build only the specified bench target",
-            "Build all benches",
+            "Build all bench targets",
             "Build all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -23,9 +23,9 @@ pub fn cli() -> Command {
             "Check only the specified example",
             "Check all examples",
             "Check only the specified test target",
-            "Check all tests",
+            "Check all test targets",
             "Check only the specified bench target",
-            "Check all benches",
+            "Check all bench targets",
             "Check all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -41,9 +41,9 @@ pub fn cli() -> Command {
             "Fix only the specified example",
             "Fix all examples",
             "Fix only the specified test target",
-            "Fix all tests",
+            "Fix all test targets",
             "Fix only the specified bench target",
-            "Fix all benches",
+            "Fix all bench targets",
             "Fix all targets (default)",
         )
         .arg_features()

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -39,9 +39,9 @@ pub fn cli() -> Command {
             "Build only the specified example",
             "Build all examples",
             "Build only the specified test target",
-            "Build all tests",
+            "Build all test targets",
             "Build only the specified bench target",
-            "Build all benches",
+            "Build all bench targets",
             "Build all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -27,9 +27,9 @@ pub fn cli() -> Command {
             "Build only the specified example",
             "Build all examples",
             "Build only the specified test target",
-            "Build all tests",
+            "Build all test targets",
             "Build only the specified bench target",
-            "Build all benches",
+            "Build all bench targets",
             "Build all targets",
         )
         .arg_features()

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -43,9 +43,9 @@ pub fn cli() -> Command {
             "Test only the specified example",
             "Test all examples",
             "Test only the specified test target",
-            "Test all tests",
+            "Test all test targets",
             "Test only the specified bench target",
-            "Test all benches",
+            "Test all bench targets",
             "Test all targets (does not include doctests)",
         )
         .arg_features()

--- a/src/cargo/util/workspace.rs
+++ b/src/cargo/util/workspace.rs
@@ -87,11 +87,11 @@ pub fn print_available_binaries(ws: &Workspace<'_>, options: &CompileOptions) ->
 }
 
 pub fn print_available_benches(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
-    print_available_targets(Target::is_bench, ws, options, "--bench", "benches")
+    print_available_targets(Target::is_bench, ws, options, "--bench", "bench targets")
 }
 
 pub fn print_available_tests(ws: &Workspace<'_>, options: &CompileOptions) -> CargoResult<()> {
-    print_available_targets(Target::is_test, ws, options, "--test", "tests")
+    print_available_targets(Target::is_test, ws, options, "--test", "test targets")
 }
 
 /// The path that we pass to rustc is actually fairly important because it will

--- a/tests/testsuite/cargo_bench/help/stdout.log
+++ b/tests/testsuite/cargo_bench/help/stdout.log
@@ -31,9 +31,9 @@ Target Selection:
       --bin [<NAME>]      Benchmark only the specified binary
       --examples          Benchmark all examples
       --example [<NAME>]  Benchmark only the specified example
-      --tests             Benchmark all tests
+      --tests             Benchmark all test targets
       --test [<NAME>]     Benchmark only the specified test target
-      --benches           Benchmark all benches
+      --benches           Benchmark all bench targets
       --bench [<NAME>]    Benchmark only the specified bench target
       --all-targets       Benchmark all targets
 

--- a/tests/testsuite/cargo_build/help/stdout.log
+++ b/tests/testsuite/cargo_build/help/stdout.log
@@ -26,9 +26,9 @@ Target Selection:
       --bin [<NAME>]      Build only the specified binary
       --examples          Build all examples
       --example [<NAME>]  Build only the specified example
-      --tests             Build all tests
+      --tests             Build all test targets
       --test [<NAME>]     Build only the specified test target
-      --benches           Build all benches
+      --benches           Build all bench targets
       --bench [<NAME>]    Build only the specified bench target
       --all-targets       Build all targets
 

--- a/tests/testsuite/cargo_check/help/stdout.log
+++ b/tests/testsuite/cargo_check/help/stdout.log
@@ -26,9 +26,9 @@ Target Selection:
       --bin [<NAME>]      Check only the specified binary
       --examples          Check all examples
       --example [<NAME>]  Check only the specified example
-      --tests             Check all tests
+      --tests             Check all test targets
       --test [<NAME>]     Check only the specified test target
-      --benches           Check all benches
+      --benches           Check all bench targets
       --bench [<NAME>]    Check only the specified bench target
       --all-targets       Check all targets
 

--- a/tests/testsuite/cargo_fix/help/stdout.log
+++ b/tests/testsuite/cargo_fix/help/stdout.log
@@ -31,9 +31,9 @@ Target Selection:
       --bin [<NAME>]      Fix only the specified binary
       --examples          Fix all examples
       --example [<NAME>]  Fix only the specified example
-      --tests             Fix all tests
+      --tests             Fix all test targets
       --test [<NAME>]     Fix only the specified test target
-      --benches           Fix all benches
+      --benches           Fix all bench targets
       --bench [<NAME>]    Fix only the specified bench target
       --all-targets       Fix all targets (default)
 

--- a/tests/testsuite/cargo_rustc/help/stdout.log
+++ b/tests/testsuite/cargo_rustc/help/stdout.log
@@ -28,9 +28,9 @@ Target Selection:
       --bin [<NAME>]      Build only the specified binary
       --examples          Build all examples
       --example [<NAME>]  Build only the specified example
-      --tests             Build all tests
+      --tests             Build all test targets
       --test [<NAME>]     Build only the specified test target
-      --benches           Build all benches
+      --benches           Build all bench targets
       --bench [<NAME>]    Build only the specified bench target
       --all-targets       Build all targets
 

--- a/tests/testsuite/cargo_rustdoc/help/stdout.log
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.log
@@ -26,9 +26,9 @@ Target Selection:
       --bin [<NAME>]      Build only the specified binary
       --examples          Build all examples
       --example [<NAME>]  Build only the specified example
-      --tests             Build all tests
+      --tests             Build all test targets
       --test [<NAME>]     Build only the specified test target
-      --benches           Build all benches
+      --benches           Build all bench targets
       --bench [<NAME>]    Build only the specified bench target
       --all-targets       Build all targets
 

--- a/tests/testsuite/cargo_test/help/stdout.log
+++ b/tests/testsuite/cargo_test/help/stdout.log
@@ -33,9 +33,9 @@ Target Selection:
       --bin [<NAME>]      Test only the specified binary
       --examples          Test all examples
       --example [<NAME>]  Test only the specified example
-      --tests             Test all tests
+      --tests             Test all test targets
       --test [<NAME>]     Test only the specified test target
-      --benches           Test all benches
+      --benches           Test all bench targets
       --bench [<NAME>]    Test only the specified bench target
       --all-targets       Test all targets (does not include doctests)
 

--- a/tests/testsuite/list_availables.rs
+++ b/tests/testsuite/list_availables.rs
@@ -59,7 +59,7 @@ Available binaries:
             .with_stderr(
                 "\
 error: \"--bench\" takes one argument.
-Available benches:
+Available bench targets:
     bench1
     bench2
 
@@ -75,7 +75,7 @@ Available benches:
             .with_stderr(
                 "\
 error: \"--test\" takes one argument.
-Available tests:
+Available test targets:
     test1
     test2
 
@@ -139,7 +139,7 @@ No binaries available.
             .with_stderr(
                 "\
 error: \"--bench\" takes one argument.
-No benches available.
+No bench targets available.
 
 ",
             )
@@ -153,7 +153,7 @@ No benches available.
             .with_stderr(
                 "\
 error: \"--test\" takes one argument.
-No tests available.
+No test targets available.
 
 ",
             )


### PR DESCRIPTION
We already refer to test targets as "test targets" instead of "tests" in `--test` but not `--tests` or in the error output.  This makes it uniformly refer to them as "test targets", making it clearer that these aren't test functions.

Fixes #7864

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
