### PR TITLE
`cargo add` - fix for adding features from repository with multiple packages.

### DIFF
--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -934,7 +934,7 @@ fn populate_available_features(
     }
 
     let possibilities = loop {
-        match registry.query_vec(&query, QueryKind::Fuzzy) {
+        match registry.query_vec(&query, QueryKind::Exact) {
             std::task::Poll::Ready(res) => {
                 break res?;
             }

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/in
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/in
@@ -1,0 +1,1 @@
+../add-basic.in

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/mod.rs
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/mod.rs
@@ -1,0 +1,63 @@
+use cargo_test_support::compare::assert_ui;
+use cargo_test_support::prelude::*;
+use cargo_test_support::Project;
+
+use cargo_test_support::curr_dir;
+
+#[cargo_test]
+fn case() {
+    cargo_test_support::registry::init();
+
+    let main_manifest = r#"
+    [package]
+    name = "main-package"
+    version = "0.1.1+main-package"
+    authors = []
+
+    [workspace]
+    members = ["package-wo-feature", "package-with-feature"]
+    "#;
+
+    let manifest_feature = r#"
+    [package]
+    name = "package-with-feature"
+    version = "0.1.3+package-with-feature"
+    [features]
+    target_feature = []
+    "#;
+
+    let project = Project::from_template(curr_dir!().join("in"));
+    let project_root = project.root();
+    let cwd = &project_root;
+    let git_dep = cargo_test_support::git::new("git-package", |project| {
+        project
+            .file("Cargo.toml", &main_manifest)
+            .file(
+                "package-wo-feature/Cargo.toml",
+                &cargo_test_support::basic_manifest(
+                    "package-wo-feature",
+                    "0.1.1+package-wo-feature",
+                ),
+            )
+            .file("package-wo-feature/src/lib.rs", "")
+            .file("package-with-feature/Cargo.toml", &manifest_feature)
+            .file("package-with-feature/src/lib.rs", "")
+    });
+    let git_url = git_dep.url().to_string();
+
+    snapbox::cmd::Command::cargo_ui()
+        .arg("add")
+        .args([
+            "--git",
+            &git_url,
+            "package-with-feature",
+            "--features=target_feature",
+        ])
+        .current_dir(cwd)
+        .assert()
+        .failure()
+        .stdout_matches_path(curr_dir!().join("stdout.log"))
+        .stderr_matches_path(curr_dir!().join("stderr.log"));
+
+    assert_ui().subset_matches(curr_dir!().join("out"), &project_root);
+}

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/mod.rs
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/mod.rs
@@ -55,7 +55,7 @@ fn case() {
         ])
         .current_dir(cwd)
         .assert()
-        .failure()
+        .success()
         .stdout_matches_path(curr_dir!().join("stdout.log"))
         .stderr_matches_path(curr_dir!().join("stderr.log"));
 

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/out/Cargo.toml
@@ -1,0 +1,5 @@
+[workspace]
+
+[package]
+name = "cargo-list-test-fixture"
+version = "0.0.0"

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/out/Cargo.toml
@@ -3,3 +3,6 @@
 [package]
 name = "cargo-list-test-fixture"
 version = "0.0.0"
+
+[dependencies]
+package-with-feature = { git = "[ROOTURL]/git-package", version = "0.1.3", features = ["target_feature"] }

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.log
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.log
@@ -1,4 +1,5 @@
     Updating git repository `[ROOTURL]/git-package`
       Adding package-with-feature (git) to dependencies.
-error: unrecognized feature for crate package-with-feature: target_feature
-no features available for crate package-with-feature
+             Features:
+             + target_feature
+    Updating git repository `[ROOTURL]/git-package`

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.log
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.log
@@ -1,0 +1,4 @@
+    Updating git repository `[ROOTURL]/git-package`
+      Adding package-with-feature (git) to dependencies.
+error: unrecognized feature for crate package-with-feature: target_feature
+no features available for crate package-with-feature

--- a/tests/testsuite/cargo_add/mod.rs
+++ b/tests/testsuite/cargo_add/mod.rs
@@ -35,6 +35,7 @@ mod git_dev;
 mod git_inferred_name;
 mod git_inferred_name_multiple;
 mod git_multiple_names;
+mod git_multiple_packages_features;
 mod git_normalized_name;
 mod git_registry;
 mod git_rev;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
Fixes #13121 

As discussed in the issue, when using `cargo add` to add a package with features from a git repository from one of it's members, the command might fail due to improper target for querying for said features. 

This PR adds a test for this edge-case where we expect it to fail with current code. It also adds a fix for this, and updates the test to expect success.

While populating available features, the current code does a `Fuzzy` search which might lead to searching for features in a wrong member package. If we change it to an `Exact` query, we get back the proper member to search within.