### PR TITLE
chore(test): remove unnecesary packages and versions for `optionals` tests

### DIFF
--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -87,6 +87,7 @@ mod overwrite_no_public;
 mod overwrite_no_public_with_public;
 mod overwrite_optional;
 mod overwrite_optional_with_no_optional;
+mod overwrite_optional_with_optional;
 mod overwrite_path_noop;
 mod overwrite_path_with_version;
 mod overwrite_preserves_inline_table;

--- a/tests/testsuite/cargo_add/no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/no_optional/mod.rs
@@ -7,19 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for name in ["my-package1", "my-package2"] {
-        for ver in [
-            "0.1.1+my-package",
-            "0.2.0+my-package",
-            "0.2.3+my-package",
-            "0.4.1+my-package",
-            "20.0.0+my-package",
-            "99999.0.0+my-package",
-            "99999.0.0-alpha.1+my-package",
-        ] {
-            cargo_test_support::registry::Package::new(name, ver).publish();
-        }
-    }
+    cargo_test_support::registry::Package::new("my-package", "0.1.0").publish();
 
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
@@ -27,7 +15,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("my-package1 my-package2@0.4.1 --no-optional")
+        .arg_line("my-package --no-optional")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/no_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/no_optional/out/Cargo.toml
@@ -5,5 +5,4 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+my-package = "0.1.0"

--- a/tests/testsuite/cargo_add/no_optional/stderr.log
+++ b/tests/testsuite/cargo_add/no_optional/stderr.log
@@ -1,3 +1,2 @@
     Updating `dummy-registry` index
-      Adding my-package1 v99999.0.0 to dependencies.
-      Adding my-package2 v0.4.1 to dependencies.
+      Adding my-package v0.1.0 to dependencies.

--- a/tests/testsuite/cargo_add/optional/mod.rs
+++ b/tests/testsuite/cargo_add/optional/mod.rs
@@ -7,19 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for name in ["my-package1", "my-package2"] {
-        for ver in [
-            "0.1.1+my-package",
-            "0.2.0+my-package",
-            "0.2.3+my-package",
-            "0.4.1+my-package",
-            "20.0.0+my-package",
-            "99999.0.0+my-package",
-            "99999.0.0-alpha.1+my-package",
-        ] {
-            cargo_test_support::registry::Package::new(name, ver).publish();
-        }
-    }
+    cargo_test_support::registry::Package::new("my-package", "0.1.0").publish();
 
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
@@ -27,7 +15,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("my-package1 my-package2@0.4.1 --optional")
+        .arg_line("my-package --optional")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/optional/out/Cargo.toml
@@ -5,9 +5,7 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", optional = true }
-my-package2 = { version = "0.4.1", optional = true }
+my-package = { version = "0.1.0", optional = true }
 
 [features]
-my-package1 = ["dep:my-package1"]
-my-package2 = ["dep:my-package2"]
+my-package = ["dep:my-package"]

--- a/tests/testsuite/cargo_add/optional/stderr.log
+++ b/tests/testsuite/cargo_add/optional/stderr.log
@@ -1,3 +1,2 @@
     Updating `dummy-registry` index
-      Adding my-package1 v99999.0.0 to optional dependencies.
-      Adding my-package2 v0.4.1 to optional dependencies.
+      Adding my-package v0.1.0 to optional dependencies.

--- a/tests/testsuite/cargo_add/overwrite_no_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/in/Cargo.toml
@@ -5,5 +5,4 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+my-package = "0.1.0"

--- a/tests/testsuite/cargo_add/overwrite_no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/mod.rs
@@ -7,19 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for name in ["my-package1", "my-package2"] {
-        for ver in [
-            "0.1.1+my-package",
-            "0.2.0+my-package",
-            "0.2.3+my-package",
-            "0.4.1+my-package",
-            "20.0.0+my-package",
-            "99999.0.0+my-package",
-            "99999.0.0-alpha.1+my-package",
-        ] {
-            cargo_test_support::registry::Package::new(name, ver).publish();
-        }
-    }
+    cargo_test_support::registry::Package::new("my-package", "0.1.0").publish();
 
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
@@ -27,7 +15,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("my-package1 my-package2@0.4.1 --no-optional")
+        .arg_line("my-package --no-optional")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/overwrite_no_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/out/Cargo.toml
@@ -5,5 +5,4 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+my-package = "0.1.0"

--- a/tests/testsuite/cargo_add/overwrite_no_optional/stderr.log
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/stderr.log
@@ -1,3 +1,2 @@
     Updating `dummy-registry` index
-      Adding my-package1 v99999.0.0 to dependencies.
-      Adding my-package2 v0.4.1 to dependencies.
+      Adding my-package v0.1.0 to dependencies.

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/in/Cargo.toml
@@ -5,5 +5,4 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", optional = false }
-my-package2 = { version = "0.4.1", optional = false }
+my-package = { version = "0.1.0", optional = false }

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/mod.rs
@@ -7,19 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for name in ["my-package1", "my-package2"] {
-        for ver in [
-            "0.1.1+my-package",
-            "0.2.0+my-package",
-            "0.2.3+my-package",
-            "0.4.1+my-package",
-            "20.0.0+my-package",
-            "99999.0.0+my-package",
-            "99999.0.0-alpha.1+my-package",
-        ] {
-            cargo_test_support::registry::Package::new(name, ver).publish();
-        }
-    }
+    cargo_test_support::registry::Package::new("my-package", "0.1.0").publish();
 
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
@@ -27,7 +15,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("my-package1 my-package2@0.4.1 --optional")
+        .arg_line("my-package --optional")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/out/Cargo.toml
@@ -5,9 +5,7 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", optional = true }
-my-package2 = { version = "0.4.1", optional = true }
+my-package = { version = "0.1.0", optional = true }
 
 [features]
