### PR TITLE
Revert "Disable flaky tests for now (#11821)"

### DIFF
--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -105,11 +105,6 @@ fn setup_failed_auth_test() -> (SocketAddr, JoinHandle<()>, Arc<AtomicUsize>) {
 // Tests that HTTP auth is offered from `credential.helper`.
 #[cargo_test]
 fn http_auth_offered() {
-    // TODO(Seb): remove this once possible.
-    if cargo_uses_gitoxide() {
-        // Without the fixes in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0 this test is flaky.
-        return;
-    }
     let (addr, t, connections) = setup_failed_auth_test();
     let p = project()
         .file(
@@ -372,11 +367,6 @@ Caused by:
 
 #[cargo_test]
 fn instead_of_url_printed() {
-    // TODO(Seb): remove this once possible.
-    if cargo_uses_gitoxide() {
-        // Without the fixes in https://github.com/Byron/gitoxide/releases/tag/gix-v0.41.0 this test is flaky.
-        return;
-    }
     let (addr, t, _connections) = setup_failed_auth_test();
     let config = paths::home().join(".gitconfig");
     let mut config = git2::Config::open(&config).unwrap();


### PR DESCRIPTION

<!-- homu-ignore:start -->

### What does this PR try to resolve?

This reverts commit c890c64080e193325584898369c729ab30994314.

gix was updated to 0.41.0 (and later) a while back. Let's see how it goes.

resolves #11821

### How should we test and review this PR?

Wait a see if those tests are still flaky in CI.

<!-- homu-ignore:end -->
