### PR TITLE
Fix panic when running `cargo tree` on a package with a cross compiled bindep

### DIFF
--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -319,8 +319,32 @@ impl ResolvedFeatures {
         pkg_id: PackageId,
         features_for: FeaturesFor,
     ) -> Vec<InternedString> {
-        self.activated_features_int(pkg_id, features_for)
-            .expect("activated_features for invalid package")
+        let fk = features_for.apply_opts(&self.opts);
+        let key = (pkg_id, fk);
+        if let Some(fs) = self.activated_features.get(&key) {
+            fs.iter().cloned().collect()
+        } else {
+            panic!(
+                "did not find features for {key:?} within activated_features:\n{:#?}",
+                self.activated_features
+            )
+        }
+    }
+
+    /// Variant of `activated_features` that returns `None` if this is
+    /// not a valid pkg_id/is_build combination. Used in places which do
+    /// not know which packages are activated (like `cargo clean`).
+    pub fn activated_features_unverified(
+        &self,
+        pkg_id: PackageId,
+        features_for: FeaturesFor,
+    ) -> Option<Vec<InternedString>> {
+        let fk = features_for.apply_opts(&self.opts);
+        if let Some(fs) = self.activated_features.get(&(pkg_id, fk)) {
+            Some(fs.iter().cloned().collect())
+        } else {
+            None
+        }
     }
 
     /// Returns if the given dependency should be included.
@@ -338,30 +362,6 @@ impl ResolvedFeatures {
             .get(&(pkg_id, key))
             .map(|deps| deps.contains(&dep_name))
             .unwrap_or(false)
-    }
-
-    /// Variant of `activated_features` that returns `None` if this is
-    /// not a valid pkg_id/is_build combination. Used in places which do
-    /// not know which packages are activated (like `cargo clean`).
-    pub fn activated_features_unverified(
-        &self,
-        pkg_id: PackageId,
-        features_for: FeaturesFor,
-    ) -> Option<Vec<InternedString>> {
-        self.activated_features_int(pkg_id, features_for).ok()
-    }
-
-    fn activated_features_int(
-        &self,
-        pkg_id: PackageId,
-        features_for: FeaturesFor,
-    ) -> CargoResult<Vec<InternedString>> {
-        let fk = features_for.apply_opts(&self.opts);
-        if let Some(fs) = self.activated_features.get(&(pkg_id, fk)) {
-            Ok(fs.iter().cloned().collect())
-        } else {
-            bail!("features did not find {:?} {:?}", pkg_id, fk)
-        }
     }
 
     /// Compares the result against the original resolver behavior.


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?


This PR fixes the `cargo tree` panic described in https://github.com/rust-lang/cargo/issues/12358 and https://github.com/rust-lang/cargo/issues/10593

### How should we test and review this PR?

The new integration test is sufficient.

### Additional information

[There was discussion](https://github.com/rust-lang/cargo/issues/10593#issuecomment-1317759526) of holding off on this until a full design of how to present bindeps in `cargo tree` is arrived at.
However I think it makes sense to land this PR first as:
* It introduces a test to catch the simple case.
* The fix itself is small and (afaik) correct.
* Provides genuine value to users by allowing usage of `cargo tree` in many more bindeps use cases.

So this PR is a good first step towards full support in `cargo tree`.

The changes to the `activated_features` methods are not related to the fix but just the improved error reporting I needed to fully diagnose the issue.
I moved `activated_features_int` into `activated_features` and `activated_features_unverified` as I was concerned of the performance cost of generating the full error when its not a fatal error and may occur many times.
I think this change will bring value in the future but I am happy to remove it if it is undesired.

I actually wrote up the test + fix independently before discovering https://github.com/rust-lang/cargo/issues/10593#issuecomment-1317759526 , once I discovered it I copied in some specific parts to improve comments + correctness

I did however leave out the `None if features_for != FeaturesFor::default() => features_for,` because that seems wrong to me. proc macro and build dependencies of a bindep need to be compiled for the host, regardless of the bindeps target, otherwise the host cant run them to build the bindep.

<!-- homu-ignore:end -->
