### PR TITLE
feat(spec): Extend PackageIdSpec with source kind + git ref for unambiguous specs

### DIFF
--- a/src/cargo/core/mod.rs
+++ b/src/cargo/core/mod.rs
@@ -8,7 +8,7 @@ pub use self::package_id_spec::PackageIdSpec;
 pub use self::registry::Registry;
 pub use self::resolver::{Resolve, ResolveVersion};
 pub use self::shell::{Shell, Verbosity};
-pub use self::source_id::{GitReference, SourceId};
+pub use self::source_id::{GitReference, SourceId, SourceKind};
 pub use self::summary::{FeatureMap, FeatureValue, Summary};
 pub use self::workspace::{
     find_workspace_root, resolve_relative_path, MaybePackage, Workspace, WorkspaceConfig,

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -7,6 +7,7 @@ use serde::{de, ser};
 use url::Url;
 
 use crate::core::PackageId;
+use crate::core::SourceKind;
 use crate::util::edit_distance;
 use crate::util::errors::CargoResult;
 use crate::util::{validate_package_name, IntoUrl};
@@ -26,6 +27,7 @@ pub struct PackageIdSpec {
     name: String,
     version: Option<PartialVersion>,
     url: Option<Url>,
+    kind: Option<SourceKind>,
 }
 
 impl PackageIdSpec {
@@ -78,6 +80,7 @@ impl PackageIdSpec {
             name: String::from(name),
             version,
             url: None,
+            kind: None,
         })
     }
 
@@ -101,6 +104,7 @@ impl PackageIdSpec {
             name: String::from(package_id.name().as_str()),
             version: Some(package_id.version().clone().into()),
             url: Some(package_id.source_id().url().clone()),
+            kind: None,
         }
     }
 
@@ -144,6 +148,7 @@ impl PackageIdSpec {
             name,
             version,
             url: Some(url),
+            kind: None,
         })
     }
 
@@ -216,6 +221,7 @@ impl PackageIdSpec {
                         name: self.name.clone(),
                         version: self.version.clone(),
                         url: None,
+                        kind: None,
                     },
                     &mut suggestion,
                 );
@@ -226,6 +232,7 @@ impl PackageIdSpec {
                         name: self.name.clone(),
                         version: None,
                         url: None,
+                        kind: None,
                     },
                     &mut suggestion,
                 );
@@ -346,6 +353,7 @@ mod tests {
                 name: String::from("foo"),
                 version: None,
                 url: Some(Url::parse("https://crates.io/foo").unwrap()),
+                kind: None,
             },
             "https://crates.io/foo",
         );
@@ -355,6 +363,7 @@ mod tests {
                 name: String::from("foo"),
                 version: Some("1.2.3".parse().unwrap()),
                 url: Some(Url::parse("https://crates.io/foo").unwrap()),
+                kind: None,
             },
             "https://crates.io/foo#1.2.3",
         );
@@ -364,6 +373,7 @@ mod tests {
                 name: String::from("foo"),
                 version: Some("1.2".parse().unwrap()),
                 url: Some(Url::parse("https://crates.io/foo").unwrap()),
+                kind: None,
             },
             "https://crates.io/foo#1.2",
         );
@@ -373,6 +383,7 @@ mod tests {
                 name: String::from("bar"),
                 version: Some("1.2.3".parse().unwrap()),
                 url: Some(Url::parse("https://crates.io/foo").unwrap()),
+                kind: None,
             },
             "https://crates.io/foo#bar@1.2.3",
         );
@@ -382,6 +393,7 @@ mod tests {
                 name: String::from("bar"),
                 version: Some("1.2.3".parse().unwrap()),
                 url: Some(Url::parse("https://crates.io/foo").unwrap()),
+                kind: None,
             },
             "https://crates.io/foo#bar@1.2.3",
         );
@@ -391,6 +403,7 @@ mod tests {
                 name: String::from("bar"),
                 version: Some("1.2".parse().unwrap()),
                 url: Some(Url::parse("https://crates.io/foo").unwrap()),
+                kind: None,
             },
             "https://crates.io/foo#bar@1.2",
         );
