### PR TITLE
fix(trim-paths): remap common prefix only

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1217,18 +1217,22 @@ fn trim_paths_args(
     let package_remap = {
         let pkg_root = unit.pkg.root();
         let ws_root = cx.bcx.ws.root();
-        let is_local = unit.pkg.package_id().source_id().is_path();
         let mut remap = OsString::from("--remap-path-prefix=");
-        // Remapped to path relative to workspace root:
+        // Remap rules for dependencies
         //
-        // * path dependencies under workspace root directory
-        //
-        // Remapped to `<pkg>-<version>`
-        //
-        // * registry dependencies
-        // * git dependencies
-        // * path dependencies outside workspace root directory
-        if is_local && pkg_root.strip_prefix(ws_root).is_ok() {
+        // * Git dependencies: remove ~/.cargo/git/checkouts prefix.
+        // * Registry dependencies: remove ~/.cargo/registry/src prefix.
+        // * Others (e.g. path dependencies):
+        //     * relative paths to workspace root if inside the workspace directory.
+        //     * otherwise remapped to `<pkg>-<version>`.
+        let source_id = unit.pkg.package_id().source_id();
+        if source_id.is_git() {
+            remap.push(cx.bcx.config.git_checkouts_path().as_path_unlocked());
+            remap.push("=");
+        } else if source_id.is_registry() {
+            remap.push(cx.bcx.config.registry_source_path().as_path_unlocked());
+            remap.push("=");
+        } else if pkg_root.strip_prefix(ws_root).is_ok() {
             remap.push(ws_root);
             remap.push("=."); // remap to relative rustc work dir explicitly
         } else {


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

New `-Ztrim-paths` remap rules for git/registry dependencies:

* Git dependencies: remove ~/.cargo/git/checkouts prefix.
* Registry dependencies: remove ~/.cargo/registry/src prefix.

This make the remap rules fixed in a finite number,
minimizing the burden for users to configure debuggers.

Part of <https://github.com/rust-lang/cargo/issues/13171>.

### How should we test and review this PR?

The new rule is a small deviation of RFC 3127.
Please review if it makes sense.

This doesn't tackle relative path dependencies described in <https://github.com/rust-lang/cargo/issues/13171>,
as git/registry should be less controversial and easier to be landed.

### Additional information

<!-- homu-ignore:end -->
