### PR TITLE
Remove the deleted feature test_2018_feature from the test 

### DIFF
--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -296,7 +296,7 @@ fn allow_features_to_rustc() {
             "src/lib.rs",
             r#"
                 #![allow(internal_features)]
-                #![feature(test_2018_feature)]
+                #![feature(rustc_attrs)]
             "#,
         )
         .build();
@@ -307,7 +307,7 @@ fn allow_features_to_rustc() {
         .with_stderr_contains("[..]E0725[..]")
         .run();
 
-    p.cargo("-Zallow-features=test_2018_feature check")
+    p.cargo("-Zallow-features=rustc_attrs check")
         .masquerade_as_nightly_cargo(&["allow-features"])
         .with_stderr(
             "\


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

See https://github.com/rust-lang/cargo/pull/13152#issuecomment-1851212620

The `test_2018_feature` has been removed in https://github.com/rust-lang/rust/pull/118802/files

### How should we test and review this PR?

Check out the unit test.

### Additional information

I am not sure if we need to pick another internal feature. I randomly picked it.
<!-- homu-ignore:end -->
