### PR TITLE
docs: Recommend a wider selection of libsecret-compatible password managers

### DIFF
--- a/src/doc/src/reference/registry-authentication.md
+++ b/src/doc/src/reference/registry-authentication.md
@@ -75,7 +75,7 @@ Any password manager with libsecret support can be used to view stored tokens.
 The following are a few examples (non-exhaustive):
 
 - [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring)
-- [KDE Wallet Manager](https://apps.kde.org/en-gb/kwalletmanager5/) (since KDE Frameworks 5.97.0)
+- [KDE Wallet Manager](https://apps.kde.org/kwalletmanager5/) (since KDE Frameworks 5.97.0)
 - [KeePassXC](https://keepassxc.org/) (since 2.5.0)
 
 ### `cargo:token-from-stdout <command> <args>`

--- a/src/doc/src/reference/registry-authentication.md
+++ b/src/doc/src/reference/registry-authentication.md
@@ -10,7 +10,7 @@ provider is used if no providers are configured.
 
 Cargo also includes platform-specific providers that use the operating system to securely store
 tokens. The `cargo:token` provider is also included which stores credentials in unencrypted plain
-text in the [credentials](config.md#credentials) file. 
+text in the [credentials](config.md#credentials) file.
 
 ## Recommended configuration
 It's recommended to configure a global credential provider list in `$CARGO_HOME/config.toml`
@@ -71,8 +71,12 @@ The Keychain Access app can be used to view stored tokens.
 ### `cargo:libsecret`
 Uses [libsecret](https://wiki.gnome.org/Projects/Libsecret) to store tokens.
 
-On GNOME, credentials can be viewed using [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring)
-applications.
+Any password manager with libsecret support can be used to view stored tokens.
+The following are a few examples (non-exhaustive):
+
+- [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring)
+- [KDE Wallet Manager](https://apps.kde.org/en-gb/kwalletmanager5/) (since KDE Frameworks 5.97.0)
+- [KeePassXC](https://keepassxc.org/) (since 2.5.0)
 
 ### `cargo:token-from-stdout <command> <args>`
 Launch a subprocess that returns a token on stdout. Newlines will be trimmed.


### PR DESCRIPTION
### What does this PR try to resolve?

Previously the only password manager recommended was Gnome Keyring, which not everyone will find ideal for a variety of reasons. A few common ones:
- GTK. The user may not want to have to install the entire toolkit.
- Look and feel. The design of Gnome software is pretty opinionated.
- They already use something else.

So I think it makes sense to recommend a few more widely-used alternatives. All three are GPL.

### How should we test and review this PR?

Documentation changes only.

### Additional information

