### PR TITLE
Avoid writing CACHEDIR.TAG if it already exists

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -719,14 +719,17 @@ pub fn exclude_from_backups_and_indexing(p: impl AsRef<Path>) {
 /// * CACHEDIR.TAG files supported by various tools in a platform-independent way
 fn exclude_from_backups(path: &Path) {
     exclude_from_time_machine(path);
-    let _ = std::fs::write(
-        path.join("CACHEDIR.TAG"),
-        "Signature: 8a477f597d28d172789f06886806bc55
+    let file = path.join("CACHEDIR.TAG");
+    if !file.exists() {
+        let _ = std::fs::write(
+            file,
+            "Signature: 8a477f597d28d172789f06886806bc55
 # This file is a cache directory tag created by cargo.
 # For information about cache directory tags see https://bford.info/cachedir/
 ",
-    );
-    // Similarly to exclude_from_time_machine() we ignore errors here as it's an optional feature.
+        );
+        // Similarly to exclude_from_time_machine() we ignore errors here as it's an optional feature.
+    }
 }
 
 /// Marks the directory as excluded from content indexing.


### PR DESCRIPTION
Cargo currently unconditionally writes `CACHEDIR.TAG` files even if they already exist. 

This practice causes problems for build systems that disallow multiple writes to the same file.