### PR TITLE
fix: reorder `--remap-path-prefix` flags for `-Zbuild-std`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1214,8 +1214,6 @@ fn trim_paths_args(
         }
         remap
     };
-    cmd.arg(sysroot_remap);
-
     let package_remap = {
         let pkg_root = unit.pkg.root();
         let ws_root = cx.bcx.ws.root();
@@ -1242,7 +1240,11 @@ fn trim_paths_args(
         }
         remap
     };
+
+    // Order of `--remap-path-prefix` flags is important for `-Zbuild-std`.
+    // We want to show `/rustc/<hash>/library/std` instead of `std-0.0.0`.
     cmd.arg(package_remap);
+    cmd.arg(sysroot_remap);
 
     Ok(())
 }

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -267,8 +267,8 @@ fn remap_path_scope() {
 [..]thread '[..]' panicked at [..]src/main.rs:3:[..]",
         )
         .with_stderr_contains("remap to /rustc/<hash>")
-        .with_stderr_contains("[..]at std-0.0.0/src/[..]")
+        .with_stderr_contains("[..]at /rustc/[..]/library/std/src/[..]")
         .with_stderr_contains("[..]at src/main.rs:3[..]")
-        .with_stderr_contains("[..]at core-0.0.0/src/[..]")
+        .with_stderr_contains("[..]at /rustc/[..]/library/core/src/[..]")
         .run();
 }

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -229,3 +229,46 @@ fn custom_test_framework() {
         .build_std_arg("core")
         .run();
 }
+
+// Fixing rust-lang/rust#117839.
+// on macOS it never gets remapped.
+// Might be a separate issue, so only run on Linux.
+#[cargo_test(build_std_real)]
+#[cfg(target_os = "linux")]
+fn remap_path_scope() {
+    let p = project()
+        .file(
+            "src/main.rs",
+            "
+                fn main() {
+                    panic!(\"remap to /rustc/<hash>\");
+                }
+            ",
+        )
+        .file(
+            ".cargo/config.toml",
+            "
+                [profile.release]
+                debug = \"line-tables-only\"
+            ",
+        )
+        .build();
+
+    p.cargo("run --release -Ztrim-paths")
+        .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
+        .env("RUST_BACKTRACE", "1")
+        .build_std()
+        .target_host()
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[FINISHED] release [optimized + debuginfo] [..]
+[RUNNING] [..]
+[..]thread '[..]' panicked at [..]src/main.rs:3:[..]",
+        )
+        .with_stderr_contains("remap to /rustc/<hash>")
+        .with_stderr_contains("[..]at std-0.0.0/src/[..]")
+        .with_stderr_contains("[..]at src/main.rs:3[..]")
+        .with_stderr_contains("[..]at core-0.0.0/src/[..]")
+        .run();
+}

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -83,8 +83,8 @@ fn release_profile_default_to_object() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] release [..]",
         )
         .run();
@@ -121,8 +121,8 @@ fn one_option() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope={option} \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]",
             ))
             .run();
@@ -158,8 +158,8 @@ fn multiple_options() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=diagnostics,macro,object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]",
         )
         .run();
@@ -193,8 +193,8 @@ fn profile_merge_works() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=diagnostics \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] custom [..]",
         )
         .run();
@@ -238,13 +238,13 @@ fn registry_dependency() {
 [COMPILING] bar v0.0.1
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix={pkg_remap} [..]
+    --remap-path-prefix={pkg_remap} \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
@@ -292,13 +292,13 @@ fn git_dependency() {
 [COMPILING] bar v0.0.1 ({url}[..])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix={pkg_remap} [..]
+    --remap-path-prefix={pkg_remap} \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
@@ -338,13 +338,13 @@ fn path_dependency() {
 [COMPILING] bar v0.0.1 ([..]/cocktail-bar)
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
@@ -387,13 +387,13 @@ fn path_dependency_outside_workspace() {
 [COMPILING] bar v0.0.1 ([..]/bar)
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix={bar_path}=bar-0.0.1 [..]
+    --remap-path-prefix={bar_path}=bar-0.0.1 \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
@@ -439,15 +439,15 @@ fn diagnostics_works() {
             "\
 [RUNNING] [..]rustc [..]\
     -Zremap-path-scope=diagnostics \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix={pkg_remap} [..]",
+    --remap-path-prefix={pkg_remap} \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]",
         ))
         .with_stderr_contains(
             "\
 [RUNNING] [..]rustc [..]\
     -Zremap-path-scope=diagnostics \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]",
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]",
         )
         .run();
 }
@@ -528,13 +528,13 @@ fn object_works() {
 [COMPILING] bar v0.0.1
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix={pkg_remap} [..]
+    --remap-path-prefix={pkg_remap} \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..] \
-    --remap-path-prefix=[CWD]= [..]
+    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]",
         ))
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

Order of `--remap-path-prefix` flags is important for `-Zbuild-std`.
We want to show `/rustc/<hash>/library/std` instead of `std-0.0.0`.

Fixes rust-lang/rust#117839

### How should we test and review this PR?

Follow the steps in rust-lang/rust#117839, or run

```
CARGO_RUN_BUILD_STD_TESTS=true cargo +nightly t --test build-std
```

to verify.
