### PR TITLE
chore(doc): doc for custom subcommands look up.

### DIFF
--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -265,6 +265,10 @@ cargo `(?<command>[^ ]+)` into an invocation of an external tool
 `cargo-${command}`. The external tool must be present in one of the user's
 `$PATH` directories.
 
+> **Note**: Cargo defaults to prioritizing external tools in `$CARGO_HOME/bin`
+> over `$PATH`. Users can override this precedence by adding `$CARGO_HOME/bin`
+> to `$PATH`.
+
 When Cargo invokes a custom subcommand, the first argument to the subcommand
 will be the filename of the custom subcommand, as usual. The second argument
 will be the subcommand name itself. For example, the second argument would be


### PR DESCRIPTION
### What does this PR try to resolve?

as the https://github.com/rust-lang/cargo/issues/13194 metions, the lookup rules for custom subcommands are only reflected in comments inside the code, and it is time to inform users of this behavior through documentation.

### How should we test and review this PR?

### Additional information