### PR TITLE
fix(timings): unnecessary backslash when error happens

### DIFF
--- a/src/cargo/core/compiler/timings.rs
+++ b/src/cargo/core/compiler/timings.rs
@@ -380,14 +380,7 @@ impl<'cfg> Timings<'cfg> {
             .unwrap_or_else(|_| "n/a".into());
         let rustc_info = render_rustc_info(bcx);
         let error_msg = match error {
-            Some(e) => format!(
-                r#"\
-  <tr>
-    <td class="error-text">Error:</td><td>{}</td>
-  </tr>
-"#,
-                e
-            ),
+            Some(e) => format!(r#"<tr><td class="error-text">Error:</td><td>{e}</td></tr>"#),
             None => "".to_string(),
         };
         write!(


### PR DESCRIPTION
<!-- homu-ignore:start -->


### What does this PR try to resolve?

Remove unnecessary backslash on timing HTML output when error happens.

### How should we test and review this PR?

Before:
<img width="200" alt="before" src="https://github.com/rust-lang/cargo/assets/14314532/48ca6a95-19e4-4839-b200-306d81330f76">

After:

<img width="200" alt="after" src="https://github.com/rust-lang/cargo/assets/14314532/f52c563d-c2a1-4c2a-a05a-160f99bd080a">

### Additional information
<!-- homu-ignore:end -->
