### PR TITLE
Handle $message_type in JSON diagnostics

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1698,6 +1698,7 @@ fn doc_message_format() {
             r#"
             {
                 "message": {
+                    "$message_type": "diagnostic",
                     "children": "{...}",
                     "code": "{...}",
                     "level": "error",

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -740,6 +740,7 @@ fn metabuild_failed_build_json() {
             r#"
             {
               "message": {
+                "$message_type": "diagnostic",
                 "children": "{...}",
                 "code": "{...}",
                 "level": "error",


### PR DESCRIPTION
### What does this PR try to resolve?

Unblocks https://github.com/rust-lang/rust/pull/115691.

Without this change, Cargo's testsuite fails in `doc::doc_message_format` and `metabuild::metabuild_failed_build_json`.

### How should we test and review this PR?

Tested with and without https://github.com/rust-lang/rust/pull/115691.

In Cargo repo: `cargo test --test testsuite`
In Rust repo: `x.py test src/tools/cargo` (separately on master and $message_type PR)