### PR TITLE
Limit exported-private-dependencies lints to libraries

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1434,6 +1434,7 @@ pub fn extern_args(
                 .require(Feature::public_dependency())
                 .is_ok()
                 && !dep.public
+                && unit.target.is_lib()
             {
                 opts.push("priv");
                 *unstable_opts = true;

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -278,9 +278,14 @@ fn allow_priv_in_tests() {
 
     p.cargo("check --tests --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
-        .with_stderr_contains(
+        .with_stderr(
             "\
-tests/mod.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] priv_dep v0.1.0 ([..])
+[CHECKING] priv_dep v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -317,9 +322,14 @@ fn allow_priv_in_benchs() {
 
     p.cargo("check --benches --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
-        .with_stderr_contains(
+        .with_stderr(
             "\
-benches/mod.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] priv_dep v0.1.0 ([..])
+[CHECKING] priv_dep v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -357,9 +367,14 @@ fn allow_priv_in_bins() {
 
     p.cargo("check --bins --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
-        .with_stderr_contains(
+        .with_stderr(
             "\
-src/main.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] priv_dep v0.1.0 ([..])
+[CHECKING] priv_dep v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -397,9 +412,14 @@ fn allow_priv_in_examples() {
 
     p.cargo("check --examples --message-format=short")
         .masquerade_as_nightly_cargo(&["public-dependency"])
-        .with_stderr_contains(
+        .with_stderr(
             "\
-examples/lib.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] priv_dep v0.1.0 ([..])
+[CHECKING] priv_dep v0.1.0
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -246,3 +246,161 @@ fn workspace_dep_made_public() {
         .masquerade_as_nightly_cargo(&["public-dependency"])
         .run()
 }
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn allow_priv_in_tests() {
+    Package::new("priv_dep", "0.1.0")
+        .file("src/lib.rs", "pub struct FromPriv;")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["public-dependency"]
+
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                priv_dep = {version = "0.1.0", public = false}
+            "#,
+        )
+        .file(
+            "tests/mod.rs",
+            "
+            extern crate priv_dep;
+            pub fn use_priv(_: priv_dep::FromPriv) {}
+        ",
+        )
+        .build();
+
+    p.cargo("check --tests --message-format=short")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stderr_contains(
+            "\
+tests/mod.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+",
+        )
+        .run()
+}
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn allow_priv_in_benchs() {
+    Package::new("priv_dep", "0.1.0")
+        .file("src/lib.rs", "pub struct FromPriv;")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["public-dependency"]
+
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                priv_dep = {version = "0.1.0", public = false}
+            "#,
+        )
+        .file(
+            "benches/mod.rs",
+            "
+            extern crate priv_dep;
+            pub fn use_priv(_: priv_dep::FromPriv) {}
+        ",
+        )
+        .build();
+
+    p.cargo("check --benches --message-format=short")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stderr_contains(
+            "\
+benches/mod.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+",
+        )
+        .run()
+}
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn allow_priv_in_bins() {
+    Package::new("priv_dep", "0.1.0")
+        .file("src/lib.rs", "pub struct FromPriv;")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["public-dependency"]
+
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                priv_dep = {version = "0.1.0", public = false}
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            "
+            extern crate priv_dep;
+            pub fn use_priv(_: priv_dep::FromPriv) {}
+            fn main() {}
+        ",
+        )
+        .build();
+
+    p.cargo("check --bins --message-format=short")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stderr_contains(
+            "\
+src/main.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+",
+        )
+        .run()
+}
+
+#[cargo_test(nightly, reason = "exported_private_dependencies lint is unstable")]
+fn allow_priv_in_examples() {
+    Package::new("priv_dep", "0.1.0")
+        .file("src/lib.rs", "pub struct FromPriv;")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["public-dependency"]
+
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [dependencies]
+                priv_dep = {version = "0.1.0", public = false}
+            "#,
+        )
+        .file(
+            "examples/lib.rs",
+            "
+            extern crate priv_dep;
+            pub fn use_priv(_: priv_dep::FromPriv) {}
+            fn main() {}
+        ",
+        )
+        .build();
+
+    p.cargo("check --examples --message-format=short")
+        .masquerade_as_nightly_cargo(&["public-dependency"])
+        .with_stderr_contains(
+            "\
+examples/lib.rs:3:13: warning: type `FromPriv` from private dependency 'priv_dep' in public interface
+",
+        )
+        .run()
+}


### PR DESCRIPTION
### What does this PR try to resolve?
Completed https://github.com/rust-lang/cargo/issues/13039.

This PR limit `exported-private-dependencies`  lint in libraray `Target`. 

### How should we test and review this PR?

Your can checkout out 2348ac2a20edf772495349d7911938251e343bf1 and run test, it will failed and then it will be passed in the commit 2348ac2a20edf772495349d7911938251e343bf1

### Additional information
