### PR TITLE
fix: only examine base URL when matching package

### DIFF
--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -551,6 +551,13 @@ mod tests {
         assert!(PackageIdSpec::parse("https://example.com#foo@1.2")
             .unwrap()
             .matches(foo));
+        // FIXME: The two tests below need to be corrected or adjusted - they should be passing.
+        assert!(!PackageIdSpec::parse("https://example.com/foo")
+            .unwrap()
+            .matches(foo));
+        assert!(!PackageIdSpec::parse("https://example.com/foo#1.2.3")
+            .unwrap()
+            .matches(foo));
         assert!(!PackageIdSpec::parse("https://bob.com#foo@1.2")
             .unwrap()
             .matches(foo));

--- a/src/cargo/core/package_id_spec.rs
+++ b/src/cargo/core/package_id_spec.rs
@@ -181,7 +181,22 @@ impl PackageIdSpec {
         }
 
         if let Some(u) = &self.url {
-            if u != package_id.source_id().url() {
+            let package_base_url = format!(
+                "{}://{}",
+                u.scheme(),
+                u.host_str().expect("package spec url should have a host")
+            );
+            let source_id = package_id.source_id();
+            let source_id_url = source_id.url();
+            let source_id_base_url = format!(
+                "{}://{}",
+                source_id_url.scheme(),
+                source_id_url
+                    .host_str()
+                    .expect("source id url should have a host")
+            );
+            // Examine only the base URL, as the package spec URL might include a package name within its path.
+            if package_base_url != source_id_base_url {
                 return false;
             }
         }
@@ -551,11 +566,10 @@ mod tests {
         assert!(PackageIdSpec::parse("https://example.com#foo@1.2")
             .unwrap()
             .matches(foo));
-        // FIXME: The two tests below need to be corrected or adjusted - they should be passing.
-        assert!(!PackageIdSpec::parse("https://example.com/foo")
+        assert!(PackageIdSpec::parse("https://example.com/foo")
             .unwrap()
             .matches(foo));
-        assert!(!PackageIdSpec::parse("https://example.com/foo#1.2.3")
+        assert!(PackageIdSpec::parse("https://example.com/foo#1.2.3")
             .unwrap()
             .matches(foo));
         assert!(!PackageIdSpec::parse("https://bob.com#foo@1.2")


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

close https://github.com/hi-rustin/cargo-information/issues/57

We should not directly compare the package spec URL with the source ID URL because the package spec URL contains the package's name in the URL.

For example:

`https://github.com/rust-lang/crates.io-index/clap`

1. spec URL: `Url { scheme: "https", cannot_be_a_base: false, username: ", password: None, host: Some(Domain("github.com")), port: None, path: "/rust-lang/crates.io-index/clap", query: None, fragment: None }`
2. source id URL: `Url { scheme: "https", cannot_be_a_base: false, username: ", password: None, host: Some(Domain("github.com")), port: None, path: "/rust-lang/crates.io-index", query: None, fragment: None }`

### How should we test and review this PR?

Could you check the unit tests? Before the fix, it could fail.

### Additional information

Do we need to change the URL itself instead of the matching process?
<!-- homu-ignore:end -->
