### PR TITLE
refactor: log when loading config from file

### DIFF
--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1200,6 +1200,8 @@ impl Config {
                 path.display()
             );
         }
+        tracing::debug!(?path, ?why_load, includes, "load config from file");
+
         let contents = fs::read_to_string(path)
             .with_context(|| format!("failed to read configuration file `{}`", path.display()))?;
         let toml = parse_document(&contents, path, self).with_context(|| {


### PR DESCRIPTION
When I was tracing some nasty bug and wanted to point at config probding, I wish there were some logs standing out and telling me I was wrong.

Would be great if every config file loading is logged.
