### PR TITLE
Fix --quiet being used with nested subcommands.

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -41,7 +41,11 @@ pub fn cli() -> clap::Command {
             .action(ArgAction::Count)
             .global(true),
         )
-        .arg_quiet()
+        .arg(
+            flag("quiet", "Do not print cargo log messages")
+                .short('q')
+                .global(true),
+        )
         .arg(
             opt("color", "Coloring: auto, always, never")
                 .value_name("WHEN")

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -589,7 +589,7 @@ See '<cyan,bold>cargo help</> <cyan><<command>></>' for more information on a sp
             .action(ArgAction::Count)
             .global(true),
         )
-        .arg_quiet()
+        .arg(flag("quiet", "Do not print cargo log messages").short('q').global(true))
         .arg(
             opt("color", "Coloring: auto, always, never")
                 .value_name("WHEN")

--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -80,7 +80,7 @@ Example uses:
         .arg_manifest_path_without_unsupported_path_tip()
         .arg_package("Package to modify")
         .arg_dry_run("Don't actually write the manifest")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .next_help_heading("Source")
         .args([
             clap::Arg::new("path")

--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -24,7 +24,7 @@ pub fn cli() -> Command {
         ))
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec(
             "Package to run benchmarks for",
             "Benchmark all packages in the workspace",

--- a/src/bin/cargo/commands/build.rs
+++ b/src/bin/cargo/commands/build.rs
@@ -10,7 +10,7 @@ pub fn cli() -> Command {
         .arg_ignore_rust_version()
         .arg_future_incompat_report()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec(
             "Package to build (see `cargo help pkgid`)",
             "Build all packages in the workspace",

--- a/src/bin/cargo/commands/check.rs
+++ b/src/bin/cargo/commands/check.rs
@@ -10,7 +10,7 @@ pub fn cli() -> Command {
         .arg_ignore_rust_version()
         .arg_future_incompat_report()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec(
             "Package(s) to check",
             "Check all packages in the workspace",

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -12,7 +12,7 @@ pub fn cli() -> Command {
     subcommand("clean")
         .about("Remove artifacts that cargo has generated in the past")
         .arg_doc("Whether or not to clean just the documentation directory")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec_simple("Package to clean artifacts for")
         .arg_release("Whether or not to clean release artifacts")
         .arg_profile("Clean artifacts of the specified profile")
@@ -25,8 +25,7 @@ pub fn cli() -> Command {
             subcommand("gc")
                 .about("Clean global caches")
                 .hide(true)
-                // FIXME: arg_quiet doesn't work because `config_configure`
-                // doesn't know about subcommands.
+                .arg_silent_suggestion()
                 .arg_dry_run("Display what would be deleted without deleting anything")
                 // NOTE: Not all of these options may get stabilized. Some of them are
                 // very low-level details, and may not be something typical users need.

--- a/src/bin/cargo/commands/doc.rs
+++ b/src/bin/cargo/commands/doc.rs
@@ -18,7 +18,7 @@ pub fn cli() -> Command {
         .arg(flag("document-private-items", "Document private items"))
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec(
             "Package to document",
             "Document all packages in the workspace",

--- a/src/bin/cargo/commands/fetch.rs
+++ b/src/bin/cargo/commands/fetch.rs
@@ -6,7 +6,7 @@ use cargo::ops::FetchOptions;
 pub fn cli() -> Command {
     subcommand("fetch")
         .about("Fetch dependencies of a package from the network")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_target_triple("Fetch dependencies for the target triple")
         .arg_manifest_path()
         .after_help(color_print::cstr!(

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -28,7 +28,7 @@ pub fn cli() -> Command {
         ))
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec(
             "Package(s) to fix",
             "Fix all packages in the workspace",

--- a/src/bin/cargo/commands/generate_lockfile.rs
+++ b/src/bin/cargo/commands/generate_lockfile.rs
@@ -5,7 +5,7 @@ use cargo::ops;
 pub fn cli() -> Command {
     subcommand("generate-lockfile")
         .about("Generate the lockfile for a package")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_manifest_path()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help generate-lockfile</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -13,7 +13,7 @@ pub fn cli() -> Command {
         )
         .arg_new_opts()
         .arg_registry("Registry to use")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help init</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -76,7 +76,7 @@ pub fn cli() -> Command {
         ))
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_targets_bins_examples(
             "Install only the specified binary",
             "Install all binaries",

--- a/src/bin/cargo/commands/locate_project.rs
+++ b/src/bin/cargo/commands/locate_project.rs
@@ -14,7 +14,7 @@ pub fn cli() -> Command {
             )
             .value_name("FMT"),
         )
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_manifest_path()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help locate-project</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -14,7 +14,7 @@ pub fn cli() -> Command {
                 .num_args(0..)
                 .last(true),
         )
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help login</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -7,7 +7,7 @@ pub fn cli() -> Command {
     subcommand("logout")
         .about("Remove an API token from the registry locally")
         .arg_registry("Registry to use")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help logout</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/metadata.rs
+++ b/src/bin/cargo/commands/metadata.rs
@@ -23,7 +23,7 @@ pub fn cli() -> Command {
                 .value_name("VERSION")
                 .value_parser(["1"]),
         )
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_features()
         .arg_manifest_path()
         .after_help(color_print::cstr!(

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -13,7 +13,7 @@ pub fn cli() -> Command {
         )
         .arg_new_opts()
         .arg_registry("Registry to use")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help new</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -27,7 +27,7 @@ pub fn cli() -> Command {
         .arg_index("Registry index URL to modify owners for")
         .arg_registry("Registry to modify owners for")
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help owner</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -24,7 +24,7 @@ pub fn cli() -> Command {
             "allow-dirty",
             "Allow dirty working directories to be packaged",
         ))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec_no_all(
             "Package(s) to assemble",
             "Assemble all packages in the workspace",

--- a/src/bin/cargo/commands/pkgid.rs
+++ b/src/bin/cargo/commands/pkgid.rs
@@ -7,7 +7,7 @@ pub fn cli() -> Command {
     subcommand("pkgid")
         .about("Print a fully qualified package specification")
         .arg(Arg::new("spec").value_name("SPEC").action(ArgAction::Set))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package("Argument to get the package ID specifier for")
         .arg_manifest_path()
         .after_help(color_print::cstr!(

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -17,7 +17,7 @@ pub fn cli() -> Command {
             "allow-dirty",
             "Allow dirty working directories to be packaged",
         ))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package("Package to publish")
         .arg_features()
         .arg_parallel()

--- a/src/bin/cargo/commands/read_manifest.rs
+++ b/src/bin/cargo/commands/read_manifest.rs
@@ -9,7 +9,7 @@ Print a JSON representation of a Cargo.toml manifest.
 Deprecated, use `<cyan,bold>cargo metadata --no-deps</>` instead.\
 "
         ))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_manifest_path()
 }
 

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -26,7 +26,7 @@ pub fn cli() -> clap::Command {
             .value_name("DEP_ID")
             .help("Dependencies to be removed")])
         .arg_dry_run("Don't actually write the manifest")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .next_help_heading("Section")
         .args([
             clap::Arg::new("dev")

--- a/src/bin/cargo/commands/run.rs
+++ b/src/bin/cargo/commands/run.rs
@@ -24,7 +24,7 @@ pub fn cli() -> Command {
         )
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package("Package with the target to run")
         .arg_targets_bin_example(
             "Name of the bin target to run",

--- a/src/bin/cargo/commands/rustc.rs
+++ b/src/bin/cargo/commands/rustc.rs
@@ -30,7 +30,7 @@ pub fn cli() -> Command {
         .arg_future_incompat_report()
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package("Package to build")
         .arg_targets_all(
             "Build only this package's library",

--- a/src/bin/cargo/commands/rustdoc.rs
+++ b/src/bin/cargo/commands/rustdoc.rs
@@ -18,7 +18,7 @@ pub fn cli() -> Command {
         ))
         .arg_ignore_rust_version()
         .arg_message_format()
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package("Package to document")
         .arg_targets_all(
             "Build only this package's library",

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -17,7 +17,7 @@ pub fn cli() -> Command {
         )
         .arg_index("Registry index URL to search packages in")
         .arg_registry("Registry to search packages in")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help search</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/tree.rs
+++ b/src/bin/cargo/commands/tree.rs
@@ -17,7 +17,7 @@ pub fn cli() -> Command {
                 .short('a')
                 .hide(true),
         )
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg(flag("no-dev-dependencies", "Deprecated, use -e=no-dev instead").hide(true))
         .arg(
             multi_opt(

--- a/src/bin/cargo/commands/uninstall.rs
+++ b/src/bin/cargo/commands/uninstall.rs
@@ -7,7 +7,7 @@ pub fn cli() -> Command {
         .about("Remove a Rust binary")
         .arg(Arg::new("spec").value_name("SPEC").num_args(0..))
         .arg(opt("root", "Directory to uninstall packages from").value_name("DIR"))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_package_spec_simple("Package to uninstall")
         .arg(
             multi_opt("bin", "NAME", "Only uninstall the binary NAME")

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -35,7 +35,7 @@ pub fn cli() -> Command {
                 .value_name("PRECISE")
                 .requires("package-group"),
         )
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg(
             flag("workspace", "Only update the workspace packages")
                 .short('w')

--- a/src/bin/cargo/commands/vendor.rs
+++ b/src/bin/cargo/commands/vendor.rs
@@ -36,7 +36,6 @@ pub fn cli() -> Command {
         .arg(unsupported("relative-path"))
         .arg(unsupported("only-git-deps"))
         .arg(unsupported("disallow-duplicates"))
-        .arg_quiet_without_unknown_silent_arg_tip()
         .arg_manifest_path()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help vendor</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/verify_project.rs
+++ b/src/bin/cargo/commands/verify_project.rs
@@ -6,7 +6,7 @@ use std::process;
 pub fn cli() -> Command {
     subcommand("verify-project")
         .about("Check correctness of crate manifest")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .arg_manifest_path()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help verify-project</>` for more detailed information.\n"

--- a/src/bin/cargo/commands/version.rs
+++ b/src/bin/cargo/commands/version.rs
@@ -4,7 +4,7 @@ use crate::command_prelude::*;
 pub fn cli() -> Command {
     subcommand("version")
         .about("Show version information")
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help version</>` for more detailed information.\n"
         ))

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -19,7 +19,7 @@ pub fn cli() -> Command {
         .arg_index("Registry index URL to yank from")
         .arg_registry("Registry to yank from")
         .arg(opt("token", "API token to use when authenticating").value_name("TOKEN"))
-        .arg_quiet()
+        .arg_silent_suggestion()
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help yank</>` for more detailed information.\n"
         ))

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -363,20 +363,19 @@ pub trait CommandExt: Sized {
         ))
     }
 
-    fn arg_quiet(self) -> Self {
-        let unsupported_silent_arg = {
-            let value_parser = UnknownArgumentValueParser::suggest_arg("--quiet");
+    /// Adds a suggestion for the `--silent` or `-s` flags to use the
+    /// `--quiet` flag instead. This is to help with people familiar with
+    /// other tools that use `-s`.
+    ///
+    /// Every command should call this, unless it has its own `-s` short flag.
+    fn arg_silent_suggestion(self) -> Self {
+        let value_parser = UnknownArgumentValueParser::suggest_arg("--quiet");
+        self._arg(
             flag("silent", "")
                 .short('s')
                 .value_parser(value_parser)
-                .hide(true)
-        };
-        self.arg_quiet_without_unknown_silent_arg_tip()
-            ._arg(unsupported_silent_arg)
-    }
-
-    fn arg_quiet_without_unknown_silent_arg_tip(self) -> Self {
-        self._arg(flag("quiet", "Do not print cargo log messages").short('q'))
+                .hide(true),
+        )
     }
 
     fn arg_timings(self) -> Self {

--- a/tests/testsuite/cargo_add/help/stdout.log
+++ b/tests/testsuite/cargo_add/help/stdout.log
@@ -45,11 +45,11 @@ Options:
   -n, --dry-run
           Don't actually write the manifest
 
-  -q, --quiet
-          Do not print cargo log messages
-
   -v, --verbose...
           Use verbose output (-vv very verbose/build.rs output)
+
+  -q, --quiet
+          Do not print cargo log messages
 
       --color <WHEN>
           Coloring: auto, always, never

--- a/tests/testsuite/cargo_bench/help/stdout.log
+++ b/tests/testsuite/cargo_bench/help/stdout.log
@@ -11,8 +11,8 @@ Options:
       --no-fail-fast          Run all benchmarks regardless of failure
       --ignore-rust-version   Ignore `rust-version` specification in packages
       --message-format <FMT>  Error format
-  -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                 Do not print cargo log messages
       --color <WHEN>          Coloring: auto, always, never
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_build/help/stdout.log
+++ b/tests/testsuite/cargo_build/help/stdout.log
@@ -6,8 +6,8 @@ Options:
       --ignore-rust-version     Ignore `rust-version` specification in packages
       --future-incompat-report  Outputs a future incompatibility report at the end of the build
       --message-format <FMT>    Error format
-  -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                   Do not print cargo log messages
       --color <WHEN>            Coloring: auto, always, never
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_check/help/stdout.log
+++ b/tests/testsuite/cargo_check/help/stdout.log
@@ -6,8 +6,8 @@ Options:
       --ignore-rust-version     Ignore `rust-version` specification in packages
       --future-incompat-report  Outputs a future incompatibility report at the end of the build
       --message-format <FMT>    Error format
-  -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                   Do not print cargo log messages
       --color <WHEN>            Coloring: auto, always, never
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_clean/help/stdout.log
+++ b/tests/testsuite/cargo_clean/help/stdout.log
@@ -4,9 +4,9 @@ Usage: cargo[EXE] clean [OPTIONS]
 
 Options:
       --doc                 Whether or not to clean just the documentation directory
-  -q, --quiet               Do not print cargo log messages
   -n, --dry-run             Display what would be deleted without deleting anything
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_config/help/stdout.log
+++ b/tests/testsuite/cargo_config/help/stdout.log
@@ -7,6 +7,7 @@ Commands:
 
 Options:
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_doc/help/stdout.log
+++ b/tests/testsuite/cargo_doc/help/stdout.log
@@ -8,8 +8,8 @@ Options:
       --document-private-items  Document private items
       --ignore-rust-version     Ignore `rust-version` specification in packages
       --message-format <FMT>    Error format
-  -q, --quiet                   Do not print cargo log messages
   -v, --verbose...              Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                   Do not print cargo log messages
       --color <WHEN>            Coloring: auto, always, never
       --config <KEY=VALUE>      Override a configuration value
   -Z <FLAG>                     Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_fetch/help/stdout.log
+++ b/tests/testsuite/cargo_fetch/help/stdout.log
@@ -3,8 +3,8 @@ Fetch dependencies of a package from the network
 Usage: cargo[EXE] fetch [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_fix/help/stdout.log
+++ b/tests/testsuite/cargo_fix/help/stdout.log
@@ -11,8 +11,8 @@ Options:
       --allow-staged          Fix code even if the working directory has staged changes
       --ignore-rust-version   Ignore `rust-version` specification in packages
       --message-format <FMT>  Error format
-  -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                 Do not print cargo log messages
       --color <WHEN>          Coloring: auto, always, never
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.log
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.log
@@ -3,8 +3,8 @@ Generate the lockfile for a package
 Usage: cargo[EXE] generate-lockfile [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_help/help/stdout.log
+++ b/tests/testsuite/cargo_help/help/stdout.log
@@ -7,6 +7,7 @@ Arguments:
 
 Options:
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_init/help/stdout.log
+++ b/tests/testsuite/cargo_init/help/stdout.log
@@ -15,8 +15,8 @@ Options:
                              2021, 2024]
       --name <NAME>          Set the resulting package name, defaults to the directory name
       --registry <REGISTRY>  Registry to use
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_install/help/stdout.log
+++ b/tests/testsuite/cargo_install/help/stdout.log
@@ -20,9 +20,9 @@ Options:
       --list                  list all installed packages and their versions
       --ignore-rust-version   Ignore `rust-version` specification in packages
       --message-format <FMT>  Error format
-  -q, --quiet                 Do not print cargo log messages
       --debug                 Build in debug mode (with the 'dev' profile) instead of release mode
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                 Do not print cargo log messages
       --color <WHEN>          Coloring: auto, always, never
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_locate_project/help/stdout.log
+++ b/tests/testsuite/cargo_locate_project/help/stdout.log
@@ -5,8 +5,8 @@ Usage: cargo[EXE] locate-project [OPTIONS]
 Options:
       --workspace             Locate Cargo.toml of the workspace root
       --message-format <FMT>  Output representation [possible values: json, plain]
-  -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                 Do not print cargo log messages
       --color <WHEN>          Coloring: auto, always, never
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_login/help/stdout.log
+++ b/tests/testsuite/cargo_login/help/stdout.log
@@ -8,8 +8,8 @@ Arguments:
 
 Options:
       --registry <REGISTRY>  Registry to use
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_logout/help/stdout.log
+++ b/tests/testsuite/cargo_logout/help/stdout.log
@@ -4,8 +4,8 @@ Usage: cargo[EXE] logout [OPTIONS]
 
 Options:
       --registry <REGISTRY>  Registry to use
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_metadata/help/stdout.log
+++ b/tests/testsuite/cargo_metadata/help/stdout.log
@@ -8,8 +8,8 @@ Options:
       --no-deps                   Output information only about the workspace members and don't
                                   fetch dependencies
       --format-version <VERSION>  Format version [possible values: 1]
-  -q, --quiet                     Do not print cargo log messages
   -v, --verbose...                Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                     Do not print cargo log messages
       --color <WHEN>              Coloring: auto, always, never
       --config <KEY=VALUE>        Override a configuration value
   -Z <FLAG>                       Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_new/help/stdout.log
+++ b/tests/testsuite/cargo_new/help/stdout.log
@@ -15,8 +15,8 @@ Options:
                              2021, 2024]
       --name <NAME>          Set the resulting package name, defaults to the directory name
       --registry <REGISTRY>  Registry to use
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_owner/help/stdout.log
+++ b/tests/testsuite/cargo_owner/help/stdout.log
@@ -12,8 +12,8 @@ Options:
       --index <INDEX>        Registry index URL to modify owners for
       --registry <REGISTRY>  Registry to modify owners for
       --token <TOKEN>        API token to use when authenticating
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_package/help/stdout.log
+++ b/tests/testsuite/cargo_package/help/stdout.log
@@ -7,8 +7,8 @@ Options:
       --no-verify           Don't verify the contents by building them
       --no-metadata         Ignore warnings about a lack of human-usable metadata
       --allow-dirty         Allow dirty working directories to be packaged
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_pkgid/help/stdout.log
+++ b/tests/testsuite/cargo_pkgid/help/stdout.log
@@ -6,8 +6,8 @@ Arguments:
   [SPEC]  
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_publish/help/stdout.log
+++ b/tests/testsuite/cargo_publish/help/stdout.log
@@ -9,8 +9,8 @@ Options:
       --token <TOKEN>        Token to use when uploading
       --no-verify            Don't verify the contents by building them
       --allow-dirty          Allow dirty working directories to be packaged
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_read_manifest/help/stdout.log
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.log
@@ -5,8 +5,8 @@ Deprecated, use `cargo metadata --no-deps` instead.
 Usage: cargo[EXE] read-manifest [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_remove/help/stdout.log
+++ b/tests/testsuite/cargo_remove/help/stdout.log
@@ -7,8 +7,8 @@ Arguments:
 
 Options:
   -n, --dry-run             Don't actually write the manifest
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_report/help/stdout.log
+++ b/tests/testsuite/cargo_report/help/stdout.log
@@ -7,6 +7,7 @@ Commands:
 
 Options:
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_run/help/stdout.log
+++ b/tests/testsuite/cargo_run/help/stdout.log
@@ -8,8 +8,8 @@ Arguments:
 Options:
       --ignore-rust-version   Ignore `rust-version` specification in packages
       --message-format <FMT>  Error format
-  -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                 Do not print cargo log messages
       --color <WHEN>          Coloring: auto, always, never
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_rustc/help/stdout.log
+++ b/tests/testsuite/cargo_rustc/help/stdout.log
@@ -11,8 +11,8 @@ Options:
       --future-incompat-report   Outputs a future incompatibility report at the end of the build
       --ignore-rust-version      Ignore `rust-version` specification in packages
       --message-format <FMT>     Error format
-  -q, --quiet                    Do not print cargo log messages
   -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                    Do not print cargo log messages
       --color <WHEN>             Coloring: auto, always, never
       --config <KEY=VALUE>       Override a configuration value
   -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_rustdoc/help/stdout.log
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.log
@@ -9,8 +9,8 @@ Options:
       --open                  Opens the docs in a browser after the operation
       --ignore-rust-version   Ignore `rust-version` specification in packages
       --message-format <FMT>  Error format
-  -q, --quiet                 Do not print cargo log messages
   -v, --verbose...            Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                 Do not print cargo log messages
       --color <WHEN>          Coloring: auto, always, never
       --config <KEY=VALUE>    Override a configuration value
   -Z <FLAG>                   Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_search/help/stdout.log
+++ b/tests/testsuite/cargo_search/help/stdout.log
@@ -9,8 +9,8 @@ Options:
       --limit <LIMIT>        Limit the number of results (default: 10, max: 100)
       --index <INDEX>        Registry index URL to search packages in
       --registry <REGISTRY>  Registry to search packages in
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_tree/help/stdout.log
+++ b/tests/testsuite/cargo_tree/help/stdout.log
@@ -3,7 +3,6 @@ Display a tree visualization of a dependency graph
 Usage: cargo[EXE] tree [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -e, --edges <KINDS>       The kinds of dependencies to display (features, normal, build, dev, all,
                             no-normal, no-build, no-dev, no-proc-macro)
   -i, --invert [<SPEC>]     Invert the tree direction and focus on the given package
@@ -17,6 +16,7 @@ Options:
                             ascii]
   -f, --format <FORMAT>     Format string used for printing dependencies [default: {p}]
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_uninstall/help/stdout.log
+++ b/tests/testsuite/cargo_uninstall/help/stdout.log
@@ -7,8 +7,8 @@ Arguments:
 
 Options:
       --root <DIR>          Directory to uninstall packages from
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_update/help/stdout.log
+++ b/tests/testsuite/cargo_update/help/stdout.log
@@ -6,8 +6,8 @@ Options:
   -n, --dry-run             Don't actually write the lockfile
       --recursive           Force updating all dependencies of [SPEC]... as well
       --precise <PRECISE>   Update [SPEC] to exactly PRECISE
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_vendor/help/stdout.log
+++ b/tests/testsuite/cargo_vendor/help/stdout.log
@@ -10,8 +10,8 @@ Options:
   -s, --sync <TOML>            Additional `Cargo.toml` to sync and vendor
       --respect-source-config  Respect `[source]` config in `.cargo/config`
       --versioned-dirs         Always include version in subdir name
-  -q, --quiet                  Do not print cargo log messages
   -v, --verbose...             Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                  Do not print cargo log messages
       --color <WHEN>           Coloring: auto, always, never
       --config <KEY=VALUE>     Override a configuration value
   -Z <FLAG>                    Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for

--- a/tests/testsuite/cargo_verify_project/help/stdout.log
+++ b/tests/testsuite/cargo_verify_project/help/stdout.log
@@ -3,8 +3,8 @@ Check correctness of crate manifest
 Usage: cargo[EXE] verify-project [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_version/help/stdout.log
+++ b/tests/testsuite/cargo_version/help/stdout.log
@@ -3,8 +3,8 @@ Show version information
 Usage: cargo[EXE] version [OPTIONS]
 
 Options:
-  -q, --quiet               Do not print cargo log messages
   -v, --verbose...          Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet               Do not print cargo log messages
       --color <WHEN>        Coloring: auto, always, never
       --config <KEY=VALUE>  Override a configuration value
   -Z <FLAG>                 Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/cargo_yank/help/stdout.log
+++ b/tests/testsuite/cargo_yank/help/stdout.log
@@ -11,8 +11,8 @@ Options:
       --index <INDEX>        Registry index URL to yank from
       --registry <REGISTRY>  Registry to yank from
       --token <TOKEN>        API token to use when authenticating
-  -q, --quiet                Do not print cargo log messages
   -v, --verbose...           Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                Do not print cargo log messages
       --color <WHEN>         Coloring: auto, always, never
       --config <KEY=VALUE>   Override a configuration value
   -Z <FLAG>                  Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -846,3 +846,29 @@ fn doc_with_package_selection() {
         .with_stderr("error: --doc cannot be used with -p")
         .run();
 }
+
+#[cargo_test]
+fn quiet_does_not_show_summary() {
+    // Checks that --quiet works with `cargo clean`, since there was a
+    // subtle issue with how the flag is defined as a global flag.
+    let p = project()
+        .file("Cargo.toml", &basic_manifest("foo", "0.1.0"))
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check").run();
+    p.cargo("clean --quiet --dry-run")
+        .with_stdout("")
+        .with_stderr("")
+        .run();
+    // Verify exact same command without -q would actually display something.
+    p.cargo("clean --dry-run")
+        .with_stdout("")
+        .with_stderr(
+            "\
+[SUMMARY] [..] files, [..] total
+[WARNING] no files deleted due to --dry-run
+",
+        )
+        .run();
+}


### PR DESCRIPTION
This fixes an issue where `--quiet` doesn't work with commands that have subcommands. This is because `config_configure` only looks at the global and top-level subcommand, and not deeper subcommands. The issue was that `--quiet` was not defined as a global flag. This was changed in https://github.com/rust-lang/cargo/pull/6358 in order to give a better help message for `cargo test --quiet`. I don't remember if clap just didn't support overriding at the time, or if we just didn't know how it worked. Anyways, it seems to work to override it now, so I think it should be fine to mark it as global.

This should bring in `--quiet` more in-line with how `--verbose` works. This means that `--quiet` is now accepted with `cargo report`, `cargo help`, and `cargo config`.

This also fixes `--quiet` with `cargo clean gc`.

This should also help with supporting `--quiet` with the new `cargo owner` subcommands being added in
https://github.com/rust-lang/cargo/pull/11879.

As for this diff, the help text changes because the `--quiet` flag is changing position (except for the 3 commands mentioned above where it is now added).

Fixes #12957
