### PR TITLE
Add a windows manifest file

### DIFF
--- a/windows.manifest.xml
+++ b/windows.manifest.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+This is a Windows application manifest file.
+See: https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests
+-->
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <!-- Versions cargo supports as hosts -->
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
+        <application> 
+            <!-- Windows 7 --><supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows 8 --><supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 8.1 --><supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 10 and 11 --><supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+        </application> 
+    </compatibility>
+    <!-- Use UTF-8 code page -->
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">
+            <activeCodePage>UTF-8</activeCodePage>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+    <!-- Remove (most) legacy path limits -->
+    <asmv3:application>
+        <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </asmv3:windowsSettings>
+    </asmv3:application>
+</assembly>


### PR DESCRIPTION
This adds a Windows [application manifest file](https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests) to the built `cargo.exe` for windows msvc. This manifest file is used to enable modern features of Windows. [`rustc`](https://github.com/rust-lang/rust/tree/7df0c211ace4157009eebd015f1a083490faa0bc/compiler/rustc) has been using a similar manifest for about a year now.

The manifest file does the following:

* States our compatibility with Windows versions 7, 8, 8.1, 10 and 11. This allows avoiding unnecessary compatibility shims.
* Sets the code page to UTF-8. This should have no real impact on existing code (which should work with any code page). That said it may avoid issues if dependencies do use the local code page because conversions to/from Unicode are lossy so if a Unicode code point has no local code page equivalent, information is lost.
* Enable long path awareness. Mostly rust itself side-steps long path issues by using `\\?\` paths internally. However, this doesn't work for the current directory whereas using this option does.

You can test that a manifest file has been embedded by extracting it to a new file:

    mt -nologo -inputresource:cargo.exe -out:embedded.manifest

You can also examine the `.rsrc` (aka resource) section using `dumpbin`

    dumpbin /SECTION:.rsrc /ALL cargo.exe

### Additional info

This also sets the [`/Wx` linker option](https://learn.microsoft.com/en-us/cpp/build/reference/wx-treat-linker-warnings-as-errors?view=msvc-170) which turns linker warnings into errors. When setting linker options manually, I prefer to also set this because, unless there are also linker errors, `rustc` will not show linker warnings by default. Linker warnings should be rare and usually do indicate an actual problem so not ignoring them should be fine.