### PR TITLE
refactor(toml): Make it more obvious to update package-dependent fields

### DIFF
--- a/crates/cargo-util-schemas/src/manifest.rs
+++ b/crates/cargo-util-schemas/src/manifest.rs
@@ -49,10 +49,31 @@ pub struct TomlManifest {
     pub workspace: Option<TomlWorkspace>,
     pub badges: Option<InheritableBtreeMap>,
     pub lints: Option<InheritableLints>,
-    // when adding new fields, be sure to check whether `to_virtual_manifest` should disallow them
+    // when adding new fields, be sure to check whether `requires_package` should disallow them
 }
 
 impl TomlManifest {
+    pub fn requires_package(&self) -> impl Iterator<Item = &'static str> {
+        [
+            self.lib.as_ref().map(|_| "lib"),
+            self.bin.as_ref().map(|_| "bin"),
+            self.example.as_ref().map(|_| "example"),
+            self.test.as_ref().map(|_| "test"),
+            self.bench.as_ref().map(|_| "bench"),
+            self.dependencies.as_ref().map(|_| "dependencies"),
+            self.dev_dependencies().as_ref().map(|_| "dev-dependencies"),
+            self.build_dependencies()
+                .as_ref()
+                .map(|_| "build-dependencies"),
+            self.features.as_ref().map(|_| "features"),
+            self.target.as_ref().map(|_| "target"),
+            self.badges.as_ref().map(|_| "badges"),
+            self.lints.as_ref().map(|_| "lints"),
+        ]
+        .into_iter()
+        .flatten()
+    }
+
     pub fn has_profiles(&self) -> bool {
         self.profile.is_some()
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1073,49 +1073,8 @@ fn to_virtual_manifest(
     root: &Path,
     config: &Config,
 ) -> CargoResult<(VirtualManifest, Vec<PathBuf>)> {
-    if me.project.is_some() {
-        bail!("this virtual manifest specifies a [project] section, which is not allowed");
-    }
-    if me.package.is_some() {
-        bail!("this virtual manifest specifies a [package] section, which is not allowed");
-    }
-    if me.lib.is_some() {
-        bail!("this virtual manifest specifies a [lib] section, which is not allowed");
-    }
-    if me.bin.is_some() {
-        bail!("this virtual manifest specifies a [[bin]] section, which is not allowed");
-    }
-    if me.example.is_some() {
-        bail!("this virtual manifest specifies a [[example]] section, which is not allowed");
-    }
-    if me.test.is_some() {
-        bail!("this virtual manifest specifies a [[test]] section, which is not allowed");
-    }
-    if me.bench.is_some() {
-        bail!("this virtual manifest specifies a [[bench]] section, which is not allowed");
-    }
-    if me.dependencies.is_some() {
-        bail!("this virtual manifest specifies a [dependencies] section, which is not allowed");
-    }
-    if me.dev_dependencies().is_some() {
-        bail!("this virtual manifest specifies a [dev-dependencies] section, which is not allowed");
-    }
-    if me.build_dependencies().is_some() {
-        bail!(
-            "this virtual manifest specifies a [build-dependencies] section, which is not allowed"
-        );
-    }
-    if me.features.is_some() {
-        bail!("this virtual manifest specifies a [features] section, which is not allowed");
-    }
-    if me.target.is_some() {
-        bail!("this virtual manifest specifies a [target] section, which is not allowed");
-    }
-    if me.badges.is_some() {
-        bail!("this virtual manifest specifies a [badges] section, which is not allowed");
-    }
-    if me.lints.is_some() {
-        bail!("this virtual manifest specifies a [lints] section, which is not allowed");
+    for field in me.requires_package() {
+        bail!("this virtual manifest specifies a `{field}` section, which is not allowed");
     }
 
     let mut nested_paths = Vec::new();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -2186,7 +2186,7 @@ fn ws_rustc_err() {
 
 #[cargo_test]
 fn ws_err_unused() {
-    for key in &[
+    for table in &[
         "[lib]",
         "[[bin]]",
         "[[example]]",
@@ -2200,6 +2200,7 @@ fn ws_err_unused() {
         "[badges]",
         "[lints]",
     ] {
+        let key = table.trim_start_matches('[').trim_end_matches(']');
         let p = project()
             .file(
                 "Cargo.toml",
@@ -2208,9 +2209,8 @@ fn ws_err_unused() {
                     [workspace]
                     members = ["a"]
 
-                    {}
+                    {table}
                     "#,
-                    key
                 ),
             )
             .file("a/Cargo.toml", &basic_lib_manifest("a"))
@@ -2223,9 +2223,8 @@ fn ws_err_unused() {
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  this virtual manifest specifies a {} section, which is not allowed
+  this virtual manifest specifies a `{key}` section, which is not allowed
 ",
-                key
             ))
             .run();
     }


### PR DESCRIPTION
Inspired by my having forgotten to add `[lints]` to the if sequence. Previously, we added a comment to suggest this but the further the code is, the harder it is to track.

I considered a custom `Deserialize` impl, possibly through a new type, that would error.
This would be the more "pure" solution.
Unfortunately, this would also have worse errors because the errors would be reported to the `Deserializer` at the document-level, rather than directly on the individual fields.
Well, we don't do on individual fields now but it is something we will soon be exploring.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
