### PR TITLE
Fix some broken links in the man pages

### DIFF
--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -35,7 +35,7 @@ When you add a package that is already present, the existing entry will be updat
 Upon successful invocation, the enabled (`+`) and disabled (`-`) [features] of the specified
 dependency will be listed in the command's output.
 
-[features]: ../reference/features.md
+[features]: ../reference/features.html
 
 ## OPTIONS
 

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -90,7 +90,7 @@ will be used, beginning discovery at `$PATH/.cargo/config.toml`.
 
 {{#option "`--vers` _version_" "`--version` _version_" }}
 Specify a version to install. This may be a [version
-requirement](../reference/specifying-dependencies.md), like `~1.2`, to have Cargo
+requirement](../reference/specifying-dependencies.html), like `~1.2`, to have Cargo
 select the newest version from the given requirement. If the version does not
 have a requirement operator (such as `^` or `~`), then it must be in the form
 _MAJOR.MINOR.PATCH_, and will install exactly that version; it is *not*

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -33,8 +33,8 @@ DESCRIPTION
        be updated with the flags specified.
 
        Upon successful invocation, the enabled (+) and disabled (-) features
-       <https://doc.rust-lang.org/cargo/reference/features.md> of the specified
-       dependency will be listed in the command’s output.
+       <https://doc.rust-lang.org/cargo/reference/features.html> of the
+       specified dependency will be listed in the command’s output.
 
 OPTIONS
    Source options

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -94,7 +94,7 @@ OPTIONS
    Install Options
        --vers version, --version version
            Specify a version to install. This may be a version requirement
-           <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.md>,
+           <https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html>,
            like ~1.2, to have Cargo select the newest version from the given
            requirement. If the version does not have a requirement operator
            (such as ^ or ~), then it must be in the form MAJOR.MINOR.PATCH, and

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -32,7 +32,7 @@ When you add a package that is already present, the existing entry will be updat
 Upon successful invocation, the enabled (`+`) and disabled (`-`) [features] of the specified
 dependency will be listed in the command's output.
 
-[features]: ../reference/features.md
+[features]: ../reference/features.html
 
 ## OPTIONS
 

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -94,7 +94,7 @@ will be used, beginning discovery at `$PATH/.cargo/config.toml`.
 
 <dt class="option-term" id="option-cargo-install---vers"><a class="option-anchor" href="#option-cargo-install---vers"></a><code>--vers</code> <em>version</em></dt>
 <dt class="option-term" id="option-cargo-install---version"><a class="option-anchor" href="#option-cargo-install---version"></a><code>--version</code> <em>version</em></dt>
-<dd class="option-desc">Specify a version to install. This may be a <a href="../reference/specifying-dependencies.md">version
+<dd class="option-desc">Specify a version to install. This may be a <a href="../reference/specifying-dependencies.html">version
 requirement</a>, like <code>~1.2</code>, to have Cargo
 select the newest version from the given requirement. If the version does not
 have a requirement operator (such as <code>^</code> or <code>~</code>), then it must be in the form

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -44,7 +44,7 @@ If no source is specified, then a best effort will be made to select one, includ
 .sp
 When you add a package that is already present, the existing entry will be updated with the flags specified.
 .sp
-Upon successful invocation, the enabled (\fB+\fR) and disabled (\fB\-\fR) \fIfeatures\fR <https://doc.rust\-lang.org/cargo/reference/features.md> of the specified
+Upon successful invocation, the enabled (\fB+\fR) and disabled (\fB\-\fR) \fIfeatures\fR <https://doc.rust\-lang.org/cargo/reference/features.html> of the specified
 dependency will be listed in the command\[cq]s output.
 .SH "OPTIONS"
 .SS "Source options"

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -114,7 +114,7 @@ will be used, beginning discovery at \fB$PATH/.cargo/config.toml\fR\&.
 \fB\-\-version\fR \fIversion\fR
 .RS 4
 Specify a version to install. This may be a \fIversion
-requirement\fR <https://doc.rust\-lang.org/cargo/reference/specifying\-dependencies.md>, like \fB~1.2\fR, to have Cargo
+requirement\fR <https://doc.rust\-lang.org/cargo/reference/specifying\-dependencies.html>, like \fB~1.2\fR, to have Cargo
 select the newest version from the given requirement. If the version does not
 have a requirement operator (such as \fB^\fR or \fB~\fR), then it must be in the form
 \fIMAJOR.MINOR.PATCH\fR, and will install exactly that version; it is \fInot\fR


### PR DESCRIPTION
The `mdman` tool does not automatically convert links with the `.md` extension to `.html` like mdbook does. When using links with `.md`, the TXT and troff files ended up with broken links. This fixes the few that I found.
