### PR TITLE
Don't rely on mtime to test changes

### DIFF
--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -3471,7 +3471,7 @@ fn rebuild_only_on_explicit_paths() {
 
     // random other files do not affect freshness
     println!("run baz");
-    p.change_file("baz", "");
+    p.change_file("baz", "// modified");
     p.cargo("build -v")
         .with_stderr(
             "\
@@ -3483,7 +3483,7 @@ fn rebuild_only_on_explicit_paths() {
 
     // but changing dependent files does
     println!("run foo change");
-    p.change_file("foo", "");
+    p.change_file("foo", "// modified");
     p.cargo("build -v")
         .with_stderr(
             "\

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -96,7 +96,7 @@ fn rerun_if_env_or_file_changes() {
         .with_stderr("[FINISHED] [..]")
         .run();
     sleep_ms(1000);
-    p.change_file("foo", "");
+    p.change_file("foo", "// modified");
     p.cargo("check")
         .env("FOO", "bar")
         .with_stderr(

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1522,7 +1522,7 @@ fn bust_patched_dep() {
         sleep_ms(1000);
     }
 
-    p.change_file("reg1new/src/lib.rs", "");
+    p.change_file("reg1new/src/lib.rs", "// modified");
     if is_coarse_mtime() {
         sleep_ms(1000);
     }


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #13139 by making sure tests aren't relying on changing the mtime alone 

### How should we test and review this PR?

The pattern to watch out for is when a file is created with empty contents, e.g. `.file("foo", "")`, then later the same file updated with empty contents, e.g. `.change_file("foo", "")`. Tests should be making an actual change to the contents.