@@ -400,6 +413,7 @@ mod tests {
                 name: String::from("foo"),
                 version: None,
                 url: None,
+                kind: None,
             },
             "foo",
         );
@@ -409,6 +423,7 @@ mod tests {
                 name: String::from("foo"),
                 version: Some("1.2.3".parse().unwrap()),
                 url: None,
+                kind: None,
             },
             "foo@1.2.3",
         );
@@ -418,6 +433,7 @@ mod tests {
                 name: String::from("foo"),
                 version: Some("1.2.3".parse().unwrap()),
                 url: None,
+                kind: None,
             },
             "foo@1.2.3",
         );
@@ -427,6 +443,7 @@ mod tests {
                 name: String::from("foo"),
                 version: Some("1.2".parse().unwrap()),
                 url: None,
+                kind: None,
             },
             "foo@1.2",
         );
@@ -438,6 +455,7 @@ mod tests {
                 name: String::from("regex"),
                 version: None,
                 url: None,
+                kind: None,
             },
             "regex",
         );
@@ -447,6 +465,7 @@ mod tests {
                 name: String::from("regex"),
                 version: Some("1.4".parse().unwrap()),
                 url: None,
+                kind: None,
             },
             "regex@1.4",
         );
@@ -456,6 +475,7 @@ mod tests {
                 name: String::from("regex"),
                 version: Some("1.4.3".parse().unwrap()),
                 url: None,
+                kind: None,
             },
             "regex@1.4.3",
         );
@@ -465,6 +485,7 @@ mod tests {
                 name: String::from("regex"),
                 version: None,
                 url: Some(Url::parse("https://github.com/rust-lang/crates.io-index").unwrap()),
+                kind: None,
             },
             "https://github.com/rust-lang/crates.io-index#regex",
         );
@@ -474,6 +495,7 @@ mod tests {
                 name: String::from("regex"),
                 version: Some("1.4.3".parse().unwrap()),
                 url: Some(Url::parse("https://github.com/rust-lang/crates.io-index").unwrap()),
+                kind: None,
             },
             "https://github.com/rust-lang/crates.io-index#regex@1.4.3",
         );
@@ -483,6 +505,7 @@ mod tests {
                 name: String::from("cargo"),
                 version: Some("0.52.0".parse().unwrap()),
                 url: Some(Url::parse("https://github.com/rust-lang/cargo").unwrap()),
+                kind: None,
             },
             "https://github.com/rust-lang/cargo#0.52.0",
         );
@@ -492,6 +515,7 @@ mod tests {
                 name: String::from("cargo-platform"),
                 version: Some("0.1.2".parse().unwrap()),
                 url: Some(Url::parse("https://github.com/rust-lang/cargo").unwrap()),
+                kind: None,
             },
             "https://github.com/rust-lang/cargo#cargo-platform@0.1.2",
         );
@@ -501,6 +525,7 @@ mod tests {
                 name: String::from("regex"),
                 version: Some("1.4.3".parse().unwrap()),
                 url: Some(Url::parse("ssh://git@github.com/rust-lang/regex.git").unwrap()),
+                kind: None,
             },
             "ssh://git@github.com/rust-lang/regex.git#regex@1.4.3",
         );
@@ -510,6 +535,7 @@ mod tests {
                 name: String::from("foo"),
                 version: None,
                 url: Some(Url::parse("file:///path/to/my/project/foo").unwrap()),
+                kind: None,
             },
             "file:///path/to/my/project/foo",
         );
@@ -519,6 +545,7 @@ mod tests {
                 name: String::from("foo"),
                 version: Some("1.1.8".parse().unwrap()),
                 url: Some(Url::parse("file:///path/to/my/project/foo").unwrap()),
+                kind: None,
             },
             "file:///path/to/my/project/foo#1.1.8",
         );

--- a/src/cargo/core/source_id.rs
+++ b/src/cargo/core/source_id.rs
@@ -373,6 +373,10 @@ impl SourceId {
         Some(self.inner.url.to_file_path().unwrap())
     }
 
