### PR TITLE
Add guidance on setting homepage in manifest

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -244,8 +244,12 @@ package.
 ```toml
 [package]
 # ...
-homepage = "https://serde.rs/"
+homepage = "https://serde.rs"
 ```
+
+A value should only be set for `homepage` if there is a dedicated website for
+the crate other than the source repository or API documentation. Do not make
+`homepage` redundant with either the `documentation` or `repository` values.
 
 ### The `repository` field
 
@@ -255,7 +259,7 @@ package.
 ```toml
 [package]
 # ...
-repository = "https://github.com/rust-lang/cargo/"
+repository = "https://github.com/rust-lang/cargo"
 ```
 
 ### The `license` and `license-file` fields


### PR DESCRIPTION
Carried over from the Rust API Guidelines: https://rust-lang.github.io/api-guidelines/documentation.html#cargotoml-includes-all-common-metadata-c-metadata

This guidance has been in place since 6.5 years ago (https://github.com/rust-lang/api-guidelines/commit/350619f84efc16260d756bbffd2c6c77045d5248).