### PR TITLE
docs: remove review capacity notice in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,8 @@
 <!-- homu-ignore:start -->
 <!--
-NOTICE: Due to limited review capacity, the Cargo team is not accepting new
-features or major changes at this time. Please consult with the team before
-opening a new PR. Only issues that have been explicitly marked as accepted
-will be reviewed.
-
 Thanks for submitting a pull request 🎉! Here are some tips for you:
 
-* If this is your first contribution, read "Cargo Contribution Guide":
+* If this is your first contribution, read "Cargo Contribution Guide" first:
   https://doc.crates.io/contrib/
 * Run `cargo fmt --all` to format your code changes.
 * Small commits and pull requests are always preferable and easy to review.


### PR DESCRIPTION
Forgot to update PR template in #12842. This updates accordingly.

Note that this doesn't mean Cargo start accepting arbitrary pull requests or features. The reviewers are still a small handful of people. The guideline never changes — issue, discuss, then pull request.