### PR TITLE
test(trim-paths): exercise with real world debugger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
     - run: rustup target add ${{ matrix.other }}
     - run: rustup component add rustc-dev llvm-tools-preview rust-docs
       if: startsWith(matrix.rust, 'nightly')
-    - run: sudo apt update -y && sudo apt install gcc-multilib libsecret-1-0 libsecret-1-dev -y
+    - run: sudo apt update -y && sudo apt install lldb gcc-multilib libsecret-1-0 libsecret-1-dev -y
       if: matrix.os == 'ubuntu-latest'
     - run: rustup component add rustfmt || echo "rustfmt not available"
     - name: Configure extra test environment

--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -208,10 +208,11 @@ fn has_command(command: &str) -> bool {
     let output = match Command::new(command).arg("--version").output() {
         Ok(output) => output,
         Err(e) => {
-            // hg is not installed on GitHub macOS or certain constrained
-            // environments like Docker. Consider installing it if Cargo gains
-            // more hg support, but otherwise it isn't critical.
-            if is_ci() && command != "hg" {
+            // * hg is not installed on GitHub macOS or certain constrained
+            //   environments like Docker. Consider installing it if Cargo
+            //   gains more hg support, but otherwise it isn't critical.
+            // * lldb is not pre-installed on Ubuntu and Windows, so skip.
+            if is_ci() && !["hg", "lldb"].contains(&command) {
                 panic!(
                     "expected command `{}` to be somewhere in PATH: {}",
                     command, e


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Although we've already check rustcflags in cargo test suite,
a basic test against real work debuggers is still wholesome.

### How should we test and review this PR?

Have lldb installed, then run the new test `lldb_works_after_trimmed`.

### Additional information

This is actually a test in preparation of a fix in rustc I am working on,
but should be fine to land this without knowing that fix.

I also plan to work on adding more test with `windbg`/`cdb`,
though I haven't found a good way to test on Windows without a physicall Windows machine.
<!-- homu-ignore:end -->
