### PR TITLE
Fix the invalidate feature name message

### DIFF
--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -448,7 +448,7 @@ fn validate_feature_name(pkg_id: PackageId, name: &str) -> CargoResult<()> {
         if !(unicode_xid::UnicodeXID::is_xid_continue(ch) || ch == '-' || ch == '+' || ch == '.') {
             bail!(
                 "invalid character `{}` in feature `{}` in package {}, \
-                characters must be Unicode XID characters, `+`, or `.` \
+                characters must be Unicode XID characters, '-', `+`, or `.` \
                 (numbers, `+`, `-`, `_`, `.`, or most letters)",
                 ch,
                 name,

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -2045,7 +2045,7 @@ error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
   invalid character `&` in feature `a&b` in package foo v0.1.0 ([ROOT]/foo), \
-  characters must be Unicode XID characters, `+`, or `.` \
+  characters must be Unicode XID characters, '-', `+`, or `.` \
   (numbers, `+`, `-`, `_`, `.`, or most letters)
 ",
         )


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Unicode XID characters don't contain `-`. So I think it is better to add it.

### How should we test and review this PR?

- [x] unit tests

### Additional information

None
<!-- homu-ignore:end -->
