### PR TITLE
refactor: give some better examples for package ID spec

### DIFF
--- a/crates/cargo-util-schemas/src/core/package_id_spec.rs
+++ b/crates/cargo-util-schemas/src/core/package_id_spec.rs
@@ -64,13 +64,15 @@ impl PackageIdSpec {
     /// use cargo_util_schemas::core::PackageIdSpec;
     ///
     /// let specs = vec![
-    ///     "https://crates.io/foo",
-    ///     "https://crates.io/foo#1.2.3",
-    ///     "https://crates.io/foo#bar:1.2.3",
-    ///     "https://crates.io/foo#bar@1.2.3",
     ///     "foo",
+    ///     "foo@1.4",
+    ///     "foo@1.4.3",
     ///     "foo:1.2.3",
-    ///     "foo@1.2.3",
+    ///     "https://github.com/rust-lang/crates.io-index#foo",
+    ///     "https://github.com/rust-lang/crates.io-index#foo@1.4.3",
+    ///     "ssh://git@github.com/rust-lang/foo.git#foo@1.4.3",
+    ///     "file:///path/to/my/project/foo",
+    ///     "file:///path/to/my/project/foo#1.1.8"
     /// ];
     /// for spec in specs {
     ///     assert!(PackageIdSpec::parse(spec).is_ok());


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

The old examples are so confusing because Cargo does not use those formats. For instance: We use `https://github.com/rust-lang/crates.io-index#foo` instead of `https://github.com/rust-lang/crates.io-index/foo`. You can verify it by using the `cargo pkgid` command.

### How should we test and review this PR?

It should covered by rustdoc tests.

### Additional information

r? @epage  

We discussed it one time during Cargo office hours.
<!-- homu-ignore:end -->
