### PR TITLE
Deprecate rustc plugin support in cargo

### DIFF
--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -203,6 +203,17 @@ fn clean_lib(
         }
     };
 
+    if lib.plugin == Some(true) {
+        warnings.push(format!(
+            "support for rustc plugins has been removed from rustc. \
+            library `{}` should not specify `plugin = true`",
+            name_or_panic(lib)
+        ));
+        warnings.push(format!(
+            "support for `plugin = true` will be removed from cargo in the future"
+        ));
+    }
+
     // Per the Macros 1.1 RFC:
     //
     // > Initially if a crate is compiled with the `proc-macro` crate type

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -896,6 +896,8 @@ fn plugin_build_script_right_arch() {
         .arg(cross_compile::alternate())
         .with_stderr(
             "\
+[WARNING] support for rustc plugins has been removed from rustc. library `foo` should not specify `plugin = true`
+[WARNING] support for `plugin = true` will be removed from cargo in the future
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/build-script-build`

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -379,6 +379,11 @@ fn proc_macro_crate_type_warning_plugin() {
 
     foo.cargo("check")
         .with_stderr_contains(
+            "[WARNING] support for rustc plugins has been removed from rustc. \
+            library `foo` should not specify `plugin = true`")
+        .with_stderr_contains(
+            "[WARNING] support for `plugin = true` will be removed from cargo in the future")
+        .with_stderr_contains(
             "[WARNING] proc-macro library `foo` should not specify `plugin = true`")
         .with_stderr_contains(
             "[WARNING] library `foo` should only specify `proc-macro = true` instead of setting `crate-type`")


### PR DESCRIPTION

<!-- homu-ignore:start -->

### What does this PR try to resolve?

Support for rustc plugins has been removed entirely from rustc itself already. Deprecate support on the cargo side to allow removing support from cargo in the future.

### Additional information

Part of https://github.com/rust-lang/cargo/issues/13246

<!-- homu-ignore:end -->
