### PR TITLE
feat: Add `rustc` style errors for manifest parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a433302f833baa830c0092100c481c7ea768c5981a3c36f549517a502f246dd"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +254,7 @@ dependencies = [
 name = "cargo"
 version = "0.78.0"
 dependencies = [
+ "annotate-snippets",
  "anstream",
  "anstyle",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 
 [workspace.dependencies]
+annotate-snippets = "0.10.1"
 anstream = "0.6.5"
 anstyle = "1.0.4"
 anyhow = "1.0.79"
@@ -139,6 +140,7 @@ name = "cargo"
 path = "src/cargo/lib.rs"
 
 [dependencies]
+annotate-snippets.workspace = true
 anstream.workspace = true
 anstyle.workspace = true
 anyhow.workspace = true

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -712,16 +712,17 @@ fn bad_registry_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 7, column 17
-    |
-  7 |                 [dependencies.bar]
-    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  invalid character ` ` in registry name: `bad name`, [..]
+[ERROR] invalid character ` ` in registry name: `bad name`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
 
 
+ --> Cargo.toml:7:17
+  |
+7 |                   [dependencies.bar]
+  |  _________________^
+8 | |                 version = \"0.0.1\"
+9 | |                 registry = \"bad name\"
+  | |_____________________________________^
+  |
 ",
         )
         .run();
@@ -1622,16 +1623,14 @@ fn empty_dependency_registry() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 7, column 23
-    |
-  7 |                 bar = { version = \"0.1.0\", registry = \"\" }
-    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  registry name cannot be empty
+[ERROR] registry name cannot be empty
 
 
+ --> Cargo.toml:7:23
+  |
+7 |                 bar = { version = \"0.1.0\", registry = \"\" }
+  |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -449,15 +449,13 @@ fn malformed_override() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 8, column 27
-    |
-  8 |                 native = {
-    |                           ^
-  invalid inline table
-  expected `}`
+[ERROR] invalid inline table
+expected `}`
+ --> Cargo.toml:8:27
+  |
+8 |                 native = {
+  |                           ^
+  |
 ",
         )
         .run();
@@ -1282,14 +1280,12 @@ fn bad_dependency() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 8, column 23
-    |
-  8 |                 bar = 3
-    |                       ^
-  invalid type: integer `3`, expected a version string like [..]
+[ERROR] invalid type: integer `3`, expected a version string like [..]
+ --> Cargo.toml:8:23
+  |
+8 |                 bar = 3
+  |                       ^
+  |
 ",
         )
         .run();
@@ -1317,14 +1313,12 @@ fn bad_debuginfo() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest [..]
-
-Caused by:
-  TOML parse error at line 8, column 25
-    |
-  8 |                 debug = 'a'
-    |                         ^^^
-  invalid value: string \"a\", expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
+[ERROR] invalid value: string \"a\", expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
+ --> Cargo.toml:8:25
+  |
+8 |                 debug = 'a'
+  |                         ^^^
+  |
 ",
         )
         .run();
@@ -1352,14 +1346,12 @@ fn bad_debuginfo2() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 8, column 25
-    |
-  8 |                 debug = 3.6
-    |                         ^^^
-  invalid type: floating point `3.6`, expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
+[ERROR] invalid type: floating point `3.6`, expected a boolean, 0, 1, 2, \"line-tables-only\", or \"line-directives-only\"
+ --> Cargo.toml:8:25
+  |
+8 |                 debug = 3.6
+  |                         ^^^
+  |
 ",
         )
         .run();
@@ -1385,14 +1377,12 @@ fn bad_opt_level() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 6, column 25
-    |
-  6 |                 build = 3
-    |                         ^
-  invalid type: integer `3`, expected a boolean or string
+[ERROR] invalid type: integer `3`, expected a boolean or string
+ --> Cargo.toml:6:25
+  |
+6 |                 build = 3
+  |                         ^
+  |
 ",
         )
         .run();
