### PR TITLE
refactor: Remove VersionExt

### DIFF
--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 use crate::core::{Dependency, PackageId, Registry, Summary};
 use crate::sources::source::QueryKind;
 use crate::util::edit_distance::edit_distance;
-use crate::util::{Config, OptVersionReq, VersionExt};
+use crate::util::{Config, OptVersionReq};
 use anyhow::Error;
 
 use super::context::Context;
@@ -275,7 +275,7 @@ pub(super) fn activation_error(
         msg.push_str(&describe_path_in_context(cx, &parent.package_id()));
 
         // If we have a pre-release candidate, then that may be what our user is looking for
-        if let Some(pre) = candidates.iter().find(|c| c.version().is_prerelease()) {
+        if let Some(pre) = candidates.iter().find(|c| !c.version().pre.is_empty()) {
             msg.push_str("\nif you are looking for the prerelease package it needs to be specified explicitly");
             msg.push_str(&format!(
                 "\n    {} = {{ version = \"{}\" }}",

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -22,7 +22,7 @@ pub use self::progress::{Progress, ProgressStyle};
 pub use self::queue::Queue;
 pub use self::restricted_names::validate_package_name;
 pub use self::rustc::Rustc;
-pub use self::semver_ext::{OptVersionReq, PartialVersion, RustVersion, VersionExt, VersionReqExt};
+pub use self::semver_ext::{OptVersionReq, PartialVersion, RustVersion, VersionReqExt};
 pub use self::to_semver::ToSemver;
 pub use self::vcs::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 pub use self::workspace::{

--- a/src/cargo/util/semver_ext.rs
+++ b/src/cargo/util/semver_ext.rs
@@ -12,18 +12,8 @@ pub enum OptVersionReq {
     UpdatePrecise(Version, VersionReq),
 }
 
-pub trait VersionExt {
-    fn is_prerelease(&self) -> bool;
-}
-
 pub trait VersionReqExt {
     fn exact(version: &Version) -> Self;
-}
-
-impl VersionExt for Version {
-    fn is_prerelease(&self) -> bool {
-        !self.pre.is_empty()
-    }
 }
 
 impl VersionReqExt for VersionReq {


### PR DESCRIPTION
This came out of my work on #12801.
I was looking at what might be appropriate to put in a `cargo-util-semver` crate and realized we have the `VersionExt` trait that exists but doesn't do much, so I dropped it.

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
