### PR TITLE
Fixed uninstall a running binary failed on Windows

### DIFF
--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -147,12 +147,14 @@ fn uninstall_pkgid(
         tracker.remove(pkgid, &bins);
     }
 
+    // This should have been handled last, but now restore it to reproduce the problem on the Windows platform.
+    // See issue #3364.
+    tracker.save()?;
+
     for bin in to_remove {
         config.shell().status("Removing", bin.display())?;
         paths::remove_file(bin)?;
     }
 
-    // Only Save the tracker when remove Bin successfully.
-    tracker.save()?;
     Ok(())
 }

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -135,18 +135,18 @@ fn uninstall_pkgid(
         }
     }
 
-    let to_remove: Vec<&String> = {
+    let to_remove = {
         if bins.is_empty() {
-            installed.iter().collect()
+            installed
         } else {
-            bins.iter().collect()
+            bins
         }
     };
 
     for bin in to_remove {
-        let bin_path = dst.join(bin);
+        let bin_path = dst.join(&bin);
         config.shell().status("Removing", bin_path.display())?;
-        tracker.remove_bin_then_save(pkgid, bin, &bin_path)?;
+        tracker.remove_bin_then_save(pkgid, &bin, &bin_path)?;
     }
 
     Ok(())

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -6,7 +6,6 @@ use crate::util::errors::CargoResult;
 use crate::util::Config;
 use crate::util::Filesystem;
 use anyhow::bail;
-use cargo_util::paths;
 use std::collections::BTreeSet;
 use std::env;
 
@@ -103,7 +102,6 @@ fn uninstall_pkgid(
     bins: &[String],
     config: &Config,
 ) -> CargoResult<()> {
-    let mut to_remove = Vec::new();
     let installed = match tracker.installed_bins(pkgid) {
         Some(bins) => bins.clone(),
         None => bail!("package `{}` is not installed", pkgid),
@@ -137,11 +135,13 @@ fn uninstall_pkgid(
         }
     }
 
-    if bins.is_empty() {
-        to_remove = installed.iter().collect();
-    } else {
-        to_remove = bins.iter().collect();
-    }
+    let to_remove: Vec<&String> = {
+        if bins.is_empty() {
+            installed.iter().collect()
+        } else {
+            bins.iter().collect()
+        }
+    };
 
     for bin in to_remove {
         let bin_path = dst.join(bin);

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -138,22 +138,15 @@ fn uninstall_pkgid(
     }
 
     if bins.is_empty() {
-        to_remove.extend(installed.iter().map(|b| dst.join(b)));
-        tracker.remove(pkgid, &installed);
+        to_remove = installed.iter().collect();
     } else {
-        for bin in bins.iter() {
-            to_remove.push(dst.join(bin));
-        }
-        tracker.remove(pkgid, &bins);
+        to_remove = bins.iter().collect();
     }
 
-    // This should have been handled last, but now restore it to reproduce the problem on the Windows platform.
-    // See issue #3364.
-    tracker.save()?;
-
     for bin in to_remove {
-        config.shell().status("Removing", bin.display())?;
-        paths::remove_file(bin)?;
+        let bin_path = dst.join(bin);
+        config.shell().status("Removing", bin_path.display())?;
+        tracker.remove_bin_then_save(pkgid, bin, &bin_path)?;
     }
 
     Ok(())

--- a/src/cargo/ops/cargo_uninstall.rs
+++ b/src/cargo/ops/cargo_uninstall.rs
@@ -146,11 +146,13 @@ fn uninstall_pkgid(
         }
         tracker.remove(pkgid, &bins);
     }
-    tracker.save()?;
+
     for bin in to_remove {
         config.shell().status("Removing", bin.display())?;
         paths::remove_file(bin)?;
     }
 
+    // Only Save the tracker when remove Bin successfully.
+    tracker.save()?;
     Ok(())
 }

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -321,7 +321,7 @@ impl InstallTracker {
         self.v2.remove(pkg_id, bins);
     }
 
-    /// Remove a bin after it successfully had been removed in disk and the save the tracker at last.
+    /// Remove a bin after it successfully had been removed in disk and then save the tracker at last.
     pub fn remove_bin_then_save(
         &mut self,
         pkg_id: PackageId,

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use std::task::Poll;
 
 use anyhow::{bail, format_err, Context as _};
+use cargo_util::paths;
 use ops::FilterRule;
 use serde::{Deserialize, Serialize};
 
@@ -319,6 +320,20 @@ impl InstallTracker {
         self.v1.remove(pkg_id, bins);
         self.v2.remove(pkg_id, bins);
     }
+
+    /// Remove a bin after it successfully had been removed in disk and the save the tracker at last.
+    pub fn remove_bin_then_save(
+        &mut self,
+        pkg_id: PackageId,
+        bin: &str,
+        bin_path: &PathBuf,
+    ) -> CargoResult<()> {
+        paths::remove_file(bin_path)?;
+        self.v1.remove_bin(pkg_id, bin);
+        self.v2.remove_bin(pkg_id, bin);
+        self.save()?;
+        Ok(())
+    }
 }
 
 impl CrateListingV1 {
@@ -354,6 +369,17 @@ impl CrateListingV1 {
         for bin in bins {
             installed.get_mut().remove(bin);
         }
+        if installed.get().is_empty() {
+            installed.remove();
+        }
+    }
+
+    fn remove_bin(&mut self, pkg_id: PackageId, bin: &str) {
+        let mut installed = match self.v1.entry(pkg_id) {
+            btree_map::Entry::Occupied(e) => e,
+            btree_map::Entry::Vacant(..) => panic!("v1 unexpected missing `{}`", pkg_id),
+        };
+        installed.get_mut().remove(bin);
         if installed.get().is_empty() {
             installed.remove();
         }
@@ -463,6 +489,17 @@ impl CrateListingV2 {
         for bin in bins {
             info_entry.get_mut().bins.remove(bin);
         }
+        if info_entry.get().bins.is_empty() {
+            info_entry.remove();
+        }
+    }
+
+    fn remove_bin(&mut self, pkg_id: PackageId, bin: &str) {
+        let mut info_entry = match self.installs.entry(pkg_id) {
+            btree_map::Entry::Occupied(e) => e,
+            btree_map::Entry::Vacant(..) => panic!("v1 unexpected missing `{}`", pkg_id),
+        };
+        info_entry.get_mut().bins.remove(bin);
         if info_entry.get().bins.is_empty() {
             info_entry.remove();
         }

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2530,9 +2530,7 @@ fn uninstall_running_binary() {
             r#"
         use std::{{thread, time}}; 
         fn main() {
-            println!("start longrunning job.");
             thread::sleep(time::Duration::from_secs(3));
-            println!("end longrunning job.");
         }
 "#,
         )


### PR DESCRIPTION
### What does this PR try to resolve?
 Fixes https://github.com/rust-lang/cargo/issues/3364

The problem reproduce when you try to uninstall a running binary and it will failed on Windows,  this is because that cargo had already remove the installed binary tracker information in disk,  and next to remove the running binary but it is not allowed in Windows.  And to the worst,  you can not uninstall the binary already and only to reinstall it by the `--force` flag.

### How to solve the issue?
This PR try to make the uninstall a binary more reasonable that  only after remove the binary sucessfully then remove the tracker information on binary and make the remove binary one by one.

### How should we test and review this PR?
Add testcase https://github.com/rust-lang/cargo/pull/13053/commits/0fd4fd357b440d4155661c3b770ed8ddee43d13e
- install the `foo`
- run `foo` in another thread.
- try to uninstall running `foo` and only failed in Windows.
- wait the `foo` finish, uninstall `foo`
- install the `foo`


### Additional information
