### PR TITLE
doc: add `public` info in `cargo-add` man page.

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -62,17 +62,17 @@ The package name will be exposed as feature of your crate.")
 The package will be removed from your features.")
                 .conflicts_with("dev")
                 .overrides_with("optional"),
-            flag("public", "Mark the dependency as public")
+            flag("public", "Mark the dependency as public (unstable)")
                 .conflicts_with("dev")
                 .conflicts_with("build")
-                .long_help("Mark the dependency as public
+                .long_help("Mark the dependency as public (unstable)
 
 The dependency can be referenced in your library's public API."),
-            flag("no-public", "Mark the dependency as private")
+            flag("no-public", "Mark the dependency as private (unstable)")
                 .conflicts_with("dev")
                 .conflicts_with("build")
                 .overrides_with("public")
-                .long_help("Mark the dependency as private
+                .long_help("Mark the dependency as private (unstable)
 
 While you can use the crate in your implementation, it cannot be referenced in your public API."),
             clap::Arg::new("rename")

--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -107,6 +107,22 @@ Mark the dependency as [optional](../reference/features.html#optional-dependenci
 Mark the dependency as [required](../reference/features.html#optional-dependencies).
 {{/option}}
 
+{{#option "`--public`" }}
+Mark the dependency as public. 
+
+The dependency can be referenced in your library's public API.
+
+[Unstable (nightly-only)](../reference/unstable.html#public-dependency)
+{{/option}}
+
+{{#option "`--no-public`" }}
+Mark the dependency as private. 
+
+While you can use the crate in your implementation, it cannot be referenced in your public API.
+
+[Unstable (nightly-only)](../reference/unstable.html#public-dependency)
+{{/option}}
+
 {{#option "`--no-default-features`" }}
 Disable the [default features](../reference/features.html#dependency-features).
 {{/option}}

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -96,6 +96,23 @@ OPTIONS
            Mark the dependency as required
            <https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies>.
 
+       --public
+           Mark the dependency as public.
+
+           The dependency can be referenced in your library’s public API.
+
+           Unstable (nightly-only)
+           <https://doc.rust-lang.org/cargo/reference/unstable.html#public-dependency>
+
+       --no-public
+           Mark the dependency as private.
+
+           While you can use the crate in your implementation, it cannot be
+           referenced in your public API.
+
+           Unstable (nightly-only)
+           <https://doc.rust-lang.org/cargo/reference/unstable.html#public-dependency>
+
        --no-default-features
            Disable the default features
            <https://doc.rust-lang.org/cargo/reference/features.html#dependency-features>.

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -107,6 +107,18 @@ which is defined by the <code>registry.default</code> config key which defaults 
 <dd class="option-desc">Mark the dependency as <a href="../reference/features.html#optional-dependencies">required</a>.</dd>
 
 
+<dt class="option-term" id="option-cargo-add---public"><a class="option-anchor" href="#option-cargo-add---public"></a><code>--public</code></dt>
+<dd class="option-desc">Mark the dependency as public. </p>
+<p>The dependency can be referenced in your library’s public API.</p>
+<p><a href="../reference/unstable.html#public-dependency">Unstable (nightly-only)</a></dd>
+
+
+<dt class="option-term" id="option-cargo-add---no-public"><a class="option-anchor" href="#option-cargo-add---no-public"></a><code>--no-public</code></dt>
+<dd class="option-desc">Mark the dependency as private. </p>
+<p>While you can use the crate in your implementation, it cannot be referenced in your public API.</p>
+<p><a href="../reference/unstable.html#public-dependency">Unstable (nightly-only)</a></dd>
+
+
 <dt class="option-term" id="option-cargo-add---no-default-features"><a class="option-anchor" href="#option-cargo-add---no-default-features"></a><code>--no-default-features</code></dt>
 <dd class="option-desc">Disable the <a href="../reference/features.html#dependency-features">default features</a>.</dd>
 

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -121,6 +121,24 @@ Mark the dependency as \fIoptional\fR <https://doc.rust\-lang.org/cargo/referenc
 Mark the dependency as \fIrequired\fR <https://doc.rust\-lang.org/cargo/reference/features.html#optional\-dependencies>\&.
 .RE
 .sp
+\fB\-\-public\fR
+.RS 4
+Mark the dependency as public. 
+.sp
+The dependency can be referenced in your library\[cq]s public API.
+.sp
+\fIUnstable (nightly\-only)\fR <https://doc.rust\-lang.org/cargo/reference/unstable.html#public\-dependency>
+.RE
+.sp
+\fB\-\-no\-public\fR
+.RS 4
+Mark the dependency as private. 
+.sp
+While you can use the crate in your implementation, it cannot be referenced in your public API.
+.sp
+\fIUnstable (nightly\-only)\fR <https://doc.rust\-lang.org/cargo/reference/unstable.html#public\-dependency>
+.RE
+.sp
 \fB\-\-no\-default\-features\fR
 .RS 4
 Disable the \fIdefault features\fR <https://doc.rust\-lang.org/cargo/reference/features.html#dependency\-features>\&.

--- a/tests/testsuite/cargo_add/help/stdout.log
+++ b/tests/testsuite/cargo_add/help/stdout.log
@@ -33,12 +33,12 @@ Options:
           The package will be removed from your features.
 
       --public
-          Mark the dependency as public
+          Mark the dependency as public (unstable)
           
           The dependency can be referenced in your library's public API.
 
       --no-public
-          Mark the dependency as private
+          Mark the dependency as private (unstable)
           
           While you can use the crate in your implementation, it cannot be referenced in your public
           API.


### PR DESCRIPTION
### What does this PR try to resolve?
follow up https://github.com/rust-lang/cargo/pull/13046
add `public/private` explanation for `cargo-add` in man page.

### How should we test and review this PR?


### Additional information

The help info would be like this

- `cargo help add`
```
        --public
           Mark the dependency as public.

           The dependency can be referenced in your library’s public API.

           Unstable (nightly-only) <https://doc.rust-lang.org/cargo/reference/unstable.html#public-dependency>

       --no-public
           Mark the dependency as private.

           While you can use the crate in your implementation, it cannot be referenced in your public API.

           Unstable (nightly-only) <https://doc.rust-lang.org/cargo/reference/unstable.html#public-dependency>
```
- `cargo add -h`
```
      --public               Mark the dependency as public (unstable)
      --no-public            Mark the dependency as private (unstable)
```

- `cargo add --help`
```
      --public
          Mark the dependency as public (unstable)
          
          The dependency can be referenced in your library's public API.

      --no-public
          Mark the dependency as private (unstable)
          
          While you can use the crate in your implementation, it cannot be referenced in your public API.
```
