### PR TITLE
fix: preserve jobserver file descriptors on rustc invocation in `fix_exec_rustc`

### DIFF
--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -447,6 +447,11 @@ pub fn fix_exec_rustc(config: &Config, lock_addr: &str) -> CargoResult<()> {
         // things like colored output to work correctly.
         rustc.arg(arg);
     }
+    // Removes `FD_CLOEXEC` set by `jobserver::Client` to pass jobserver
+    // as environment variables specify.
+    if let Some(client) = config.jobserver_from_env() {
+        rustc.inherit_jobserver(client);
+    }
     debug!("calling rustc to display remaining diagnostics: {rustc}");
     exit_with(rustc.status()?);
 }


### PR DESCRIPTION
Similar to #12447

Command `cargo fix` invokes `cargo rustc`. It sends environment variable which points to closed file descriptors.

This PR makes cargo compatible with https://github.com/rust-lang/rust/pull/113730.

It should be enough to have tests in rustc. It seems to be good to have more centralized way to pass jobserver.