@@ -1685,16 +1675,14 @@ fn bad_trim_paths() {
     p.cargo("check -Ztrim-paths")
         .masquerade_as_nightly_cargo(&["trim-paths"])
         .with_status(101)
-        .with_stderr(
-            r#"error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 7, column 30
-    |
-  7 |                 trim-paths = "split-debuginfo"
-    |                              ^^^^^^^^^^^^^^^^^
-  expected a boolean, "none", "diagnostics", "macro", "object", "all", or an array with these options
-"#,
+        .with_stderr("\
+[ERROR] expected a boolean, \"none\", \"diagnostics\", \"macro\", \"object\", \"all\", or an array with these options
+ --> Cargo.toml:7:30
+  |
+7 |                 trim-paths = \"split-debuginfo\"
+  |                              ^^^^^^^^^^^^^^^^^
+  |
+",
         )
         .run();
 }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -353,15 +353,13 @@ fn cargo_compile_with_invalid_manifest2() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 3, column 23
-    |
-  3 |                 foo = bar
-    |                       ^
-  invalid string
-  expected `\"`, `'`
+[ERROR] invalid string
+expected `\"`, `'`
+ --> Cargo.toml:3:23
+  |
+3 |                 foo = bar
+  |                       ^
+  |
 ",
         )
         .run();
@@ -375,15 +373,13 @@ fn cargo_compile_with_invalid_manifest3() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 1, column 5
-    |
-  1 | a = bar
-    |     ^
-  invalid string
-  expected `\"`, `'`
+[ERROR] invalid string
+expected `\"`, `'`
+ --> src/Cargo.toml:1:5
+  |
+1 | a = bar
+  |     ^
+  |
 ",
         )
         .run();
@@ -434,14 +430,12 @@ fn cargo_compile_with_invalid_version() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 4, column 19
-    |
-  4 |         version = \"1.0\"
-    |                   ^^^^^
-  unexpected end of input while parsing minor version number
+[ERROR] unexpected end of input while parsing minor version number
+ --> Cargo.toml:4:19
+  |
+4 |         version = \"1.0\"
+  |                   ^^^^^
+  |
 ",
         )
         .run();
@@ -457,14 +451,12 @@ fn cargo_compile_with_empty_package_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 3, column 16
-    |
-  3 |         name = \"\"
-    |                ^^
-  package name cannot be empty
+[ERROR] package name cannot be empty
+ --> Cargo.toml:3:16
+  |
+3 |         name = \"\"
+  |                ^^
+  |
 ",
         )
         .run();
@@ -480,14 +472,12 @@ fn cargo_compile_with_invalid_package_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 3, column 16
-    |
-  3 |         name = \"foo::bar\"
-    |                ^^^^^^^^^^
-  invalid character `:` in package name: `foo::bar`, [..]
+[ERROR] invalid character `:` in package name: `foo::bar`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
+ --> Cargo.toml:3:16
+  |
+3 |         name = \"foo::bar\"
+  |                ^^^^^^^^^^
+  |
 ",
         )
         .run();
