### PR TITLE
Improve GitHub Actions CI config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     - test
     - test_gitoxide
     runs-on: ubuntu-latest
-    if: "success() && github.event_name == 'push' && github.ref == 'refs/heads/auto-cargo'"
+    if: "success() && github.event_name == 'push' && (github.ref == 'refs/heads/auto-cargo' || github.ref == 'refs/heads/try') && github.repository == 'rust-lang/cargo'"
     steps:
     - run: echo ok
   failure:
@@ -54,7 +54,7 @@ jobs:
     - test
     - test_gitoxide
     runs-on: ubuntu-latest
-    if: "!success() && github.event_name == 'push' && github.ref == 'refs/heads/auto-cargo'"
+    if: "!success() && github.event_name == 'push' && (github.ref == 'refs/heads/auto-cargo' || github.ref == 'refs/heads/try') && github.repository == 'rust-lang/cargo'"
     steps:
     - run: exit 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,13 @@
 name: CI
 on:
   push:
-    branches-ignore: [master]
+    branches:
+      - auto-cargo
+      - try
+      - automation/bors/try
   pull_request:
-    branches: ['*']
+    branches:
+      - "**"
 
 defaults:
   run:
@@ -11,6 +15,10 @@ defaults:
 
 permissions:
   contents: read
+
+concurrency:
+  group: "${{ github.workflow }}-${{ (github.ref == 'refs/heads/try' && github.sha) || github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   success:


### PR DESCRIPTION
This pull request improves Cargo CI by:
 1. Explicitly listing the branches the main CI should be run on (to avoid running on unwanted branches, particularly in forks)
 2. By adding a [concurrency](https://docs.github.com/en/actions/using-jobs/using-concurrency) config so that only one "CI" runs for each "group" (one by PR), very inspired by rust-lang/rust [one](https://github.com/rust-lang/rust/blob/c485ee71477a29041895c47cc441b364670f3772/.github/workflows/ci.yml#L35)
 3. ~~By making all the jobs run only if triggered from this repository (to avoid having forks unnecessarily run CI jobs)~~
 4. ~~By making all the checkouts take `fetch-depth: 2` like done in [rust-lang/rust](https://github.com/rust-lang/rust/blob/c485ee71477a29041895c47cc441b364670f3772/.github/workflows/ci.yml#L452-L455) (to avoid unnecessary work, saves bandwidth and maybe a bit of time)~~
 5. By including `refs/heads/try` in the `success` and `failure` bors job gates (to fix `bors try` from timing out)

The main motivation for this PR was (at first) to make the CI jobs not run on forks since it's a waste of CI resources as well as always failing (like [this](https://github.com/Urgau/cargo/actions/runs/7567435677/job/20606586124)); but after looking at the `main.yml` config I took the opportunity to improve the situation by using rust-lang/rust [ci.yml](https://github.com/rust-lang/rust/blob/master/.github/workflows/ci.yml) as reference.