### PR TITLE
Exited with hard error when custom build file no existence or not in package 

### DIFF
--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -439,7 +439,7 @@ fn warn_custom_build_file_not_in_package(
         "the source file of {:?} target `{}` doesn't appear to be a path inside of the package.\n\
         It is at {}, whereas the root the package is {}.\n\
         This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.\n\
-        Please update the `build` setting in the manifest at `{}` and point to a path inside the root of the package.\n",
+        Please update the `build` setting in the manifest at `{}` and point to a path inside the root of the package.",
         target.kind(), target.name(), path.display(), pkg.root().display(),  pkg.manifest_path().display()
     );
 

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use crate::core::compiler::{BuildConfig, CompileMode, DefaultExecutor, Executor};
+use crate::core::manifest::Target;
 use crate::core::resolver::CliFeatures;
 use crate::core::{registry::PackageRegistry, resolver::HasDevUnits};
 use crate::core::{Feature, Shell, Verbosity, Workspace};
@@ -331,6 +332,29 @@ fn build_ar_list(
             warn_on_nonexistent_file(&pkg, &readme_path, "readme", &ws)?;
         }
     }
+
+    for t in pkg
+        .manifest()
+        .targets()
+        .iter()
+        .filter(|t| t.is_custom_build())
+    {
+        if let Some(custome_build_path) = t.src_path().path() {
+            let abs_custome_build_path =
+                paths::normalize_path(&pkg.root().join(custome_build_path));
+            if abs_custome_build_path.is_file() {
+                if !abs_custome_build_path
+                    .ancestors()
+                    .any(|ancestor| ancestor == pkg.root())
+                {
+                    warn_custom_build_file_not_in_package(pkg, &abs_custome_build_path, t, &ws)?
+                }
+            } else {
+                warn_on_nonexistent_file(&pkg, &custome_build_path, "build", &ws)?
+            }
+        }
+    }
+
     result.sort_unstable_by(|a, b| a.rel_path.cmp(&b.rel_path));
 
     Ok(result)
@@ -403,6 +427,23 @@ fn warn_on_nonexistent_file(
         rel_msg,
         pkg.manifest_path().display()
     ))
+}
+
+fn warn_custom_build_file_not_in_package(
+    pkg: &Package,
+    path: &Path,
+    target: &Target,
+    ws: &Workspace<'_>,
+) -> CargoResult<()> {
+    let msg = format!(
+        "the source file of {:?} target `{}` doesn't appear to be a path inside of the package.\n\
+        It is at {}, whereas the root the package is {}.\n\
+        This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.\n\
+        Please update the `build` setting in the manifest at `{}` and point to a path inside the root of the package.\n",
+        target.kind(), target.name(), path.display(), pkg.root().display(),  pkg.manifest_path().display()
+    );
+
+    ws.config().shell().warn(&msg)
 }
 
 /// Construct `Cargo.lock` for the package to be published.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -431,12 +431,12 @@ fn error_custom_build_file_not_in_package(
     let tip = {
         let description_name = target.description_named();
         if path.is_file() {
-            format!("the source file of `{description_name}` doesn't appear to be a path inside of the package.\n\
+            format!("the source file of {description_name} doesn't appear to be a path inside of the package.\n\
             It is at `{}`, whereas the root the package is `{}`.\n",
             path.display(), pkg.root().display()
             )
         } else {
-            format!("the source file of `{description_name}` doesn't appear to exist.\n",)
+            format!("the source file of {description_name} doesn't appear to exist.\n",)
         }
     };
     let msg = format!(

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3325,7 +3325,7 @@ fn build_script_outside_pkg_root() {
     let mut expect_msg = String::from("\
 warning: manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-error: the source file of `build script` doesn't appear to exist.
+error: the source file of build script doesn't appear to exist.
 This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.
 Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and point to a path inside the root of the package.
 ");
@@ -3343,7 +3343,7 @@ Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and poin
         "\
 warning: manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-error: the source file of `build script` doesn't appear to be a path inside of the package.
+error: the source file of build script doesn't appear to be a path inside of the package.
 It is at `{}/t_custom_build/custom_build.rs`, whereas the root the package is `[CWD]`.
 This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.
 Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and point to a path inside the root of the package.

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3325,26 +3325,31 @@ fn build_script_outside_pkg_root() {
     let mut expect_msg = String::from("\
 warning: manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-error: the source file of \"custom-build\" target `build-script-custom_build` doesn't appear to exist.
+error: the source file of `build script` doesn't appear to exist.
 This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.
 Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and point to a path inside the root of the package.
 ");
     // custom_build.rs does not exist
-    p.cargo("package -l").with_stderr(&expect_msg).run();
+    p.cargo("package -l")
+        .with_status(101)
+        .with_stderr(&expect_msg)
+        .run();
 
     // custom_build.rs outside the package root
-    let custom_build_root = p.root().parent().unwrap().join("t_custom_build");
+    let custom_build_root = paths::root().join("t_custom_build");
     _ = fs::create_dir(&custom_build_root).unwrap();
     _ = fs::write(&custom_build_root.join("custom_build.rs"), "fn main() {}");
     expect_msg = format!(
         "\
 warning: manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-error: the source file of \"custom-build\" target `build-script-custom_build` doesn't appear to be a path inside of the package.
+error: the source file of `build script` doesn't appear to be a path inside of the package.
 It is at `{}/t_custom_build/custom_build.rs`, whereas the root the package is `[CWD]`.
 This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.
 Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and point to a path inside the root of the package.
-", p.root().parent().unwrap().display());
-    p.cargo("package -l").with_stderr(&expect_msg).run();
-    _ = fs::remove_dir_all(&custom_build_root).unwrap();
+", paths::root().display());
+    p.cargo("package -l")
+        .with_status(101)
+        .with_stderr(&expect_msg)
+        .run();
 }


### PR DESCRIPTION
## What does this PR try to resolve?
Fixed https://github.com/rust-lang/cargo/issues/11383

## How should we test and review this PR?
Add test `build_script_outside_pkg_root`,  this will check `custom_build.rs` existence and whether in the package root, if not then exited with a hard error

## Additional information
The code just handle the `custom build` target that i know how to test it.  Other target type is skipped.
