### PR TITLE
Fix some test output validation.

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -2167,8 +2167,11 @@ fn doc_lib_true() {
 
     p.cargo("doc -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .env("CARGO_LOG", "cargo::ops::cargo_rustc::fingerprint")
-        .with_stdout("")
+        .with_stderr(
+            "\
+[FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html",
+        )
         .run();
 
     assert!(p.root().join("target/doc").is_dir());

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -2959,12 +2959,12 @@ fn freshness_ignores_excluded() {
 
     // Smoke test to make sure it doesn't compile again
     println!("first pass");
-    foo.cargo("build").with_stdout("").run();
+    foo.cargo("build").with_stderr("[FINISHED] [..]").run();
 
     // Modify an ignored file and make sure we don't rebuild
     println!("second pass");
     foo.change_file("src/bar.rs", "");
-    foo.cargo("build").with_stdout("").run();
+    foo.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -3064,7 +3064,7 @@ fn recompile_space_in_name() {
         .build();
     foo.cargo("build").run();
     foo.root().move_into_the_past();
-    foo.cargo("build").with_stdout("").run();
+    foo.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cfg(unix)]

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3245,7 +3245,6 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .run();
 
     p.cargo("build -v")
-        .env("CARGO_LOG", "cargo::ops::cargo_rustc::fingerprint=info")
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([..])

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -34,7 +34,10 @@ fn different_dir() {
     p.cargo("build").run();
     assert!(p.build_dir().is_dir());
 
-    p.cargo("clean").cwd("src").with_stdout("").run();
+    p.cargo("clean")
+        .cwd("src")
+        .with_stderr("[REMOVED] [..]")
+        .run();
     assert!(!p.build_dir().is_dir());
 }
 
@@ -82,7 +85,7 @@ fn clean_multiple_packages() {
 
     p.cargo("clean -p d1 -p d2")
         .cwd("src")
-        .with_stdout("")
+        .with_stderr("[REMOVED] [..]")
         .run();
     assert!(p.bin("foo").is_file());
     assert!(!d1_path.is_file());
@@ -227,7 +230,9 @@ fn clean_release() {
     p.cargo("build --release").run();
 
     p.cargo("clean -p foo").run();
-    p.cargo("build --release").with_stdout("").run();
+    p.cargo("build --release")
+        .with_stderr("[FINISHED] [..]")
+        .run();
 
     p.cargo("clean -p foo --release").run();
     p.cargo("build --release")
@@ -355,7 +360,7 @@ fn clean_git() {
         .build();
 
     p.cargo("build").run();
-    p.cargo("clean -p dep").with_stdout("").run();
+    p.cargo("clean -p dep").with_stderr("[REMOVED] [..]").run();
     p.cargo("build").run();
 }
 
@@ -380,7 +385,7 @@ fn registry() {
     Package::new("bar", "0.1.0").publish();
 
     p.cargo("build").run();
-    p.cargo("clean -p bar").with_stdout("").run();
+    p.cargo("clean -p bar").with_stderr("[REMOVED] [..]").run();
     p.cargo("build").run();
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -75,7 +75,14 @@ fn doc_twice() {
         )
         .run();
 
-    p.cargo("doc").with_stdout("").run();
+    p.cargo("doc")
+        .with_stderr(
+            "\
+[FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
+        )
+        .run();
 }
 
 #[cargo_test]
@@ -118,9 +125,14 @@ fn doc_deps() {
     assert_eq!(p.glob("target/debug/**/*.rlib").count(), 0);
     assert_eq!(p.glob("target/debug/deps/libbar-*.rmeta").count(), 1);
 
+    // Make sure it doesn't recompile.
     p.cargo("doc")
-        .env("CARGO_LOG", "cargo::ops::cargo_rustc::fingerprint")
-        .with_stdout("")
+        .with_stderr(
+            "\
+[FINISHED] [..]
+[GENERATED] [CWD]/target/doc/foo/index.html
+",
+        )
         .run();
 
     assert!(p.root().join("target/doc").is_dir());

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -627,7 +627,14 @@ fn cyclic_feature2() {
         .file("src/main.rs", "fn main() {}")
         .build();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check")
+        .with_stderr(
+            "\
+[CHECKING] foo [..]
+[FINISHED] [..]
+",
+        )
+        .run();
 }
 
 #[cargo_test]
@@ -1047,8 +1054,8 @@ fn no_rebuild_when_frobbing_default_feature() {
         .build();
 
     p.cargo("check").run();
-    p.cargo("check").with_stdout("").run();
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -1098,8 +1105,8 @@ fn unions_work_with_no_default_features() {
         .build();
 
     p.cargo("check").run();
-    p.cargo("check").with_stdout("").run();
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -11,7 +11,7 @@ fn no_deps() {
         .file("src/a.rs", "")
         .build();
 
-    p.cargo("fetch").with_stdout("").run();
+    p.cargo("fetch").with_stderr("").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -34,7 +34,7 @@ fn modifying_and_moving() {
         )
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]").run();
     p.root().move_into_the_past();
     p.root().join("target").move_into_the_past();
 
@@ -223,7 +223,7 @@ fn changing_lib_features_caches_targets() {
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]").run();
 
     p.cargo("build --features foo")
         .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
@@ -666,7 +666,7 @@ fn rerun_if_changed_in_dep() {
         .build();
 
     p.cargo("build").run();
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -161,13 +161,13 @@ fn cargo_update_generate_lockfile() {
 
     let lockfile = p.root().join("Cargo.lock");
     assert!(!lockfile.is_file());
-    p.cargo("update").with_stdout("").run();
+    p.cargo("update").with_stderr("").run();
     assert!(lockfile.is_file());
 
     fs::remove_file(p.root().join("Cargo.lock")).unwrap();
 
     assert!(!lockfile.is_file());
-    p.cargo("update").with_stdout("").run();
+    p.cargo("update").with_stderr("").run();
     assert!(lockfile.is_file());
 }
 

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -55,7 +55,19 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[WARNING] manifest has no documentation[..]
+See [..]
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PACKAGED] 4 files, [..] ([..] compressed)
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     validate_crate_contents(
@@ -696,6 +708,7 @@ fn ignore_nested() {
             authors = []
             license = "MIT"
             description = "foo"
+            homepage = "https://example.com/"
         "#;
     let main_rs = r#"
             fn main() { println!("hello"); }
@@ -712,8 +725,6 @@ fn ignore_nested() {
     p.cargo("package")
         .with_stderr(
             "\
-[WARNING] manifest has no documentation[..]
-See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
@@ -733,7 +744,17 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PACKAGED] 4 files, [..] ([..] compressed)
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     validate_crate_contents(
@@ -2731,6 +2752,7 @@ fn basic_filesizes() {
                 exclude = ["*.txt"]
                 license = "MIT"
                 description = "foo"
+                homepage = "https://example.com/"
             "#;
     let main_rs_contents = r#"fn main() { println!("🦀"); }"#;
     let cargo_toml_contents = format!(
@@ -2741,6 +2763,7 @@ version = "0.0.1"
 authors = []
 exclude = ["*.txt"]
 description = "foo"
+homepage = "https://example.com/"
 license = "MIT"
 "#,
         cargo::core::package::MANIFEST_PREAMBLE
@@ -2776,7 +2799,17 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[PACKAGING] foo v0.0.1 [..]
+[VERIFYING] foo v0.0.1 [..]
+[COMPILING] foo v0.0.1 [..]
+[FINISHED] [..]
+[PACKAGED] 4 files[..]
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     let compressed_size = f.metadata().unwrap().len();
@@ -2803,6 +2836,7 @@ fn larger_filesizes() {
                 authors = []
                 license = "MIT"
                 description = "foo"
+                documentation = "https://example.com/"
             "#;
     let lots_of_crabs = std::iter::repeat("🦀").take(1337).collect::<String>();
     let main_rs_contents = format!(r#"fn main() {{ println!("{}"); }}"#, lots_of_crabs);
@@ -2821,6 +2855,7 @@ name = "foo"
 version = "0.0.1"
 authors = []
 description = "foo"
+documentation = "https://example.com/"
 license = "MIT"
 "#,
         cargo::core::package::MANIFEST_PREAMBLE
@@ -2858,7 +2893,17 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[PACKAGING] foo v0.0.1 [..]
+[VERIFYING] foo v0.0.1 [..]
+[COMPILING] foo v0.0.1 [..]
+[FINISHED] [..]
+[PACKAGED] 5 files, [..]
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     let compressed_size = f.metadata().unwrap().len();
@@ -2896,6 +2941,7 @@ fn symlink_filesizes() {
                 authors = []
                 license = "MIT"
                 description = "foo"
+                homepage = "https://example.com/"
             "#;
     let lots_of_crabs = std::iter::repeat("🦀").take(1337).collect::<String>();
     let main_rs_contents = format!(r#"fn main() {{ println!("{}"); }}"#, lots_of_crabs);
@@ -2914,6 +2960,7 @@ name = "foo"
 version = "0.0.1"
 authors = []
 description = "foo"
+homepage = "https://example.com/"
 license = "MIT"
 "#,
         cargo::core::package::MANIFEST_PREAMBLE
@@ -2956,7 +3003,17 @@ src/main.rs.bak
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[PACKAGING] foo v0.0.1 [..]
+[VERIFYING] foo v0.0.1 [..]
+[COMPILING] foo v0.0.1 [..]
+[FINISHED] [..]
+[PACKAGED] 7 files, [..]
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     let compressed_size = f.metadata().unwrap().len();
@@ -3032,7 +3089,19 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[WARNING] manifest has no documentation[..]
+See [..]
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PACKAGED] 4 files, [..] ([..] compressed)
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     validate_crate_contents(
@@ -3086,7 +3155,19 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[WARNING] manifest has no documentation[..]
+See [..]
+[PACKAGING] foo v0.0.1 ([CWD])
+[VERIFYING] foo v0.0.1 ([CWD])
+[COMPILING] foo v0.0.1 ([CWD][..])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[PACKAGED] 4 files, [..] ([..] compressed)
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     validate_crate_contents(

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -83,7 +83,12 @@ fn cargo_compile_with_nested_deps_shorthand() {
     p.process(&p.bin("foo")).with_stdout("test passed\n").run();
 
     println!("cleaning");
-    p.cargo("clean -v").with_stdout("").run();
+    p.cargo("clean -v")
+        .with_stderr(
+            "[REMOVING] [CWD]/target\n\
+             [REMOVED] [..]",
+        )
+        .run();
     println!("building baz");
     p.cargo("build -p baz")
         .with_stderr(
@@ -350,7 +355,7 @@ fn deep_dependencies_trigger_rebuild() {
              in [..]\n",
         )
         .run();
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     // Make sure an update to baz triggers a rebuild of bar
     //
@@ -437,7 +442,7 @@ fn no_rebuild_two_deps() {
         )
         .run();
     assert!(p.bin("foo").is_file());
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]").run();
     assert!(p.bin("foo").is_file());
 }
 

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -92,7 +92,17 @@ src/main.rs
 ",
         )
         .run();
-    p.cargo("package").with_stdout("").run();
+    p.cargo("package")
+        .with_stderr(
+            "\
+[PACKAGING] foo v0.0.1 [..]
+[VERIFYING] foo v0.0.1 [..]
+[COMPILING] foo v0.0.1 [..]
+[FINISHED] [..]
+[PACKAGED] 4 files, [..]
+",
+        )
+        .run();
 
     let f = File::open(&p.root().join("target/package/foo-0.0.1.crate")).unwrap();
     validate_crate_contents(

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -549,7 +549,7 @@ fn lockfile_locks() {
     p.root().move_into_the_past();
     Package::new("bar", "0.0.2").publish();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -602,7 +602,7 @@ fn lockfile_locks_transitively() {
     Package::new("baz", "0.0.2").publish();
     Package::new("bar", "0.0.2").dep("baz", "*").publish();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -739,7 +739,7 @@ fn yanks_in_lockfiles_are_ok() {
 
     Package::new("bar", "0.0.1").yanked(true).publish();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     p.cargo("update")
         .with_status(101)
@@ -792,7 +792,7 @@ fn yanks_in_lockfiles_are_ok_for_other_update() {
     Package::new("bar", "0.0.1").yanked(true).publish();
     Package::new("baz", "0.0.1").publish();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     Package::new("baz", "0.0.2").publish();
 
@@ -868,7 +868,18 @@ fn yanks_in_lockfiles_are_ok_with_new_dep() {
         "#,
     );
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
+[CHECKING] baz v0.0.1
+[CHECKING] foo v0.0.1 [..]
+[FINISHED] [..]
+",
+        )
+        .run();
 }
 
 #[cargo_test]
@@ -1272,7 +1283,7 @@ fn git_and_registry_dep() {
     p.root().move_into_the_past();
 
     println!("second");
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -305,7 +305,7 @@ fn transitive() {
         )
         .run();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -354,7 +354,7 @@ fn persists_across_rebuilds() {
         )
         .run();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -530,7 +530,7 @@ fn override_adds_some_deps() {
         )
         .run();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 
     Package::new("baz", "0.1.2").publish();
     p.cargo("update")
@@ -550,7 +550,7 @@ fn override_adds_some_deps() {
         )
         .run();
 
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -601,8 +601,8 @@ fn locked_means_locked_yes_no_seriously_i_mean_locked() {
 
     p.cargo("check").run();
 
-    p.cargo("check").with_stdout("").run();
-    p.cargo("check").with_stdout("").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -456,7 +456,7 @@ fn env_rustflags_no_recompile() {
     p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
     p.cargo("check")
         .env("RUSTFLAGS", "--cfg foo")
-        .with_stdout("")
+        .with_stderr("[FINISHED] [..]")
         .run();
 }
 
@@ -944,7 +944,7 @@ fn build_rustflags_no_recompile() {
     p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
     p.cargo("check")
         .env("RUSTFLAGS", "--cfg foo")
-        .with_stdout("")
+        .with_stderr("[FINISHED] [..]")
         .run();
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1433,7 +1433,7 @@ fn test_then_build() {
         .with_stdout_contains("running 0 tests")
         .run();
 
-    p.cargo("build").with_stdout("").run();
+    p.cargo("build").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]
@@ -2423,7 +2423,7 @@ fn dylib_doctest2() {
         )
         .build();
 
-    p.cargo("test").with_stdout("").run();
+    p.cargo("test").with_stderr("[FINISHED] [..]").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
A bunch of these tests weren't testing what they claimed to. For some reason, a bunch of them were checking for cargo's output with `.with_stdout("")`, but since cargo almost never prints to stdout, that doesn't actually validate the test. Most of these are checking that cargo doesn't recompile when run a second time, and in those cases it should be checking that there is a single line of output ("Finished"). I don't know the history here, many of these tests were before my time, perhaps cargo did use to print something to stdout? Or perhaps it was a long run of bad copy-and-paste.

There were a few other tests that were checking `with_stdout("")` for no apparent reason. I switched those to check the stderr output.
