### PR TITLE
cargo-credential-1password: Add missing `--account` argument to `op signin` command

### DIFF
--- a/credential/cargo-credential-1password/src/main.rs
+++ b/credential/cargo-credential-1password/src/main.rs
@@ -79,6 +79,10 @@ impl OnePasswordKeychain {
         }
         let mut cmd = Command::new("op");
         cmd.args(["signin", "--raw"]);
+        if let Some(account) = &self.account {
+            cmd.arg("--account");
+            cmd.arg(account);
+        }
         cmd.stdout(Stdio::piped());
         let mut child = cmd
             .spawn()


### PR DESCRIPTION
### What does this PR try to resolve?

Without this the account chooser is shown by the `op signin` command, even though the user has already specified an account via the `--account` command line argument to the `cargo-credential-1password` CLI.

Note that the `--vault` in this case does not need to be forwarded to `op`, since it is irrelevant for the `op signin` command.

### How should we test and review this PR?

- Have a 1password installation with multiple accounts
- Use `global-credential-providers = ["cargo-credential-1password --account my.1password.com"]` in the cargo config file
- Run e.g. `cargo publish`
- Notice how you are seeing an account switcher even though `--account` was used
- Apply this patch and notice that the account switcher is no longer there and the correct account is selected automatically

### Additional information

see https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/1password.20credentials.20provider