### PR TITLE
test: support publish package with a `public` field.

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -558,6 +558,7 @@ pub struct Dependency {
     package: Option<String>,
     optional: bool,
     default_features: bool,
+    public: bool,
 }
 
 /// Entry with data that corresponds to [`tar::EntryType`].
@@ -1428,6 +1429,7 @@ impl Package {
                     "kind": dep.kind,
                     "registry": registry_url,
                     "package": dep.package,
+                    "public": dep.public,
                 })
             })
             .collect::<Vec<_>>();
@@ -1678,6 +1680,7 @@ impl Dependency {
             optional: false,
             registry: None,
             default_features: true,
+            public: false,
         }
     }
 
@@ -1728,6 +1731,12 @@ impl Dependency {
     /// Changes this to an optional dependency.
     pub fn optional(&mut self, optional: bool) -> &mut Self {
         self.optional = optional;
+        self
+    }
+
+    /// Changes this to an public dependency.
+    pub fn public(&mut self, public: bool) -> &mut Self {
+        self.public = public;
         self
     }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This PR add a `public` alike method to support add a dependency as public/private, 
```
Package::new("foo", "0.1.0")
        .cargo_feature("public-dependency").add_dep(Dependency::new("bar", "0.1.0").public(true))
```

and then get it from registry in test.

This PR was seperated from the https://github.com/rust-lang/cargo/pull/13183. 

### How should we test and review this PR?
You can review on per commit.  

After running the test case `publish_package_with_public_dependency`,  you can check a "public" field in `./target/tmp/cit/t0/registry/3/b/bar`. 

### Additional information
r? epage