### PR TITLE
[beta-1.76.0] chore: tracing be compat with rustc_log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ thiserror = "1.0.50"
 time = { version = "0.3", features = ["parsing", "formatting", "serde"] }
 toml = "0.8.8"
 toml_edit = { version = "0.21.0", features = ["serde"] }
-tracing = "0.1.40"
+tracing = "0.1.37" # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 unicase = "2.7.0"
 unicode-width = "0.1.11"


### PR DESCRIPTION
Beta backports:

- <https://github.com/rust-lang/cargo/pull/13239>

In order to make CI pass, the following PRs are also cherry-picked:

- 