### PR TITLE
feat: make bundled SQLite optional 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ proptest = "1.4.0"
 pulldown-cmark = { version = "0.9.3", default-features = false }
 rand = "0.8.5"
 regex = "1.10.2"
-rusqlite = { version = "0.30.0", features = ["bundled"] }
+rusqlite = "0.30.0"
 rustfix = { version = "0.7.0", path = "crates/rustfix" }
 same-file = "1.0.6"
 security-framework = "2.9.2"
@@ -243,10 +243,11 @@ test = false
 doc = false
 
 [features]
-vendored-openssl = ["openssl/vendored"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
+vendored-openssl = ["openssl/vendored"]
+vendored-sqlite = ["rusqlite/bundled"]
 # This is primarily used by rust-lang/rust distributing cargo the executable.
-all-static = ['vendored-openssl', 'curl/static-curl', 'curl/force-system-lib-on-osx']
+all-static = ['vendored-openssl', 'vendored-sqlite', 'curl/static-curl', 'curl/force-system-lib-on-osx']
 
 [lints]
 workspace = true

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Cargo requires the following tools and packages to build:
 The following are optional based on your platform and needs.
 
 * `pkg-config` — This is used to help locate system packages, such as `libssl` headers/libraries. This may not be required in all cases, such as using vendored OpenSSL, or on Windows.
+
+* SQLite — Only needed if the `vendored-sqlite` Cargo feature is not used.
+
+  This requires the development headers, which can be obtained from the `libsqlite3-dev` package on Ubuntu or `sqlite-devel` with yum or the `sqlite3` package from Homebrew on macOS.
+
+  If using the `vendored-sqlite` Cargo feature, then a static copy of SQLite will be built from source instead of using the system SQLite.
+
 * OpenSSL — Only needed on Unix-like systems and only if the `vendored-openssl` Cargo feature is not used.
 
   This requires the development headers, which can be obtained from the `libssl-dev` package on Ubuntu or `openssl-devel` with apk or yum or the `openssl` package from Homebrew on macOS.


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This helps cargo-the-library consumers easier to manipulate their
dependency graph if they don't want to bundle SQLite3. For example,
Linux distro maintainers want full control of the dependency closure.

### How should we test and review this PR?

Make sure 

* `cargo build` fails when without SQLite3 development headers
* `cargo build` succeeds when with SQLite3 development headers
* `cargo build -F vendored-sqlite` always works

One drawback of this is that people now need to take care of one extra system library.

### Additional information


See also <https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/cache.20cleaning.20blog.20post/near/405596136>.

<!-- homu-ignore:end -->
