### PR TITLE
`all-static` feature should include `vendored-libgit2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,7 +246,7 @@ doc = false
 vendored-openssl = ["openssl/vendored"]
 vendored-libgit2 = ["libgit2-sys/vendored"]
 # This is primarily used by rust-lang/rust distributing cargo the executable.
-all-static = ['vendored-openssl', 'curl/static-curl', 'curl/force-system-lib-on-osx']
+all-static = ['vendored-openssl', 'curl/static-curl', 'curl/force-system-lib-on-osx', 'vendored-libgit2']
 
 [lints]
 workspace = true


### PR DESCRIPTION
Cargo has an `all-static` feature which is supposed to statically link dependencies for distributing.

However, it doesn't include `libgit2`. If the system has a compatible version of `libgit2` and `pkg-config` installed, then the `all-static` build will still use the system `libgit2`.