### PR TITLE
fix bash completion in directory with spaces

### DIFF
--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -209,12 +209,12 @@ _get_names_from_array()
 				line=${line##*=}
 				line=${line%%\"}
 				line=${line##*\"}
-				names+=($line)
+				names+=("$line")
 			fi
 		fi
 
 		last_line=$line
-	done < $manifest
+	done < "$manifest"
 	echo "${names[@]}"
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR fixes bash completion for `cargo run --bin <TAB>` when the path to the project contains a space.

### How should we test and review this PR?

1. create a project in a directory with a space, for example `mkdir '/tmp/has space' && cd '/tmp/has space' && cargo new foo && cd foo`.
2. add a binary to Cargo.toml, e.g.
   ```
   [[bin]]
   name = "bar"
   ```
3. on bash, type `cargo run --bin b` and press tab
4. observe error message `bash: $manifest: ambiguous redirect`, command is not completed
5. apply the fix to `$(rustc --print sysroot)/etc/bash_completion.d/cargo`
6. repeat step 3 and observe that the command is completed successfully