@@ -1187,14 +1177,12 @@ fn cargo_compile_with_invalid_dep_rename() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 7, column 17
-    |
-  7 |                 \"haha this isn't a valid name 🐛\" = { package = \"libc\", version = \"0.1\" }
-    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
+[ERROR] invalid character ` ` in package name: `haha this isn't a valid name 🐛`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
+ --> Cargo.toml:7:17
+  |
+7 |                 \"haha this isn't a valid name 🐛\" = { package = \"libc\", version = \"0.1\" }
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/cargo_add/invalid_manifest/stderr.log
+++ b/tests/testsuite/cargo_add/invalid_manifest/stderr.log
@@ -1,9 +1,7 @@
-error: failed to parse manifest at `[ROOT]/case/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 8, column 7
-    |
-  8 | key = invalid-value
-    |       ^
-  invalid string
-  expected `"`, `'`
+error: invalid string
+expected `"`, `'`
+ --> Cargo.toml:8:7
+  |
+8 | key = invalid-value
+  |       ^
+  |

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -679,14 +679,12 @@ fn wrong_position() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at [..]
-
-Caused by:
-  TOML parse error at line 5, column 34
-    |
-  5 |                 cargo-features = [\"test-dummy-unstable\"]
-    |                                  ^^^^^^^^^^^^^^^^^^^^^^^
-  the field `cargo-features` should be set at the top of Cargo.toml before any tables
+[ERROR] the field `cargo-features` should be set at the top of Cargo.toml before any tables
+ --> Cargo.toml:5:34
+  |
+5 |                 cargo-features = [\"test-dummy-unstable\"]
+  |                                  ^^^^^^^^^^^^^^^^^^^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -57,14 +57,12 @@ fn empty_feature_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 8, column 17
-    |
-  8 |                 \"\" = []
-    |                 ^^
-  feature name cannot be empty
+[ERROR] feature name cannot be empty
+ --> Cargo.toml:8:17
+  |
+8 |                 \"\" = []
+  |                 ^^
+  |
 ",
         )
         .run();
@@ -2056,16 +2054,12 @@ fn invalid_feature_names_error() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 8, column 17
-    |
-  8 |                 \"+foo\" = []
-    |                 ^^^^^^
-  invalid character `+` in feature name: `+foo`, \
-  the first character must be a Unicode XID start character or digit \
-  (most letters or `_` or `0` to `9`)
+[ERROR] invalid character `+` in feature name: `+foo`, the first character must be a Unicode XID start character or digit (most letters or `_` or `0` to `9`)
+ --> Cargo.toml:8:17
+  |
+8 |                 \"+foo\" = []
+  |                 ^^^^^^
+  |
 ",
         )
         .run();
@@ -2087,16 +2081,12 @@ Caused by:
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 8, column 13
-    |
-  8 |             \"a&b\" = []
-    |             ^^^^^
-  invalid character `&` in feature name: `a&b`, \
-  characters must be Unicode XID characters, '-', `+`, or `.` \
-  (numbers, `+`, `-`, `_`, `.`, or most letters)
+[ERROR] invalid character `&` in feature name: `a&b`, characters must be Unicode XID characters, '-', `+`, or `.` (numbers, `+`, `-`, `_`, `.`, or most letters)
+ --> Cargo.toml:8:13
+  |
+8 |             \"a&b\" = []
+  |             ^^^^^
+  |
 ",
         )
         .run();