-my-package1 = ["dep:my-package1"]
-my-package2 = ["dep:my-package2"]
+my-package = ["dep:my-package"]

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.log
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.log
@@ -1,3 +1,2 @@
     Updating `dummy-registry` index
-      Adding my-package1 v99999.0.0 to optional dependencies.
-      Adding my-package2 v0.4.1 to optional dependencies.
+      Adding my-package v0.1.0 to optional dependencies.

--- a/tests/testsuite/cargo_add/overwrite_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional/in/Cargo.toml
@@ -5,5 +5,4 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+my-package = "0.1.0"

--- a/tests/testsuite/cargo_add/overwrite_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional/mod.rs
@@ -7,19 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for name in ["my-package1", "my-package2"] {
-        for ver in [
-            "0.1.1+my-package",
-            "0.2.0+my-package",
-            "0.2.3+my-package",
-            "0.4.1+my-package",
-            "20.0.0+my-package",
-            "99999.0.0+my-package",
-            "99999.0.0-alpha.1+my-package",
-        ] {
-            cargo_test_support::registry::Package::new(name, ver).publish();
-        }
-    }
+    cargo_test_support::registry::Package::new("my-package", "0.1.0").publish();
 
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();
@@ -27,7 +15,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("my-package1 my-package2@0.4.1 --optional")
+        .arg_line("my-package --optional")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/overwrite_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional/out/Cargo.toml
@@ -5,9 +5,7 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", optional = true }
-my-package2 = { version = "0.4.1", optional = true }
+my-package = { version = "0.1.0", optional = true }
 
 [features]
-my-package1 = ["dep:my-package1"]
-my-package2 = ["dep:my-package2"]
+my-package = ["dep:my-package"]

--- a/tests/testsuite/cargo_add/overwrite_optional/stderr.log
+++ b/tests/testsuite/cargo_add/overwrite_optional/stderr.log
@@ -1,3 +1,2 @@
     Updating `dummy-registry` index
-      Adding my-package1 v99999.0.0 to optional dependencies.
-      Adding my-package2 v0.4.1 to optional dependencies.
+      Adding my-package v0.1.0 to optional dependencies.

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/in/Cargo.toml
@@ -10,4 +10,3 @@ other = ["your-face/nose"]
 
 [dependencies]
 your-face = { version = "99999.0.0", optional = true }
-my-package2 = { version = "0.4.1", optional = true }

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/mod.rs
@@ -7,17 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for ver in [
-        "0.1.1+my-package",
-        "0.2.0+my-package",
-        "0.2.3+my-package",
-        "0.4.1+my-package",
-        "20.0.0+my-package",
-        "99999.0.0+my-package",
-        "99999.0.0-alpha.1+my-package",
-    ] {
-        cargo_test_support::registry::Package::new("my-package2", ver).publish();
-    }
+
     cargo_test_support::registry::Package::new("your-face", "99999.0.0+my-package")
         .feature("nose", &[])
         .feature("mouth", &[])
@@ -31,7 +21,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("your-face my-package2@0.4.1 --no-optional")
+        .arg_line("your-face --no-optional")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/out/Cargo.toml
@@ -10,4 +10,3 @@ other = ["your-face/nose"]
 
 [dependencies]
 your-face = { version = "99999.0.0" }
-my-package2 = { version = "0.4.1" }

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.log
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.log
@@ -5,4 +5,3 @@
              - eyes
              - mouth
              - nose
-      Adding my-package2 v0.4.1 to dependencies.

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/mod.rs
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/mod.rs
@@ -7,17 +7,7 @@ use cargo_test_support::curr_dir;
 #[cargo_test]
 fn case() {
     cargo_test_support::registry::init();
-    for ver in [
-        "0.1.1+my-package",
-        "0.2.0+my-package",
-        "0.2.3+my-package",
-        "0.4.1+my-package",
-        "20.0.0+my-package",
-        "99999.0.0+my-package",
-        "99999.0.0-alpha.1+my-package",
-    ] {
-        cargo_test_support::registry::Package::new("my-package1", ver).publish();
-    }
+    cargo_test_support::registry::Package::new("my-package1", "99999.0.0").publish();
 
     let project = Project::from_template(curr_dir!().join("in"));
     let project_root = project.root();

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.log
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.log
@@ -1,3 +1,2 @@
     Updating `dummy-registry` index
       Adding my-package1 v99999.0.0 to optional dependencies.
-      Adding my-package2 v0.4.1 to optional dependencies.


### PR DESCRIPTION
### What does this PR try to resolve?

This PR was inspired by https://github.com/rust-lang/cargo/pull/13046#discussion_r1406387864 and https://github.com/rust-lang/cargo/pull/12189.

There is unnecessary to keep more pacakages and versions on test case and the more pacakage added, the more test time and CI resource taken up.

And this PR also fixed a issue that  `overwrite_optional_with_optional` had not been added to `tests/testsuite/cargo_add/mod.rs`.

### How should we test and review this PR?

### Additional information