### PR TITLE
ci: check SemVer for cargo-util-schemas on CI

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -168,7 +168,6 @@ fn bump_check(args: &clap::ArgMatches, config: &cargo::util::Config) -> CargoRes
     let mut cmd = ProcessBuilder::new("cargo");
     cmd.arg("semver-checks")
         .arg("check-release")
-        .args(&["--exclude", "cargo-util-schemas"]) // FIXME: Remove once 1.76 is stable
         .arg("--workspace");
     config.shell().status("Running", &cmd)?;
     cmd.exec()?;


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

[cargo-util-schemas](https://crates.io/crates/cargo-util-schemas) 0.1.0 has just been  released (thanks epage and ehuss). Now we can re-enable bump-check against crates.io for it.

### How should we test and review this PR?

See if CI checks semver against crates.io for cargo-util-schemas

### Additional information
<!-- homu-ignore:end -->
