### PR TITLE
Check keywords length during publish --dry-run

### DIFF
--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -407,6 +407,9 @@ fn transmit(
             bail!("the license file `{}` does not exist", file)
         }
     }
+    if keywords.len() > 5 {
+        bail!("Number of keywords in Cargo.toml must be upto 5.")
+    }
 
     // Do not upload if performing a dry run
     if dry_run {


### PR DESCRIPTION
This commit adds a length check on keywords in Cargo.toml. This will ensure that the user is aware of the limit on the length of keywords when running `cargo publish --dry-run`
