### PR TITLE
crates-io: Add support for other 2xx HTTP status codes

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -436,7 +436,8 @@ impl Registry {
             .map(|s| s.errors.into_iter().map(|s| s.detail).collect::<Vec<_>>());
 
         match (self.handle.response_code()?, errors) {
-            (0, None) | (200, None) => Ok(body),
+            (0, None) => Ok(body),
+            (code, None) if is_success(code) => Ok(body),
             (code, Some(errors)) => Err(Error::Api {
                 code,
                 headers,
@@ -451,8 +452,12 @@ impl Registry {
     }
 }
 
+fn is_success(code: u32) -> bool {
+    code >= 200 && code < 300
+}
+
 fn status(code: u32) -> String {
-    if code == 200 {
+    if is_success(code) {
         String::new()
     } else {
         let reason = reason(code);


### PR DESCRIPTION
Replying with `201 Created` of `202 Accepted` should not result in showing errors.

Related:

- https://github.com/rust-lang/cargo/issues/3995
- https://github.com/rust-lang/cargo/pull/6771