### PR TITLE
fix(resolver): Prefer MSRV, rather than ignore incompatible

### DIFF
--- a/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
@@ -26,7 +26,7 @@ fn case() {
         .current_dir(cwd)
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
-        .code(101)
+        .code(0)
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/tests/testsuite/cargo_add/rust_version_ignore/stderr.log
+++ b/tests/testsuite/cargo_add/rust_version_ignore/stderr.log
@@ -1,7 +1,2 @@
     Updating `dummy-registry` index
       Adding rust-version-user v0.2.1 to dependencies.
-error: failed to select a version for the requirement `rust-version-user = "^0.2.1"`
-candidate versions found which didn't match: 0.2.1, 0.1.0
-location searched: `dummy-registry` index (which is replacing registry `crates-io`)
-required by package `cargo-list-test-fixture v0.0.0 ([ROOT]/case)`
-perhaps a crate was updated and forgotten to be re-vendored?

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -245,37 +245,13 @@ fn dependency_rust_version_newer_than_package() {
         .file("src/main.rs", "fn main(){}")
         .build();
 
-    p.cargo("check --ignore-rust-version")
-        .arg("-Zmsrv-policy")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
-        // This shouldn't fail
-        .with_status(101)
-        .with_stderr(
-            "\
-[UPDATING] `dummy-registry` index
-[ERROR] failed to select a version for the requirement `bar = \"^1.0.0\"`
-candidate versions found which didn't match: 1.6.0
-location searched: `dummy-registry` index (which is replacing registry `crates-io`)
-required by package `foo v0.0.1 ([CWD])`
-perhaps a crate was updated and forgotten to be re-vendored?
-",
-        )
-        .run();
     p.cargo("check")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_status(101)
-        // This should have a better error message
-        .with_stderr(
-            "\
-[UPDATING] `dummy-registry` index
-[ERROR] failed to select a version for the requirement `bar = \"^1.0.0\"`
-candidate versions found which didn't match: 1.6.0
-location searched: `dummy-registry` index (which is replacing registry `crates-io`)
-required by package `foo v0.0.1 ([CWD])`
-perhaps a crate was updated and forgotten to be re-vendored?
-",
-        )
+        .run();
+    p.cargo("check --ignore-rust-version")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
         .run();
 }
 
@@ -369,8 +345,10 @@ fn dependency_rust_version_backtracking() {
             "\
 [UPDATING] `dummy-registry` index
 [DOWNLOADING] crates ...
-[DOWNLOADED] no-rust-version v2.1.0 (registry `dummy-registry`)
-[CHECKING] no-rust-version v2.1.0
+[DOWNLOADED] no-rust-version v2.2.0 (registry `dummy-registry`)
+[DOWNLOADED] has-rust-version v1.6.0 (registry `dummy-registry`)
+[CHECKING] has-rust-version v1.6.0
+[CHECKING] no-rust-version v2.2.0
 [CHECKING] [..]
 [FINISHED] [..]
 ",


### PR DESCRIPTION
### What does this PR try to resolve?

This is another experiment for #9930.

Comparing preferring over exclusively using MSRV compatible:

Benefits
- Better error messages
- `--ignore-rust-version` is implicitly sticky

Downsides
- Can't backtrack for MSRV compatible version
- Still requires workspace-wide MSRV (compared to our desired end state of declaring MSRV as yet another dependency)


### How should we test and review this PR?


### Additional information

Note: `--ignore-rust-version` is not yet implemented for the resolver.

This builds on #12930