### PR TITLE
refactor: centralize git checkouts and db paths

### DIFF
--- a/src/cargo/core/global_cache_tracker.rs
+++ b/src/cargo/core/global_cache_tracker.rs
@@ -560,11 +560,10 @@ impl GlobalCacheTracker {
     ) -> CargoResult<()> {
         let _p = crate::util::profile::start("cleaning global cache files");
         let config = clean_ctx.config;
-        let base_git_path = config.git_path().into_path_unlocked();
         let base = BasePaths {
             index: config.registry_index_path().into_path_unlocked(),
-            git_db: base_git_path.join("db"),
-            git_co: base_git_path.join("checkouts"),
+            git_db: config.git_db_path().into_path_unlocked(),
+            git_co: config.git_checkouts_path().into_path_unlocked(),
             crate_dir: config.registry_cache_path().into_path_unlocked(),
             src: config.registry_source_path().into_path_unlocked(),
         };

--- a/src/cargo/sources/git/source.rs
+++ b/src/cargo/sources/git/source.rs
@@ -248,7 +248,8 @@ impl<'cfg> Source for GitSource<'cfg> {
         // exists.
         exclude_from_backups_and_indexing(&git_path);
 
-        let db_path = git_path.join("db").join(&self.ident);
+        let db_path = self.config.git_db_path().join(&self.ident);
+        let db_path = db_path.into_path_unlocked();
 
         let db = self.remote.db_at(&db_path).ok();
         let (db, actual_rev) = match (self.locked_rev, db) {
@@ -305,10 +306,12 @@ impl<'cfg> Source for GitSource<'cfg> {
         // Check out `actual_rev` from the database to a scoped location on the
         // filesystem. This will use hard links and such to ideally make the
         // checkout operation here pretty fast.
-        let checkout_path = git_path
-            .join("checkouts")
+        let checkout_path = self
+            .config
+            .git_checkouts_path()
             .join(&self.ident)
             .join(short_id.as_str());
+        let checkout_path = checkout_path.into_path_unlocked();
         db.copy_to(actual_rev, &checkout_path, self.config)?;
 
         let source_id = self

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -368,6 +368,18 @@ impl Config {
         self.home_path.join("git")
     }
 
+    /// Gets the directory of code sources Cargo checkouts from Git bare repos
+    /// (`<cargo_home>/git/checkouts`).
+    pub fn git_checkouts_path(&self) -> Filesystem {
+        self.git_path().join("checkouts")
+    }
+
+    /// Gets the directory for all Git bare repos Cargo clones
+    /// (`<cargo_home>/git/db`).
+    pub fn git_db_path(&self) -> Filesystem {
+        self.git_path().join("db")
+    }
+
     /// Gets the Cargo base directory for all registry information (`<cargo_home>/registry`).
     pub fn registry_base_path(&self) -> Filesystem {
         self.home_path.join("registry")


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This moves the logic of getting `$CARGO_HOME/git/checkouts` and `$CARGO_HOME/.cargo/git/db` to a central place.

### How should we test and review this PR?

There is no functional change.

### Additional information
<!-- homu-ignore:end -->
