### PR TITLE
fix: Fill in more empty name holes

### DIFF
--- a/src/cargo/ops/cargo_add/crate_spec.rs
+++ b/src/cargo/ops/cargo_add/crate_spec.rs
@@ -1,5 +1,6 @@
 //! Crate name parsing.
 
+use anyhow::bail;
 use anyhow::Context as _;
 
 use super::Dependency;
@@ -28,6 +29,9 @@ impl CrateSpec {
             .map(|(n, v)| (n, Some(v)))
             .unwrap_or((pkg_id, None));
 
+        if name.is_empty() {
+            bail!("dependency name cannot be empty");
+        }
         validate_package_name(name, "dependency name", "")?;
 
         if let Some(version) = version {

--- a/src/cargo/ops/cargo_add/crate_spec.rs
+++ b/src/cargo/ops/cargo_add/crate_spec.rs
@@ -1,6 +1,5 @@
 //! Crate name parsing.
 
-use anyhow::bail;
 use anyhow::Context as _;
 
 use super::Dependency;
@@ -29,9 +28,6 @@ impl CrateSpec {
             .map(|(n, v)| (n, Some(v)))
             .unwrap_or((pkg_id, None));
 
-        if name.is_empty() {
-            bail!("dependency name cannot be empty");
-        }
         validate_package_name(name, "dependency name", "")?;
 
         if let Some(version) = version {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -4,7 +4,7 @@ use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::toml_mut::is_sorted;
 use crate::util::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 use crate::util::{restricted_names, Config};
-use anyhow::{anyhow, bail, Context};
+use anyhow::{anyhow, Context};
 use cargo_util::paths::{self, write_atomic};
 use serde::de;
 use serde::Deserialize;
@@ -197,9 +197,6 @@ fn check_name(
         }
         help
     };
-    if name.is_empty() {
-        bail!("package name cannot be empty");
-    }
     restricted_names::validate_package_name(name, "package name", &bin_help())?;
 
     if restricted_names::is_keyword(name) {

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -4,7 +4,7 @@ use crate::util::important_paths::find_root_manifest_for_wd;
 use crate::util::toml_mut::is_sorted;
 use crate::util::{existing_vcs_repo, FossilRepo, GitRepo, HgRepo, PijulRepo};
 use crate::util::{restricted_names, Config};
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow, bail, Context};
 use cargo_util::paths::{self, write_atomic};
 use serde::de;
 use serde::Deserialize;
@@ -197,6 +197,9 @@ fn check_name(
         }
         help
     };
+    if name.is_empty() {
+        bail!("package name cannot be empty");
+    }
     restricted_names::validate_package_name(name, "package name", &bin_help())?;
 
     if restricted_names::is_keyword(name) {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -833,9 +833,6 @@ Run `{cmd}` to see possible targets."
             (None, None) => config.default_registry()?.map(RegistryOrIndex::Registry),
             (None, Some(i)) => Some(RegistryOrIndex::Index(i.into_url()?)),
             (Some(r), None) => {
-                if r.is_empty() {
-                    bail!("registry name cannot be empty");
-                }
                 restricted_names::validate_package_name(r, "registry name", "")?;
                 Some(RegistryOrIndex::Registry(r.to_string()))
             }
@@ -851,9 +848,6 @@ Run `{cmd}` to see possible targets."
         match self._value_of("registry").map(|s| s.to_string()) {
             None => config.default_registry(),
             Some(registry) => {
-                if registry.is_empty() {
-                    bail!("registry name cannot be empty");
-                }
                 restricted_names::validate_package_name(&registry, "registry name", "")?;
                 Ok(Some(registry))
             }

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -833,6 +833,9 @@ Run `{cmd}` to see possible targets."
             (None, None) => config.default_registry()?.map(RegistryOrIndex::Registry),
             (None, Some(i)) => Some(RegistryOrIndex::Index(i.into_url()?)),
             (Some(r), None) => {
+                if r.is_empty() {
+                    bail!("registry name cannot be empty");
+                }
                 restricted_names::validate_package_name(r, "registry name", "")?;
                 Some(RegistryOrIndex::Registry(r.to_string()))
             }
@@ -848,6 +851,9 @@ Run `{cmd}` to see possible targets."
         match self._value_of("registry").map(|s| s.to_string()) {
             None => config.default_registry(),
             Some(registry) => {
+                if registry.is_empty() {
+                    bail!("registry name cannot be empty");
+                }
                 restricted_names::validate_package_name(&registry, "registry name", "")?;
                 Ok(Some(registry))
             }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1551,9 +1551,6 @@ impl Config {
 
     /// Gets the index for a registry.
     pub fn get_registry_index(&self, registry: &str) -> CargoResult<Url> {
-        if registry.is_empty() {
-            bail!("registry name cannot be empty");
-        }
         validate_package_name(registry, "registry name", "")?;
         if let Some(index) = self.get_string(&format!("registries.{}.index", registry))? {
             self.resolve_registry_index(&index).with_context(|| {

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1551,6 +1551,9 @@ impl Config {
 
     /// Gets the index for a registry.
     pub fn get_registry_index(&self, registry: &str) -> CargoResult<Url> {
+        if registry.is_empty() {
+            bail!("registry name cannot be empty");
+        }
         validate_package_name(registry, "registry name", "")?;
         if let Some(index) = self.get_string(&format!("registries.{}.index", registry))? {
             self.resolve_registry_index(&index).with_context(|| {

--- a/src/cargo/util/restricted_names.rs
+++ b/src/cargo/util/restricted_names.rs
@@ -43,6 +43,10 @@ pub fn is_conflicting_artifact_name(name: &str) -> bool {
 /// elsewhere. `cargo new` has a few restrictions, such as checking for
 /// reserved names. crates.io has even more restrictions.
 pub fn validate_package_name(name: &str, what: &str, help: &str) -> CargoResult<()> {
+    if name.is_empty() {
+        bail!("{what} cannot be empty");
+    }
+
     let mut chars = name.chars();
     if let Some(ch) = chars.next() {
         if ch.is_digit(10) {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -480,10 +480,6 @@ pub fn to_real_manifest(
     };
 
     let package_name = package.name.trim();
-    if package_name.is_empty() {
-        bail!("package name cannot be an empty string")
-    }
-
     validate_package_name(package_name, "package name", "")?;
 
     let resolved_path = package_root.join("Cargo.toml");

--- a/src/cargo/util_schemas/core/package_id_spec.rs
+++ b/src/cargo/util_schemas/core/package_id_spec.rs
@@ -97,9 +97,6 @@ impl PackageIdSpec {
             Some(version) => Some(version.parse::<PartialVersion>()?),
             None => None,
         };
-        if name.is_empty() {
-            bail!("package ID specification must have a name: `{spec}`");
-        }
         validate_package_name(name, "pkgid", "")?;
         Ok(PackageIdSpec {
             name: String::from(name),
@@ -185,9 +182,6 @@ impl PackageIdSpec {
                 None => (String::from(path_name), None),
             }
         };
-        if name.is_empty() {
-            bail!("package ID specification must have a name: `{url}`");
-        }
         validate_package_name(name.as_str(), "pkgid", "")?;
         Ok(PackageIdSpec {
             name,

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1568,7 +1568,7 @@ fn config_empty_registry_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] registry index was not found in any configuration: ``",
+[ERROR] registry name cannot be empty",
         )
         .run();
 }
@@ -1583,7 +1583,7 @@ fn empty_registry_flag() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] registry index was not found in any configuration: ``",
+[ERROR] registry name cannot be empty",
         )
         .run();
 }
@@ -1618,7 +1618,7 @@ fn empty_dependency_registry() {
 [ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
 
 Caused by:
-  registry index was not found in any configuration: ``",
+  registry name cannot be empty",
         )
         .run();
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -460,7 +460,7 @@ fn cargo_compile_with_empty_package_name() {
 [ERROR] failed to parse manifest at `[..]`
 
 Caused by:
-  package name cannot be an empty string
+  package name cannot be empty
 ",
         )
         .run();

--- a/tests/testsuite/cargo_add/empty_dep_name/in
+++ b/tests/testsuite/cargo_add/empty_dep_name/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/empty_dep_name/mod.rs
+++ b/tests/testsuite/cargo_add/empty_dep_name/mod.rs
@@ -1,0 +1,24 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::Project;
+
+use cargo_test_support::curr_dir;
+
+#[cargo_test]
+fn case() {
+    cargo_test_support::registry::init();
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .arg_line("@1.2.3")
+        .current_dir(cwd)
+        .assert()
+        .failure()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/empty_dep_name/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/empty_dep_name/out/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"

--- a/tests/testsuite/cargo_add/empty_dep_name/stderr.log
+++ b/tests/testsuite/cargo_add/empty_dep_name/stderr.log
@@ -1,0 +1,3 @@
+thread 'main' panicked at src/cargo/core/dependency.rs:164:9:
+assertion failed: !name.is_empty()
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

--- a/tests/testsuite/cargo_add/empty_dep_name/stderr.log
+++ b/tests/testsuite/cargo_add/empty_dep_name/stderr.log
@@ -1,3 +1,1 @@
-thread 'main' panicked at src/cargo/core/dependency.rs:164:9:
-assertion failed: !name.is_empty()
-note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: dependency name cannot be empty

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -17,6 +17,7 @@ mod dev;
 mod dev_build_conflict;
 mod dev_prefer_existing_version;
 mod dry_run;
+mod empty_dep_name;
 mod empty_dep_table;
 mod features;
 mod features_activated_over_limit;

--- a/tests/testsuite/cargo_new/empty_name/mod.rs
+++ b/tests/testsuite/cargo_new/empty_name/mod.rs
@@ -1,0 +1,22 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::curr_dir;
+use cargo_test_support::CargoCommand;
+use cargo_test_support::Project;
+
+#[cargo_test]
+fn case() {
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("new")
+        .args(["foo", "--name", ""])
+        .current_dir(cwd)
+        .assert()
+        .success()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_new/empty_name/mod.rs
+++ b/tests/testsuite/cargo_new/empty_name/mod.rs
@@ -14,7 +14,7 @@ fn case() {
         .args(["foo", "--name", ""])
         .current_dir(cwd)
         .assert()
-        .success()
+        .failure()
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/tests/testsuite/cargo_new/empty_name/stderr.log
+++ b/tests/testsuite/cargo_new/empty_name/stderr.log
@@ -1,7 +1,1 @@
-warning: compiling this new package may not work due to invalid workspace configuration
-
-failed to parse manifest at `[ROOT]/case/foo/Cargo.toml`
-
-Caused by:
-  package name cannot be an empty string
-     Created binary (application) `` package
+error: package name cannot be empty

--- a/tests/testsuite/cargo_new/empty_name/stderr.log
+++ b/tests/testsuite/cargo_new/empty_name/stderr.log
@@ -1,0 +1,7 @@
+warning: compiling this new package may not work due to invalid workspace configuration
+
+failed to parse manifest at `[ROOT]/case/foo/Cargo.toml`
+
+Caused by:
+  package name cannot be an empty string
+     Created binary (application) `` package

--- a/tests/testsuite/cargo_new/mod.rs
+++ b/tests/testsuite/cargo_new/mod.rs
@@ -4,6 +4,7 @@ mod add_members_to_workspace_with_absolute_package_path;
 mod add_members_to_workspace_with_empty_members;
 mod add_members_to_workspace_with_exclude_list;
 mod add_members_to_workspace_with_members_glob;
+mod empty_name;
 mod help;
 mod inherit_workspace_lints;
 mod inherit_workspace_package_table;


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #13152 and expands on work done in #12928.

This is also part of #12801 as I am refactoring how we do validation so that it parts of it can move into the schema, removing the last dependency the schema has on the rest of cargo.

### How should we test and review this PR?

This prevents empty registry names which should be fine for the same reason as preventing empty feature names in #12928, that this was a regression due to changes in toml parsers

### Additional information

