### PR TITLE
fix: use spec id instead of name to match package

### DIFF
--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1566,3 +1566,47 @@ fn run_link_system_path_macos() {
     p2.cargo("run").env(VAR, &libdir).run();
     p2.cargo("test").env(VAR, &libdir).run();
 }
+
+#[cargo_test]
+fn run_binary_with_same_name_as_dependency() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                authors = []
+
+                [dependencies]
+                foo = { path = "foo" }
+            "#,
+        )
+        .file(
+            "src/main.rs",
+            r#"
+                fn main() {}
+            "#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                authors = []
+
+                [lib]
+                name = "foo"
+                path = "foo.rs"
+            "#,
+        )
+        .file("foo/foo.rs", "")
+        .build();
+
+    p.cargo("run").run();
+    p.cargo("run -p foo@0.5.0")
+        .with_status(101)
+        .with_stderr("[ERROR] package(s) `foo@0.5.0` not found in workspace [..]")
+        .run();
+}

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1603,10 +1603,7 @@ fn run_binary_with_same_name_as_dependency() {
         )
         .file("foo/foo.rs", "")
         .build();
-
     p.cargo("run").run();
-    p.cargo("run -p foo@0.5.0")
-        .with_status(101)
-        .with_stderr("[ERROR] package(s) `foo@0.5.0` not found in workspace [..]")
-        .run();
+    p.cargo("check -p foo@0.5.0").run();
+    p.cargo("run -p foo@0.5.0").run();
 }

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1606,4 +1606,9 @@ fn run_binary_with_same_name_as_dependency() {
     p.cargo("run").run();
     p.cargo("check -p foo@0.5.0").run();
     p.cargo("run -p foo@0.5.0").run();
+    p.cargo("run -p foo@0.5").run();
+    p.cargo("run -p foo@0.4")
+        .with_status(101)
+        .with_stderr("[ERROR] package(s) `foo@0.4` not found in workspace `[..]`")
+        .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?
close https://github.com/rust-lang/cargo/issues/13310

Users tried `cargo run -p foo@0.5.0`.

The bug came from here:

1. We store the spec as the name in this function: [hi-rustin/cargo@aa64447/src/cargo/ops/cargo_compile/packages.rs#L201](https://github.com/hi-rustin/cargo/blob/aa6444734d0049b3534fa1ae623c55dfbef63412/src/cargo/ops/cargo_compile/packages.rs#L201)
2. But we use it here to match only the name of the package: [hi-rustin/cargo@aa64447/src/cargo/ops/cargo_compile/packages.rs#L128](https://github.com/hi-rustin/cargo/blob/aa6444734d0049b3534fa1ae623c55dfbef63412/src/cargo/ops/cargo_compile/packages.rs#L128)

So `foo@0.5.0` didn't match with `foo`. It said there is no `foo@0.5.0` in the workspace.

In order to resolve this issue, we need to utilize the package specification ID directly. If we only extract the name and drop the version specification, it could potentially lead to another bug. For instance, if you have a package `foo@0.1.1 in your workspace and you intend to use `foo@0.2.2`, extracting only the name would result in the selection of `foo@0.1.1` instead.

So in this PR I parsed the package spec ID and used it to match the package's spec ID.

### How should we test and review this PR?

Check out the unit test.

### Additional information

None

<!-- homu-ignore:end -->
