### PR TITLE
refactor: replace `iter_join` with `itertools::join`

### DIFF
--- a/src/cargo/core/compiler/future_incompat.rs
+++ b/src/cargo/core/compiler/future_incompat.rs
@@ -38,7 +38,7 @@ use crate::core::{Dependency, PackageId, Workspace};
 use crate::sources::source::QueryKind;
 use crate::sources::SourceConfigMap;
 use crate::util::cache_lock::CacheLockMode;
-use crate::util::{iter_join, CargoResult};
+use crate::util::CargoResult;
 use anyhow::{bail, format_err, Context};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
@@ -228,7 +228,7 @@ impl OnDiskReports {
     /// Returns an ANSI-styled report
     pub fn get_report(&self, id: u32, package: Option<&str>) -> CargoResult<String> {
         let report = self.reports.iter().find(|r| r.id == id).ok_or_else(|| {
-            let available = iter_join(self.reports.iter().map(|r| r.id.to_string()), ", ");
+            let available = itertools::join(self.reports.iter().map(|r| r.id), ", ");
             format_err!(
                 "could not find report with ID {}\n\
                  Available IDs are: {}",
@@ -250,7 +250,7 @@ impl OnDiskReports {
                 Available packages are: {}\n
                 Omit the `--package` flag to display a report for all packages",
                         package,
-                        iter_join(report.per_package.keys(), ", ")
+                        itertools::join(report.per_package.keys(), ", ")
                     )
                 })?
                 .to_string()
@@ -353,14 +353,8 @@ fn get_updates(ws: &Workspace<'_>, package_ids: &BTreeSet<PackageId>) -> Option<
             .collect();
         updated_versions.sort();
 
-        let updated_versions = iter_join(
-            updated_versions
-                .into_iter()
-                .map(|version| version.to_string()),
-            ", ",
-        );
-
         if !updated_versions.is_empty() {
+            let updated_versions = itertools::join(updated_versions, ", ");
             writeln!(
                 updates,
                 "{} has the following newer versions available: {}",

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -93,7 +93,7 @@ use crate::core::{Feature, PackageId, Target, Verbosity};
 use crate::util::errors::{CargoResult, VerboseError};
 use crate::util::interning::InternedString;
 use crate::util::machine_message::{self, Message};
-use crate::util::{add_path_args, internal, iter_join_onto, profile};
+use crate::util::{add_path_args, internal, profile};
 use cargo_util::{paths, ProcessBuilder, ProcessError};
 use cargo_util_schemas::manifest::TomlDebugInfo;
 use cargo_util_schemas::manifest::TomlTrimPaths;
@@ -910,9 +910,12 @@ fn add_cap_lints(bcx: &BuildContext<'_, '_>, unit: &Unit, cmd: &mut ProcessBuild
 /// [`-Zallow-features`]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#allow-features
 fn add_allow_features(cx: &Context<'_, '_>, cmd: &mut ProcessBuilder) {
     if let Some(allow) = &cx.bcx.config.cli_unstable().allow_features {
+        use std::fmt::Write;
         let mut arg = String::from("-Zallow-features=");
-        let _ = iter_join_onto(&mut arg, allow, ",");
-        cmd.arg(&arg);
+        for f in allow {
+            let _ = write!(&mut arg, "{f},");
+        }
+        cmd.arg(arg.trim_end_matches(','));
     }
 }
 

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -147,7 +147,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::core::resolver::ResolveBehavior;
 use crate::util::errors::CargoResult;
-use crate::util::{indented_lines, iter_join};
+use crate::util::indented_lines;
 use crate::Config;
 
 pub const SEE_CHANNELS: &str =
@@ -603,7 +603,7 @@ impl Features {
                         bail!(
                             "the feature `{}` is not in the list of allowed features: [{}]",
                             feature_name,
-                            iter_join(allow, ", "),
+                            itertools::join(allow, ", "),
                         );
                     }
                 }
@@ -1031,7 +1031,7 @@ impl CliUnstable {
                 bail!(
                     "the feature `{}` is not in the list of allowed features: [{}]",
                     k,
-                    iter_join(allowed, ", ")
+                    itertools::join(allowed, ", ")
                 );
             }
         }

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -92,32 +91,6 @@ pub fn human_readable_bytes(bytes: u64) -> (f32, &'static str) {
     let bytes = bytes as f32;
     let i = ((bytes.log2() / 10.0) as usize).min(UNITS.len() - 1);
     (bytes / 1024_f32.powi(i as i32), UNITS[i])
-}
-
-pub fn iter_join_onto<W, I, T>(mut w: W, iter: I, delim: &str) -> fmt::Result
-where
-    W: fmt::Write,
-    I: IntoIterator<Item = T>,
-    T: std::fmt::Display,
-{
-    let mut it = iter.into_iter().peekable();
-    while let Some(n) = it.next() {
-        write!(w, "{}", n)?;
-        if it.peek().is_some() {
-            write!(w, "{}", delim)?;
-        }
-    }
-    Ok(())
-}
-
-pub fn iter_join<I, T>(iter: I, delim: &str) -> String
-where
-    I: IntoIterator<Item = T>,
-    T: std::fmt::Display,
-{
-    let mut s = String::new();
-    let _ = iter_join_onto(&mut s, iter, delim);
-    s
 }
 
 pub fn indented_lines(text: &str) -> String {

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -830,7 +830,7 @@ fn clean_dry_run() {
     // Verify it didn't delete anything.
     let after = p.build_dir().ls_r();
     assert_eq!(before, after);
-    let expected = cargo::util::iter_join(before.iter().map(|p| p.to_str().unwrap()), "\n");
+    let expected = itertools::join(before.iter().map(|p| p.to_str().unwrap()), "\n");
     eprintln!("{expected}");
     // Verify the verbose output.
     p.cargo("clean --dry-run -v")


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This removes ad-hoc functions `iter_join` and `iter_join_onto`.

### How should we test and review this PR?

There is no functional change.

### Additional information
<!-- homu-ignore:end -->
