### PR TITLE
fix: clarify `--path` is the installation source not destination

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -569,7 +569,7 @@ Rust's package manager
     <cyan,bold>update</>      Update dependencies listed in Cargo.lock
     <cyan,bold>search</>      Search registry for crates
     <cyan,bold>publish</>     Package and upload this package to the registry
-    <cyan,bold>install</>     Install a Rust binary. Default location is $HOME/.cargo/bin
+    <cyan,bold>install</>     Install a Rust binary
     <cyan,bold>uninstall</>   Uninstall a Rust binary
     <cyan>...</>         See all commands with <cyan,bold>--list</>
 

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -15,7 +15,7 @@ use cargo_util::paths;
 
 pub fn cli() -> Command {
     subcommand("install")
-        .about("Install a Rust binary. Default location is $HOME/.cargo/bin")
+        .about("Install a Rust binary")
         .arg(
             Arg::new("crate")
                 .value_name("CRATE[@<VER>]")

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -63,7 +63,7 @@ pub fn cli() -> Command {
                 .requires("git"),
         )
         .arg(
-            opt("path", "Filesystem path to local crate to install")
+            opt("path", "Filesystem path to local crate to install from")
                 .value_name("PATH")
                 .conflicts_with_all(&["git", "index", "registry"]),
         )

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -210,14 +210,14 @@ impl<'cfg> InstallablePackage<'cfg> {
         if from_cwd {
             if pkg.manifest().edition() == Edition::Edition2015 {
                 config.shell().warn(
-                    "Using `cargo install` to install the binaries for the \
+                    "Using `cargo install` to install the binaries from the \
                      package in current working directory is deprecated, \
                      use `cargo install --path .` instead. \
                      Use `cargo build` if you want to simply build the package.",
                 )?
             } else {
                 bail!(
-                    "Using `cargo install` to install the binaries for the \
+                    "Using `cargo install` to install the binaries from the \
                      package in current working directory is no longer supported, \
                      use `cargo install --path .` instead. \
                      Use `cargo build` if you want to simply build the package."

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -114,7 +114,7 @@ Specific commit to use when installing from git.
 {{/option}}
 
 {{#option "`--path` _path_" }}
-Filesystem path to local crate to install.
+Filesystem path to local crate to install from.
 {{/option}}
 
 {{#option "`--list`" }}

--- a/src/doc/man/cargo-install.md
+++ b/src/doc/man/cargo-install.md
@@ -24,8 +24,8 @@ installed, and all executables are installed into the installation root's
 {{> description-install-root }}
 
 There are multiple sources from which a crate can be installed. The default
-location is crates.io but the `--git`, `--path`, and `--registry` flags can
-change this source. If the source contains more than one package (such as
+source location is crates.io but the `--git`, `--path`, and `--registry` flags
+can change this source. If the source contains more than one package (such as
 crates.io or a git repository with multiple crates) the _crate_ argument is
 required to indicate which crate should be installed.
 

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -114,7 +114,7 @@ OPTIONS
            Specific commit to use when installing from git.
 
        --path path
-           Filesystem path to local crate to install.
+           Filesystem path to local crate to install from.
 
        --list
            List all installed packages and their versions.

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -30,10 +30,11 @@ DESCRIPTION
        o  $HOME/.cargo
 
        There are multiple sources from which a crate can be installed. The
-       default location is crates.io but the --git, --path, and --registry
-       flags can change this source. If the source contains more than one
-       package (such as crates.io or a git repository with multiple crates) the
-       crate argument is required to indicate which crate should be installed.
+       default source location is crates.io but the --git, --path, and
+       --registry flags can change this source. If the source contains more
+       than one package (such as crates.io or a git repository with multiple
+       crates) the crate argument is required to indicate which crate should be
+       installed.
 
        Crates from crates.io can optionally specify the version they wish to
        install via the --version flags, and similarly packages from git

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -26,8 +26,8 @@ The installation root is determined, in order of precedence:
 - `$HOME/.cargo`
 
 There are multiple sources from which a crate can be installed. The default
-location is crates.io but the `--git`, `--path`, and `--registry` flags can
-change this source. If the source contains more than one package (such as
+source location is crates.io but the `--git`, `--path`, and `--registry` flags
+can change this source. If the source contains more than one package (such as
 crates.io or a git repository with multiple crates) the _crate_ argument is
 required to indicate which crate should be installed.
 

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -117,7 +117,7 @@ treated as a caret requirement like Cargo dependencies are.</dd>
 
 
 <dt class="option-term" id="option-cargo-install---path"><a class="option-anchor" href="#option-cargo-install---path"></a><code>--path</code> <em>path</em></dt>
-<dd class="option-desc">Filesystem path to local crate to install.</dd>
+<dd class="option-desc">Filesystem path to local crate to install from.</dd>
 
 
 <dt class="option-term" id="option-cargo-install---list"><a class="option-anchor" href="#option-cargo-install---list"></a><code>--list</code></dt>

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -42,8 +42,8 @@ The installation root is determined, in order of precedence:
 .RE
 .sp
 There are multiple sources from which a crate can be installed. The default
-location is crates.io but the \fB\-\-git\fR, \fB\-\-path\fR, and \fB\-\-registry\fR flags can
-change this source. If the source contains more than one package (such as
+source location is crates.io but the \fB\-\-git\fR, \fB\-\-path\fR, and \fB\-\-registry\fR flags
+can change this source. If the source contains more than one package (such as
 crates.io or a git repository with multiple crates) the \fIcrate\fR argument is
 required to indicate which crate should be installed.
 .sp

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -143,7 +143,7 @@ Specific commit to use when installing from git.
 .sp
 \fB\-\-path\fR \fIpath\fR
 .RS 4
-Filesystem path to local crate to install.
+Filesystem path to local crate to install from.
 .RE
 .sp
 \fB\-\-list\fR

--- a/tests/testsuite/cargo/help/stdout.log
+++ b/tests/testsuite/cargo/help/stdout.log
@@ -33,7 +33,7 @@ Commands:
     update      Update dependencies listed in Cargo.lock
     search      Search registry for crates
     publish     Package and upload this package to the registry
-    install     Install a Rust binary. Default location is $HOME/.cargo/bin
+    install     Install a Rust binary
     uninstall   Uninstall a Rust binary
     ...         See all commands with --list
 

--- a/tests/testsuite/cargo_install/help/stdout.log
+++ b/tests/testsuite/cargo_install/help/stdout.log
@@ -13,7 +13,7 @@ Options:
       --branch <BRANCH>       Branch to use when installing from git
       --tag <TAG>             Tag to use when installing from git
       --rev <SHA>             Specific commit to use when installing from git
-      --path <PATH>           Filesystem path to local crate to install
+      --path <PATH>           Filesystem path to local crate to install from
       --root <DIR>            Directory to install packages into
   -f, --force                 Force overwriting existing crates or binaries
       --no-track              Do not save tracking information

--- a/tests/testsuite/cargo_install/help/stdout.log
+++ b/tests/testsuite/cargo_install/help/stdout.log
@@ -1,4 +1,4 @@
-Install a Rust binary. Default location is $HOME/.cargo/bin
+Install a Rust binary
 
 Usage: cargo[EXE] install [OPTIONS] [CRATE[@<VER>]]...
 

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1195,7 +1195,7 @@ fn installs_from_cwd_by_default() {
 
     p.cargo("install")
         .with_stderr_contains(
-            "warning: Using `cargo install` to install the binaries for the \
+            "warning: Using `cargo install` to install the binaries from the \
              package in current working directory is deprecated, \
              use `cargo install --path .` instead. \
              Use `cargo build` if you want to simply build the package.",
@@ -1223,7 +1223,7 @@ fn installs_from_cwd_with_2018_warnings() {
     p.cargo("install")
         .with_status(101)
         .with_stderr_contains(
-            "error: Using `cargo install` to install the binaries for the \
+            "error: Using `cargo install` to install the binaries from the \
              package in current working directory is no longer supported, \
              use `cargo install --path .` instead. \
              Use `cargo build` if you want to simply build the package.",


### PR DESCRIPTION


### What does this PR try to resolve?

There is a misunderstanding of “default location” mentioned in `cargo install --help`.
I don't think one-line explanation helps much there, So remove that imprecise description.

This PR also add more "from" for places mentioning installation sources.

### How should we test and review this PR?

Read the new help text.

<!-- homu-ignore:start -->
### Additional information

Fixes #13200

<!-- homu-ignore:end -->
