### PR TITLE
fix: Print rustc messages colored on wincon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
 dependencies = [
  "anstyle",
  "anstyle-parse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-anstream = "0.6.4"
+anstream = "0.6.5"
 anstyle = "1.0.4"
 anyhow = "1.0.75"
 base64 = "0.21.5"


### PR DESCRIPTION
### What does this PR try to resolve?

The real fix is over in rust-cli/anstyle#150; this just upgrades to it

Fixes #13104

### How should we test and review this PR?

I hacked vt console support off, ran a build before and rustc messages weren't colored.  Now with this change, rustc messages are colored.

### Additional information

This still doesn't address why wincon is being used on their system