### PR TITLE
Ignore test `fix_in_dependency` to make a change in rustc

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1859,6 +1859,8 @@ fn non_edition_lint_migration() {
 }
 
 // For rust-lang/cargo#9857
+#[ignore = "rustc no longer suggests the fix in dependency, try reproducing \
+            in a different way after landing rust#119204 and follow up PRs"]
 #[cargo_test]
 fn fix_in_dependency() {
     Package::new("bar", "1.0.0")


### PR DESCRIPTION
This test relies on some specific diagnostics being produced in rustc, but those diagnostics are currently going through changes (https://github.com/rust-lang/rust/pull/119204 and there will be some more follow up PRs).