### PR TITLE
chore: downgrade to openssl v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.61"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b8419dc8cc6d866deb801274bba2e6f8f6108c1bb7fcc10ee5ab864931dbb45"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2354,18 +2354,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "111.28.1+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.97"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3eaad34cdd97d81de97964fc7f29e2d104f483840d906ef56daa1912338460b"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ libloading = "0.8.1"
 memchr = "2.6.4"
 miow = "0.6.0"
 opener = "0.6.1"
-openssl ="0.10.61"
+openssl = "0.10.57"
 os_info = "3.7.0"
 pasetors = { version = "0.6.7", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"


### PR DESCRIPTION
riscv64 detection bug is fixed but is not released (openssl/openssl#22871)
See also https://github.com/rust-lang/rust/pull/119007#issuecomment-1859231819