@@ -2124,14 +2114,12 @@ fn invalid_feature_name_slash_error() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 7, column 17
-    |
-  7 |                 \"foo/bar\" = []
-    |                 ^^^^^^^^^
-  invalid character `/` in feature name: `foo/bar`, feature name is not allowed to contain slashes
+[ERROR] invalid character `/` in feature name: `foo/bar`, feature name is not allowed to contain slashes
+ --> Cargo.toml:7:17
+  |
+7 |                 \"foo/bar\" = []
+  |                 ^^^^^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -436,14 +436,12 @@ fn crate_syntax_bad_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at [..]/foo/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 10, column 17
-     |
-  10 |                 \"dep:bar\" = []
-     |                 ^^^^^^^^^
-  feature named `dep:bar` is not allowed to start with `dep:`
+[ERROR] feature named `dep:bar` is not allowed to start with `dep:`
+  --> Cargo.toml:10:17
+   |
+10 |                 \"dep:bar\" = []
+   |                 ^^^^^^^^^
+   |
 ",
         )
         .run();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2573,6 +2573,12 @@ fn invalid_git_dependency_manifest() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`
+[ERROR] duplicate key `categories` in table `package`
+ --> [..]/Cargo.toml:8:21
+  |
+8 |                     categories = [\"algorithms\"]
+  |                     ^
+  |
 [ERROR] failed to get `dep1` as a dependency of package `foo v0.5.0 ([..])`
 
 Caused by:
@@ -2580,16 +2586,6 @@ Caused by:
 
 Caused by:
   Unable to update {}
-
-Caused by:
-  failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 8, column 21
-    |
-  8 |                     categories = [\"algorithms\"]
-    |                     ^
-  duplicate key `categories` in table `package`
 ",
             path2url(&git_root),
             path2url(&git_root),

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1231,14 +1231,12 @@ fn error_workspace_false() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 7, column 41
-    |
-  7 |             description = { workspace = false }
-    |                                         ^^^^^
-  `workspace` cannot be false
+[ERROR] `workspace` cannot be false
+ --> Cargo.toml:7:41
+  |
+7 |             description = { workspace = false }
+  |                                         ^^^^^
+  |
 ",
         )
         .run();
@@ -1322,15 +1320,13 @@ fn error_malformed_workspace_root() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
-
-Caused by:
-  [..]
-    |
-  3 |             members = [invalid toml
-    |                        ^
-  invalid array
-  expected `]`
+[ERROR] invalid array
+expected `]`
+ --> ../Cargo.toml:3:24
+  |
+3 |             members = [invalid toml
+  |                        ^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2060,7 +2060,7 @@ fn git_install_reads_workspace_manifest() {
 
     cargo_process(&format!("install --git {}", p.url().to_string()))
         .with_status(101)
-        .with_stderr_contains("  invalid type: integer `3`[..]")
+        .with_stderr_contains("error: invalid type: integer `3`[..]")
         .run();
 }
 

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -70,14 +70,12 @@ fn malformed_on_stable() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest[..]
-
-Caused by:
-  TOML parse error at line 2, column 25
-    |
-  2 |                 lints = 20
-    |                         ^^
-  invalid type: integer `20`, expected a lints table
+[ERROR] invalid type: integer `20`, expected a lints table
+ --> Cargo.toml:2:25
+  |
+2 |                 lints = 20
+  |                         ^^
+  |
 ",
         )
         .run();
@@ -135,14 +133,12 @@ fn invalid_type_in_lint_value() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 7, column 36
-    |
-  7 |                 rust-2018-idioms = -1
-    |                                    ^^
-  invalid type: integer `-1`, expected a string or map
+[ERROR] invalid type: integer `-1`, expected a string or map
+ --> Cargo.toml:7:36
+  |
+7 |                 rust-2018-idioms = -1
+  |                                    ^^
+  |
 ",
         )
         .run();
@@ -339,14 +335,12 @@ pub fn foo(num: i32) -> u32 {
         .with_status(101)
         .with_stderr_contains(
             "\
-error: failed to parse manifest at `[CWD]/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 8, column 29
-    |
-  8 |                 workspace = false
-    |                             ^^^^^
-  `workspace` cannot be false
+error: `workspace` cannot be false
+ --> Cargo.toml:8:29
+  |
+8 |                 workspace = false
+  |                             ^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1818,14 +1818,13 @@ fn cargo_metadata_with_invalid_authors_field() {
     p.cargo("metadata")
         .with_status(101)
         .with_stderr(
-            r#"[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 3, column 27
-    |
-  3 |                 authors = ""
-    |                           ^^
-  invalid type: string "", expected a vector of strings or workspace"#,
+            r#"[ERROR] invalid type: string "", expected a vector of strings or workspace
+ --> Cargo.toml:3:27
+  |
+3 |                 authors = ""
+  |                           ^^
+  |
+"#,
         )
         .run();
 }
@@ -1846,14 +1845,14 @@ fn cargo_metadata_with_invalid_version_field() {
     p.cargo("metadata")
         .with_status(101)
         .with_stderr(
-            r#"[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 3, column 27
-    |
-  3 |                 version = 1
-    |                           ^
-  invalid type: integer `1`, expected SemVer version"#,
+            "\
+[ERROR] invalid type: integer `1`, expected SemVer version
+ --> Cargo.toml:3:27
+  |
+3 |                 version = 1
+  |                           ^
+  |
+",
         )
         .run();
 }
