### PR TITLE
re-enable flaky tests thanks to update to `gix-config`. (#11821)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,9 +1173,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada0e0b904b17a3f2636b70a33e2c8b075b8eb947db80f6c6e94549f2d5b78d1"
+checksum = "0341471d55d8676e98b88e121d7065dfa4c9c5acea4b6d6ecdd2846e85cce0c3"
 dependencies = [
  "bstr",
  "gix-config-value",

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -105,11 +105,6 @@ fn setup_failed_auth_test() -> (SocketAddr, JoinHandle<()>, Arc<AtomicUsize>) {
 // Tests that HTTP auth is offered from `credential.helper`.
 #[cargo_test]
 fn http_auth_offered() {
-    // TODO: remove this once possible.
-    // See https://github.com/rust-lang/cargo/issues/11821
-    if cargo_uses_gitoxide() {
-        return;
-    }
     let (addr, t, connections) = setup_failed_auth_test();
     let p = project()
         .file(
@@ -139,7 +134,6 @@ fn http_auth_offered() {
     // This is a "contains" check because the last error differs by platform,
     // may span multiple lines, and isn't relevant to this test.
     p.cargo("check")
-        .env("GIX_CREDENTIALS_HELPER_STDERR", "0")
         .with_status(101)
         .with_stderr_contains(&format!(
             "\
@@ -373,11 +367,6 @@ Caused by:
 
 #[cargo_test]
 fn instead_of_url_printed() {
-    // TODO: remove this once possible.
-    // See https://github.com/rust-lang/cargo/issues/11821
-    if cargo_uses_gitoxide() {
-        return;
-    }
     let (addr, t, _connections) = setup_failed_auth_test();
     let config = paths::home().join(".gitconfig");
     let mut config = git2::Config::open(&config).unwrap();
@@ -404,7 +393,6 @@ fn instead_of_url_printed() {
         .build();
 
     p.cargo("check")
-        .env("GIX_CREDENTIALS_HELPER_STDERR", "0")
         .with_status(101)
         .with_stderr(&format!(
             "\


### PR DESCRIPTION
Related to #11821.

With `gix-config` now being fixed, it will properly respect `GIT_CONFIG_NOSYSTEM` both for system-wide configuration as well as for the git installation configuration.

That way, credential helpers provided by the git installation won't be called anymore, which prevents them from 'somehow' emitting information to stderr.

The latter was previously disabled for credential helpers, and despite [everything looking like it should work][1], it simply didn't.

[1]: https://github.com/rust-lang/cargo/pull/13117#issuecomment-1844881287

