### PR TITLE
Delete sentence about parentheses being unsupported in license

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -266,8 +266,8 @@ containing the text of the license (relative to this `Cargo.toml`).
 
 [crates.io] interprets the `license` field as an [SPDX 2.3 license
 expression][spdx-2.3-license-expressions]. The name must be a known license
-from the [SPDX license list 3.20][spdx-license-list-3.20]. Parentheses are not
-currently supported. See the [SPDX site] for more information.
+from the [SPDX license list 3.20][spdx-license-list-3.20]. See the [SPDX site]
+for more information.
 
 SPDX license expressions support AND and OR operators to combine multiple
 licenses.[^slash]


### PR DESCRIPTION
Parentheses have been supported by crates.io since 2 years ago.

- https://github.com/rust-lang/crates.io/pull/4257

Their functionality is tested by this test: https://github.com/rust-lang/crates.io/blob/3acd63c1f3625d83322e4819d76296ae5ef291c5/tests/utils/license-test.js#L68-L79.

I think a separate test in Cargo is most likely not valuable because Cargo does not parse these license strings, they are just treated as `Option<String>`.

Here is an example of an extremely widely used package (147 million downloads) with parentheses in its license: https://crates.io/crates/unicode-ident.