### PR TITLE
Link to rustc lint levels

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -551,7 +551,7 @@ This is short-hand for:
 unsafe_code = { level = "forbid", priority = 0 }
 ```
 
-`level` corresponds to the lint levels in `rustc`:
+`level` corresponds to the [lint levels](https://doc.rust-lang.org/rustc/lints/levels.html) in `rustc`:
 - `forbid`
 - `deny`
 - `warn`


### PR DESCRIPTION
This simply changes a mention of rustc lint levels, in to a link to the relevant rustc docs.