### PR TITLE
cargo-test-support: Add features to the default Cargo.toml file

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -1523,6 +1523,30 @@ impl Package {
             manifest.push_str(&format!("rust-version = \"{}\"", version));
         }
 
+        if !self.features.is_empty() {
+            let features: Vec<String> = self
+                .features
+                .iter()
+                .map(|(feature, features)| {
+                    if features.is_empty() {
+                        format!("{} = []", feature)
+                    } else {
+                        format!(
+                            "{} = [{}]",
+                            feature,
+                            features
+                                .iter()
+                                .map(|s| format!("\"{}\"", s))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )
+                    }
+                })
+                .collect();
+
+            manifest.push_str(&format!("\n[features]\n{}", features.join("\n")));
+        }
+
         for dep in self.deps.iter() {
             let target = match dep.target {
                 None => String::new(),

--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -1564,6 +1564,9 @@ impl Package {
             "#,
                 target, kind, dep.name, dep.vers
             ));
+            if dep.optional {
+                manifest.push_str("optional = true\n");
+            }
             if let Some(artifact) = &dep.artifact {
                 manifest.push_str(&format!("artifact = \"{}\"\n", artifact));
             }

--- a/tests/testsuite/cargo_remove/update_lock_file/in/Cargo.lock
+++ b/tests/testsuite/cargo_remove/update_lock_file/in/Cargo.lock
@@ -43,13 +43,13 @@ checksum = "31162e7d23a085553c42dee375787b451a481275473f7779c4a63bcc267a24fd"
 name = "semver"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3031434e07edc922bf1b8262f075fac1522694f17b1ee7ad314c4cabd5d2723f"
+checksum = "106bee742e3199d9e59f4269e458dfc825c1b4648c483b1c2b7a45cd2610a308"
 
 [[package]]
 name = "serde"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d9264696ebbf5315a6b068e9910c4df9274365afac2d88abf66525df660218"
+checksum = "be7d269f612a60e3c2c4a4a120e2d878a3f3298a5285eda6e95453905a107d9a"
 
 [[package]]
 name = "toml"

--- a/tests/testsuite/cargo_remove/update_lock_file/out/Cargo.lock
+++ b/tests/testsuite/cargo_remove/update_lock_file/out/Cargo.lock
@@ -36,13 +36,13 @@ checksum = "84949cb53285a6c481d0133065a7b669871acfd9e20f273f4ce1283c309775d5"
 name = "semver"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3031434e07edc922bf1b8262f075fac1522694f17b1ee7ad314c4cabd5d2723f"
+checksum = "106bee742e3199d9e59f4269e458dfc825c1b4648c483b1c2b7a45cd2610a308"
 
 [[package]]
 name = "serde"
 version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75d9264696ebbf5315a6b068e9910c4df9274365afac2d88abf66525df660218"
+checksum = "be7d269f612a60e3c2c4a4a120e2d878a3f3298a5285eda6e95453905a107d9a"
 
 [[package]]
 name = "toml"


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Found in https://github.com/hi-rustin/cargo-information/pull/32#issuecomment-1815625144.

I think we need to add features to the default `Cargo.toml` file.

### How should we test and review this PR?

- [x] Tested in https://github.com/hi-rustin/cargo-information/pull/32
<img width="974" alt="image" src="https://github.com/rust-lang/cargo/assets/29879298/17ef2dad-5b09-41fc-a514-197e463ddc2d">


### Additional information

Do you which Cargo command can cover this case? I want to add a unit test for it.
It seems I can use `cargo metadata` to cover it. I can add a dep to the package and try to check the output JSON.
<!-- homu-ignore:end -->
