### PR TITLE
fix(resolver): do not panic when sorting empty summaries

### DIFF
--- a/src/cargo/core/resolver/version_prefs.rs
+++ b/src/cargo/core/resolver/version_prefs.rs
@@ -125,7 +125,7 @@ impl VersionPreferences {
                 VersionOrdering::MinimumVersionsFirst => cmp,
             }
         });
-        if first_version.is_some() {
+        if first_version.is_some() && !summaries.is_empty() {
             let _ = summaries.split_off(1);
         }
     }
@@ -284,12 +284,12 @@ mod test {
         );
     }
 
-    #[should_panic = "`at` split index (is 1) should be <= len (is 0)"]
     #[test]
     fn test_empty_summaries() {
         let vp = VersionPreferences::default();
         let mut summaries = vec![];
 
         vp.sort_summaries(&mut summaries, Some(VersionOrdering::MaximumVersionsFirst));
+        assert_eq!(summaries, vec![]);
     }
 }

--- a/src/cargo/core/resolver/version_prefs.rs
+++ b/src/cargo/core/resolver/version_prefs.rs
@@ -283,4 +283,13 @@ mod test {
                 .to_string()
         );
     }
+
+    #[should_panic = "`at` split index (is 1) should be <= len (is 0)"]
+    #[test]
+    fn test_empty_summaries() {
+        let vp = VersionPreferences::default();
+        let mut summaries = vec![];
+
+        vp.sort_summaries(&mut summaries, Some(VersionOrdering::MaximumVersionsFirst));
+    }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

This is very unlikely to misuse… but I encountered that today.
At our best we should prevent this from happening.

(I didn't hit this when we had `first_version` and `version_ordering` separately)

### How should we test and review this PR?

Commit by commit.
<!-- homu-ignore:end -->
