### PR TITLE
doc: add a heading to highlight "How to find features enabled on dependencies"

### DIFF
--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -511,7 +511,9 @@ rand v0.8.5
 └── ...
 ```
 
-You might identify that it was an activated feature that caused `rand` to show up.  To figure out which package activated the feature, you can add the `--edges features`
+### Why was that feature on this dependency enabled?
+
+You might identify that it was an activated feature that caused `rand` to show up.  **To figure out which package activated the feature, you can add the `--edges features`**
 ```console
 $ cargo tree --workspace --target all --all-features --edges features --invert rand
 rand v0.8.5


### PR DESCRIPTION
### What does this PR try to resolve?

Maybe fixes https://github.com/rust-lang/cargo/issues/13289

Add a title to highlight "How to find features enabled on dependencies"?

### How should we test and review this PR?

### Additional information

