### PR TITLE
home: reduce MSRV to 1.64

### DIFF
--- a/crates/home/Cargo.toml
+++ b/crates/home/Cargo.toml
@@ -2,7 +2,7 @@
 name = "home"
 version = "0.5.11"
 authors = ["Brian Anderson <andersrb@gmail.com>"]
-rust-version = "1.73"  # MSRV:3
+rust-version = "1.64"  # MSRV:3
 documentation = "https://docs.rs/home"
 edition.workspace = true
 include = [


### PR DESCRIPTION
In #12654 the MSRV for `home` was set to #12654. The actual crate still works fine with 1.64 (except for some warnings about the unrecognized `lints` key). Though I read the discussion in the original PR (and so I recognize this PR might be controversial), I would like to suggest that for a crate as popular as home (with 9.1M recent downloads) -- and as small/low on change -- IMO it would be nice to be a little more conservative and at the very least avoid bumping the MSRV proactively unless there is a need to do so.

(As a library maintainer of a bunch of very popular libraries, I am pretty unhappy with a N - 2 sliding window approach to MSRV -- asking people to justify an MSRV bump is a good thing IMO especially if the bump is aggressive -- or if you want to do a sliding window, at least be more conservative about the window; at least N - 4, preferably more like N - 6 or N - 8. Most of the libraries I maintain are currently in the 1.61 - 1.63 range.)