### PR TITLE
fix: explicitly remap current dir by using `.`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1230,7 +1230,7 @@ fn trim_paths_args(
         // * path dependencies outside workspace root directory
         if is_local && pkg_root.strip_prefix(ws_root).is_ok() {
             remap.push(ws_root);
-            remap.push("="); // empty to remap to relative paths.
+            remap.push("=."); // remap to relative rustc work dir explicitly
         } else {
             remap.push(pkg_root);
             remap.push("=");

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -523,22 +523,9 @@ fn object_works_helper(run: impl Fn(&std::path::Path) -> Vec<u8>) {
 
     p.cargo("clean").run();
 
-    p.change_file(
-        "Cargo.toml",
-        r#"
-            [package]
-            name = "foo"
-            version = "0.0.1"
-
-            [dependencies]
-            bar = "0.0.1"
-
-            [profile.dev]
-            trim-paths = "object"
-       "#,
-    );
-
     p.cargo("build --verbose -Ztrim-paths")
+        .arg("--config")
+        .arg(r#"profile.dev.trim-paths="object""#)
         .masquerade_as_nightly_cargo(&["-Ztrim-paths"])
         .with_stderr(&format!(
             "\

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -83,7 +83,7 @@ fn release_profile_default_to_object() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] release [..]",
         )
@@ -121,7 +121,7 @@ fn one_option() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope={option} \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]",
             ))
@@ -158,7 +158,7 @@ fn multiple_options() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=diagnostics,macro,object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]",
         )
@@ -193,7 +193,7 @@ fn profile_merge_works() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=diagnostics \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] custom [..]",
         )
@@ -243,7 +243,7 @@ fn registry_dependency() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
@@ -297,7 +297,7 @@ fn git_dependency() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
@@ -338,12 +338,12 @@ fn path_dependency() {
 [COMPILING] bar v0.0.1 ([..]/cocktail-bar)
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
@@ -392,7 +392,7 @@ fn path_dependency_outside_workspace() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]
 [RUNNING] `target/debug/foo[EXE]`"
@@ -446,7 +446,7 @@ fn diagnostics_works() {
             "\
 [RUNNING] [..]rustc [..]\
     -Zremap-path-scope=diagnostics \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]",
         )
         .run();
@@ -574,7 +574,7 @@ fn object_works_helper(split_debuginfo: &str, run: impl Fn(&std::path::Path) -> 
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]-C split-debuginfo={split_debuginfo} [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
 [FINISHED] dev [..]",
         ))
@@ -737,7 +737,7 @@ fn lldb_works_after_trimmed() {
             "\
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
-    --remap-path-prefix=[CWD]= \
+    --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]",
         )
         .run();

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -487,7 +487,8 @@ mod object_works {
 
     fn inspect_debuginfo(path: &std::path::Path) -> Vec<u8> {
         std::process::Command::new("readelf")
-            .arg("-wi")
+            .arg("--debug-dump=info")
+            .arg("--debug-dump=no-follow-links") // older version can't recognized but just a warning
             .arg(path)
             .output()
             .expect("readelf works")


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

In https://github.com/rust-lang/rust/blob/87e1447aa/compiler/rustc_codegen_llvm/src/debuginfo/metadata.rs#L856
when the remap result of `work_dir` is an empty string,
LLVM won't generate some symbols for root debuginfo node.
For example, `N_SO` and `N_OSO` on macOS,
or `DW_AT_comp_dir` and `DW_AT_GNU_dwo_name` when debuginfo is splitted.
Precisely, it is observed that when the `DIFile` of a root DI node of a
compile unit `DIFile` was provied with an empty `Directory` string,
LLVM would not emit those symbols for the root DI node.

This behavior is not desired,
resulting in corrupted debuginfo and degrading debugging experience.

This is might not be a bug of `--remap-path-prefix` in rustc,
since `-fdebug-prefix-map` in clang 16 could have the same result
(`DW_AT_comp_dir` is gone when `work_dir` is remapped to an empty string).
However, in gcc 12 `fdebug-prefix-map` will return an absolute work_dir
when an empty string occurs.

To not bother whether this needs to be fixed in rustc or not,
let's fix it by always appending an explicit `.`
when `--remap-path-prefix` remaps to relative workspace root
a.k.a. where rustc is invoking.

### How should we test and review this PR?

#### Build rustc

Without a possible fix in rustc like <https://github.com/rust-lang/rust/pull/118518>, the debuginfo is not corrputed even we dont remap to `.` explicitly. Therefore, to test it manually you need to build rustc from <https://github.com/rust-lang/rust/pull/118518>. Generally,

```
# in rust-lang/rust
./x b library --stage 1
rustup toolchain link stage1 build/host/stage1
```

Then cargo +stage1 build is available, and you can build package via

```
CARGO_PROFILE_DEV_TRIM_PATHS=object cargo +stage1 -Ztrim-paths b
```

After build a package, I would recommend playing with debuggers, either gdb or lldb.
After remapping, supposedly you need to launch the debugger from the same location the build kicked off, usually the workspace root.

Please help verify that source files still show, and breakpoints can pause/resume at either local or registry packages.

#### I don't want to build rustc

You can use either `objdump -Wi` or `readelf -wi` or `dsymutil -s` to inspect debug symbols, though it doesn't help much.

### Additional information


It would be awesome if somebody can help verify the behavior on Windows 😆.
<!-- homu-ignore:end -->
