### PR TITLE
docs(unstable): doc comments for items and fields

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -13,7 +13,6 @@ use super::commands;
 use super::list_commands;
 use crate::command_prelude::*;
 use crate::util::is_rustup;
-use cargo::core::features::HIDDEN;
 use cargo::util::style;
 
 pub fn main(config: &mut LazyConfig) -> CliResult {
@@ -63,15 +62,16 @@ pub fn main(config: &mut LazyConfig) -> CliResult {
         let options = CliUnstable::help();
         let max_length = options
             .iter()
-            .filter(|(_, help)| *help != HIDDEN)
+            .filter(|(_, help)| help.is_some())
             .map(|(option_name, _)| option_name.len())
             .max()
             .unwrap_or(0);
         let z_flags = options
             .iter()
-            .filter(|(_, help)| *help != HIDDEN)
+            .filter(|(_, help)| help.is_some())
             .map(|(opt, help)| {
                 let opt = opt.replace("_", "-");
+                let help = help.unwrap();
                 format!("    {literal}-Z {opt:<max_length$}{reset}  {help}")
             })
             .join("\n");

--- a/tests/testsuite/cargo/z_help/stdout.log
+++ b/tests/testsuite/cargo/z_help/stdout.log
@@ -15,7 +15,7 @@ Available unstable (nightly-only) flags:
     -Z dual-proc-macros         Build proc-macros for both the host and the target
     -Z gc                       Track cache usage and "garbage collect" unused files
     -Z gitoxide                 Use gitoxide for the given git interactions, or all of them if no argument is given
-    -Z host-config              Enable the [host] section in the .cargo/config.toml file
+    -Z host-config              Enable the `[host]` section in the .cargo/config.toml file
     -Z lints                    Pass `[lints]` to the linting tools
     -Z minimal-versions         Resolve minimal dependency versions instead of maximum
     -Z msrv-policy              Enable rust-version aware policy within cargo


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Add more doc comments for unstable feature module.

The macro updates are for auto generating doc comments from existing docs.

### How should we test and review this PR?

`cargo doc --document-private-items --no-deps` and proofread.

### Additional information
<!-- homu-ignore:end -->
