### PR TITLE
Fix a rustflags test using a wrong buildfile name

### DIFF
--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1658,7 +1658,7 @@ fn host_config_rustflags_with_target() {
     // regression test for https://github.com/rust-lang/cargo/issues/10206
     let p = project()
         .file("src/lib.rs", "")
-        .file("build.rs.rs", "fn main() { assert!(cfg!(foo)); }")
+        .file("build.rs", "fn main() { assert!(cfg!(foo)); }")
         .file(".cargo/config.toml", "target-applies-to-host = false")
         .build();
 


### PR DESCRIPTION
 The test seem to have always had the wrong buildfile `build.rs.rs`.
