### PR TITLE
docs(book): make old title anchorable

### DIFF
--- a/src/doc/src/reference/specifying-dependencies.md
+++ b/src/doc/src/reference/specifying-dependencies.md
@@ -113,6 +113,7 @@ Here are some examples of comparison requirements:
 = 1.2.3
 ```
 
+<span id="multiple-requirements"></span>
 ### Multiple version requirements
 
 As shown in the examples above, multiple version requirements can be


### PR DESCRIPTION


<!-- homu-ignore:start -->


### What does this PR try to resolve?

An alternative way to fix <https://github.com/rust-lang/blog.rust-lang.org/pull/1172>

### How should we test and review this PR?

I've tried [custom heading attribute](https://rust-lang.github.io/mdBook/format/markdown.html#heading-attributes) but that didn't work as you can only have one `id` per element.

If there is a preferred solution, do let me know.

### Additional information

r? ehuss
<!-- homu-ignore:end -->
