### PR TITLE
docs: link to the packages lint table from the related workspace table

### DIFF
--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -227,7 +227,7 @@ rand.workspace = true
 
 The `workspace.lints` table is where you define lint configuration to be inherited by members of a workspace.
 
-Specifying a workspace lint configuration is similar to package lints.
+Specifying a workspace lint configuration is similar to [package lints](manifest.md#the-lints-section).
 
 Example:
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR makes the exact format and definition of the workspace `lints` table easier to discover. It also follows the style of the surrounding documentation, such as the section immediately before about the `dependencies` table, which cross-references related package table documentation.

### How should we test and review this PR?

N/A

### Additional information

N/A