### PR TITLE
docs(changelog): Call out cargo-new lockfile change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -474,6 +474,8 @@
   [#12515](https://github.com/rust-lang/cargo/pull/12515)
 - ❗️ cargo-clean: error out if `--doc` is mixed with `-p`.
   [#12637](https://github.com/rust-lang/cargo/pull/12637)
+- ❗ cargo-new / cargo-init no longer exclude `Cargo.lock` in VCS ignore files for libraries.
+  [#12382](https://github.com/rust-lang/cargo/pull/12382)
 - cargo-update: silently deprecate `--aggressive` in favor of the new `--recursive`.
   [#12544](https://github.com/rust-lang/cargo/pull/12544)
 - cargo-update: `-p/--package` can be used as a positional argument.


### PR DESCRIPTION
I was looking for what release this happened in but we didn't have it listed.
We do list the documentation change.
This was likely from the PR focusing on the entire policy change which made it easy to overlook each aspect of the policy change.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
