### PR TITLE
refactor(toml): Further clean up inheritance

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1568,13 +1568,6 @@ impl<T> schema::InheritableField<T> {
             }),
         }
     }
-
-    fn as_value(&self) -> Option<&T> {
-        match self {
-            schema::InheritableField::Inherit(_) => None,
-            schema::InheritableField::Value(defined) => Some(defined),
-        }
-    }
 }
 
 impl schema::InheritableDependency {

--- a/src/cargo/util/toml/schema.rs
+++ b/src/cargo/util/toml/schema.rs
@@ -411,7 +411,19 @@ impl<'de> de::Deserialize<'de> for InheritableBtreeMap {
 #[serde(rename_all = "kebab-case")]
 pub struct TomlInheritedField {
     #[serde(deserialize_with = "bool_no_false")]
-    pub workspace: bool,
+    workspace: bool,
+}
+
+impl TomlInheritedField {
+    pub fn new() -> Self {
+        TomlInheritedField { workspace: true }
+    }
+}
+
+impl Default for TomlInheritedField {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 fn bool_no_false<'de, D: de::Deserializer<'de>>(deserializer: D) -> Result<bool, D::Error> {

--- a/src/cargo/util/toml/schema.rs
+++ b/src/cargo/util/toml/schema.rs
@@ -170,6 +170,15 @@ pub enum InheritableField<T> {
     Inherit(TomlInheritedField),
 }
 
+impl<T> InheritableField<T> {
+    pub fn as_value(&self) -> Option<&T> {
+        match self {
+            InheritableField::Inherit(_) => None,
+            InheritableField::Value(defined) => Some(defined),
+        }
+    }
+}
+
 //. This already has a `Deserialize` impl from version_trim_whitespace
 pub type InheritableSemverVersion = InheritableField<semver::Version>;
 impl<'de> de::Deserialize<'de> for InheritableSemverVersion {


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #12971 that was found as I continued working towards #12801.

The first is a more general purpose API cleanup.  I was bothered by the idea that a caller could create a `field.workspace = false` when that is disallowed, so I modified the API to prevent that.

The second is part of needing to find a home for everything in `toml/mod.rs`.  I figured `IneheritableField::as_value` is reasonable in the API, so I carried that forward.  It would be reasonable to add other methods, from an API perspective, but I left that for future exploration.

### How should we test and review this PR?



### Additional information

