### PR TITLE
[beta-1.75.0] chore: bump `cargo-credential-*` crates as e58b84d broke stuff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-libsecret"
-version = "0.3.3"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "cargo-credential",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-macos-keychain"
-version = "0.3.2"
+version = "0.4.1"
 dependencies = [
  "cargo-credential",
  "security-framework",
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential-wincred"
-version = "0.3.2"
+version = "0.4.1"
 dependencies = [
  "cargo-credential",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ anyhow = "1.0.75"
 base64 = "0.21.5"
 bytesize = "1.3"
 cargo = { path = "" }
-cargo-credential = { version = "0.4.0", path = "credential/cargo-credential" }
-cargo-credential-libsecret = { version = "0.3.1", path = "credential/cargo-credential-libsecret" }
-cargo-credential-macos-keychain = { version = "0.3.0", path = "credential/cargo-credential-macos-keychain" }
-cargo-credential-wincred = { version = "0.3.0", path = "credential/cargo-credential-wincred" }
+cargo-credential = { version = "0.4.1", path = "credential/cargo-credential" }
+cargo-credential-libsecret = { version = "0.4.1", path = "credential/cargo-credential-libsecret" }
+cargo-credential-macos-keychain = { version = "0.4.1", path = "credential/cargo-credential-macos-keychain" }
+cargo-credential-wincred = { version = "0.4.1", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.4" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }

--- a/credential/cargo-credential-libsecret/Cargo.toml
+++ b/credential/cargo-credential-libsecret/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-libsecret"
-version = "0.3.3"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/credential/cargo-credential-macos-keychain/Cargo.toml
+++ b/credential/cargo-credential-macos-keychain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-macos-keychain"
-version = "0.3.2"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/credential/cargo-credential-wincred/Cargo.toml
+++ b/credential/cargo-credential-wincred/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential-wincred"
-version = "0.3.2"
+version = "0.4.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
e58b84d changed the shape of response of cargo credential protocol trait,
so credential plugins crates effectively depend on `cargo-credential@0.4.0`.
However, `cargo@0.74.0` still depends on`cargo-credential@0.3.0`.
They must depends on the same major version of `cargo-credential`
otherwise incompatible.

This PR

* bumps the version to `cargo-credential-wincred@0.4.1`
* bumps the version to `cargo-credential-macos-keychain@0.4.1`
* bumps the version to `cargo-credential-li@0.4.1`


See https://github.com/rust-lang/cargo/pull/13004 for more.

