### PR TITLE
[beta-1.76.0] fix(`--package`): accept `?` if it's a valid pkgid spec

### DIFF
--- a/src/cargo/ops/cargo_compile/packages.rs
+++ b/src/cargo/ops/cargo_compile/packages.rs
@@ -195,7 +195,7 @@ fn opt_patterns_and_names(
     let mut opt_patterns = Vec::new();
     let mut opt_names = BTreeSet::new();
     for x in opt.iter() {
-        if is_glob_pattern(x) {
+        if PackageIdSpec::parse(x).is_err() && is_glob_pattern(x) {
             opt_patterns.push((build_glob(x)?, false));
         } else {
             opt_names.insert(String::as_str(x));

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -3,6 +3,7 @@
 use std::fmt::{self, Write};
 
 use crate::messages::raw_rustc_output;
+use cargo_test_support::compare;
 use cargo_test_support::install::exe;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
@@ -1516,6 +1517,46 @@ fn versionless_package() {
 [CHECKING] foo v0.0.0 ([CWD])
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
 ",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn pkgid_querystring_works() {
+    let git_project = git::new("gitdep", |p| {
+        p.file("Cargo.toml", &basic_manifest("gitdep", "1.0.0"))
+            .file("src/lib.rs", "")
+    });
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &format!(
+                r#"
+                [package]
+                name = "foo"
+
+                [dependencies]
+                gitdep = {{ git = "{}", branch = "master" }}
+                "#,
+                git_project.url()
+            ),
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("generate-lockfile").run();
+
+    let output = p.cargo("pkgid").arg("gitdep").exec_with_output().unwrap();
+    let gitdep_pkgid = String::from_utf8(output.stdout).unwrap();
+    let gitdep_pkgid = gitdep_pkgid.trim();
+    compare::assert_match_exact("git+file://[..]/gitdep?branch=master#1.0.0", &gitdep_pkgid);
+
+    p.cargo("build -p")
+        .arg(gitdep_pkgid)
+        .with_stderr(
+            "\
+[COMPILING] gitdep v1.0.0 (file:///[..]/gitdep?branch=master#[..])
+[FINISHED] dev [..]",
         )
         .run();
 }


### PR DESCRIPTION
Beta backports:

- <https://github.com/rust-lang/cargo/pull/13315>

In order to make CI pass, the following PRs are also cherry-picked:

- 1ef1b7e313534c59b712d742bc4e4445aa510c92