### PR TITLE
docs: add more links to pkgid spec chapter

### DIFF
--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -388,4 +388,6 @@ reproduction of the information within `Cargo.toml`.
        cargo metadata --format-version=1
 
 ## SEE ALSO
-{{man "cargo" 1}}
+{{man "cargo" 1}}, {{man "cargo-pkgid" 1}}, [Package ID Specifications]
+
+[Package ID Specifications]: ../reference/pkgid-spec.html

--- a/src/doc/man/cargo-pkgid.md
+++ b/src/doc/man/cargo-pkgid.md
@@ -33,6 +33,8 @@ _url_`#`_version_          | `https://github.com/rust-lang/cargo#0.33.0`
 _url_`#`_name_             | `https://github.com/rust-lang/crates.io-index#bitflags`
 _url_`#`_name_`@`_version_ | `https://github.com/rust-lang/cargo#crates-io@0.21.0`
 
+The specification grammar can be found in chapter [Package ID Specifications].
+
 ## OPTIONS
 
 ### Package Selection
@@ -86,4 +88,6 @@ Get the package ID for the given package instead of the current package.
        cargo pkgid file:///path/to/local/package#foo
 
 ## SEE ALSO
-{{man "cargo" 1}}, {{man "cargo-generate-lockfile" 1}}, {{man "cargo-metadata" 1}}
+{{man "cargo" 1}}, {{man "cargo-generate-lockfile" 1}}, {{man "cargo-metadata" 1}}, [Package ID Specifications]
+
+[Package ID Specifications]: ../reference/pkgid-spec.html

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -476,5 +476,6 @@ EXAMPLES
               cargo metadata --format-version=1
 
 SEE ALSO
-       cargo(1)
+       cargo(1), cargo-pkgid(1), Package ID Specifications
+       <https://doc.rust-lang.org/cargo/reference/pkgid-spec.html>
 

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -39,6 +39,10 @@ DESCRIPTION
        | url#name@version | https://github.com/rust-lang/cargo#crates-io@0.21.0 |
        +-----------------+--------------------------------------------------+
 
+       The specification grammar can be found in chapter Package ID
+       Specifications
+       <https://doc.rust-lang.org/cargo/reference/pkgid-spec.html>.
+
 OPTIONS
    Package Selection
        -p spec, --package spec
@@ -166,5 +170,7 @@ EXAMPLES
               cargo pkgid file:///path/to/local/package#foo
 
 SEE ALSO
-       cargo(1), cargo-generate-lockfile(1), cargo-metadata(1)
+       cargo(1), cargo-generate-lockfile(1), cargo-metadata(1), Package ID
+       Specifications
+       <https://doc.rust-lang.org/cargo/reference/pkgid-spec.html>
 

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -507,4 +507,6 @@ details on environment variables that Cargo reads.
        cargo metadata --format-version=1
 
 ## SEE ALSO
-[cargo(1)](cargo.html)
+[cargo(1)](cargo.html), [cargo-pkgid(1)](cargo-pkgid.html), [Package ID Specifications]
+
+[Package ID Specifications]: ../reference/pkgid-spec.html

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -33,6 +33,8 @@ _url_`#`_version_          | `https://github.com/rust-lang/cargo#0.33.0`
 _url_`#`_name_             | `https://github.com/rust-lang/crates.io-index#bitflags`
 _url_`#`_name_`@`_version_ | `https://github.com/rust-lang/cargo#crates-io@0.21.0`
 
+The specification grammar can be found in chapter [Package ID Specifications].
+
 ## OPTIONS
 
 ### Package Selection
@@ -181,4 +183,6 @@ details on environment variables that Cargo reads.
        cargo pkgid file:///path/to/local/package#foo
 
 ## SEE ALSO
-[cargo(1)](cargo.html), [cargo-generate-lockfile(1)](cargo-generate-lockfile.html), [cargo-metadata(1)](cargo-metadata.html)
+[cargo(1)](cargo.html), [cargo-generate-lockfile(1)](cargo-generate-lockfile.html), [cargo-metadata(1)](cargo-metadata.html), [Package ID Specifications]
+
+[Package ID Specifications]: ../reference/pkgid-spec.html

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -523,4 +523,4 @@ cargo metadata \-\-format\-version=1
 .RE
 .RE
 .SH "SEE ALSO"
-\fBcargo\fR(1)
+\fBcargo\fR(1), \fBcargo\-pkgid\fR(1), \fIPackage ID Specifications\fR <https://doc.rust\-lang.org/cargo/reference/pkgid\-spec.html>

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -62,6 +62,8 @@ T}:T{
 T}
 .TE
 .sp
+.sp
+The specification grammar can be found in chapter \fIPackage ID Specifications\fR <https://doc.rust\-lang.org/cargo/reference/pkgid\-spec.html>\&.
 .SH "OPTIONS"
 .SS "Package Selection"
 .sp
@@ -240,4 +242,4 @@ cargo pkgid file:///path/to/local/package#foo
 .RE
 .RE
 .SH "SEE ALSO"
-\fBcargo\fR(1), \fBcargo\-generate\-lockfile\fR(1), \fBcargo\-metadata\fR(1)
+\fBcargo\fR(1), \fBcargo\-generate\-lockfile\fR(1), \fBcargo\-metadata\fR(1), \fIPackage ID Specifications\fR <https://doc.rust\-lang.org/cargo/reference/pkgid\-spec.html>


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

More cross-links to Package ID Specifications chapter.

### How should we test and review this PR?

```
mdbook serve src/doc
# and check "cargo pkgid" and "cargo metadadta" chapters.
```

and

```
./target/debug/cargo help pkgid
./target/debug/cargo help metadata
```

### Additional information

<!-- homu-ignore:end -->
