### PR TITLE
fix(cargo-rustdoc): use same path by output format logic everywhere

### DIFF
--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -48,6 +48,7 @@ fn rustdoc_simple_json() {
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc [..]--crate-name foo [..]-o [CWD]/target/doc [..]--output-format=json[..]
 [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[GENERATED] [CWD]/target/doc/foo.json
 ",
         )
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Different rustdoc output format places output artifact at different paths. This PR introduces a helper function that can be used whenever we needs to address the output artifact.

Fixes #13303 

### How should we test and review this PR?

The change is covered by the existing tests and the modified `rustdoc_simple_json` test.

    cargo test --test testsuite -- rustdoc_simple_json

### Additional information

N/A

<!-- homu-ignore:end -->
