### PR TITLE
Fix book page specifying-dependencies.md

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -315,10 +315,10 @@ syntax](../../reference/conditional-compilation.html) will be used to define
 these sections:
 
 ```toml
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 winhttp = "0.4.0"
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(target_os = "unix")'.dependencies]
 openssl = "1.0.1"
 
 [target.'cfg(target_arch = "x86")'.dependencies]
@@ -404,7 +404,7 @@ You can also have target-specific development dependencies by using
 example:
 
 ```toml
-[target.'cfg(unix)'.dev-dependencies]
+[target.'cfg(target_os = "unix")'.dev-dependencies]
 mio = "0.0.1"
 ```
 
@@ -431,7 +431,7 @@ You can also have target-specific build dependencies by using
 example:
 
 ```toml
-[target.'cfg(unix)'.build-dependencies]
+[target.'cfg(target_os = "unix")'.build-dependencies]
 cc = "1.0.3"
 ```
 


### PR DESCRIPTION
### What does this PR try to resolve?

The Cargo Book currently suggests a wrong syntax for specifying target OS specific dependencies, i.e.:

`[target.'cfg(unix)'.dependencies]`) 

That leads to many 'use of undeclared crate or module' errors, because it doesn't recognize this as a syntax error (could be an issue of it's own).

I replaced these occurrences in the book with the correct syntax (`[target.'cfg(target_os = "unix")'.dependencies]`).

<!-- homu-ignore:start -->
<!--
NOTICE: Due to limited review capacity, the Cargo team is not accepting new
features or major changes at this time. Please consult with the team before
opening a new PR. Only issues that have been explicitly marked as accepted
will be reviewed.

Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide":
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
