### PR TITLE
crates-io: Set `Content-Type: application/json` only for requests with a body payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "crates-io"
-version = "0.39.2"
+version = "0.40.0"
 dependencies = [
  "curl",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ cargo_metadata = "0.18.1"
 clap = "4.4.12"
 color-print = "0.3.5"
 core-foundation = { version = "0.9.4", features = ["mac_os_10_7_support"] }
-crates-io = { version = "0.39.0", path = "crates/crates-io" }
+crates-io = { version = "0.40.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
 curl-sys = "0.4.70"

--- a/crates/crates-io/Cargo.toml
+++ b/crates/crates-io/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crates-io"
-version = "0.39.2"
+version = "0.40.0"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -389,7 +389,9 @@ impl Registry {
         self.handle.url(&format!("{}/api/v1{}", self.host, path))?;
         let mut headers = List::new();
         headers.append("Accept: application/json")?;
-        headers.append("Content-Type: application/json")?;
+        if body.is_some() {
+            headers.append("Content-Type: application/json")?;
+        }
 
         if self.auth_required || authorized == Auth::Authorized {
             headers.append(&format!("Authorization: {}", self.token()?))?;

--- a/src/doc/src/reference/registry-web-api.md
+++ b/src/doc/src/reference/registry-web-api.md
@@ -40,7 +40,7 @@ be required in the future.
 
 Cargo sets the following headers for all requests:
 
-- `Content-Type`: `application/json`
+- `Content-Type`: `application/json` (for requests with a body payload)
 - `Accept`: `application/json`
 - `User-Agent`: The Cargo version such as `cargo 1.32.0 (8610973aa
   2019-01-02)`. This may be modified by the user in a configuration value.


### PR DESCRIPTION
### What does this PR try to resolve?

The `Content-Type` **request** header is only supposed to be used if the request comes with a body payload. `cargo` is currently sending it unconditionally, even for `GET` requests that typically don't have a payload attached to them.

This PR changes the implementation to only attach the header if the request has a body payload.

