### PR TITLE
chore: tracing be compat with rustc_log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ thiserror = "1.0.56"
 time = { version = "0.3", features = ["parsing", "formatting", "serde"] }
 toml = "0.8.8"
 toml_edit = { version = "0.21.0", features = ["serde"] }
-tracing = "0.1.40"
+tracing = "0.1.37" # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 unicase = "2.7.0"
 unicode-width = "0.1.11"


### PR DESCRIPTION


<!-- homu-ignore:start -->
### What does this PR try to resolve?

The current version of rustfix cannot be used in rust-lang/rust due to the dependency on `tracing`. `tracing-core` is currently locked to 0.1.30, which is too old for the version in the cargo repo (it looks like they are trying to avoid a known deadlock).

See: https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/rustfix.20is.20incompatible.20with.20rust-lang.2Frust

### Additional information

I guess we need a beta-backport for this?

<!-- homu-ignore:end -->
