### PR TITLE
fix(manifest): Provide unused key warnings for lints table 

### DIFF
--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -170,6 +170,7 @@ fn warn_on_unused_key() {
     foo.cargo("check")
         .with_stderr(
             "\
+[WARNING] [CWD]/Cargo.toml: unused manifest key: lints.rust.rust-2018-idioms.unused
 [WARNING] [CWD]/Cargo.toml: unused manifest key: workspace.lints.rust.rust-2018-idioms.unused
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -149,6 +149,36 @@ Caused by:
 }
 
 #[cargo_test]
+fn warn_on_unused_key() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+
+                [workspace.lints.rust]
+                rust-2018-idioms = { level = "allow", unused = true }
+                [lints.rust]
+                rust-2018-idioms = { level = "allow", unused = true }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    foo.cargo("check")
+        .with_stderr(
+            "\
+[WARNING] [CWD]/Cargo.toml: unused manifest key: workspace.lints.rust.rust-2018-idioms.unused
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn fail_on_tool_injection() {
     let foo = project()
         .file(


### PR DESCRIPTION
### What does this PR try to resolve?

The use of `flatten` was getting in the way of `serde_ignored`.
A common workaround is to add our own `unused` tracking but that would
cause duplicates with `workspace.lints` (or we'd just ignore it).

Since the manual deserializer was relatively simple, I went that route.

Fixes #12917

### How should we test and review this PR?

Per commit

A test was added for the issue.  I then was worried about regressions in `workspace = false` errors (and I was right) so I added a test for that.  To get `workspace = false` to work nicely, I made it share code with other `workspace: bool` fields.

### Additional information