### PR TITLE
[beta 1.75] Backport 1password fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-1password"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "cargo-credential",
  "serde",

--- a/credential/cargo-credential-1password/Cargo.toml
+++ b/credential/cargo-credential-1password/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-1password"
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license.workspace = true
 rust-version = "1.70.0"  # MSRV:3

--- a/credential/cargo-credential-1password/README.md
+++ b/credential/cargo-credential-1password/README.md
@@ -2,17 +2,31 @@
 
 A Cargo [credential provider] for [1password].
 
-`cargo-credential-1password` uses the 1password `op` CLI to store the token. You must
-install the `op` CLI from the [1password
-website](https://1password.com/downloads/command-line/). You must run `op signin`
-at least once with the appropriate arguments (such as `op signin my.1password.com user@example.com`),
-unless you provide the sign-in-address and email arguments. The master password will be required on each request
-unless the appropriate `OP_SESSION` environment variable is set. It supports
-the following command-line arguments:
-* `--account`: The account shorthand name to use.
-* `--vault`: The vault name to use.
-* `--sign-in-address`: The sign-in-address, which is a web address such as `my.1password.com`.
-* `--email`: The email address to sign in with.
+## Usage
+
+`cargo-credential-1password` uses the 1password `op` CLI to store the token. You
+must install the `op` CLI from the [1password
+website](https://1password.com/downloads/command-line/).
+
+Afterward you need to configure `cargo` to use `cargo-credential-1password` as
+the credential provider. You can do this by adding something like the following
+to your [cargo config file][credential provider]:
+
+```toml
+[registry]
+global-credential-providers = ["cargo-credential-1password --account my.1password.com"]
+```
+
+Finally, run `cargo login` to save your registry token in 1password.
+
+## CLI Arguments
+
+`cargo-credential-1password` supports the following command-line arguments:
+
+* `--account`: The account name to use. For a list of available accounts, 
+  run `op account list`.
+* `--vault`: The vault name to use. For a list of available vaults,
+  run `op vault list`.
 
 [1password]: https://1password.com/
-[credential provider]: https://doc.rust-lang.org/nightly/cargo/reference/registry-authentication.html
+[credential provider]: https://doc.rust-lang.org/stable/cargo/reference/registry-authentication.html

--- a/credential/cargo-credential-1password/src/main.rs
+++ b/credential/cargo-credential-1password/src/main.rs
@@ -79,6 +79,10 @@ impl OnePasswordKeychain {
         }
         let mut cmd = Command::new("op");
         cmd.args(["signin", "--raw"]);
+        if let Some(account) = &self.account {
+            cmd.arg("--account");
+            cmd.arg(account);
+        }
         cmd.stdout(Stdio::piped());
         let mut child = cmd
             .spawn()

--- a/src/doc/src/reference/registry-authentication.md
+++ b/src/doc/src/reference/registry-authentication.md
@@ -103,7 +103,7 @@ Install the provider with `cargo install cargo-credential-1password`
 In the config, add to (or create) `registry.global-credential-providers`:
 ```toml
 [registry]
-global-credential-providers = ["cargo:token", "cargo-credential-1password --email you@example.com"]
+global-credential-providers = ["cargo:token", "cargo-credential-1password --account my.1password.com"]
 ```
 
 The values in `global-credential-providers` are split on spaces into path and command-line arguments. To


### PR DESCRIPTION
This backports these fixes to 1.75 for the cargo-credential-1password helper. I'd like to publish these fixes and get the docs updated sooner rather than later. Unfortunately it uses an unpublished version of cargo-credential, so I can't publish directly from master.

Backports:
* #12985 — cargo-credential-1password: Add missing `--account` argument to `op signin` command
* #12986 — cargo-credential-1password: Fix README