### PR TITLE
Bump cargo-credential to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "libc",

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential"
-version = "0.4.2"
+version = "0.4.3"
 rust-version = "1.70.0"  # MSRV:3
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This should fix the check-version-bump CI job. #13216 made some changes without bumping the version.