### PR TITLE
Only filter out target if its in the package root

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -327,7 +327,12 @@ impl<'cfg> PathSource<'cfg> {
 
             match file_path.file_name().and_then(|s| s.to_str()) {
                 // The `target` directory is never included.
-                Some("target") => continue,
+                Some("target") => {
+                    // Only filter out target if its in the package root.
+                    if file_path.parent().unwrap() == pkg_path {
+                        continue;
+                    }
+                }
 
                 // Keep track of all sub-packages found and also strip out all
                 // matches we've found so far. Note, though, that if we find

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3162,10 +3162,10 @@ src/main.rs
 fn include_files_called_target_git() {
     // https://github.com/rust-lang/cargo/issues/12790
     // files and folders called "target" should be included, unless they're the actual target directory
-    let (p, repo) = git::new_repo("target_uncommitted", |p| init_and_add_inner_target(p));
+    let (p, repo) = git::new_repo("foo", |p| init_and_add_inner_target(p));
     // add target folder but not committed.
-    let _ = fs::create_dir_all(&repo.workdir().unwrap().join("target/foo.txt")).unwrap();
-
+    _ = fs::create_dir(p.build_dir()).unwrap();
+    _ = fs::write(p.build_dir().join("foo.txt"), "").unwrap();
     p.cargo("package -l")
         .with_stdout(
             "\
@@ -3183,9 +3183,8 @@ src/main.rs
         .run();
 
     // if target is committed, it should be include.
-    let p = git::new("target_committed", |p| {
-        init_and_add_inner_target(p).file("target/foo.txt", "")
-    });
+    git::add(&repo);
+    git::commit(&repo);
     p.cargo("package -l")
         .with_stdout(
             "\

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -5,6 +5,7 @@ use cargo_test_support::publish::validate_crate_contents;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{
     basic_manifest, cargo_process, git, path2url, paths, project, symlink_supported, t,
+    ProjectBuilder,
 };
 use flate2::read::GzDecoder;
 use std::fs::{self, read_to_string, File};
@@ -3131,4 +3132,74 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
         &["Cargo.lock", "Cargo.toml", "Cargo.toml.orig", "src/main.rs"],
         &[],
     );
+}
+
+#[cargo_test]
+fn include_files_called_target_project() {
+    // https://github.com/rust-lang/cargo/issues/12790
+    // files and folders called "target" should be included, unless they're the actual target directory
+
+    let p = init_project_files_called_target(project()).build();
+
+    p.cargo("package -l")
+        .with_stdout(
+            "\
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+data/not_target
+data/target
+derp/not_target/foo.txt
+derp/target/foo.txt
+src/main.rs
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn include_files_called_target_git() {
+    // https://github.com/rust-lang/cargo/issues/12790
+    // files and folders called "target" should be included, unless they're the actual target directory
+
+    let p = git::new("all", |p| init_project_files_called_target(p));
+
+    p.cargo("package -l")
+        .with_stdout(
+            "\
+.cargo_vcs_info.json
+Cargo.lock
+Cargo.toml
+Cargo.toml.orig
+data/not_target
+data/target
+derp/not_target/foo.txt
+derp/target/foo.txt
+src/main.rs
+",
+        )
+        .run();
+}
+
+fn init_project_files_called_target(p: ProjectBuilder) -> ProjectBuilder {
+    p.file(
+        "Cargo.toml",
+        r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                authors = []
+                license = "MIT"
+                description = "foo"
+            "#,
+    )
+    .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
+    // actual target dir, should be excluded
+    .file("target/foo.txt", "")
+    // file called target, should be included
+    .file("data/target", "")
+    .file("data/not_target", "")
+    // folder called target, should be included
+    .file("derp/target/foo.txt", "")
+    .file("derp/not_target/foo.txt", "")
 }


### PR DESCRIPTION
### What does this PR try to resolve?
Only filter out target if its in the package root. Fixed https://github.com/rust-lang/cargo/issues/12790

### How should we test and review this PR?
Add two testcase in tests/testsuite/package.rs for this PR.

- `include_files_called_target_project` testcase test the logic for none git repository. By the way, our PR was based on git repository,  so this testcase was a little irrelevant.
-  `include_files_called_target_git` testcase was made for git repository.  There are two cases here, one is the target in the uncommitted state, at this time should not be included, and one is the target in the committed state, at this time should be included


### Additional information