### PR TITLE
[WIP] feat(cargo-vendor): vendor path dep if it is not in any given workspaces

### DIFF
--- a/src/cargo/sources/config.rs
+++ b/src/cargo/sources/config.rs
@@ -33,6 +33,8 @@ pub struct SourceConfigMap<'gctx> {
 struct SourceConfigDef {
     /// Indicates this source should be replaced with another of the given name.
     replace_with: OptValue<String>,
+    /// A path source.
+    path: Option<ConfigRelativePath>,
     /// A directory source.
     directory: Option<ConfigRelativePath>,
     /// A registry source. Value is a URL.
@@ -248,6 +250,10 @@ restore the source replacement configuration to continue the build
         if let Some(directory) = def.directory {
             let path = directory.resolve_path(self.gctx);
             srcs.push(SourceId::for_directory(&path)?);
+        }
+        if let Some(path) = def.path {
+            let path = path.resolve_path(self.config);
+            srcs.push(SourceId::for_path(&path)?);
         }
         if let Some(git) = def.git {
             let url = url(&git, &format!("source.{}.git", name))?;


### PR DESCRIPTION


### What does this PR try to resolve?

feat(cargo-vendor): vendor path dep if it is not in any given workspaces

Generally cargo don't vendor path dependencies.
This seems quiet reasonable path dependencies are "local" comparing
to git or registry dependencies, and usually under the user's control.
However, it is not always the case.

A workspace might contain

* any `[patch]` to local path dependencies
* a set of shared path dependencies outside the current workspace

These use cases demonstrate that users might not have controls or
permissions to those dependencies. When they want to create a
reproducible tarball for their own workspace, `cargo vendor` is not a
tool helping them achieve the goal.

There is one workaround: Have a `[patch]` to a local git repository
instead of a lcoal path dependency. This is not ergonomic and adds
overhead of setting git repositories.

This PR proposes that Cargo vendors path dependencies if they are
not belong to any given workspaces.

As a side effect, this exposes a new  `[source]` kind `path`:

```toml
[source."path+file:///path/to/package"]
path = "/path/to/package"
replace-with = "vendored-sources"
```

### How should we test and review this PR?

This is a proof-of-concept, not ready for serious code review.

### Additional information

An alternative to #12858
Fixes #9172
Possibly also #10134, but I am not sure if they intend to vendor workspace members.
<!-- homu-ignore:end -->
