### PR TITLE
feat: support `target.<triple>.rustdocflags` officially 

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -698,6 +698,8 @@ impl Flags {
 /// For those artifacts, _only_ `host.*.rustflags` is respected, and no other configuration
 /// sources, _regardless of the value of `target-applies-to-host`_. This is counterintuitive, but
 /// necessary to retain backwards compatibility with older versions of Cargo.
+///
+/// Rules above also applies to rustdoc. Just the key would be `rustdocflags`/`RUSTDOCFLAGS`.
 fn extra_args(
     gctx: &GlobalContext,
     requested_kinds: &[CompileKind],

--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -800,7 +800,6 @@ fn rustflags_from_target(
                         .as_ref()
                         .map(|rustflags| (key, &rustflags.val)),
                     // `target.cfg(…).rustdocflags` is currently not supported.
-                    // In fact, neither is `target.<triple>.rustdocflags`.
                     Flags::Rustdoc => None,
                 }
             })

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -21,7 +21,7 @@ pub struct TargetCfgConfig {
 }
 
 /// Config definition of a `[target]` table or `[host]`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct TargetConfig {
     /// Process to run as a wrapper for `cargo run`, `test`, and `bench` commands.
     pub runner: OptValue<PathAndArgs>,
@@ -97,13 +97,7 @@ pub(super) fn load_host_triple(gctx: &GlobalContext, triple: &str) -> CargoResul
         };
         load_config_table(gctx, &host_prefix)
     } else {
-        Ok(TargetConfig {
-            runner: None,
-            rustflags: None,
-            rustdocflags: None,
-            linker: None,
-            links_overrides: BTreeMap::new(),
-        })
+        Ok(TargetConfig::default())
     }
 }
 

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -27,6 +27,8 @@ pub struct TargetConfig {
     pub runner: OptValue<PathAndArgs>,
     /// Additional rustc flags to pass.
     pub rustflags: OptValue<StringList>,
+    /// Additional rustdoc flags to pass.
+    pub rustdocflags: OptValue<StringList>,
     /// The path of the linker for this target.
     pub linker: OptValue<ConfigRelativePath>,
     /// Build script override for the given library name.
@@ -98,6 +100,7 @@ pub(super) fn load_host_triple(gctx: &GlobalContext, triple: &str) -> CargoResul
         Ok(TargetConfig {
             runner: None,
             rustflags: None,
+            rustdocflags: None,
             linker: None,
             links_overrides: BTreeMap::new(),
         })
@@ -118,6 +121,7 @@ fn load_config_table(gctx: &GlobalContext, prefix: &str) -> CargoResult<TargetCo
     // environment variables would not work.
     let runner: OptValue<PathAndArgs> = gctx.get(&format!("{}.runner", prefix))?;
     let rustflags: OptValue<StringList> = gctx.get(&format!("{}.rustflags", prefix))?;
+    let rustdocflags: OptValue<StringList> = gctx.get(&format!("{}.rustdocflags", prefix))?;
     let linker: OptValue<ConfigRelativePath> = gctx.get(&format!("{}.linker", prefix))?;
     // Links do not support environment variables.
     let target_key = ConfigKey::from_str(prefix);
@@ -128,6 +132,7 @@ fn load_config_table(gctx: &GlobalContext, prefix: &str) -> CargoResult<TargetCo
     Ok(TargetConfig {
         runner,
         rustflags,
+        rustdocflags,
         linker,
         links_overrides,
     })
@@ -144,7 +149,7 @@ fn parse_links_overrides(
         // Skip these keys, it shares the namespace with `TargetConfig`.
         match lib_name.as_str() {
             // `ar` is a historical thing.
-            "ar" | "linker" | "runner" | "rustflags" => continue,
+            "ar" | "linker" | "runner" | "rustflags" | "rustdocflags" => continue,
             _ => {}
         }
         let mut output = BuildOutput::default();

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -113,10 +113,10 @@ fn load_config_table(gctx: &GlobalContext, prefix: &str) -> CargoResult<TargetCo
     // because it causes serde to use `deserialize_map` which means the config
     // deserializer does not know which keys to deserialize, which means
     // environment variables would not work.
-    let runner: OptValue<PathAndArgs> = gctx.get(&format!("{}.runner", prefix))?;
-    let rustflags: OptValue<StringList> = gctx.get(&format!("{}.rustflags", prefix))?;
-    let rustdocflags: OptValue<StringList> = gctx.get(&format!("{}.rustdocflags", prefix))?;
-    let linker: OptValue<ConfigRelativePath> = gctx.get(&format!("{}.linker", prefix))?;
+    let runner: OptValue<PathAndArgs> = gctx.get(&format!("{prefix}.runner"))?;
+    let rustflags: OptValue<StringList> = gctx.get(&format!("{prefix}.rustflags"))?;
+    let rustdocflags: OptValue<StringList> = gctx.get(&format!("{prefix}.rustdocflags"))?;
+    let linker: OptValue<ConfigRelativePath> = gctx.get(&format!("{prefix}.linker"))?;
     // Links do not support environment variables.
     let target_key = ConfigKey::from_str(prefix);
     let links_overrides = match gctx.get_table(&target_key)? {

--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -158,9 +158,10 @@ tag = "…"            # tag name for the git repository
 rev = "…"            # revision for the git repository
 
 [target.<triple>]
-linker = "…"            # linker to use
-runner = "…"            # wrapper to run executables
-rustflags = ["…", "…"]  # custom flags for `rustc`
+linker = "…"              # linker to use
+runner = "…"              # wrapper to run executables
+rustflags = ["…", "…"]    # custom flags for `rustc`
+rustdocflags = ["…", "…"] # custom flags for `rustdoc`
 
 [target.<cfg>]
 runner = "…"            # wrapper to run executables
@@ -500,14 +501,21 @@ appropriate profile setting.
 Extra command-line flags to pass to `rustdoc`. The value may be an array of
 strings or a space-separated string.
 
-There are three mutually exclusive sources of extra flags. They are checked in
+There are four mutually exclusive sources of extra flags. They are checked in
 order, with the first one being used:
 
 1. `CARGO_ENCODED_RUSTDOCFLAGS` environment variable.
 2. `RUSTDOCFLAGS` environment variable.
-3. `build.rustdocflags` config value.
+3. All matching `target.<triple>.rustdocflags` config entries joined together.
+4. `build.rustdocflags` config value.
 
 Additional flags may also be passed with the [`cargo rustdoc`] command.
+
+> **Caution**: Due to the low-level nature of passing flags directly to the
+> compiler, this may cause a conflict with future versions of Cargo which may
+> issue the same or similar flags on its own which may interfere with the
+> flags you specify. This is an area where Cargo may not always be backwards
+> compatible.
 
 #### `build.incremental`
 * Type: bool
@@ -1215,6 +1223,17 @@ ways to specific extra flags.
 This is similar to the [target rustflags](#targettriplerustflags), but
 using a [`cfg()` expression]. If several `<cfg>` and [`<triple>`] entries
 match the current target, the flags are joined together.
+
+#### `target.<triple>.rustdocflags`
+* Type: string or array of strings
+* Default: none
+* Environment: `CARGO_TARGET_<triple>_RUSTDOCFLAGS`
+
+Passes a set of custom flags to the compiler for this [`<triple>`].
+The value may be an array of strings or a space-separated string.
+
+See [`build.rustdocflags`](#buildrustdocflags) for more details on the different
+ways to specific extra flags.
 
 #### `target.<triple>.<links>`
 

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -184,3 +184,49 @@ fn target_triple_rustdocflags_works() {
         .with_stderr_contains("[RUNNING] `rustdoc[..]--cfg[..]foo[..]`")
         .run();
 }
+
+#[cargo_test]
+fn target_triple_rustdocflags_works_through_cargo_test() {
+    let host = rustc_host();
+    let host_env = rustc_host_env();
+    let p = project()
+        .file(
+            "src/lib.rs",
+            r#"
+                //! ```
+                //! assert!(cfg!(foo));
+                //! ```
+            "#,
+        )
+        .build();
+
+    // target.triple.rustdocflags in env works
+    p.cargo("test --doc -v")
+        .env(
+            &format!("CARGO_TARGET_{host_env}_RUSTDOCFLAGS"),
+            "--cfg=foo",
+        )
+        .with_stderr_contains("[RUNNING] `rustdoc[..]--test[..]--cfg[..]foo[..]`")
+        .with_stdout_contains(
+            "\
+running 1 test
+test src/lib.rs - (line 2) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]",
+        )
+        .run();
+
+    // target.triple.rustdocflags in config works
+    p.cargo("test --doc -v")
+        .arg("--config")
+        .arg(format!("target.{host}.rustdocflags=['--cfg', 'foo']"))
+        .with_stderr_contains("[RUNNING] `rustdoc[..]--test[..]--cfg[..]foo[..]`")
+        .with_stdout_contains(
+            "\
+running 1 test
+test src/lib.rs - (line 2) ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]",
+        )
+        .run();
+}

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -177,13 +177,10 @@ fn target_triple_rustdocflags_works() {
         .with_stderr_contains("[RUNNING] `rustdoc[..]--cfg[..]foo[..]`")
         .run();
 
-    // target.triple.rustdocflags in config is not supported.
+    // target.triple.rustdocflags in config works
     p.cargo("doc -v")
         .arg("--config")
         .arg(format!("target.{host}.rustdocflags=['--cfg', 'foo']"))
-        .with_status(101)
-        .with_stderr(format!(
-            "[ERROR] expected a table, but found a array for `target.{host}.rustdocflags` in --config cli option"
-        ))
+        .with_stderr_contains("[RUNNING] `rustdoc[..]--cfg[..]foo[..]`")
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

`CARGO_TARGET_<TRIPLE>_RUSTDOCFLAGS` was accidentally accepted somehow,
so support both config and env officially,
given that removing env support would be a breaking change.

Fixes #13189

### How should we test and review this PR?

Commit by commit.

### Additional information

I leave `target.<cfg>.rustdocflags` for future possibilities,
as it might incur the same convergence issue `target.<cfg>.rustflags` has. 
<!-- homu-ignore:end -->