@@ -1874,14 +1873,13 @@ fn cargo_metadata_with_invalid_publish_field() {
     p.cargo("metadata")
         .with_status(101)
         .with_stderr(
-            r#"[ERROR] failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 3, column 27
-    |
-  3 |                 publish = "foo"
-    |                           ^^^^^
-  invalid type: string "foo", expected a boolean, a vector of strings, or workspace"#,
+            r#"[ERROR] invalid type: string "foo", expected a boolean, a vector of strings, or workspace
+ --> Cargo.toml:3:27
+  |
+3 |                 publish = "foo"
+  |                           ^^^^^
+  |
+"#,
         )
         .run();
 }

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -83,14 +83,12 @@ fn invalid_profile_name() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] failed to parse manifest at [..]
-
-Caused by:
-  TOML parse error at line 7, column 26
-    |
-  7 |                 [profile.'.release-lto']
-    |                          ^^^^^^^^^^^^^^
-  invalid character `.` in profile name: `.release-lto`, allowed characters are letters, numbers, underscore, and hyphen
+[ERROR] invalid character `.` in profile name: `.release-lto`, allowed characters are letters, numbers, underscore, and hyphen
+ --> Cargo.toml:7:26
+  |
+7 |                 [profile.'.release-lto']
+  |                          ^^^^^^^^^^^^^^
+  |
 ",
         )
         .run();
@@ -634,17 +632,15 @@ See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configur
             .with_status(101)
             .with_stderr(&format!(
                 "\
-error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 6, column 30
-    |
-  6 |                     [profile.{name}]
-    |                              {highlight}
-  profile name `{name}` is reserved
-  Please choose a different name.
-  See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
-",
+[ERROR] profile name `{name}` is reserved
+Please choose a different name.
+See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
+ --> Cargo.toml:6:30
+  |
+6 |                     [profile.{name}]
+  |                              {highlight}
+  |
+"
             ))
             .run();
     }
@@ -667,16 +663,14 @@ Caused by:
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 7, column 25
-    |
-  7 |                [profile.debug]
-    |                         ^^^^^
-  profile name `debug` is reserved
-  To configure the default development profile, use the name `dev` as in [profile.dev]
-  See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
+[ERROR] profile name `debug` is reserved
+To configure the default development profile, use the name `dev` as in [profile.dev]
+See https://doc.rust-lang.org/cargo/reference/profiles.html for more on configuring profiles.
+ --> Cargo.toml:7:25
+  |
+7 |                [profile.debug]
+  |                         ^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -45,14 +45,13 @@ fn rust_version_bad_caret() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 6, column 28
-    |
-  6 |             rust-version = \"^1.43\"
-    |                            ^^^^^^^
-  unexpected version requirement, expected a version like \"1.32\"",
+[ERROR] unexpected version requirement, expected a version like \"1.32\"
+ --> Cargo.toml:6:28
+  |
+6 |             rust-version = \"^1.43\"
+  |                            ^^^^^^^
+  |
+",
         )
         .run();
 }
@@ -78,14 +77,13 @@ fn rust_version_good_pre_release() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 6, column 28
-    |
-  6 |             rust-version = \"1.43.0-beta.1\"
-    |                            ^^^^^^^^^^^^^^^
-  unexpected prerelease field, expected a version like \"1.32\"",
+[ERROR] unexpected prerelease field, expected a version like \"1.32\"
+ --> Cargo.toml:6:28
+  |
+6 |             rust-version = \"1.43.0-beta.1\"
+  |                            ^^^^^^^^^^^^^^^
+  |
+",
         )
         .run();
 }
