### PR TITLE
Do not allow empty feature name

### DIFF
--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -431,6 +431,9 @@ impl fmt::Display for FeatureValue {
 pub type FeatureMap = BTreeMap<InternedString, Vec<FeatureValue>>;
 
 fn validate_feature_name(pkg_id: PackageId, name: &str) -> CargoResult<()> {
+    if name.is_empty() {
+        bail!("feature name cannot be empty");
+    }
     let mut chars = name.chars();
     if let Some(ch) = chars.next() {
         if !(unicode_xid::UnicodeXID::is_xid_start(ch) || ch == '_' || ch.is_digit(10)) {
@@ -488,5 +491,6 @@ mod tests {
         assert!(validate_feature_name(pkg_id, "?foo").is_err());
         assert!(validate_feature_name(pkg_id, "ⒶⒷⒸ").is_err());
         assert!(validate_feature_name(pkg_id, "a¼").is_err());
+        assert!(validate_feature_name(pkg_id, "").is_err());
     }
 }

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -36,6 +36,37 @@ Caused by:
 }
 
 #[cargo_test]
+fn empty_feature_name() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+
+                [features]
+                "" = []
+            "#,
+        )
+        .file("src/main.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[..]`
+
+Caused by:
+  feature name cannot be empty
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn same_name() {
     // Feature with the same name as a dependency.
     let p = project()


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Found it when I was working on https://github.com/rust-lang/crates.io/pull/7379

### How should we test and review this PR?

See the unit tests and integration tests.

### Additional information

Do we have any special reasons to allow empty names? I am not sure. It seems there is no way to use an empty feature.
<!-- homu-ignore:end -->
