### PR TITLE
Revert "chore(deps): update rust crate openssl to 0.10.60 [security]"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.60"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -2361,18 +2361,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.6+3.1.4"
+version = "111.26.0+1.1.1u"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.96"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ libloading = "0.8.1"
 memchr = "2.6.4"
 miow = "0.6.0"
 opener = "0.6.1"
-openssl ="0.10.60"
+openssl ="0.10.57"
 os_info = "3.7.0"
 pasetors = { version = "0.6.7", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"


### PR DESCRIPTION
Reverts https://github.com/rust-lang/cargo/pull/13068

`openssl@0.10.160` switches to OpenSSL v3,
which causes Cargo build failure on loongarch64.

See <https://github.com/rust-lang/rust/pull/118541#issuecomment-1837197918>