### PR TITLE
Fix `--check-cfg` invocations with zero features

### DIFF
--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -15,16 +15,16 @@ macro_rules! x {
                     $what, '(', $($who,)* ')', "'", "[..]")
         }
     }};
-    ($tool:tt => $what:tt of $who:tt with $($first_value:tt $($other_values:tt)*)?) => {{
+    ($tool:tt => $what:tt of $who:tt with $first_value:tt $($other_values:tt)*) => {{
         #[cfg(windows)]
         {
             concat!("[RUNNING] [..]", $tool, "[..] --check-cfg \"",
-                    $what, '(', $who, ", values(", $("/\"", $first_value, "/\"", $(", ", "/\"", $other_values, "/\"",)*)* "))", '"', "[..]")
+                    $what, '(', $who, ", values(", "/\"", $first_value, "/\"", $(", ", "/\"", $other_values, "/\"",)* "))", '"', "[..]")
         }
         #[cfg(not(windows))]
         {
             concat!("[RUNNING] [..]", $tool, "[..] --check-cfg '",
-                    $what, '(', $who, ", values(", $("\"", $first_value, "\"", $(", ", "\"", $other_values, "\"",)*)* "))", "'", "[..]")
+                    $what, '(', $who, ", values(", "\"", $first_value, "\"", $(", ", "\"", $other_values, "\"",)* "))", "'", "[..]")
         }
     }};
 }
@@ -150,7 +150,7 @@ fn well_known_names_values() {
 
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
-        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg"))
         .run();
 }
 
@@ -213,7 +213,7 @@ fn well_known_names_values_test() {
 
     p.cargo("test -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
-        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg"))
         .run();
 }
 
@@ -226,8 +226,8 @@ fn well_known_names_values_doctest() {
 
     p.cargo("test -v --doc -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
-        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
-        .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg"))
+        .with_stderr_contains(x!("rustdoc" => "cfg"))
         .run();
 }
 


### PR DESCRIPTION
When generating the `--check-cfg` arguments for `-Zcheck-cfg` we currently generate `cfg(feature, values())` when there is 0 features. This is wrong since a empty `values()` would mean that it's possible to have `#[cfg(feature)]` without a feature name which is impossible.

We replace this by a simple `cfg()` to still enable well known names and values.

----

Note that currently `rustc` defines `feature` as a well known name with ANY values if it's not overridden by Cargo. I plan on submitting a PR to `rustc` to remove `feature` from being a well known name so that Cargo is the only source of truth.

*This doesn't block this PR from being merged*