### PR TITLE
Go back to passing an empty `values()` when no features are declared

### DIFF
--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -15,16 +15,16 @@ macro_rules! x {
                     $what, '(', $($who,)* ')', "'", "[..]")
         }
     }};
-    ($tool:tt => $what:tt of $who:tt with $first_value:tt $($other_values:tt)*) => {{
+    ($tool:tt => $what:tt of $who:tt with $($first_value:tt $($other_values:tt)*)?) => {{
         #[cfg(windows)]
         {
             concat!("[RUNNING] [..]", $tool, "[..] --check-cfg \"",
-                    $what, '(', $who, ", values(", "/\"", $first_value, "/\"", $(", ", "/\"", $other_values, "/\"",)* "))", '"', "[..]")
+                    $what, '(', $who, ", values(", $("/\"", $first_value, "/\"", $(", ", "/\"", $other_values, "/\"",)*)* "))", '"', "[..]")
         }
         #[cfg(not(windows))]
         {
             concat!("[RUNNING] [..]", $tool, "[..] --check-cfg '",
-                    $what, '(', $who, ", values(", "\"", $first_value, "\"", $(", ", "\"", $other_values, "\"",)* "))", "'", "[..]")
+                    $what, '(', $who, ", values(", $("\"", $first_value, "\"", $(", ", "\"", $other_values, "\"",)*)* "))", "'", "[..]")
         }
     }};
 }
@@ -221,7 +221,7 @@ fn well_known_names_values() {
 
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
-        .with_stderr_contains(x!("rustc" => "cfg"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
         .run();
 }
 
@@ -284,7 +284,7 @@ fn well_known_names_values_test() {
 
     p.cargo("test -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
-        .with_stderr_contains(x!("rustc" => "cfg"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
         .run();
 }
 
@@ -297,8 +297,8 @@ fn well_known_names_values_doctest() {
 
     p.cargo("test -v --doc -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
-        .with_stderr_contains(x!("rustc" => "cfg"))
-        .with_stderr_contains(x!("rustdoc" => "cfg"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with))
         .run();
 }
 


### PR DESCRIPTION
This PR is basically a revert of https://github.com/rust-lang/cargo/pull/13011, which made the `--check-cfg` invocation be `cfg()` when no features are declared instead of `cfg(feature, values())` since it meant declaring that the config `feature` were to be available in this form: `#[cfg(feature)]`, which is not the case.

Thankfully after some brainstorming, I [proposed](https://github.com/rust-lang/rust/pull/119930) changing the behavior of empty `values()` in `rustc` to no longer imply the _none_ value and simply create an empty set of expected values. :smiley:

For Cargo, always using `cfg(feature, values(...))` means that the config `feature` is always expected, regardless of the number of features. This makes the warning better, as it will now always be `unexpected config value` (instead of `unexpected config name`). :tada:

Fixes https://github.com/rust-lang/cargo/pull/13011#issuecomment-1819427800 as well as the concern in the [tracking issue](https://github.com/rust-lang/cargo/issues/10554).

r? @epage