### PR TITLE
Do not allow empty name in package ID spec

### DIFF
--- a/src/cargo/util_schemas/core/package_id_spec.rs
+++ b/src/cargo/util_schemas/core/package_id_spec.rs
@@ -602,5 +602,6 @@ mod tests {
         .is_err());
         assert!(PackageIdSpec::parse("@1.2.3").is_err());
         assert!(PackageIdSpec::parse("registry+https://github.com").is_ok());
+        assert!(PackageIdSpec::parse("https://crates.io/1foo#1.2.3").is_ok())
     }
 }

--- a/src/cargo/util_schemas/core/package_id_spec.rs
+++ b/src/cargo/util_schemas/core/package_id_spec.rs
@@ -601,5 +601,6 @@ mod tests {
         )
         .is_err());
         assert!(PackageIdSpec::parse("@1.2.3").is_err());
+        assert!(PackageIdSpec::parse("registry+https://github.com").is_ok());
     }
 }

--- a/src/cargo/util_schemas/core/package_id_spec.rs
+++ b/src/cargo/util_schemas/core/package_id_spec.rs
@@ -197,6 +197,10 @@ impl PackageIdSpec {
                 None => (String::from(path_name), None),
             }
         };
+        if name.is_empty() {
+            bail!("package ID specification must have a name: `{url}`");
+        }
+        validate_package_name(name.as_str(), "pkgid", "")?;
         Ok(PackageIdSpec {
             name,
             version,
@@ -601,7 +605,7 @@ mod tests {
         )
         .is_err());
         assert!(PackageIdSpec::parse("@1.2.3").is_err());
-        assert!(PackageIdSpec::parse("registry+https://github.com").is_ok());
-        assert!(PackageIdSpec::parse("https://crates.io/1foo#1.2.3").is_ok())
+        assert!(PackageIdSpec::parse("registry+https://github.com").is_err());
+        assert!(PackageIdSpec::parse("https://crates.io/1foo#1.2.3").is_err())
     }
 }

--- a/src/cargo/util_schemas/core/package_id_spec.rs
+++ b/src/cargo/util_schemas/core/package_id_spec.rs
@@ -98,6 +98,9 @@ impl PackageIdSpec {
             Some(version) => Some(version.parse::<PartialVersion>()?),
             None => None,
         };
+        if name.is_empty() {
+            bail!("package ID specification must have a name: `{spec}`");
+        }
         validate_package_name(name, "pkgid", "")?;
         Ok(PackageIdSpec {
             name: String::from(name),
@@ -597,6 +600,6 @@ mod tests {
             "sparse+https://github.com/rust-lang/cargo#0.52.0?branch=dev"
         )
         .is_err());
-        assert!(PackageIdSpec::parse("@1.2.3").is_ok());
+        assert!(PackageIdSpec::parse("@1.2.3").is_err());
     }
 }

--- a/src/cargo/util_schemas/core/package_id_spec.rs
+++ b/src/cargo/util_schemas/core/package_id_spec.rs
@@ -597,5 +597,6 @@ mod tests {
             "sparse+https://github.com/rust-lang/cargo#0.52.0?branch=dev"
         )
         .is_err());
+        assert!(PackageIdSpec::parse("@1.2.3").is_ok());
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Do not allow empty names in package ID spec.

See: https://github.com/hi-rustin/cargo-information/pull/63

### How should we test and review this PR?

Check unit tests.

### Additional information

<!-- homu-ignore:end -->
