### PR TITLE
remove jobserver env var in some tests

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -110,6 +110,7 @@ fn rustc_shim_for_cargo_fix() -> Project {
                     }
                     let status = Command::new("rustc")
                         .args(env::args().skip(1))
+                        .env_remove("CARGO_MAKEFLAGS")
                         .status()
                         .expect("failed to run rustc");
                     process::exit(status.code().unwrap_or(2));


### PR DESCRIPTION
This PR makes cargo compatible with [rust-lang/rust#113730](https://github.com/rust-lang/rust/pull/113730). Linked [comment](https://github.com/rust-lang/rust/pull/113730#issuecomment-1821892786). Problem to be fixed: shim for cargo fix spawns rustc with make environment variable inherited, which points to closed jobserver.

r? @weihanglo 