### PR TITLE
fix list option description starting with uppercase

### DIFF
--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -72,7 +72,7 @@ pub fn cli() -> Command {
         .arg(flag("no-track", "Do not save tracking information"))
         .arg(flag(
             "list",
-            "list all installed packages and their versions",
+            "List all installed packages and their versions",
         ))
         .arg_ignore_rust_version()
         .arg_message_format()

--- a/tests/testsuite/cargo_install/help/stdout.log
+++ b/tests/testsuite/cargo_install/help/stdout.log
@@ -17,7 +17,7 @@ Options:
       --root <DIR>            Directory to install packages into
   -f, --force                 Force overwriting existing crates or binaries
       --no-track              Do not save tracking information
-      --list                  list all installed packages and their versions
+      --list                  List all installed packages and their versions
       --ignore-rust-version   Ignore `rust-version` specification in packages
       --message-format <FMT>  Error format
       --debug                 Build in debug mode (with the 'dev' profile) instead of release mode


### PR DESCRIPTION
All options' description start with uppercase except list.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?
Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
