### PR TITLE
Filter `cargo-credential-*` dependencies by OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,9 +128,6 @@ anyhow.workspace = true
 base64.workspace = true
 bytesize.workspace = true
 cargo-credential.workspace = true
-cargo-credential-libsecret.workspace = true
-cargo-credential-macos-keychain.workspace = true
-cargo-credential-wincred.workspace = true
 cargo-platform.workspace = true
 cargo-util.workspace = true
 clap = { workspace = true, features = ["wrap_help"] }
@@ -189,8 +186,17 @@ unicode-xid.workspace = true
 url.workspace = true
 walkdir.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+cargo-credential-libsecret.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+cargo-credential-macos-keychain.workspace = true
+
 [target.'cfg(not(windows))'.dependencies]
 openssl = { workspace = true, optional = true }
+
+[target.'cfg(windows)'.dependencies]
+cargo-credential-wincred.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/src/cargo/util/auth/mod.rs
+++ b/src/cargo/util/auth/mod.rs
@@ -529,9 +529,15 @@ fn credential_action(
             }
             "cargo:paseto" => bail!("cargo:paseto requires -Zasymmetric-token"),
             "cargo:token-from-stdout" => Box::new(BasicProcessCredential {}),
+            #[cfg(windows)]
             "cargo:wincred" => Box::new(cargo_credential_wincred::WindowsCredential {}),
+            #[cfg(target_os = "macos")]
             "cargo:macos-keychain" => Box::new(cargo_credential_macos_keychain::MacKeychain {}),
+            #[cfg(target_os = "linux")]
             "cargo:libsecret" => Box::new(cargo_credential_libsecret::LibSecretCredential {}),
+            name if BUILT_IN_PROVIDERS.contains(&name) => {
+                Box::new(cargo_credential::UnsupportedCredential {})
+            }
             process => Box::new(CredentialProcessCredential::new(process)),
         };
         config.shell().verbose(|c| {


### PR DESCRIPTION
### What does this PR try to resolve?

The `cargo-credential-*` crates have OS-specific functionality, with `cfg` for an "unsupported" fallback, and these are unconditional dependencies of `cargo`. In distros like Fedora that package dependencies individually, that means these crates still have to be packaged even when they are useless on Linux. (Or else patch them out as a downstream change.) Instead, we can filter those dependencies in `Cargo.toml` and add the fallback at the point of use.

Fixes #12945.

### Additional information

We could further *remove* the `cfg`-unsupported fallbacks from the individual crates, and just have them `#![cfg(..)]` themselves globally. I haven't done that yet, because it would look like a big change for mostly just whitespace removing the nested module. I'm happy to add that if desired though.