### PR TITLE
feat(cargo-update): `--precise` to allow yanked versions

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -748,7 +748,7 @@ impl<'cfg> Source for RegistrySource<'cfg> {
             .precise_registry_version(dep.package_name().as_str())
             .filter(|(c, _)| req.matches(c))
         {
-            req.update_precise(&requested);
+            req.precise_to(&requested);
         }
 
         let mut called = false;

--- a/src/cargo/util/semver_ext.rs
+++ b/src/cargo/util/semver_ext.rs
@@ -33,7 +33,11 @@ pub enum OptVersionReq {
     /// The exact locked version and the original version requirement.
     Locked(Version, VersionReq),
     /// The exact requested version and the original version requirement.
-    UpdatePrecise(Version, VersionReq),
+    ///
+    /// This looks identical to [`OptVersionReq::Locked`] but has a different
+    /// meaning, and is used for the `--precise` field of `cargo update`.
+    /// See comments in [`OptVersionReq::matches`] for more.
+    Precise(Version, VersionReq),
 }
 
 impl OptVersionReq {
@@ -51,7 +55,7 @@ impl OptVersionReq {
     pub fn is_exact(&self) -> bool {
         match self {
             OptVersionReq::Any => false,
-            OptVersionReq::Req(req) | OptVersionReq::UpdatePrecise(_, req) => {
+            OptVersionReq::Req(req) | OptVersionReq::Precise(_, req) => {
                 req.comparators.len() == 1 && {
                     let cmp = &req.comparators[0];
                     cmp.op == Op::Exact && cmp.minor.is_some() && cmp.patch.is_some()
@@ -67,18 +71,19 @@ impl OptVersionReq {
         let version = version.clone();
         *self = match self {
             Any => Locked(version, VersionReq::STAR),
-            Req(req) | Locked(_, req) | UpdatePrecise(_, req) => Locked(version, req.clone()),
+            Req(req) | Locked(_, req) | Precise(_, req) => Locked(version, req.clone()),
         };
     }
 
-    pub fn update_precise(&mut self, version: &Version) {
+    /// Makes the requirement precise to the requested version.
+    ///
+    /// This is used for the `--precise` field of `cargo update`.
+    pub fn precise_to(&mut self, version: &Version) {
         use OptVersionReq::*;
         let version = version.clone();
         *self = match self {
-            Any => UpdatePrecise(version, VersionReq::STAR),
-            Req(req) | Locked(_, req) | UpdatePrecise(_, req) => {
-                UpdatePrecise(version, req.clone())
-            }
+            Any => Precise(version, VersionReq::STAR),
+            Req(req) | Locked(_, req) | Precise(_, req) => Precise(version, req.clone()),
         };
     }
 
@@ -108,7 +113,7 @@ impl OptVersionReq {
                 // we should not silently use `1.0.0+foo` even though they have the same version.
                 v == version
             }
-            OptVersionReq::UpdatePrecise(v, _) => {
+            OptVersionReq::Precise(v, _) => {
                 // This is used for the `--precise` field of cargo update.
                 //
                 // Unfortunately crates.io allowed versions to differ only
@@ -135,7 +140,7 @@ impl Display for OptVersionReq {
             OptVersionReq::Any => f.write_str("*"),
             OptVersionReq::Req(req)
             | OptVersionReq::Locked(_, req)
-            | OptVersionReq::UpdatePrecise(_, req) => Display::fmt(req, f),
+            | OptVersionReq::Precise(_, req) => Display::fmt(req, f),
         }
     }
 }

--- a/src/cargo/util/semver_ext.rs
+++ b/src/cargo/util/semver_ext.rs
@@ -87,6 +87,18 @@ impl OptVersionReq {
         };
     }
 
+    pub fn is_precise(&self) -> bool {
+        matches!(self, OptVersionReq::Precise(..))
+    }
+
+    /// Gets the version to which this req is precise to, if any.
+    pub fn precise_version(&self) -> Option<&Version> {
+        match self {
+            OptVersionReq::Precise(version, _) => Some(version),
+            _ => None,
+        }
+    }
+
     pub fn is_locked(&self) -> bool {
         matches!(self, OptVersionReq::Locked(..))
     }

--- a/src/doc/man/cargo-update.md
+++ b/src/doc/man/cargo-update.md
@@ -42,6 +42,10 @@ Cannot be used with `--precise`.
 When used with _spec_, allows you to specify a specific version number to set
 the package to. If the package comes from a git repository, this can be a git
 revision (such as a SHA hash or tag).
+
+While not recommended, you can specify a yanked version of a package (nightly only).
+When possible, try other non-yanked SemVer-compatible versions or seek help
+from the maintainers of the package.
 {{/option}}
 
 {{#option "`-w`" "`--workspace`" }}

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -35,6 +35,11 @@ OPTIONS
            to set the package to. If the package comes from a git repository,
            this can be a git revision (such as a SHA hash or tag).
 
+           While not recommended, you can specify a yanked version of a package
+           (nightly only). When possible, try other non-yanked
+           SemVer-compatible versions or seek help from the maintainers of the
+           package.
+
        -w, --workspace
            Attempt to update only packages defined in the workspace. Other
            packages are updated only if they don’t already exist in the

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -39,7 +39,10 @@ Cannot be used with <code>--precise</code>.</dd>
 <dt class="option-term" id="option-cargo-update---precise"><a class="option-anchor" href="#option-cargo-update---precise"></a><code>--precise</code> <em>precise</em></dt>
 <dd class="option-desc">When used with <em>spec</em>, allows you to specify a specific version number to set
 the package to. If the package comes from a git repository, this can be a git
-revision (such as a SHA hash or tag).</dd>
+revision (such as a SHA hash or tag).</p>
+<p>While not recommended, you can specify a yanked version of a package (nightly only).
+When possible, try other non-yanked SemVer-compatible versions or seek help
+from the maintainers of the package.</dd>
 
 
 <dt class="option-term" id="option-cargo-update--w"><a class="option-anchor" href="#option-cargo-update--w"></a><code>-w</code></dt>

--- a/src/doc/src/reference/resolver.md
+++ b/src/doc/src/reference/resolver.md
@@ -325,9 +325,11 @@ the `links` field if your library is in common use.
 
 [Yanked releases][yank] are those that are marked that they should not be
 used. When the resolver is building the graph, it will ignore all yanked
-releases unless they already exist in the `Cargo.lock` file.
+releases unless they already exist in the `Cargo.lock` file or are explicitly
+requested by the [`--precise`] flag of `cargo update` (nightly only).
 
 [yank]: publishing.md#cargo-yank
+[`--precise`]: ../commands/cargo-update.md#option-cargo-update---precise
 
 ## Dependency updates
 

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -39,6 +39,10 @@ Cannot be used with \fB\-\-precise\fR\&.
 When used with \fIspec\fR, allows you to specify a specific version number to set
 the package to. If the package comes from a git repository, this can be a git
 revision (such as a SHA hash or tag).
+.sp
+While not recommended, you can specify a yanked version of a package (nightly only).
+When possible, try other non\-yanked SemVer\-compatible versions or seek help
+from the maintainers of the package.
 .RE
 .sp
 \fB\-w\fR, 

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1419,9 +1419,8 @@ Caused by:
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[WARNING] yanked package `bar@0.1.1` is selected by the `--precise` flag from registry `dummy-registry`
-[NOTE] it is not recommended to depend on a yanked version
-[NOTE] if possible, try other SemVer-compatbile versions
+[WARNING] selected package `bar@0.1.1` was yanked by the author
+[NOTE] if possible, try a compatible non-yanked version
 [UPDATING] bar v0.1.0 -> v0.1.1
 ",
         )
@@ -1463,12 +1462,8 @@ fn precise_yanked_multiple_presence() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[WARNING] yanked package `bar@0.1.1` is selected by the `--precise` flag from registry `dummy-registry`
-[NOTE] it is not recommended to depend on a yanked version
-[NOTE] if possible, try other SemVer-compatbile versions
-[WARNING] yanked package `bar@0.1.1` is selected by the `--precise` flag from registry `dummy-registry`
-[NOTE] it is not recommended to depend on a yanked version
-[NOTE] if possible, try other SemVer-compatbile versions
+[WARNING] selected package `bar@0.1.1` was yanked by the author
+[NOTE] if possible, try a compatible non-yanked version
 [UPDATING] bar v0.1.0 -> v0.1.1
 ",
         )


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Address #4225

Supports specifying yanked versions via the `--precise` flag of `cargo update`.
This is still behind `-Zunstable-options` nightly flag.


### How should we test and review this PR?

Review this commit by commit.

As Jacob mentioned in <https://github.com/rust-lang/cargo/issues/4225#issuecomment-1863755272>, only indexes in registry sources can be yanked. None of [git source](https://github.com/rust-lang/cargo/blob/7bb7b539558dc88bea44cee4168b6269bf8177b0/src/cargo/sources/git/source.rs#L410-L412), [path source](https://github.com/rust-lang/cargo/blob/7bb7b539558dc88bea44cee4168b6269bf8177b0/src/cargo/sources/path.rs#L609-L611), [directory source](https://github.com/rust-lang/cargo/blob/7bb7b539558dc88bea44cee4168b6269bf8177b0/src/cargo/sources/directory.rs#L264-L266) can. It should be pretty safe not checking sources.

The other thing needing a review is the warning. It is pretty slim at this moment, but a big warning can be added if we want to scare people away from using yanked versions 👻.

### Additional information
<!-- homu-ignore:end -->
