### PR TITLE
Add `include` and `exclude` information to metadata

### DIFF
--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -106,6 +106,8 @@ pub struct SerializedPackage {
     metabuild: Option<Vec<String>>,
     default_run: Option<String>,
     rust_version: Option<RustVersion>,
+    include: Vec<String>,
+    exclude: Vec<String>,
 }
 
 impl Package {
@@ -262,6 +264,8 @@ impl Package {
             publish: self.publish().as_ref().cloned(),
             default_run: self.manifest().default_run().map(|s| s.to_owned()),
             rust_version: self.rust_version().cloned(),
+            include: self.manifest().include().to_vec(),
+            exclude: self.manifest().exclude().to_vec(),
         }
     }
 }

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -61,7 +61,9 @@ fn cargo_metadata_simple() {
                 "features": {},
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": ["path+file:[..]foo#0.5.0"],
@@ -161,7 +163,9 @@ crate-type = ["lib", "staticlib"]
                 "features": {},
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": ["path+file:[..]foo#0.5.0"],
@@ -255,7 +259,9 @@ optional_feat = []
                 },
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": ["path+file:[..]foo#0.5.0"],
@@ -345,6 +351,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
                 "publish": null,
+                "include": [],
+                "exclude": [],
                 "name": "bar",
                 "readme": null,
                 "repository": null,
@@ -386,6 +394,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
                 "publish": null,
+                "include": [],
+                "exclude": [],
                 "name": "baz",
                 "readme": null,
                 "repository": null,
@@ -452,6 +462,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
                 "publish": null,
+                "include": [],
+                "exclude": [],
                 "name": "foo",
                 "readme": null,
                 "repository": null,
