### PR TITLE
Only filter out target if its in the package root

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -327,7 +327,12 @@ impl<'cfg> PathSource<'cfg> {
 
             match file_path.file_name().and_then(|s| s.to_str()) {
                 // The `target` directory is never included.
-                Some("target") => continue,
+                Some("target") => {
+                    // Only filter out target if its in the package root.
+                    if file_path.parent().unwrap() == pkg_path {
+                        continue;
+                    }
+                }
 
                 // Keep track of all sub-packages found and also strip out all
                 // matches we've found so far. Note, though, that if we find


### PR DESCRIPTION
## What does this PR try to resolve?
Only filter out target if its in the package root. Fixed https://github.com/rust-lang/cargo/issues/12790

## How should we test and review this PR?


## Additional information