### PR TITLE
chore: remove `version` field from `publish=false` packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,4 +258,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@cargo-hack
-    - run: cargo hack check --all-targets --rust-version --workspace --no-private
+    - run: cargo hack check --rust-version --workspace --no-private --no-dev-deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -258,4 +258,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@cargo-hack
-    - run: cargo hack check --all-targets --rust-version --workspace --ignore-private
+    - run: cargo hack check --all-targets --rust-version --workspace --no-private

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "capture"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "cargo_metadata",
  "flate2",
@@ -394,11 +394,11 @@ dependencies = [
 
 [[package]]
 name = "cargo-test-macro"
-version = "0.1.0"
+version = "0.0.0"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/benches/benchsuite/Cargo.toml
+++ b/benches/benchsuite/Cargo.toml
@@ -1,12 +1,10 @@
 [package]
 name = "benchsuite"
-version = "0.0.0"
 edition.workspace = true
 license.workspace = true
 homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 description = "Benchmarking suite for Cargo."
-publish = false
 
 [dependencies]
 cargo.workspace = true

--- a/benches/capture/Cargo.toml
+++ b/benches/capture/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "capture"
-version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 description = "Tool for capturing a real-world workspace for benchmarking."
-publish = false
 
 [dependencies]
 cargo_metadata.workspace = true

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -1,13 +1,11 @@
 [package]
 name = "cargo-test-macro"
-version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation = "https://github.com/rust-lang/cargo"
 description = "Helper proc-macro for Cargo's testsuite."
-publish = false
 
 [lib]
 proc-macro = true

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "cargo-test-support"
-version = "0.1.0"
 license.workspace = true
 edition.workspace = true
-publish = false
 
 [lib]
 doctest = false

--- a/crates/mdman/Cargo.toml
+++ b/crates/mdman/Cargo.toml
@@ -1,10 +1,8 @@
 [package]
 name = "mdman"
-version = "0.0.0"
 edition.workspace = true
 license.workspace = true
 description = "Creates a man page page from markdown."
-publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/resolver-tests/Cargo.toml
+++ b/crates/resolver-tests/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "resolver-tests"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [dependencies]
 cargo.workspace = true

--- a/crates/semver-check/Cargo.toml
+++ b/crates/semver-check/Cargo.toml
@@ -1,9 +1,7 @@
 [package]
 name = "semver-check"
-version = "0.0.0"
 authors = ["Eric Huss"]
 edition.workspace = true
-publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/xtask-build-man/Cargo.toml
+++ b/crates/xtask-build-man/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "xtask-build-man"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [dependencies]
 

--- a/crates/xtask-bump-check/Cargo.toml
+++ b/crates/xtask-bump-check/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "xtask-bump-check"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/xtask-stale-label/Cargo.toml
+++ b/crates/xtask-stale-label/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "xtask-stale-label"
-version = "0.0.0"
 edition.workspace = true
-publish = false
 
 [dependencies]
 toml_edit.workspace = true

--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -173,7 +173,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@cargo-hack
-    - run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+    - run: cargo hack check --rust-version --workspace --all-targets --no-private
 ```
 This tries to balance thoroughness with turnaround time:
 - A single platform is used as most projects are platform-agnostic, trusting platform-specific dependencies to verify their behavior.


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

In 1.75 cargo allows `version`less manifest. 
We should keep up and dogfood ourselves.

### How should we test and review this PR?

### Additional information
<!-- homu-ignore:end -->
