### PR TITLE
Respect `rust-lang/rust`'s `omit-git-hash`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -50,6 +50,14 @@ fn commit_info() {
     if !Path::new(".git").exists() {
         return;
     }
+
+    // Var set by bootstrap whenever omit-git-hash is enabled in rust-lang/rust's config.toml.
+    println!("cargo:rerun-if-env-changed=CFG_OMIT_GIT_HASH");
+    #[allow(clippy::disallowed_methods)]
+    if std::env::var_os("CFG_OMIT_GIT_HASH").is_some() {
+        return;
+    }
+
     let output = match Command::new("git")
         .arg("log")
         .arg("-1")


### PR DESCRIPTION
The `config.toml` file in `rust-lang/rust` has the `omit-git-hash` option, which prevents git information from being embedded into binaries. This works for most tools, as they rely on the git information provided by bootstrap through environment variables.

Cargo does its own git detection in its build script though, which didn't adhere to to that option. This changes that by skipping git detection whenever bootstrap signals the option is enabled.