### PR TITLE
Fix typo in test

### DIFF
--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -675,7 +675,7 @@ fn do_not_strip_debuginfo_with_requested_debug() {
             r#"
                 [package]
                 name = "bar"
-                verison = "0.1.0"
+                version = "0.1.0"
         "#,
         )
         .file("bar/src/lib.rs", "")


### PR DESCRIPTION
The typo was introduced in https://github.com/rust-lang/cargo/pull/13257, it only produced a warning, so it didn't break the test.
Noticed [here](https://github.com/rust-lang/cargo/pull/13257#discussion_r1464506596).