+    pub fn kind(&self) -> &SourceKind {
+        &self.inner.kind
+    }
+
     /// Returns `true` if this source is from a registry (either local or not).
     pub fn is_registry(self) -> bool {
         matches!(
@@ -748,7 +752,7 @@ impl SourceKind {
             SourceKind::Path => Some("path"),
             SourceKind::Git(_) => Some("git"),
             SourceKind::Registry => Some("registry"),
-            // Sparse registry URL already includes the `sparse+` prefix
+            // Sparse registry URL already includes the `sparse+` prefix, see `SourceId::new`
             SourceKind::SparseRegistry => None,
             SourceKind::LocalRegistry => Some("local-registry"),
             SourceKind::Directory => Some("directory"),

--- a/src/cargo/core/source_id.rs
+++ b/src/cargo/core/source_id.rs
@@ -85,7 +85,7 @@ impl fmt::Display for Precise {
 /// The possible kinds of code source.
 /// Along with [`SourceIdInner`], this fully defines the source.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum SourceKind {
+pub enum SourceKind {
     /// A git repository.
     Git(GitReference),
     /// A local path.

--- a/src/doc/src/reference/pkgid-spec.md
+++ b/src/doc/src/reference/pkgid-spec.md
@@ -22,7 +22,8 @@ The formal grammar for a Package Id Specification is:
 
 ```notrust
 spec := pkgname |
-        [ kind "+" ] proto "://" hostname-and-path [ "#" ( pkgname | semver ) ]
+        [ kind "+" ] proto "://" hostname-and-path [ "?" query] [ "#" ( pkgname | semver ) ]
+query = ( "branch" | "tag" | "rev" ) "=" ref
 pkgname := name [ ("@" | ":" ) semver ]
 semver := digits [ "." digits [ "." digits [ "-" prerelease ] [ "+" build ]]]
 
@@ -56,6 +57,7 @@ The following are some examples of specs for several different git dependencies:
 | `https://github.com/rust-lang/cargo#cargo-platform@0.1.2`  | <nobr>`cargo-platform`</nobr> | `0.1.2`  |
 | `ssh://git@github.com/rust-lang/regex.git#regex@1.4.3`     | `regex`          | `1.4.3`  |
 | `git+ssh://git@github.com/rust-lang/regex.git#regex@1.4.3` | `regex`          | `1.4.3`  |
+| `git+ssh://git@github.com/rust-lang/regex.git?branch=dev#regex@1.4.3` | `regex`          | `1.4.3`  |
 
 Local packages on the filesystem can use `file://` URLs to reference them:
 

--- a/src/doc/src/reference/pkgid-spec.md
+++ b/src/doc/src/reference/pkgid-spec.md
@@ -21,11 +21,12 @@ qualified with a version to make it unique, such as `regex@1.4.3`.
 The formal grammar for a Package Id Specification is:
 
 ```notrust
-spec := pkgname
-       | proto "://" hostname-and-path [ "#" ( pkgname | semver ) ]
+spec := pkgname |
+        [ kind "+" ] proto "://" hostname-and-path [ "#" ( pkgname | semver ) ]
 pkgname := name [ ("@" | ":" ) semver ]
 semver := digits [ "." digits [ "." digits [ "-" prerelease ] [ "+" build ]]]
 
+kind = "registry" | "git" | "file"
 proto := "http" | "git" | ...
 ```
 
@@ -38,28 +39,31 @@ that come from different sources such as different registries.
 
 The following are references to the `regex` package on `crates.io`:
 
-| Spec                                                        | Name    | Version |
-|:------------------------------------------------------------|:-------:|:-------:|
-| `regex`                                                     | `regex` | `*`     |
-| `regex@1.4`                                                 | `regex` | `1.4.*` |
-| `regex@1.4.3`                                               | `regex` | `1.4.3` |
-| `https://github.com/rust-lang/crates.io-index#regex`        | `regex` | `*`     |
-| `https://github.com/rust-lang/crates.io-index#regex@1.4.3`  | `regex` | `1.4.3` |
+| Spec                                                              | Name    | Version |
+|:------------------------------------------------------------------|:-------:|:-------:|
+| `regex`                                                           | `regex` | `*`     |
+| `regex@1.4`                                                       | `regex` | `1.4.*` |
+| `regex@1.4.3`                                                     | `regex` | `1.4.3` |
+| `https://github.com/rust-lang/crates.io-index#regex`              | `regex` | `*`     |
+| `https://github.com/rust-lang/crates.io-index#regex@1.4.3`        | `regex` | `1.4.3` |
+| `registry+https://github.com/rust-lang/crates.io-index#regex@1.4.3` | `regex` | `1.4.3` |
 
 The following are some examples of specs for several different git dependencies:
 
-| Spec                                                      | Name             | Version  |
-|:----------------------------------------------------------|:----------------:|:--------:|
-| `https://github.com/rust-lang/cargo#0.52.0`               | `cargo`          | `0.52.0` |
-| `https://github.com/rust-lang/cargo#cargo-platform@0.1.2` | <nobr>`cargo-platform`</nobr> | `0.1.2`  |
-| `ssh://git@github.com/rust-lang/regex.git#regex@1.4.3`    | `regex`          | `1.4.3`  |
+| Spec                                                       | Name             | Version  |
+|:-----------------------------------------------------------|:----------------:|:--------:|
+| `https://github.com/rust-lang/cargo#0.52.0`                | `cargo`          | `0.52.0` |
+| `https://github.com/rust-lang/cargo#cargo-platform@0.1.2`  | <nobr>`cargo-platform`</nobr> | `0.1.2`  |
+| `ssh://git@github.com/rust-lang/regex.git#regex@1.4.3`     | `regex`          | `1.4.3`  |
+| `git+ssh://git@github.com/rust-lang/regex.git#regex@1.4.3` | `regex`          | `1.4.3`  |
 
 Local packages on the filesystem can use `file://` URLs to reference them:
 
-| Spec                                   | Name  | Version |
-|:---------------------------------------|:-----:|:-------:|
-| `file:///path/to/my/project/foo`       | `foo` | `*`     |
-| `file:///path/to/my/project/foo#1.1.8` | `foo` | `1.1.8` |
+| Spec                                        | Name  | Version |
+|:--------------------------------------------|:-----:|:-------:|
+| `file:///path/to/my/project/foo`            | `foo` | `*`     |
+| `file:///path/to/my/project/foo#1.1.8`      | `foo` | `1.1.8` |
+| `path+file:///path/to/my/project/foo#1.1.8` | `foo` | `1.1.8` |
 
 ### Brevity of specifications
 

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -36,7 +36,10 @@ fn local() {
     p.cargo("generate-lockfile").run();
 
     p.cargo("pkgid foo")
-        .with_stdout(format!("file://[..]{}#0.1.0", p.root().to_str().unwrap()))
+        .with_stdout(format!(
+            "path+file://[..]{}#0.1.0",
+            p.root().to_str().unwrap()
+        ))
         .run();
 
     // Bad file URL.
@@ -91,7 +94,7 @@ fn registry() {
     p.cargo("generate-lockfile").run();
 
     p.cargo("pkgid crates-io")
-        .with_stdout("https://github.com/rust-lang/crates.io-index#crates-io@0.1.0")
+        .with_stdout("registry+https://github.com/rust-lang/crates.io-index#crates-io@0.1.0")
         .run();
 
     // Bad URL.
@@ -145,7 +148,7 @@ fn multiple_versions() {
     p.cargo("generate-lockfile").run();
 
     p.cargo("pkgid two-ver:0.2.0")
-        .with_stdout("https://github.com/rust-lang/crates.io-index#two-ver@0.2.0")
+        .with_stdout("registry+https://github.com/rust-lang/crates.io-index#two-ver@0.2.0")
         .run();
 
     // Incomplete version.
@@ -165,7 +168,7 @@ Please re-run this command with one of the following specifications:
     p.cargo("pkgid two-ver@0.2")
         .with_stdout(
             "\
-https://github.com/rust-lang/crates.io-index#two-ver@0.2.0
+registry+https://github.com/rust-lang/crates.io-index#two-ver@0.2.0
 ",
         )
         .run();
@@ -274,8 +277,8 @@ foo v0.1.0 ([..]/foo)
             "\
 error: There are multiple `xyz` packages in your project, and the specification `xyz` is ambiguous.
 Please re-run this command with one of the following specifications:
-  file://[..]/xyz#0.5.0
-  file://[..]/xyz#0.5.0
+  git+file://[..]/xyz#0.5.0
+  git+file://[..]/xyz#0.5.0
 ",
         )
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -277,8 +277,8 @@ foo v0.1.0 ([..]/foo)
             "\
 error: There are multiple `xyz` packages in your project, and the specification `xyz` is ambiguous.
 Please re-run this command with one of the following specifications:
-  git+file://[..]/xyz#0.5.0
-  git+file://[..]/xyz#0.5.0
+  git+file://[..]/xyz?rev=[..]#0.5.0
+  git+file://[..]/xyz?rev=[..]#0.5.0
 ",
         )
         .run();

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo pkgid` command.
 
+use cargo_test_support::basic_lib_manifest;
+use cargo_test_support::git;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 
@@ -194,4 +196,89 @@ Did you mean one of these?
 ",
         )
         .run();
+}
+
+// Not for `cargo pkgid` but the `PackageIdSpec` format
+#[cargo_test]
+fn multiple_git_same_version() {
+    // Test what happens if different packages refer to the same git repo with
+    // different refs, and the package version is the same.
+    let (xyz_project, xyz_repo) = git::new_repo("xyz", |project| {
+        project
+            .file("Cargo.toml", &basic_lib_manifest("xyz"))
+            .file("src/lib.rs", "fn example() {}")
+    });
+    let rev1 = xyz_repo.revparse_single("HEAD").unwrap().id();
+    xyz_project.change_file("src/lib.rs", "pub fn example() {}");
+    git::add(&xyz_repo);
+    let rev2 = git::commit(&xyz_repo);
+    // Both rev1 and rev2 point to version 0.1.0.
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "foo"
+                    version = "0.1.0"
+
+                    [dependencies]
+                    bar = {{ path = "bar" }}
+                    xyz = {{ git = "{}", rev = "{}" }}
+
+                "#,
+                xyz_project.url(),
+                rev1
+            ),
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "bar/Cargo.toml",
+            &format!(
+                r#"
+                    [package]
+                    name = "bar"
+                    version = "0.1.0"
+
+                    [dependencies]
+                    xyz = {{ git = "{}", rev = "{}" }}
+                "#,
+                xyz_project.url(),
+                rev2
+            ),
+        )
+        .file("bar/src/lib.rs", "")
+        .build();
+
+    p.cargo("check").run();
+    p.cargo("tree")
+        .with_stdout(&format!(
+            "\
+foo v0.1.0 ([..]/foo)
+├── bar v0.1.0 ([..]/foo/bar)
+│   └── xyz v0.5.0 (file://[..]/xyz?rev={}#{})
+└── xyz v0.5.0 (file://[..]/xyz?rev={}#{})
+",
+            rev2,
+            &rev2.to_string()[..8],
+            rev1,
+            &rev1.to_string()[..8]
+        ))
+        .run();
+    // FIXME: This fails since xyz is ambiguous, but the
+    // possible pkgids are also ambiguous.
+    p.cargo("pkgid xyz")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: There are multiple `xyz` packages in your project, and the specification `xyz` is ambiguous.
+Please re-run this command with one of the following specifications:
+  file://[..]/xyz#0.5.0
+  file://[..]/xyz#0.5.0
+",
+        )
+        .run();
+    // TODO, what should the `-p` value be here?
+    //p.cargo("update -p")
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This tries to add just enough information to Package ID Specs that we can be sure they are unambiguous.  On its own thats important but this will unblock #12914 so we can have a user-facing ID that can be used with cargo's CLI.

More specifically, this adds
- `git+`, etc prefixes to the scheme
  - These were previously stabilized for `cargo metadata`s source id urls
  - Like with `SourceID`, this will allow `PackageIDSpec` to generate `directory+` and `local-registry+` prefixes but not parse them.  I'm assuming that the layers where those are dealt with they won't appear here but I don't have enough experience with them
- git ref query strings for URLs

Things from `SourceID` that this does not include
- precise: this seems less related to matching (e.g. ignored for `impl Ord for SourceId`)
- canonical URL for git kinds: this could be nice for users but users aren't the target audience and we can switch to these later

Fixes #10256

### How should we test and review this PR?

Per-commit

### Additional information
