### PR TITLE
Fix static_mut_ref warning.

### DIFF
--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -187,7 +187,7 @@ fn to_token_stream(code: &str) -> TokenStream {
 
 static mut VERSION: (u32, bool) = (0, false);
 
-fn version() -> &'static (u32, bool) {
+fn version() -> (u32, bool) {
     static INIT: Once = Once::new();
     INIT.call_once(|| {
         let output = Command::new("rustc")
@@ -201,7 +201,7 @@ fn version() -> &'static (u32, bool) {
         let minor = vers.split('.').skip(1).next().unwrap().parse().unwrap();
         unsafe { VERSION = (minor, is_nightly) }
     });
-    unsafe { &VERSION }
+    unsafe { VERSION }
 }
 
 fn has_command(command: &str) -> bool {


### PR DESCRIPTION
The nightly compiler has recently added the [`static_mut_ref`](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#static-mut-ref) lint, which warns about taking a reference to a `mut static`. This fixes the issue by copying the value instead of taking a reference. I don't recall what I was thinking when I wrote this, but it was probably a bad reflex against making copies.
