### PR TITLE
Update curl-sys to bring in curl 8.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.68+curl-8.4.0"
+version = "0.4.70+curl-8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a0d18d88360e374b16b2273c832b5e57258ffc1d4aa4f96b108e0738d5752f"
+checksum = "3c0333d8849afe78a4c8102a429a446bfdd055832af071945520e835ae2d841e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ core-foundation = { version = "0.9.4", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.39.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
-curl-sys = "0.4.68"
+curl-sys = "0.4.70"
 filetime = "0.2.22"
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib"] }
 git2 = "0.18.1"


### PR DESCRIPTION
This is a routine update for curl.
The security issues don't appear to affect cargo.
https://daniel.haxx.se/blog/2023/12/06/curl-8-5-0/
Changelog: https://curl.se/changes.html#8_5_0
