### PR TITLE
[stable 1.74] Bump cargo patch version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
 
 [[package]]
 name = "cargo"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ windows-sys = "0.48"
 
 [package]
 name = "cargo"
-version = "0.75.0"
+version = "0.75.1"
 edition.workspace = true
 license.workspace = true
 homepage = "https://crates.io"


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/13004 bumped the credential crate versions to deal with a semver-incompatible change, but I believe we also need to bump and publish cargo.

My thinking is that:
* cargo 0.75.0 currently depends on cargo-credential-libsecret="0.3.1"
    * The `Cargo.lock` is locked to **0.3.2**
* We plan to yank cargo-credential-libsecret 0.3.2
* Users who depend on cargo 0.75.0 as a library will be unable to do so since after yanking it will pick up cargo-credential-libsecret="0.3.1", but this won't work.
    * cargo 0.75.0 -> cargo-credential 0.4.0
    * cargo-credential-libsecret 0.3.1 -> cargo-credential **0.3.0**

(Users using a `Cargo.lock`, like doing rust builds, shouldn't be affected by the yank.)

So, after publishing the new credential crates, I think we'll also need to publish a new 0.75.1 which depends on the correct versions so that users can use 0.75. It also probably makes sense to yank 0.75.0.
