### PR TITLE
fix(toml)!: Disallow `[lints]` in virtual workspaces

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1122,6 +1122,9 @@ fn to_virtual_manifest(
     if me.badges.is_some() {
         bail!("this virtual manifest specifies a [badges] section, which is not allowed");
     }
+    if me.lints.is_some() {
+        bail!("this virtual manifest specifies a [lints] section, which is not allowed");
+    }
 
     let mut nested_paths = Vec::new();
     let mut warnings = Vec::new();

--- a/src/cargo/util_schemas/manifest.rs
+++ b/src/cargo/util_schemas/manifest.rs
@@ -45,6 +45,7 @@ pub struct TomlManifest {
     pub workspace: Option<TomlWorkspace>,
     pub badges: Option<InheritableBtreeMap>,
     pub lints: Option<InheritableLints>,
+    // when adding new fields, be sure to check whether `to_virtual_manifest` should disallow them
 }
 
 impl TomlManifest {

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2198,6 +2198,7 @@ fn ws_err_unused() {
         "[features]",
         "[target]",
         "[badges]",
+        "[lints]",
     ] {
         let p = project()
             .file(


### PR DESCRIPTION
This was missed with the initial `[lints]` implementation.

While this is a breaking change, this is aligned with ones we've done in the past.  A lot of times, we warn first.  My hope is that isn't needed this time because
- It only exists virtual workspaces so they aren't published
- It is a nop to have this which is likely to be caught
- This is so new that the number of people using it, and likely running into this case, is quite low.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
