### PR TITLE
Document why `du` function uses mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,7 +414,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "anyhow",
  "core-foundation",

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util"
-version = "0.2.9"
+version = "0.2.10"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util/src/du.rs
+++ b/crates/cargo-util/src/du.rs
@@ -39,7 +39,14 @@ fn du_inner(path: &Path, patterns: &[&str]) -> Result<u64> {
         .git_ignore(false)
         .git_exclude(false);
     let walker = builder.build_parallel();
+
+    // Platforms like PowerPC don't support AtomicU64, so we a Mutex instead.
+    //
+    // See:
+    // - https://github.com/rust-lang/cargo/pull/12981
+    // - https://github.com/rust-lang/rust/pull/117916#issuecomment-1812635848
     let total = Arc::new(Mutex::new(0u64));
+
     // A slot used to indicate there was an error while walking.
     //
     // It is possible that more than one error happens (such as in different

--- a/crates/cargo-util/src/du.rs
+++ b/crates/cargo-util/src/du.rs
@@ -40,7 +40,7 @@ fn du_inner(path: &Path, patterns: &[&str]) -> Result<u64> {
         .git_exclude(false);
     let walker = builder.build_parallel();
 
-    // Platforms like PowerPC don't support AtomicU64, so we a Mutex instead.
+    // Platforms like PowerPC don't support AtomicU64, so we use a Mutex instead.
     //
     // See:
     // - https://github.com/rust-lang/cargo/pull/12981


### PR DESCRIPTION
### What does this PR try to resolve?

After closing #13253, it [was suggested](https://github.com/rust-lang/cargo/pull/13253#issuecomment-1883286035) to document why the `du` function uses a `Mutex` instead of an `AtomicU64`. This will prevent others from making the same mistake I did. :)

### How should we test and review this PR?

N/A

### Additional information

N/A