### PR TITLE
refactor: factor out `Config` from `core::features`

### DIFF
--- a/src/cargo/util/config/contexts.rs
+++ b/src/cargo/util/config/contexts.rs
@@ -1,0 +1,13 @@
+use crate::core::features::AllowFeatures;
+use crate::core::features::UnstableFeatureContext;
+use crate::Config;
+
+impl UnstableFeatureContext for Config {
+    fn nightly_features_allowed(&self) -> bool {
+        self.nightly_features_allowed
+    }
+
+    fn allow_features(&self) -> Option<&AllowFeatures> {
+        self.unstable_flags.allow_features.as_ref()
+    }
+}

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -111,6 +111,8 @@ pub use target::{TargetCfgConfig, TargetConfig};
 mod environment;
 use environment::Env;
 
+mod contexts;
+
 use super::auth::RegistryConfig;
 
 // Helper macro for creating typed access methods.


### PR DESCRIPTION


<!-- homu-ignore:start -->

### What does this PR try to resolve?

To decouple manifest logic from `config.toml` behavior, a trait
`UnstableFeatureContext` is created for `Features` to query any
necessary information from the outer context.

This is a path toward a new package for high-level manifest processing
logic. The goal is to break out behavior for `Config` into several
small contexts, which can be imported when needed.
### How should we test and review this PR?

There is no functional change.

The plan is to add more context impls into `util::config::context`.

### Additional information

Related to #4614
<!-- homu-ignore:end -->
