### PR TITLE
credential: include license files in all published crates

### DIFF
--- a/credential/cargo-credential-1password/LICENSE-APACHE
+++ b/credential/cargo-credential-1password/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/credential/cargo-credential-1password/LICENSE-MIT
+++ b/credential/cargo-credential-1password/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/credential/cargo-credential-libsecret/LICENSE-APACHE
+++ b/credential/cargo-credential-libsecret/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/credential/cargo-credential-libsecret/LICENSE-MIT
+++ b/credential/cargo-credential-libsecret/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/credential/cargo-credential-macos-keychain/LICENSE-APACHE
+++ b/credential/cargo-credential-macos-keychain/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/credential/cargo-credential-macos-keychain/LICENSE-MIT
+++ b/credential/cargo-credential-macos-keychain/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/credential/cargo-credential-wincred/LICENSE-APACHE
+++ b/credential/cargo-credential-wincred/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/credential/cargo-credential-wincred/LICENSE-MIT
+++ b/credential/cargo-credential-wincred/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/credential/cargo-credential/LICENSE-APACHE
+++ b/credential/cargo-credential/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/credential/cargo-credential/LICENSE-MIT
+++ b/credential/cargo-credential/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT


### PR DESCRIPTION
### What does this PR try to resolve?

It appears that the addition of license files was missed when the cargo-credential* crates were added to this cargo workspace. This PR adds symbolic links to the license files so that `cargo publish` picks them up and includes the files when publishing them to crates.io (which is a requirement for both the Apache-2.0 and the MIT license).

### How should we test and review this PR?

Running `cargo package` for the cargo-credential* crates should result in a copy of the LICENSE-APACHE and LICENSE-MIT files to be included in the "packaged" files.

### Additional information

Similar changes have been pushed for other workspace members in the past, for example https://github.com/rust-lang/cargo/pull/7886 
