### PR TITLE
Ignore changing_spec_relearns_crate_types on windows-gnu

### DIFF
--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -178,6 +178,8 @@ fn changing_spec_rebuilds() {
 }
 
 #[cargo_test(nightly, reason = "requires features no_core, lang_items")]
+// This is randomly crashing in lld. See https://github.com/rust-lang/rust/issues/115985
+#[cfg_attr(all(windows, target_env = "gnu"), ignore = "windows-gnu lld crashing")]
 fn changing_spec_relearns_crate_types() {
     // Changing the .json file will invalidate the cache of crate types.
     let p = project()


### PR DESCRIPTION
This disables the `custom_target::changing_spec_relearns_crate_types` on windows-gnu targets for the same reason as #12763. The update to LLVM 17 has started to cause lld to crash when using a custom target. cc https://github.com/rust-lang/rust/issues/115985

I surveyed the rest of the testsuite, and I don't see any other tests that perform linking with custom targets.
