### PR TITLE
fix(`--package`): accept `?` if it's a valid pkgid spec 

### DIFF
--- a/src/cargo/ops/cargo_compile/packages.rs
+++ b/src/cargo/ops/cargo_compile/packages.rs
@@ -195,7 +195,7 @@ fn opt_patterns_and_names(
     let mut opt_patterns = Vec::new();
     let mut opt_names = BTreeSet::new();
     for x in opt.iter() {
-        if is_glob_pattern(x) {
+        if PackageIdSpec::parse(x).is_err() && is_glob_pattern(x) {
             opt_patterns.push((build_glob(x)?, false));
         } else {
             opt_names.insert(String::as_str(x));

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1553,7 +1553,10 @@ fn pkgid_querystring_works() {
 
     p.cargo("build -p")
         .arg(gitdep_pkgid)
-        .with_status(101)
-        .with_stderr("[ERROR] package pattern(s) `git+file:///[..]/gitdep?branch=master#1.0.0` not found in workspace `[CWD]`")
+        .with_stderr(
+            "\
+[COMPILING] gitdep v1.0.0 (file:///[..]/gitdep?branch=master#[..])
+[FINISHED] dev [..]",
+        )
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Previously if a value from `--package` flag contains `?`, Cargo
considered it as a glob pattern. However, staring from #12933 the
Package Id Spec has been extended to accept `?` for git sources.
This PR adjust accordingly to accept `?` from `--package` flag
when it is a valid Package Id Spec.


### How should we test and review this PR?

The first commit demonstrates the current behavior, the second fixes it.

### Additional information

I'd like to propose a beta backport for this.
<!-- homu-ignore:end -->
