### PR TITLE
fix: set OUT_DIR for all units with build scripts

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1286,7 +1286,8 @@ pub trait TestEnv: Sized {
             .env_remove("RUSTFLAGS")
             .env_remove("SSH_AUTH_SOCK") // ensure an outer agent is never contacted
             .env_remove("USER") // not set on some rust-lang docker images
-            .env_remove("XDG_CONFIG_HOME"); // see #2345
+            .env_remove("XDG_CONFIG_HOME") // see #2345
+            .env_remove("OUT_DIR"); // see #13204
         if cfg!(target_os = "macos") {
             // Work-around a bug in macOS 10.15, see `link_or_copy` for details.
             self = self.env("__CARGO_COPY_DONT_LINK_DO_NOT_USE_THIS", "1");

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4941,7 +4941,5 @@ fn cargo_test_set_out_dir_env_var() {
 
     p.cargo("test").run();
     p.cargo("test --package foo --test case -- tests::test_add --exact --nocapture")
-        .with_stdout_contains("test tests::test_add ... FAILED")
-        .with_status(101)
         .run();
 }

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4897,3 +4897,51 @@ fn cargo_test_print_env_verbose() {
         )
         .run();
 }
+
+#[cargo_test]
+fn cargo_test_set_out_dir_env_var() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2021"
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                pub fn add(left: usize, right: usize) -> usize {
+                    left + right
+                }
+            "#,
+        )
+        .file(
+            "build.rs",
+            r#"
+                fn main() {}
+            "#,
+        )
+        .file(
+            "tests/case.rs",
+            r#"
+                #[cfg(test)]
+                pub mod tests {
+                    #[test]
+                    fn test_add() {
+                        assert!(std::env::var("OUT_DIR").is_ok());
+                        assert_eq!(foo::add(2, 5), 7);
+                    }
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("test").run();
+    p.cargo("test --package foo --test case -- tests::test_add --exact --nocapture")
+        .with_stdout_contains("test tests::test_add ... FAILED")
+        .with_status(101)
+        .run();
+}


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/13127

- Added a minimal case to cover this behavior.
- Set OUT_DIR for all units with build scripts.

### How should we test and review this PR?

Check out the unit test.

### Additional information
None
<!-- homu-ignore:end -->