@@ -111,14 +109,13 @@ fn rust_version_bad_pre_release() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 6, column 28
-    |
-  6 |             rust-version = \"1.43-beta.1\"
-    |                            ^^^^^^^^^^^^^
-  unexpected prerelease field, expected a version like \"1.32\"",
+[ERROR] unexpected prerelease field, expected a version like \"1.32\"
+ --> Cargo.toml:6:28
+  |
+6 |             rust-version = \"1.43-beta.1\"
+  |                            ^^^^^^^^^^^^^
+  |
+",
         )
         .run();
 }
@@ -144,14 +141,13 @@ fn rust_version_bad_nonsense() {
         .with_status(101)
         .with_stderr(
             "\
-error: failed to parse manifest at `[..]`
-
-Caused by:
-  TOML parse error at line 6, column 28
-    |
-  6 |             rust-version = \"foodaddle\"
-    |                            ^^^^^^^^^^^
-  expected a version like \"1.32\"",
+[ERROR] expected a version like \"1.32\"
+ --> Cargo.toml:6:28
+  |
+6 |             rust-version = \"foodaddle\"
+  |                            ^^^^^^^^^^^
+  |
+",
         )
         .run();
 }

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1073,17 +1073,15 @@ fn new_warning_with_corrupt_ws() {
     p.cargo("new bar")
         .with_stderr(
             "\
+[ERROR] expected `.`, `=`
+ --> Cargo.toml:1:5
+  |
+1 | asdf
+  |     ^
+  |
 [WARNING] compiling this new package may not work due to invalid workspace configuration
 
-failed to parse manifest at `[..]foo/Cargo.toml`
-
-Caused by:
-  TOML parse error at line 1, column 5
-    |
-  1 | asdf
-    |     ^
-  expected `.`, `=`
-     Created binary (application) `bar` package
+[CREATED] binary (application) `bar` package
 ",
         )
         .run();
@@ -1343,7 +1341,16 @@ fn error_if_parent_cargo_toml_is_invalid() {
     p.cargo("check")
         .cwd("bar")
         .with_status(101)
-        .with_stderr_contains("[ERROR] failed to parse manifest at `[..]`")
+        .with_stderr(
+            "\
+[ERROR] expected `.`, `=`
+ --> ../Cargo.toml:1:9
+  |
+1 | Totally not a TOML file
+  |         ^
+  |
+",
+        )
         .run();
 }
 


### PR DESCRIPTION
#12235 is tracking user control over warnings. One part of that is making `cargo`'s diagnostic system output messages in the style of `rustc`. To make it so that `cargo` doesn't have to manage a formatter and renderer, I decided to use [`annotate-snippets`](https://crates.io/crates/annotate-snippets), which matches `rustc`'s style well (at one time it was meant to be the formatted for `rustc`).

To get this work kicked off, it was suggested to me that we should start with styling manifest parsing errors, and that is what his PR does.

What manifest parsing errors look like after this change:
![image](https://github.com/rust-lang/cargo/assets/23045215/0eb388b9-8d72-48ad-84a9-585160995078)

---

Note: `cargo` does not currently match `rustc` in color (#12740), `rustc`  specifies their colors [here](https://github.com/rust-lang/rust/blob/740cea81d6e34fc03c4495890e29f1c5ecb40b96/compiler/rustc_errors/src/lib.rs#L1755-L1768) and [here](https://github.com/rust-lang/rust/blob/740cea81d6e34fc03c4495890e29f1c5ecb40b96/compiler/rustc_errors/src/emitter.rs#L2689-L2723). I used `annotate-snippets` default colors which match what `rustc` currently uses for colors. I did this as a stopgap while I work to unify the colors used between `rustc` and `cargo`.

---

Note: the error messages come directly from `toml` and can be quite long. It would be nice if we could put some of the message below the highlight but this would require changes to `toml`.
Example:
```
error: invalid type: integer `3`
 --> Cargo.toml:7:7
  |
7 | bar = 3
  |       ^ expected a version string like "0.9.8" or a detailed dependency like { version = "0.9.8" }
  |
```