### PR TITLE
Replace SHGetFolderPathW with SHGetKnownFolderPath

### DIFF
--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -17,7 +17,7 @@ repository = "https://github.com/rust-lang/cargo"
 description = "Shared definitions of home directories."
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_UI_Shell"] }
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_UI_Shell", "Win32_System_Com"] }
 
 [lints]
 workspace = true

--- a/crates/home/src/lib.rs
+++ b/crates/home/src/lib.rs
@@ -44,11 +44,11 @@ use std::path::{Path, PathBuf};
 ///
 /// Returns the value of the `USERPROFILE` environment variable if it is set
 /// **and** it is not an empty string. Otherwise, it tries to determine the
-/// home directory by invoking the [`SHGetFolderPathW`][shgfp] function with
-/// [`CSIDL_PROFILE`][csidl].
+/// home directory by invoking the [`SHGetKnownFolderPath`][shgkfp] function with
+/// [`FOLDERID_Profile`][knownfolderid].
 ///
-/// [shgfp]: https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetfolderpathw
-/// [csidl]: https://learn.microsoft.com/en-us/windows/win32/shell/csidl
+/// [shgkfp]: https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath
+/// [knownfolderid]: https://learn.microsoft.com/en-us/windows/win32/shell/knownfolderid
 ///
 /// # Examples
 ///

--- a/src/cargo/sources/git/known_hosts.rs
+++ b/src/cargo/sources/git/known_hosts.rs
@@ -538,7 +538,7 @@ fn user_known_host_location() -> Option<PathBuf> {
     // - OpenSSH (most unix platforms): Uses `pw->pw_dir` from `getpwuid()`.
     //
     // This doesn't do anything close to that. home_dir's behavior is:
-    // - Windows: $USERPROFILE, or SHGetFolderPathW()
+    // - Windows: $USERPROFILE, or SHGetKnownFolderPath()
     // - Unix: $HOME, or getpwuid_r()
     //
     // Since there is a mismatch here, the location returned here might be


### PR DESCRIPTION
### What does this PR try to resolve?

Resolves #13138 by replacing `SHGetFolderPathW` with `SHGetKnownFolderPath`.

### How should we test and review this PR?

Aside from running the existing tests, this introduces two new functions whose documentation you may want to double check: [`SHGetKnownFolderPath`](https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath) and [`CoTaskMemFree`](https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree).