@@ -493,6 +505,8 @@ fn cargo_metadata_with_deps_and_version() {
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
                 "publish": null,
+                "include": [],
+                "exclude": [],
                 "name": "foobar",
                 "readme": null,
                 "repository": null,
@@ -668,7 +682,9 @@ name = "ex"
                 "features": {},
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": [
@@ -766,7 +782,9 @@ crate-type = ["rlib", "dylib"]
                 "features": {},
                 "manifest_path": "[..]Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": [
@@ -861,7 +879,9 @@ fn workspace_metadata() {
                 "features": {},
                 "manifest_path": "[..]bar/Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             },
             {
                 "authors": [
@@ -900,7 +920,9 @@ fn workspace_metadata() {
                 "features": {},
                 "manifest_path": "[..]baz/Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": [
@@ -1053,6 +1075,8 @@ fn workspace_metadata_with_dependencies_no_deps() {
                 "manifest_path": "[..]bar/Cargo.toml",
                 "metadata": null,
                 "publish": null
+                "include": [],
+                "exclude": []
             },
             {
               "authors": [
@@ -1075,6 +1099,8 @@ fn workspace_metadata_with_dependencies_no_deps() {
               "metadata": null,
               "name": "artifact",
               "publish": null,
+              "include": [],
+              "exclude": [],
               "readme": null,
               "repository": null,
               "rust_version": null,
@@ -1134,7 +1160,9 @@ fn workspace_metadata_with_dependencies_no_deps() {
                 "features": {},
                 "manifest_path": "[..]baz/Cargo.toml",
                 "metadata": null,
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": [
@@ -1269,6 +1297,8 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "metadata": null,
                   "name": "artifact",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -1497,6 +1527,8 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "metadata": null,
                   "name": "bar",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -1552,6 +1584,8 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "metadata": null,
                   "name": "bin-only-artifact",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -1607,6 +1641,8 @@ fn workspace_metadata_with_dependencies_and_resolve() {
                   "metadata": null,
                   "name": "non-artifact",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -1983,6 +2019,8 @@ const MANIFEST_OUTPUT: &str = r#"
         "manifest_path":"[..]Cargo.toml",
         "metadata": null,
         "publish": null,
+        "include": [],
+        "exclude": [],
         "readme": null,
         "repository": null,
         "rust_version": null,
@@ -2181,7 +2219,9 @@ fn package_metadata() {
                         "baz": "quux"
                     }
                 },
-                "publish": null
+                "publish": null,
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": ["[..]foo#0.1.0"],
@@ -2257,7 +2297,9 @@ fn package_publish() {
                 "features": {},
                 "manifest_path": "[..]foo/Cargo.toml",
                 "metadata": null,
-                "publish": ["my-registry"]
+                "publish": ["my-registry"],
+                "include": [],
+                "exclude": []
             }
         ],
         "workspace_members": ["[..]foo#0.1.0"],
@@ -2315,6 +2357,8 @@ fn cargo_metadata_path_to_cargo_toml_project() {
                     "manifest_path": "[..]Cargo.toml",
                     "metadata": null,
                     "publish": null,
+                    "include": [],
+                    "exclude": [],
                     "name": "bar",
                     "readme": null,
                     "repository": null,
@@ -2406,6 +2450,8 @@ fn package_edition_2018() {
                         "manifest_path": "[..]Cargo.toml",
                         "metadata": null,
                         "publish": null,
+                        "include": [],
+                        "exclude": [],
                         "name": "foo",
                         "readme": null,
                         "repository": null,
@@ -2543,6 +2589,8 @@ fn target_edition_2018() {
                         "manifest_path": "[..]Cargo.toml",
                         "metadata": null,
                         "publish": null,
+                        "include": [],
+                        "exclude": [],
                         "name": "foo",
                         "readme": null,
                         "repository": null,
@@ -2653,6 +2701,8 @@ fn rename_dependency() {
             "manifest_path": "[..]",
             "metadata": null,
             "publish": null,
+            "include": [],
+            "exclude": [],
             "name": "bar",
             "readme": null,
             "repository": null,
@@ -2694,6 +2744,8 @@ fn rename_dependency() {
             "manifest_path": "[..]",
             "metadata": null,
             "publish": null,
+            "include": [],
+            "exclude": [],
             "name": "bar",
             "readme": null,
             "repository": null,
@@ -2760,6 +2812,8 @@ fn rename_dependency() {
             "manifest_path": "[..]",
             "metadata": null,
             "publish": null,
+            "include": [],
+            "exclude": [],
             "name": "foo",
             "readme": null,
             "repository": null,
@@ -2885,6 +2939,8 @@ fn metadata_links() {
                   "manifest_path": "[..]/foo/Cargo.toml",
                   "metadata": null,
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "name": "foo",
                   "readme": null,
                   "repository": null,
@@ -3018,6 +3074,8 @@ fn deps_with_bin_only() {
                   "manifest_path": "[..]/foo/Cargo.toml",
                   "metadata": null,
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "authors": [],
                   "categories": [],
                   "default_run": null,
@@ -3126,6 +3184,8 @@ fn filter_platform() {
       "manifest_path": "[..]/alt-dep-0.0.1/Cargo.toml",
       "metadata": null,
       "publish": null,
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "default_run": null,
@@ -3170,6 +3230,8 @@ fn filter_platform() {
       "manifest_path": "[..]/cfg-dep-0.0.1/Cargo.toml",
       "metadata": null,
       "publish": null,
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "default_run": null,
@@ -3214,6 +3276,8 @@ fn filter_platform() {
       "manifest_path": "[..]/host-dep-0.0.1/Cargo.toml",
       "metadata": null,
       "publish": null,
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "default_run": null,
@@ -3258,6 +3322,8 @@ fn filter_platform() {
       "manifest_path": "[..]/normal-dep-0.0.1/Cargo.toml",
       "metadata": null,
       "publish": null,
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "default_run": null,
@@ -3365,6 +3431,8 @@ fn filter_platform() {
       "manifest_path": "[..]/foo/Cargo.toml",
       "metadata": null,
       "publish": null,
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "default_run": null,
@@ -4133,6 +4201,8 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                   "metadata": null,
                   "name": "bar",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -4176,6 +4246,8 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                   "metadata": null,
                   "name": "artifact",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -4219,6 +4291,8 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
                   "metadata": null,
                   "name": "baz",
                   "publish": null,
+                  "include": [],
+                  "exclude": [],
                   "readme": null,
                   "repository": null,
                   "rust_version": null,
@@ -4358,6 +4432,8 @@ fn versionless_packages() {
       "manifest_path": "[..]/bar/Cargo.toml",
       "metadata": null,
       "publish": [],
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "keywords": [],
@@ -4412,6 +4488,8 @@ fn versionless_packages() {
       "manifest_path": "[..]/baz/Cargo.toml",
       "metadata": null,
       "publish": [],
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "keywords": [],
@@ -4453,6 +4531,8 @@ fn versionless_packages() {
       "manifest_path": "[..]/foobar-0.0.1/Cargo.toml",
       "metadata": null,
       "publish": null,
+      "include": [],
+      "exclude": [],
       "authors": [],
       "categories": [],
       "keywords": [],
@@ -4540,6 +4620,191 @@ fn versionless_packages() {
   "metadata": null
 }
 "#,
+        )
+        .run();
+}
+
+#[cargo_test]
+fn cargo_metadata_include() {
+    let p = project()
+        .file("src/foo.rs", "")
+        .file("Cargo.toml", r#"
+[package]
+name = "foo"
+version = "0.5.0"
+authors = ["wycats@example.com"]
+include = ["./ssh.rs"]
+
+[lib]
+crate-type = ["lib"]
+            "#,
+        )
+        .build();
+
+    p.cargo("metadata")
+        .with_json(
+            r#"
+    {
+        "packages": [
+            {
+                "authors": [
+                    "wycats@example.com"
+                ],
+                "categories": [],
+                "default_run": null,
+                "name": "foo",
+                "version": "0.5.0",
+                "id": "[..]foo#0.5.0",
+                "keywords": [],
+                "source": null,
+                "dependencies": [],
+                "edition": "2015",
+                "license": null,
+                "license_file": null,
+                "links": null,
+                "description": null,
+                "readme": null,
+                "repository": null,
+                "rust_version": null,
+                "homepage": null,
+                "documentation": null,
+                "homepage": null,
+                "documentation": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "lib"
+                        ],
+                        "crate_types": [
+                            "lib"
+                        ],
+                        "doc": true,
+                        "doctest": true,
+                        "test": true,
+                        "edition": "2015",
+                        "name": "foo",
+                        "src_path": "[..]/foo/src/foo.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml",
+                "metadata": null,
+                "publish": null,
+                "include": ["./ssh.rs"],
+                "exclude": []
+            }
+        ],
+        "workspace_members": ["path+file:[..]foo#0.5.0"],
+        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "deps": [],
+                    "features": [],
+                    "id": "path+file:[..]foo#0.5.0"
+                }
+            ],
+            "root": "path+file:[..]foo#0.5.0"
+        },
+        "target_directory": "[..]foo/target",
+        "version": 1,
+        "workspace_root": "[..]/foo",
+        "metadata": null
+    }"#,
+        )
+        .run();
+}
+
+
+#[cargo_test]
+fn cargo_metadata_exclude() {
+    let p = project()
+        .file("src/foo.rs", "")
+        .file("Cargo.toml", r#"
+[package]
+name = "foo"
+version = "0.5.0"
+authors = ["wycats@example.com"]
+exclude = ["./ssh.rs"]
+
+[lib]
+crate-type = ["lib"]
+            "#,
+        )
+        .build();
+
+    p.cargo("metadata")
+        .with_json(
+            r#"
+    {
+        "packages": [
+            {
+                "authors": [
+                    "wycats@example.com"
+                ],
+                "categories": [],
+                "default_run": null,
+                "name": "foo",
+                "version": "0.5.0",
+                "id": "[..]foo#0.5.0",
+                "keywords": [],
+                "source": null,
+                "dependencies": [],
+                "edition": "2015",
+                "license": null,
+                "license_file": null,
+                "links": null,
+                "description": null,
+                "readme": null,
+                "repository": null,
+                "rust_version": null,
+                "homepage": null,
+                "documentation": null,
+                "homepage": null,
+                "documentation": null,
+                "targets": [
+                    {
+                        "kind": [
+                            "lib"
+                        ],
+                        "crate_types": [
+                            "lib"
+                        ],
+                        "doc": true,
+                        "doctest": true,
+                        "test": true,
+                        "edition": "2015",
+                        "name": "foo",
+                        "src_path": "[..]/foo/src/foo.rs"
+                    }
+                ],
+                "features": {},
+                "manifest_path": "[..]Cargo.toml",
+                "metadata": null,
+                "publish": null,
+                "include": [],
+                "exclude": ["./ssh.rs"]
+            }
+        ],
+        "workspace_members": ["path+file:[..]foo#0.5.0"],
+        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
+        "resolve": {
+            "nodes": [
+                {
+                    "dependencies": [],
+                    "deps": [],
+                    "features": [],
+                    "id": "path+file:[..]foo#0.5.0"
+                }
+            ],
+            "root": "path+file:[..]foo#0.5.0"
+        },
+        "target_directory": "[..]foo/target",
+        "version": 1,
+        "workspace_root": "[..]/foo",
+        "metadata": null
+    }"#,
         )
         .run();
 }


### PR DESCRIPTION
I'll need this information to fix https://github.com/rust-lang/rust-clippy/issues/11677. I'll also send a PR to `cargo_metadata` once merged.

Of course, if there is another way to retrieve this information without needing this PR, I'd love to hear it. :)