### PR TITLE
fix(config): Deprecate non-extension files 

### DIFF
--- a/crates/cargo-test-support/src/registry.rs
+++ b/crates/cargo-test-support/src/registry.rs
@@ -279,7 +279,7 @@ impl RegistryBuilder {
     /// Initializes the registry.
     #[must_use]
     pub fn build(self) -> TestRegistry {
-        let config_path = paths::home().join(".cargo/config");
+        let config_path = paths::home().join(".cargo/config.toml");
         t!(fs::create_dir_all(config_path.parent().unwrap()));
         let prefix = if let Some(alternative) = &self.alternative {
             format!("{alternative}-")
@@ -1195,7 +1195,7 @@ impl Package {
     /// Creates a new package builder.
     /// Call `publish()` to finalize and build the package.
     pub fn new(name: &str, vers: &str) -> Package {
-        let config = paths::home().join(".cargo/config");
+        let config = paths::home().join(".cargo/config.toml");
         if !config.exists() {
             init();
         }

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -1507,7 +1507,7 @@ impl Config {
         let possible_with_extension = dir.join(format!("{}.toml", filename_without_extension));
 
         if possible.exists() {
-            if warn && possible_with_extension.exists() {
+            if warn {
                 // We don't want to print a warning if the version
                 // without the extension is just a symlink to the version
                 // WITH an extension, which people may want to do to
@@ -1520,12 +1520,22 @@ impl Config {
                 };
 
                 if !skip_warning {
-                    self.shell().warn(format!(
-                        "Both `{}` and `{}` exist. Using `{}`",
-                        possible.display(),
-                        possible_with_extension.display(),
-                        possible.display()
-                    ))?;
+                    if possible_with_extension.exists() {
+                        self.shell().warn(format!(
+                            "Both `{}` and `{}` exist. Using `{}`",
+                            possible.display(),
+                            possible_with_extension.display(),
+                            possible.display()
+                        ))?;
+                    } else {
+                        self.shell().warn(format!(
+                            "`{}` is deprecated in favor of `{filename_without_extension}.toml`",
+                            possible.display(),
+                        ))?;
+                        self.shell().note(
+                            format!("If you need to support cargo 1.38 or earlier, you can symlink `{filename_without_extension}` to `{filename_without_extension}.toml`"),
+                        )?;
+                    }
                 }
             }
 

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -621,7 +621,7 @@ You may press ctrl-c to skip waiting; the crate should be available shortly.
 fn passwords_in_registries_index_url_forbidden() {
     registry::alt_init();
 
-    let config = paths::home().join(".cargo/config");
+    let config = paths::home().join(".cargo/config.toml");
 
     fs::write(
         config,
@@ -638,7 +638,7 @@ fn passwords_in_registries_index_url_forbidden() {
         .with_status(101)
         .with_stderr(
             "\
-error: invalid index URL for registry `alternative` defined in [..]/home/.cargo/config
+error: invalid index URL for registry `alternative` defined in [..]/home/.cargo/config.toml
 
 Caused by:
   registry URLs may not contain passwords
@@ -1153,7 +1153,7 @@ fn unknown_registry() {
         .publish();
 
     // Remove "alternative" from config.
-    let cfg_path = paths::home().join(".cargo/config");
+    let cfg_path = paths::home().join(".cargo/config.toml");
     let mut config = fs::read_to_string(&cfg_path).unwrap();
     let start = config.find("[registries.alternative]").unwrap();
     config.insert(start, '#');
@@ -1296,7 +1296,7 @@ fn unknown_registry() {
 #[cargo_test]
 fn registries_index_relative_url() {
     registry::alt_init();
-    let config = paths::root().join(".cargo/config");
+    let config = paths::root().join(".cargo/config.toml");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(
         &config,
@@ -1343,7 +1343,7 @@ fn registries_index_relative_url() {
 #[cargo_test]
 fn registries_index_relative_path_not_allowed() {
     registry::alt_init();
-    let config = paths::root().join(".cargo/config");
+    let config = paths::root().join(".cargo/config.toml");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(
         &config,
@@ -1379,7 +1379,7 @@ fn registries_index_relative_path_not_allowed() {
 error: failed to parse manifest at `{root}/foo/Cargo.toml`
 
 Caused by:
-  invalid index URL for registry `relative` defined in [..]/.cargo/config
+  invalid index URL for registry `relative` defined in [..]/.cargo/config.toml
 
 Caused by:
   invalid url `alternative-registry`: relative URL without a base

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -9,7 +9,7 @@ fn bad1() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                   [target]
                   nonexistent-target = "foo"
@@ -21,7 +21,7 @@ fn bad1() {
         .with_stderr(
             "\
 [ERROR] expected table for configuration key `target.nonexistent-target`, \
-but found string in [..]/config
+but found string in [..]/config.toml
 ",
         )
         .run();
@@ -32,7 +32,7 @@ fn bad2() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                   [http]
                     proxy = 3.0
@@ -46,7 +46,7 @@ fn bad2() {
 [ERROR] could not load Cargo configuration
 
 Caused by:
-  failed to load TOML configuration from `[..]config`
+  failed to load TOML configuration from `[..]config.toml`
 
 Caused by:
   failed to parse key `http`
@@ -67,7 +67,7 @@ fn bad3() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [http]
                   proxy = true
@@ -84,7 +84,7 @@ fn bad3() {
 error: failed to update registry [..]
 
 Caused by:
-  error in [..]config: `http.proxy` expected a string, but found a boolean
+  error in [..]config.toml: `http.proxy` expected a string, but found a boolean
 ",
         )
         .run();
@@ -94,7 +94,7 @@ Caused by:
 fn bad4() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [cargo-new]
                   vcs = false
@@ -108,7 +108,7 @@ fn bad4() {
 [ERROR] Failed to create package `foo` at `[..]`
 
 Caused by:
-  error in [..]config: `cargo-new.vcs` expected a string, but found a boolean
+  error in [..]config.toml: `cargo-new.vcs` expected a string, but found a boolean
 ",
         )
         .run();
@@ -120,7 +120,7 @@ fn bad6() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [http]
                   user-agent = true
@@ -137,7 +137,7 @@ fn bad6() {
 error: failed to update registry [..]
 
 Caused by:
-  error in [..]config: `http.user-agent` expected a string, but found a boolean
+  error in [..]config.toml: `http.user-agent` expected a string, but found a boolean
 ",
         )
         .run();
@@ -158,7 +158,7 @@ fn invalid_global_config() {
                 foo = "0.1.0"
             "#,
         )
-        .file(".cargo/config", "4")
+        .file(".cargo/config.toml", "4")
         .file("src/lib.rs", "")
         .build();
 
@@ -788,7 +788,7 @@ or workspace dependency to use. This will be considered an error in future versi
 #[cargo_test]
 fn invalid_toml_historically_allowed_fails() {
     let p = project()
-        .file(".cargo/config", "[bar] baz = 2")
+        .file(".cargo/config.toml", "[bar] baz = 2")
         .file("src/main.rs", "fn main() {}")
         .build();
 
@@ -880,7 +880,7 @@ use `rev = \"foo\"` in the dependency declaration.
 fn bad_source_config1() {
     let p = project()
         .file("src/lib.rs", "")
-        .file(".cargo/config", "[source.foo]")
+        .file(".cargo/config.toml", "[source.foo]")
         .build();
 
     p.cargo("check")
@@ -906,7 +906,7 @@ fn bad_source_config2() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.crates-io]
                 registry = 'http://example.com'
@@ -952,7 +952,7 @@ fn bad_source_config3() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.crates-io]
                 registry = 'https://example.com'
@@ -997,7 +997,7 @@ fn bad_source_config4() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.crates-io]
                 replace-with = 'bar'
@@ -1046,7 +1046,7 @@ fn bad_source_config5() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.crates-io]
                 registry = 'https://example.com'
@@ -1120,7 +1120,7 @@ fn bad_source_config6() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.crates-io]
                 registry = 'https://example.com'
@@ -1133,10 +1133,10 @@ fn bad_source_config6() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..]/foo/.cargo/config: could not load config key `source.crates-io.replace-with`
+[ERROR] error in [..]/foo/.cargo/config.toml: could not load config key `source.crates-io.replace-with`
 
 Caused by:
-  error in [..]/foo/.cargo/config: `source.crates-io.replace-with` expected a string, but found a array
+  error in [..]/foo/.cargo/config.toml: `source.crates-io.replace-with` expected a string, but found a array
 "
         )
         .run();
@@ -1207,7 +1207,7 @@ fn bad_source_config7() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.foo]
                 registry = 'https://example.com'
@@ -1241,7 +1241,7 @@ fn bad_source_config8() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.foo]
                 branch = "somebranch"
@@ -1253,7 +1253,7 @@ fn bad_source_config8() {
         .with_status(101)
         .with_stderr(
             "[ERROR] source definition `source.foo` specifies `branch`, \
-             but that requires a `git` key to be specified (in [..]/foo/.cargo/config)",
+             but that requires a `git` key to be specified (in [..]/foo/.cargo/config.toml)",
         )
         .run();
 }
@@ -1532,7 +1532,7 @@ fn bad_target_cfg() {
     // the message.
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [target.'cfg(not(target_os = "none"))']
             runner = false
@@ -1545,17 +1545,17 @@ fn bad_target_cfg() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..]/foo/.cargo/config: \
+[ERROR] error in [..]/foo/.cargo/config.toml: \
 could not load config key `target.\"cfg(not(target_os = \\\"none\\\"))\".runner`
 
 Caused by:
-  error in [..]/foo/.cargo/config: \
+  error in [..]/foo/.cargo/config.toml: \
   could not load config key `target.\"cfg(not(target_os = \\\"none\\\"))\".runner`
 
 Caused by:
   invalid configuration for key `target.\"cfg(not(target_os = \\\"none\\\"))\".runner`
   expected a string or array of strings, but found a boolean for \
-  `target.\"cfg(not(target_os = \\\"none\\\"))\".runner` in [..]/foo/.cargo/config
+  `target.\"cfg(not(target_os = \\\"none\\\"))\".runner` in [..]/foo/.cargo/config.toml
 ",
         )
         .run();
@@ -1571,7 +1571,7 @@ fn bad_target_links_overrides() {
     // currently is designed with serde.
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [target.{}.somelib]
@@ -1587,12 +1587,12 @@ fn bad_target_links_overrides() {
         .with_status(101)
         .with_stderr(
             "[ERROR] Only `-l` and `-L` flags are allowed in target config \
-             `target.[..].rustc-flags` (in [..]foo/.cargo/config): `foo`",
+             `target.[..].rustc-flags` (in [..]foo/.cargo/config.toml): `foo`",
         )
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         &format!(
             "[target.{}.somelib]
             warning = \"foo\"
@@ -1611,7 +1611,7 @@ fn redefined_sources() {
     // Cannot define a source multiple times.
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [source.foo]
             registry = "https://github.com/rust-lang/crates.io-index"
@@ -1632,7 +1632,7 @@ note: Sources are not allowed to be defined multiple times.
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
         [source.one]
         directory = "index"

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -116,7 +116,7 @@ fn incremental_config() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 incremental = false
@@ -3316,7 +3316,7 @@ fn bad_cargo_config() {
     let foo = project()
         .file("Cargo.toml", &basic_manifest("foo", "0.0.0"))
         .file("src/lib.rs", "")
-        .file(".cargo/config", "this is not valid toml")
+        .file(".cargo/config.toml", "this is not valid toml")
         .build();
     foo.cargo("build -v")
         .with_status(101)
@@ -3945,7 +3945,7 @@ fn custom_target_dir_env() {
     assert!(p.root().join("foo2/target/debug").join(&exe_name).is_file());
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
             [build]
             target-dir = "foo/target"
@@ -3972,7 +3972,7 @@ fn custom_target_dir_line_parameter() {
     assert!(p.root().join("target/debug").join(&exe_name).is_file());
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
             [build]
             target-dir = "foo/target"
@@ -5881,7 +5881,7 @@ fn default_cargo_config_jobs() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 jobs = 1
@@ -5896,7 +5896,7 @@ fn good_cargo_config_jobs() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 jobs = 4
@@ -5925,7 +5925,7 @@ fn invalid_cargo_config_jobs() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 jobs = 0

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -255,7 +255,7 @@ fn custom_build_env_var_rustflags() {
     let rustflags_alt = "--cfg=notspecial";
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [build]
@@ -300,7 +300,7 @@ fn custom_build_env_var_encoded_rustflags() {
     // thing either way.
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["-Clink-arg=-B nope", "--cfg=foo"]
@@ -426,7 +426,7 @@ fn custom_build_env_var_rustc_linker() {
     let target = cross_compile::alternate();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [target.{}]
@@ -466,7 +466,7 @@ fn custom_build_env_var_rustc_linker_with_target_cfg() {
     let target = cross_compile::alternate();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [target.'cfg(target_pointer_width = "32")']
             linker = "/path/to/linker"
@@ -495,7 +495,7 @@ fn custom_build_env_var_rustc_linker_bad_host_target() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [target.{}]
@@ -526,7 +526,7 @@ fn custom_build_env_var_rustc_linker_host_target() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 target-applies-to-host = false
@@ -562,7 +562,7 @@ fn custom_build_env_var_rustc_linker_host_target_env() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [target.{}]
@@ -598,7 +598,7 @@ fn custom_build_invalid_host_config_feature_flag() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [target.{}]
@@ -629,7 +629,7 @@ fn custom_build_linker_host_target_with_bad_host_config() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [host]
@@ -664,7 +664,7 @@ fn custom_build_linker_bad_host() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [host]
@@ -699,7 +699,7 @@ fn custom_build_linker_bad_host_with_arch() {
     let target = rustc_host();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [host]
@@ -737,7 +737,7 @@ fn custom_build_env_var_rustc_linker_cross_arch_host() {
     let cross_target = cross_compile::alternate();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [host.{}]
@@ -775,7 +775,7 @@ fn custom_build_linker_bad_cross_arch_host() {
     let cross_target = cross_compile::alternate();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [host]
@@ -1186,7 +1186,7 @@ fn overrides_and_links() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.foo]
@@ -1245,7 +1245,7 @@ fn unused_overrides() {
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.foo]
@@ -1538,7 +1538,7 @@ fn propagation_of_l_flags() {
         .file("b/src/lib.rs", "")
         .file("b/build.rs", "bad file")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.foo]
@@ -1613,7 +1613,7 @@ fn propagation_of_l_flags_new() {
         .file("b/src/lib.rs", "")
         .file("b/build.rs", "bad file")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.foo]
@@ -2511,7 +2511,7 @@ fn cfg_override() {
         .file("src/main.rs", "#[cfg(foo)] fn main() {}")
         .file("build.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.a]
@@ -2646,7 +2646,7 @@ fn cfg_override_test() {
         )
         .file("build.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.a]
@@ -2716,7 +2716,7 @@ fn cfg_override_doc() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{target}.a]
@@ -3041,7 +3041,7 @@ fn adding_an_override_invalidates() {
             "#,
         )
         .file("src/lib.rs", "")
-        .file(".cargo/config", "")
+        .file(".cargo/config.toml", "")
         .file(
             "build.rs",
             r#"
@@ -3065,7 +3065,7 @@ fn adding_an_override_invalidates() {
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         &format!(
             "
                 [target.{}.foo]
@@ -3103,7 +3103,7 @@ fn changing_an_override_invalidates() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [target.{}.foo]
@@ -3126,7 +3126,7 @@ fn changing_an_override_invalidates() {
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         &format!(
             "
                 [target.{}.foo]
@@ -3166,7 +3166,7 @@ fn fresh_builds_possible_with_link_libs() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [target.{}.nativefoo]
@@ -3218,7 +3218,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [target.{}.foo]
@@ -3662,7 +3662,7 @@ fn custom_target_dir() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 target-dir = 'test'
@@ -4008,7 +4008,7 @@ fn links_with_dots() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.'a.b']

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -11,7 +11,7 @@ fn alias_incorrect_config_type() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 b-cargo-test = 5
@@ -35,7 +35,7 @@ fn alias_malformed_config_string() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 b-cargo-test = `
@@ -50,7 +50,7 @@ fn alias_malformed_config_string() {
 [ERROR] could not load Cargo configuration
 
 Caused by:
-  could not parse TOML configuration in `[..]/config`
+  could not parse TOML configuration in `[..]/config.toml`
 
 Caused by:
   TOML parse error at line [..]
@@ -70,7 +70,7 @@ fn alias_malformed_config_list() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 b-cargo-test = [1, 2]
@@ -85,7 +85,7 @@ fn alias_malformed_config_list() {
 [ERROR] could not load Cargo configuration
 
 Caused by:
-  failed to load TOML configuration from `[..]/config`
+  failed to load TOML configuration from `[..]/config.toml`
 
 Caused by:
   [..] `alias`
@@ -106,7 +106,7 @@ fn alias_config() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 b-cargo-test = "build"
@@ -129,7 +129,7 @@ fn dependent_alias() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 b-cargo-test = "build"
@@ -178,7 +178,7 @@ fn alias_shadowing_external_subcommand() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 echo = "build"
@@ -210,7 +210,7 @@ fn default_args_alias() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 echo = "echo --flag1 --flag2"
@@ -266,7 +266,7 @@ fn corecursive_alias() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [alias]
                 test-1 = "test-2 --flag1"
@@ -297,7 +297,7 @@ fn alias_list_test() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                [alias]
                b-cargo-test = ["build", "--release"]
@@ -317,7 +317,7 @@ fn alias_with_flags_config() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                [alias]
                b-cargo-test = "build --release"
@@ -337,7 +337,7 @@ fn alias_cannot_shadow_builtin_command() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                [alias]
                build = "fetch"
@@ -362,7 +362,7 @@ fn alias_override_builtin_alias() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                [alias]
                b = "run"

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -18,7 +18,7 @@ fn env_basic() {
         "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [env]
                 ENV_TEST_1233 = "Hello"
@@ -44,7 +44,7 @@ fn env_invalid() {
         "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [env]
                 ENV_TEST_BOOL = false
@@ -68,7 +68,7 @@ fn env_no_disallowed() {
 
     for disallowed in &["CARGO_HOME", "RUSTUP_HOME", "RUSTUP_TOOLCHAIN"] {
         p.change_file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [env]
@@ -102,7 +102,7 @@ fn env_force() {
         "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [env]
                 ENV_TEST_UNFORCED_DEFAULT = "from-config"
@@ -143,7 +143,7 @@ fn env_relative() {
         "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [env]
                 ENV_TEST_REGULAR = { value = "Cargo.toml", relative = false }
@@ -170,7 +170,7 @@ fn env_no_override() {
         "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [env]
                 CARGO_PKG_NAME = { value = "from-config", force = true }
@@ -216,7 +216,7 @@ fn env_applied_to_target_info_discovery_rustc() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [env]
                 ENV_TEST = "from-config"

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -377,7 +377,7 @@ error: the feature `unstable-options` is not in the list of allowed features: [p
         )
         .run();
 
-    // -Zallow-features overrides .cargo/config
+    // -Zallow-features overrides .cargo/config.toml
     p.cargo("-Zallow-features=test-dummy-unstable -Zprint-im-a-teapot check")
         .masquerade_as_nightly_cargo(&[
             "allow-features",

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -410,7 +410,7 @@ fn build_script_override() {
         .file("src/main.rs", "fn main() {}")
         .file("build.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.a]
@@ -444,7 +444,7 @@ fn build_script_override_feature_gate() {
         .file("src/main.rs", "fn main() {}")
         .file("build.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.a]

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -272,6 +272,10 @@ f1 = 1
     let config = new_config();
 
     assert_eq!(config.get::<Option<i32>>("foo.f1").unwrap(), Some(1));
+
+    // It should NOT have warned for the symlink.
+    let output = read_output(config);
+    assert_eq!(output, "");
 }
 
 #[cargo_test]

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -275,7 +275,10 @@ f1 = 1
 
     // It should NOT have warned for the symlink.
     let output = read_output(config);
-    assert_match("", &output);
+    let expected = "\
+warning: `[ROOT]/.cargo/config` is deprecated in favor of `config.toml`
+note: If you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`";
+    assert_match(expected, &output);
 }
 
 #[cargo_test]

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -275,7 +275,7 @@ f1 = 1
 
     // It should NOT have warned for the symlink.
     let output = read_output(config);
-    assert_eq!(output, "");
+    assert_match("", &output);
 }
 
 #[cargo_test]
@@ -301,7 +301,7 @@ f1 = 1
 
     // It should NOT have warned for the symlink.
     let output = read_output(config);
-    assert_eq!(output, "");
+    assert_match("", &output);
 }
 
 #[cargo_test]

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -158,7 +158,7 @@ fn read_env_vars_for_config() {
     p.cargo("check").env("CARGO_BUILD_JOBS", "100").run();
 }
 
-pub fn write_config(config: &str) {
+pub fn write_config_extless(config: &str) {
     write_config_at(paths::root().join(".cargo/config"), config);
 }
 
@@ -215,7 +215,7 @@ pub fn assert_match(expected: &str, actual: &str) {
 
 #[cargo_test]
 fn get_config() {
-    write_config(
+    write_config_toml(
         "\
 [S]
 f1 = 123
@@ -261,8 +261,8 @@ fn environment_variable_casing() {
 }
 
 #[cargo_test]
-fn config_works_with_extension() {
-    write_config_toml(
+fn config_works_without_extension() {
+    write_config_extless(
         "\
 [foo]
 f1 = 1
@@ -302,7 +302,7 @@ f1 = 1
 
 #[cargo_test]
 fn config_ambiguous_filename() {
-    write_config(
+    write_config_extless(
         "\
 [foo]
 f1 = 1
@@ -332,7 +332,7 @@ warning: Both `[..]/.cargo/config` and `[..]/.cargo/config.toml` exist. Using `[
 
 #[cargo_test]
 fn config_unused_fields() {
-    write_config(
+    write_config_toml(
         "\
 [S]
 unused = 456
@@ -359,14 +359,14 @@ unused = 456
     // Verify the warnings.
     let output = read_output(config);
     let expected = "\
-warning: unused config key `S.unused` in `[..]/.cargo/config`
+warning: unused config key `S.unused` in `[..]/.cargo/config.toml`
 ";
     assert_match(expected, &output);
 }
 
 #[cargo_test]
 fn config_load_toml_profile() {
-    write_config(
+    write_config_toml(
         "\
 [profile.dev]
 opt-level = 's'
@@ -483,7 +483,7 @@ fn profile_env_var_prefix() {
 fn config_deserialize_any() {
     // Some tests to exercise deserialize_any for deserializers that need to
     // be told the format.
-    write_config(
+    write_config_toml(
         "\
 a = true
 b = ['b']
@@ -546,10 +546,10 @@ Caused by:
     assert_error(
         config.unwrap_err(),
         "\
-failed to merge --config key `a` into `[..]/.cargo/config`
+failed to merge --config key `a` into `[..]/.cargo/config.toml`
 
 Caused by:
-  failed to merge config value from `--config cli option` into `[..]/.cargo/config`: \
+  failed to merge config value from `--config cli option` into `[..]/.cargo/config.toml`: \
 expected boolean, but found array",
     );
 
@@ -583,7 +583,7 @@ expected boolean, but found array",
 
 #[cargo_test]
 fn config_toml_errors() {
-    write_config(
+    write_config_toml(
         "\
 [profile.dev]
 opt-level = 'foo'
@@ -597,7 +597,7 @@ opt-level = 'foo'
             .get::<cargo_toml::TomlProfile>("profile.dev")
             .unwrap_err(),
         "\
-error in [..]/.cargo/config: could not load config key `profile.dev.opt-level`
+error in [..]/.cargo/config.toml: could not load config key `profile.dev.opt-level`
 
 Caused by:
   must be `0`, `1`, `2`, `3`, `s` or `z`, but found the string: \"foo\"",
@@ -619,7 +619,7 @@ Caused by:
 
 #[cargo_test]
 fn load_nested() {
-    write_config(
+    write_config_toml(
         "\
 [nest.foo]
 f1 = 1
@@ -656,7 +656,7 @@ asdf = 3
 
 #[cargo_test]
 fn get_errors() {
-    write_config(
+    write_config_toml(
         "\
 [S]
 f1 = 123
@@ -679,12 +679,12 @@ big = 123456789
     );
     assert_error(
         config.get::<i64>("S.f2").unwrap_err(),
-        "error in [..]/.cargo/config: `S.f2` expected an integer, but found a string",
+        "error in [..]/.cargo/config.toml: `S.f2` expected an integer, but found a string",
     );
     assert_error(
         config.get::<u8>("S.big").unwrap_err(),
         "\
-error in [..].cargo/config: could not load config key `S.big`
+error in [..].cargo/config.toml: could not load config key `S.big`
 
 Caused by:
   invalid value: integer `123456789`, expected u8",
@@ -717,7 +717,7 @@ Caused by:
 
 #[cargo_test]
 fn config_get_option() {
-    write_config(
+    write_config_toml(
         "\
 [foo]
 f1 = 1
@@ -735,7 +735,7 @@ f1 = 1
 
 #[cargo_test]
 fn config_bad_toml() {
-    write_config("asdf");
+    write_config_toml("asdf");
     let config = new_config();
     assert_error(
         config.get::<i32>("foo").unwrap_err(),
@@ -743,7 +743,7 @@ fn config_bad_toml() {
 could not load Cargo configuration
 
 Caused by:
-  could not parse TOML configuration in `[..]/.cargo/config`
+  could not parse TOML configuration in `[..]/.cargo/config.toml`
 
 Caused by:
   TOML parse error at line 1, column 5
@@ -756,7 +756,7 @@ expected `.`, `=`",
 
 #[cargo_test]
 fn config_get_list() {
-    write_config(
+    write_config_toml(
         "\
 l1 = []
 l2 = ['one', 'two']
@@ -797,7 +797,7 @@ l = ['y']
         config.get::<L>("l3").unwrap_err(),
         "\
 invalid configuration for key `l3`
-expected a list, but found a integer for `l3` in [..]/.cargo/config",
+expected a list, but found a integer for `l3` in [..]/.cargo/config.toml",
     );
     assert_eq!(
         config.get::<L>("l4").unwrap(),
@@ -879,7 +879,7 @@ expected `]`
 
 #[cargo_test]
 fn config_get_other_types() {
-    write_config(
+    write_config_toml(
         "\
 ns = 123
 ns2 = 456
@@ -905,7 +905,7 @@ ns2 = 456
 
 #[cargo_test]
 fn config_relative_path() {
-    write_config(&format!(
+    write_config_toml(&format!(
         "\
 p1 = 'foo/bar'
 p2 = '../abc'
@@ -959,7 +959,7 @@ abs = '{}'
 
 #[cargo_test]
 fn config_get_integers() {
-    write_config(
+    write_config_toml(
         "\
 npos = 123456789
 nneg = -123456789
@@ -993,7 +993,7 @@ i64max = 9223372036854775807
     assert_error(
         config.get::<u32>("nneg").unwrap_err(),
         "\
-error in [..].cargo/config: could not load config key `nneg`
+error in [..].cargo/config.toml: could not load config key `nneg`
 
 Caused by:
   invalid value: integer `-123456789`, expected u32",
@@ -1009,7 +1009,7 @@ Caused by:
     assert_error(
         config.get::<i8>("npos").unwrap_err(),
         "\
-error in [..].cargo/config: could not load config key `npos`
+error in [..].cargo/config.toml: could not load config key `npos`
 
 Caused by:
   invalid value: integer `123456789`, expected i8",
@@ -1026,7 +1026,7 @@ Caused by:
 
 #[cargo_test]
 fn config_get_ssl_version_missing() {
-    write_config(
+    write_config_toml(
         "\
 [http]
 hello = 'world'
@@ -1043,7 +1043,7 @@ hello = 'world'
 
 #[cargo_test]
 fn config_get_ssl_version_single() {
-    write_config(
+    write_config_toml(
         "\
 [http]
 ssl-version = 'tlsv1.2'
@@ -1064,7 +1064,7 @@ ssl-version = 'tlsv1.2'
 
 #[cargo_test]
 fn config_get_ssl_version_min_max() {
-    write_config(
+    write_config_toml(
         "\
 [http]
 ssl-version.min = 'tlsv1.2'
@@ -1090,7 +1090,7 @@ ssl-version.max = 'tlsv1.3'
 #[cargo_test]
 fn config_get_ssl_version_both_forms_configured() {
     // this is not allowed
-    write_config(
+    write_config_toml(
         "\
 [http]
 ssl-version = 'tlsv1.1'
@@ -1109,7 +1109,7 @@ ssl-version.max = 'tlsv1.3'
 could not load Cargo configuration
 
 Caused by:
-  could not parse TOML configuration in `[..]/.cargo/config`
+  could not parse TOML configuration in `[..]/.cargo/config.toml`
 
 Caused by:
   TOML parse error at line 3, column 1
@@ -1125,7 +1125,7 @@ dotted key `ssl-version` attempted to extend non-table type (string)
 /// Assert that unstable options can be configured with the `unstable` table in
 /// cargo config files
 fn unstable_table_notation() {
-    write_config(
+    write_config_toml(
         "\
 [unstable]
 print-im-a-teapot = true
@@ -1138,7 +1138,7 @@ print-im-a-teapot = true
 #[cargo_test]
 /// Assert that dotted notation works for configuring unstable options
 fn unstable_dotted_notation() {
-    write_config(
+    write_config_toml(
         "\
 unstable.print-im-a-teapot = true
 ",
@@ -1150,7 +1150,7 @@ unstable.print-im-a-teapot = true
 #[cargo_test]
 /// Assert that Zflags on the CLI take precedence over those from config
 fn unstable_cli_precedence() {
-    write_config(
+    write_config_toml(
         "\
 unstable.print-im-a-teapot = true
 ",
@@ -1168,7 +1168,7 @@ unstable.print-im-a-teapot = true
 /// Assert that attempting to set an unstable flag that doesn't exist via config
 /// is ignored on stable
 fn unstable_invalid_flag_ignored_on_stable() {
-    write_config(
+    write_config_toml(
         "\
 unstable.an-invalid-flag = 'yes'
 ",
@@ -1180,7 +1180,7 @@ unstable.an-invalid-flag = 'yes'
 /// Assert that unstable options can be configured with the `unstable` table in
 /// cargo config files
 fn unstable_flags_ignored_on_stable() {
-    write_config(
+    write_config_toml(
         "\
 [unstable]
 print-im-a-teapot = true
@@ -1195,14 +1195,14 @@ print-im-a-teapot = true
 fn table_merge_failure() {
     // Config::merge fails to merge entries in two tables.
     write_config_at(
-        "foo/.cargo/config",
+        "foo/.cargo/config.toml",
         "
         [table]
         key = ['foo']
         ",
     );
     write_config_at(
-        ".cargo/config",
+        ".cargo/config.toml",
         "
         [table]
         key = 'bar'
@@ -1221,16 +1221,16 @@ fn table_merge_failure() {
 could not load Cargo configuration
 
 Caused by:
-  failed to merge configuration at `[..]/.cargo/config`
+  failed to merge configuration at `[..]/.cargo/config.toml`
 
 Caused by:
-  failed to merge key `table` between [..]/foo/.cargo/config and [..]/.cargo/config
+  failed to merge key `table` between [..]/foo/.cargo/config.toml and [..]/.cargo/config.toml
 
 Caused by:
-  failed to merge key `key` between [..]/foo/.cargo/config and [..]/.cargo/config
+  failed to merge key `key` between [..]/foo/.cargo/config.toml and [..]/.cargo/config.toml
 
 Caused by:
-  failed to merge config value from `[..]/.cargo/config` into `[..]/foo/.cargo/config`: \
+  failed to merge config value from `[..]/.cargo/config.toml` into `[..]/foo/.cargo/config.toml`: \
   expected array, but found string",
     );
 }
@@ -1238,7 +1238,7 @@ Caused by:
 #[cargo_test]
 fn non_string_in_array() {
     // Currently only strings are supported.
-    write_config("foo = [1, 2, 3]");
+    write_config_toml("foo = [1, 2, 3]");
     let config = new_config();
     assert_error(
         config.get::<Vec<i32>>("foo").unwrap_err(),
@@ -1246,7 +1246,7 @@ fn non_string_in_array() {
 could not load Cargo configuration
 
 Caused by:
-  failed to load TOML configuration from `[..]/.cargo/config`
+  failed to load TOML configuration from `[..]/.cargo/config.toml`
 
 Caused by:
   failed to parse key `foo`
@@ -1440,16 +1440,16 @@ fn string_list_tricky_env() {
 #[cargo_test]
 fn string_list_wrong_type() {
     // What happens if StringList is given then wrong type.
-    write_config("some_list = 123");
+    write_config_toml("some_list = 123");
     let config = ConfigBuilder::new().build();
     assert_error(
         config.get::<StringList>("some_list").unwrap_err(),
         "\
 invalid configuration for key `some_list`
-expected a string or array of strings, but found a integer for `some_list` in [..]/.cargo/config",
+expected a string or array of strings, but found a integer for `some_list` in [..]/.cargo/config.toml",
     );
 
-    write_config("some_list = \"1 2\"");
+    write_config_toml("some_list = \"1 2\"");
     let config = ConfigBuilder::new().build();
     let x = config.get::<StringList>("some_list").unwrap();
     assert_eq!(x.as_slice(), &["1".to_string(), "2".to_string()]);
@@ -1476,7 +1476,7 @@ fn string_list_advanced_env() {
 
 #[cargo_test]
 fn parse_strip_with_string() {
-    write_config(
+    write_config_toml(
         "\
 [profile.release]
 strip = 'debuginfo'
@@ -1495,7 +1495,7 @@ strip = 'debuginfo'
 
 #[cargo_test]
 fn cargo_target_empty_cfg() {
-    write_config(
+    write_config_toml(
         "\
 [build]
 target-dir = ''
@@ -1506,7 +1506,7 @@ target-dir = ''
 
     assert_error(
         config.target_dir().unwrap_err(),
-        "the target directory is set to an empty string in [..]/.cargo/config",
+        "the target directory is set to an empty string in [..]/.cargo/config.toml",
     );
 }
 
@@ -1673,7 +1673,7 @@ fn debuginfo_parsing() {
 
 #[cargo_test]
 fn build_jobs_missing() {
-    write_config(
+    write_config_toml(
         "\
 [build]
 ",
@@ -1689,7 +1689,7 @@ fn build_jobs_missing() {
 
 #[cargo_test]
 fn build_jobs_default() {
-    write_config(
+    write_config_toml(
         "\
 [build]
 jobs = \"default\"
@@ -1711,7 +1711,7 @@ jobs = \"default\"
 
 #[cargo_test]
 fn build_jobs_integer() {
-    write_config(
+    write_config_toml(
         "\
 [build]
 jobs = 2

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -1,7 +1,7 @@
 //! Tests for the --config CLI option.
 
 use super::config::{
-    assert_error, assert_match, read_output, write_config, write_config_at, ConfigBuilder,
+    assert_error, assert_match, read_output, write_config_at, write_config_toml, ConfigBuilder,
 };
 use cargo::util::config::Definition;
 use cargo_test_support::paths;
@@ -17,7 +17,7 @@ fn basic() {
 #[cargo_test]
 fn cli_priority() {
     // Command line takes priority over files and env vars.
-    write_config(
+    write_config_toml(
         "
         demo_list = ['a']
         [build]
@@ -124,7 +124,7 @@ fn merge_primitives_for_multiple_cli_occurrences() {
 #[cargo_test]
 fn merges_array() {
     // Array entries are appended.
-    write_config(
+    write_config_toml(
         "
         [build]
         rustflags = ['--file']
@@ -173,7 +173,7 @@ fn merges_array() {
 #[cargo_test]
 fn string_list_array() {
     // Using the StringList type.
-    write_config(
+    write_config_toml(
         "
         [build]
         rustflags = ['--file']
@@ -221,7 +221,7 @@ fn string_list_array() {
 #[cargo_test]
 fn merges_table() {
     // Tables are merged.
-    write_config(
+    write_config_toml(
         "
         [foo]
         key1 = 1
@@ -258,7 +258,7 @@ fn merges_table() {
 #[cargo_test]
 fn merge_array_mixed_def_paths() {
     // Merging of arrays with different def sites.
-    write_config(
+    write_config_toml(
         "
         paths = ['file']
         ",

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -1,12 +1,12 @@
 //! Tests for `include` config field.
 
-use super::config::{assert_error, write_config, write_config_at, ConfigBuilder};
+use super::config::{assert_error, write_config_at, write_config_toml, ConfigBuilder};
 use cargo_test_support::{no_such_file_err_msg, project};
 
 #[cargo_test]
 fn gated() {
     // Requires -Z flag.
-    write_config("include='other.toml'");
+    write_config_toml("include='other.toml'");
     write_config_at(
         ".cargo/other.toml",
         "
@@ -23,7 +23,7 @@ fn gated() {
 fn simple() {
     // Simple test.
     write_config_at(
-        ".cargo/config",
+        ".cargo/config.toml",
         "
         include = 'other.toml'
         key1 = 1
@@ -87,7 +87,7 @@ fn works_with_cli() {
 fn left_to_right_bottom_to_top() {
     // How it merges multiple nested includes.
     write_config_at(
-        ".cargo/config",
+        ".cargo/config.toml",
         "
         include = ['left-middle.toml', 'right-middle.toml']
         top = 1
@@ -140,7 +140,7 @@ fn left_to_right_bottom_to_top() {
 #[cargo_test]
 fn missing_file() {
     // Error when there's a missing file.
-    write_config("include='missing.toml'");
+    write_config_toml("include='missing.toml'");
     let config = ConfigBuilder::new()
         .unstable_flag("config-include")
         .build_err();
@@ -151,7 +151,7 @@ fn missing_file() {
 could not load Cargo configuration
 
 Caused by:
-  failed to load config include `missing.toml` from `[..]/.cargo/config`
+  failed to load config include `missing.toml` from `[..]/.cargo/config.toml`
 
 Caused by:
   failed to read configuration file `[..]/.cargo/missing.toml`
@@ -166,7 +166,7 @@ Caused by:
 #[cargo_test]
 fn wrong_file_extension() {
     // Error when it doesn't end with `.toml`.
-    write_config("include='config.png'");
+    write_config_toml("include='config.png'");
     let config = ConfigBuilder::new()
         .unstable_flag("config-include")
         .build_err();
@@ -176,7 +176,7 @@ fn wrong_file_extension() {
 could not load Cargo configuration
 
 Caused by:
-  expected a config include path ending with `.toml`, but found `config.png` from `[..]/.cargo/config`
+  expected a config include path ending with `.toml`, but found `config.png` from `[..]/.cargo/config.toml`
 ",
     );
 }
@@ -214,7 +214,7 @@ fn cli_include() {
     // Using --config with include.
     // CLI takes priority over files.
     write_config_at(
-        ".cargo/config",
+        ".cargo/config.toml",
         "
         foo = 1
         bar = 2
@@ -232,7 +232,7 @@ fn cli_include() {
 #[cargo_test]
 fn bad_format() {
     // Not a valid format.
-    write_config("include = 1");
+    write_config_toml("include = 1");
     let config = ConfigBuilder::new()
         .unstable_flag("config-include")
         .build_err();
@@ -242,7 +242,7 @@ fn bad_format() {
 could not load Cargo configuration
 
 Caused by:
-  `include` expected a string or list, but found integer in `[..]/.cargo/config`",
+  `include` expected a string or list, but found integer in `[..]/.cargo/config.toml`",
     );
 }
 
@@ -275,7 +275,7 @@ Caused by:
 #[cargo_test]
 fn cli_merge_failed() {
     // Error message when CLI include merge fails.
-    write_config("foo = ['a']");
+    write_config_toml("foo = ['a']");
     write_config_at(
         ".cargo/other.toml",
         "
@@ -290,10 +290,10 @@ fn cli_merge_failed() {
     assert_error(
         config.unwrap_err(),
         "\
-failed to merge --config key `foo` into `[..]/.cargo/config`
+failed to merge --config key `foo` into `[..]/.cargo/config.toml`
 
 Caused by:
-  failed to merge config value from `[..]/.cargo/other.toml` into `[..]/.cargo/config`: \
+  failed to merge config value from `[..]/.cargo/other.toml` into `[..]/.cargo/config.toml`: \
   expected array, but found string",
     );
 }

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -37,7 +37,7 @@ fn get_token_test() -> (Project, TestRegistry) {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [registries.alternative]
@@ -293,7 +293,7 @@ fn all_not_found() {
         .build();
     let not_found = build_provider("not_found", r#"{"Err": {"kind": "not-found"}}"#);
     cargo_util::paths::append(
-        &paths::home().join(".cargo/config"),
+        &paths::home().join(".cargo/config.toml"),
         format!(
             r#"
                 [registry]
@@ -333,7 +333,7 @@ fn all_not_supported() {
     let not_supported =
         build_provider("not_supported", r#"{"Err": {"kind": "url-not-supported"}}"#);
     cargo_util::paths::append(
-        &paths::home().join(".cargo/config"),
+        &paths::home().join(".cargo/config.toml"),
         format!(
             r#"
                 [registry]
@@ -378,7 +378,7 @@ fn multiple_providers() {
     let success_provider = build_provider("success_provider", r#"{"Ok": {"kind": "login"}}"#);
 
     cargo_util::paths::append(
-        &paths::home().join(".cargo/config"),
+        &paths::home().join(".cargo/config.toml"),
         format!(
             r#"
                 [registry]
@@ -428,7 +428,7 @@ k3.public[..]
 fn registry_provider_overrides_global() {
     let server = registry::RegistryBuilder::new().build();
     cargo_util::paths::append(
-        &paths::home().join(".cargo/config"),
+        &paths::home().join(".cargo/config.toml"),
         format!(
             r#"
                 [registry]
@@ -458,7 +458,7 @@ fn registry_provider_overrides_global() {
 fn both_asymmetric_and_token() {
     let server = registry::RegistryBuilder::new().build();
     cargo_util::paths::append(
-        &paths::home().join(".cargo/config"),
+        &paths::home().join(".cargo/config.toml"),
         format!(
             r#"
                 [registry]
@@ -475,7 +475,7 @@ fn both_asymmetric_and_token() {
         .replace_crates_io(server.index_url())
         .with_stderr(
             r#"[UPDATING] [..]
-[WARNING] registry `crates-io` has a `secret_key` configured in [..]config that will be ignored because a `token` is also configured, and the `cargo:token` provider is configured with higher precedence
+[WARNING] registry `crates-io` has a `secret_key` configured in [..]config.toml that will be ignored because a `token` is also configured, and the `cargo:token` provider is configured with higher precedence
 [CREDENTIAL] cargo:token login crates-io
 [LOGIN] token for `crates-io` saved
 "#,
@@ -510,7 +510,7 @@ fn token_caching() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [registries.alternative]
@@ -554,7 +554,7 @@ You may press ctrl-c [..]
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         &format!(
             r#"
                 [registries.alternative]
@@ -679,7 +679,7 @@ fn alias_builtin_warning() {
         .build();
 
     cargo_util::paths::append(
-        &paths::home().join(".cargo/config"),
+        &paths::home().join(".cargo/config.toml"),
         format!(
             r#"
                 [credential-alias]

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -64,7 +64,7 @@ fn simple_cross_config() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [build]
@@ -367,7 +367,7 @@ fn linker() {
     let target = cross_compile::alternate();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}]
@@ -1227,7 +1227,7 @@ fn doctest_xcompile_linker() {
     let target = cross_compile::alternate();
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}]

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -16,7 +16,7 @@ fn setup() {
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));
     t!(fs::write(
-        root.join(".cargo/config"),
+        root.join(".cargo/config.toml"),
         r#"
             [source.crates-io]
             replace-with = 'my-awesome-local-registry'
@@ -586,7 +586,7 @@ fn git_lock_file_doesnt_change() {
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));
     t!(fs::write(
-        root.join(".cargo/config"),
+        root.join(".cargo/config.toml"),
         format!(
             r#"
                 [source.my-git-repo]
@@ -641,7 +641,7 @@ fn git_override_requires_lockfile() {
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));
     t!(fs::write(
-        root.join(".cargo/config"),
+        root.join(".cargo/config.toml"),
         r#"
             [source.my-git-repo]
             git = 'https://example.com/'
@@ -707,7 +707,7 @@ fn workspace_different_locations() {
         )
         .file("bar/src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 target-dir = './target'

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -290,7 +290,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
     let p = project()
         .no_manifest()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 target-dir = "./target"
@@ -724,7 +724,7 @@ fn same_build_dir_cached_packages() {
         .file("d/Cargo.toml", &basic_manifest("d", "0.0.1"))
         .file("d/src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 target-dir = "./target"
@@ -2522,7 +2522,7 @@ fn lld_is_fresh() {
     // Check for bug when using lld linker that it remains fresh with dylib.
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [target.x86_64-pc-windows-msvc]
                 linker = "rust-lld"

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2697,7 +2697,7 @@ fn use_the_cli() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             "
                 [net]
                 git-fetch-with-cli = true
@@ -2799,7 +2799,7 @@ fn git_with_cli_force() {
         )
         .file("src/main.rs", "fn main() { dep1::f(); }")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             "
             [net]
             git-fetch-with-cli = true
@@ -2857,7 +2857,7 @@ fn git_fetch_cli_env_clean() {
             )
             .file("src/lib.rs", "pub extern crate dep1;")
             .file(
-                ".cargo/config",
+                ".cargo/config.toml",
                 "
                 [net]
                 git-fetch-with-cli = true
@@ -3126,7 +3126,10 @@ fn historical_lockfile_works_with_vendor() {
         .build();
 
     let output = project.cargo("vendor").exec_with_output().unwrap();
-    project.change_file(".cargo/config", str::from_utf8(&output.stdout).unwrap());
+    project.change_file(
+        ".cargo/config.toml",
+        str::from_utf8(&output.stdout).unwrap(),
+    );
     project.change_file(
         "Cargo.lock",
         &format!(

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -124,7 +124,7 @@ fn http_auth_offered() {
         )
         .file("src/main.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             "[net]
              retry = 0
             ",
@@ -196,7 +196,7 @@ fn https_something_happens() {
         )
         .file("src/main.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             "[net]
              retry = 0
             ",
@@ -351,7 +351,7 @@ Caused by:
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         "
             [net]
             git-fetch-with-cli = true

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -129,7 +129,7 @@ fn help_alias() {
     // Check that `help some_alias` will resolve.
     help_with_man_and_path("", "b", "build", Path::new(""));
 
-    let config = paths::root().join(".cargo/config");
+    let config = paths::root().join(".cargo/config.toml");
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     fs::write(
         config,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -437,7 +437,7 @@ fn install_location_precedence() {
 
     fs::create_dir(root.join(".cargo")).unwrap();
     fs::write(
-        root.join(".cargo/config"),
+        root.join(".cargo/config.toml"),
         &format!(
             "[install]
              root = '{}'
@@ -470,7 +470,7 @@ fn install_location_precedence() {
     assert_has_installed_exe(&t3, "foo");
     assert_has_not_installed_exe(&t4, "foo");
 
-    fs::remove_file(root.join(".cargo/config")).unwrap();
+    fs::remove_file(root.join(".cargo/config.toml")).unwrap();
 
     println!("install cargo home");
 
@@ -1943,7 +1943,7 @@ fn install_ignores_local_cargo_config() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 target = "non-existing-target"
@@ -1962,7 +1962,7 @@ fn install_ignores_unstable_table_in_local_cargo_config() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [unstable]
                 build-std = ["core"]
@@ -2002,7 +2002,7 @@ fn install_global_cargo_config() {
 fn install_path_config() {
     project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             target = 'nonexistent'

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -9,7 +9,7 @@ fn setup() {
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));
     t!(fs::write(
-        root.join(".cargo/config"),
+        root.join(".cargo/config.toml"),
         r#"
             [source.crates-io]
             registry = 'https://wut'
@@ -381,7 +381,7 @@ fn invalid_dir_bad() {
         )
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [source.crates-io]
                 registry = 'https://wut'
@@ -479,7 +479,7 @@ fn crates_io_registry_url_is_optional() {
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));
     t!(fs::write(
-        root.join(".cargo/config"),
+        root.join(".cargo/config.toml"),
         r#"
             [source.crates-io]
             replace-with = 'my-awesome-local-registry'

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -323,7 +323,7 @@ fn default_registry_configured() {
     let _alternative = RegistryBuilder::new().alternative().build();
     let cargo_home = paths::home().join(".cargo");
     cargo_util::paths::append(
-        &cargo_home.join("config"),
+        &cargo_home.join("config.toml"),
         br#"
             [registry]
             default = "alternative"

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -345,7 +345,7 @@ fn metabuild_override() {
             r#"pub fn metabuild() { panic!("should not run"); }"#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}.cat]

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -19,7 +19,7 @@ fn net_retry_loads_from_config() {
         )
         .file("src/main.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
            [net]
            retry=1
@@ -54,7 +54,7 @@ fn net_retry_git_outputs_warning() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
            [http]
            timeout=1

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -260,7 +260,7 @@ fn git_prefers_command_line() {
     let root = paths::root();
     fs::create_dir(&root.join(".cargo")).unwrap();
     fs::write(
-        &root.join(".cargo/config"),
+        &root.join(".cargo/config.toml"),
         r#"
             [cargo-new]
             vcs = "none"

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -181,7 +181,7 @@ retry without the offline flag.
         .run();
 
     // While we're here, also check the config works.
-    p.change_file(".cargo/config", "net.offline = true");
+    p.change_file(".cargo/config.toml", "net.offline = true");
     p.cargo("check").with_status(101).with_stderr(msg).run();
 }
 

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -291,7 +291,7 @@ fn new_features() {
 
     let toolchains = collect_all_toolchains();
 
-    let config_path = paths::home().join(".cargo/config");
+    let config_path = paths::home().join(".cargo/config.toml");
     let lock_path = p.root().join("Cargo.lock");
 
     struct ToolchainBehavior {

--- a/tests/testsuite/out_dir.rs
+++ b/tests/testsuite/out_dir.rs
@@ -260,7 +260,7 @@ fn cargo_build_out_dir() {
     let p = project()
         .file("src/main.rs", r#"fn main() { println!("Hello, World!") }"#)
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             out-dir = "out"

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -543,7 +543,11 @@ fn override_relative() {
         .build();
 
     fs::create_dir(&paths::root().join(".cargo")).unwrap();
-    fs::write(&paths::root().join(".cargo/config"), r#"paths = ["bar"]"#).unwrap();
+    fs::write(
+        &paths::root().join(".cargo/config.toml"),
+        r#"paths = ["bar"]"#,
+    )
+    .unwrap();
 
     let p = project()
         .file(
@@ -578,7 +582,10 @@ fn override_self() {
     let p = project();
     let root = p.root();
     let p = p
-        .file(".cargo/config", &format!("paths = ['{}']", root.display()))
+        .file(
+            ".cargo/config.toml",
+            &format!("paths = ['{}']", root.display()),
+        )
         .file(
             "Cargo.toml",
             &format!(
@@ -626,7 +633,7 @@ fn override_path_dep() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "paths = ['{}', '{}']",
                 bar.root().join("p1").display(),
@@ -869,7 +876,7 @@ fn override_and_depend() {
             "#,
         )
         .file("b/src/lib.rs", "")
-        .file("b/.cargo/config", r#"paths = ["../a"]"#)
+        .file("b/.cargo/config.toml", r#"paths = ["../a"]"#)
         .build();
     p.cargo("check")
         .cwd("b")
@@ -891,7 +898,7 @@ fn missing_path_dependency() {
         .file("Cargo.toml", &basic_manifest("a", "0.5.0"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"paths = ["../whoa-this-does-not-exist"]"#,
         )
         .build();

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -48,7 +48,7 @@ fn broken_path_override_warns() {
             "#,
         )
         .file("a2/src/lib.rs", "")
-        .file(".cargo/config", r#"paths = ["a2"]"#)
+        .file(".cargo/config.toml", r#"paths = ["a2"]"#)
         .build();
 
     p.cargo("check")
@@ -115,7 +115,7 @@ fn override_to_path_dep() {
         .file("bar/src/lib.rs", "")
         .file("bar/baz/Cargo.toml", &basic_manifest("baz", "0.0.1"))
         .file("bar/baz/src/lib.rs", "")
-        .file(".cargo/config", r#"paths = ["bar"]"#)
+        .file(".cargo/config.toml", r#"paths = ["bar"]"#)
         .build();
 
     p.cargo("check").run();
@@ -165,7 +165,7 @@ fn paths_ok_with_optional() {
             "#,
         )
         .file("bar2/src/lib.rs", "")
-        .file(".cargo/config", r#"paths = ["bar2"]"#)
+        .file(".cargo/config.toml", r#"paths = ["bar2"]"#)
         .build();
 
     p.cargo("check")
@@ -212,7 +212,7 @@ fn paths_add_optional_bad() {
             "#,
         )
         .file("bar2/src/lib.rs", "")
-        .file(".cargo/config", r#"paths = ["bar2"]"#)
+        .file(".cargo/config.toml", r#"paths = ["bar2"]"#)
         .build();
 
     p.cargo("check")

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -72,7 +72,7 @@ fn profile_config_validate_warnings() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.test]
                 opt-level = 3
@@ -95,9 +95,9 @@ fn profile_config_validate_warnings() {
     p.cargo("build")
         .with_stderr_unordered(
             "\
-[WARNING] unused config key `profile.dev.bad-key` in `[..].cargo/config`
-[WARNING] unused config key `profile.dev.package.bar.bad-key-bar` in `[..].cargo/config`
-[WARNING] unused config key `profile.dev.build-override.bad-key-bo` in `[..].cargo/config`
+[WARNING] unused config key `profile.dev.bad-key` in `[..].cargo/config.toml`
+[WARNING] unused config key `profile.dev.package.bar.bad-key-bar` in `[..].cargo/config.toml`
+[WARNING] unused config key `profile.dev.build-override.bad-key-bo` in `[..].cargo/config.toml`
 [COMPILING] foo [..]
 [FINISHED] [..]
 ",
@@ -112,14 +112,14 @@ fn profile_config_error_paths() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev]
                 opt-level = 3
             "#,
         )
         .file(
-            paths::home().join(".cargo/config"),
+            paths::home().join(".cargo/config.toml"),
             r#"
             [profile.dev]
             rpath = "foo"
@@ -131,10 +131,10 @@ fn profile_config_error_paths() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..]/foo/.cargo/config: could not load config key `profile.dev`
+[ERROR] error in [..]/foo/.cargo/config.toml: could not load config key `profile.dev`
 
 Caused by:
-  error in [..]/home/.cargo/config: `profile.dev.rpath` expected true/false, but found a string
+  error in [..]/home/.cargo/config.toml: `profile.dev.rpath` expected true/false, but found a string
 ",
         )
         .run();
@@ -146,7 +146,7 @@ fn profile_config_validate_errors() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev.package.foo]
                 panic = "abort"
@@ -158,7 +158,7 @@ fn profile_config_validate_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] config profile `dev` is not valid (defined in `[..]/foo/.cargo/config`)
+[ERROR] config profile `dev` is not valid (defined in `[..]/foo/.cargo/config.toml`)
 
 Caused by:
   `panic` may not be specified in a `package` profile
@@ -173,7 +173,7 @@ fn profile_config_syntax_errors() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev]
                 codegen-units = "foo"
@@ -185,10 +185,10 @@ fn profile_config_syntax_errors() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..]/.cargo/config: could not load config key `profile.dev`
+[ERROR] error in [..]/.cargo/config.toml: could not load config key `profile.dev`
 
 Caused by:
-  error in [..]/foo/.cargo/config: `profile.dev.codegen-units` expected an integer, but found a string
+  error in [..]/foo/.cargo/config.toml: `profile.dev.codegen-units` expected an integer, but found a string
 ",
         )
         .run();
@@ -209,7 +209,7 @@ fn profile_config_override_spec_multiple() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev.package.bar]
                 opt-level = 3
@@ -241,7 +241,7 @@ fn profile_config_all_options() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [profile.release]
             opt-level = 1
@@ -303,7 +303,7 @@ fn profile_config_override_precedence() {
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev.package.bar]
                 opt-level = 2
@@ -329,7 +329,7 @@ fn profile_config_no_warn_unknown_override() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev.package.bar]
                 codegen-units = 4
@@ -348,14 +348,14 @@ fn profile_config_mixed_types() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [profile.dev]
                 opt-level = 3
             "#,
         )
         .file(
-            paths::home().join(".cargo/config"),
+            paths::home().join(".cargo/config.toml"),
             r#"
             [profile.dev]
             opt-level = 's'
@@ -372,7 +372,7 @@ fn profile_config_mixed_types() {
 fn named_config_profile() {
     // Exercises config named profiles.
     // foo -> middle -> bar -> dev
-    // middle exists in Cargo.toml, the others in .cargo/config
+    // middle exists in Cargo.toml, the others in .cargo/config.toml
     use super::config::ConfigBuilder;
     use cargo::core::compiler::CompileKind;
     use cargo::core::profiles::{Profiles, UnitFor};
@@ -381,7 +381,7 @@ fn named_config_profile() {
     use std::fs;
     paths::root().join(".cargo").mkdir_p();
     fs::write(
-        paths::root().join(".cargo/config"),
+        paths::root().join(".cargo/config.toml"),
         r#"
             [profile.foo]
             inherits = "middle"

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -7,7 +7,7 @@ use cargo_test_support::registry::Package;
 fn bad_progress_config_unknown_when() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [term]
             progress = { when = 'unknown' }
@@ -20,7 +20,7 @@ fn bad_progress_config_unknown_when() {
         .with_status(101)
         .with_stderr(
             "\
-[ERROR] error in [..].cargo/config: \
+[ERROR] error in [..].cargo/config.toml: \
 could not load config key `term.progress.when`
 
 Caused by:
@@ -34,7 +34,7 @@ Caused by:
 fn bad_progress_config_missing_width() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [term]
             progress = { when = 'always' }
@@ -57,7 +57,7 @@ fn bad_progress_config_missing_width() {
 fn bad_progress_config_missing_when() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [term]
             progress = { width = 1000 }
@@ -87,7 +87,7 @@ fn always_shows_progress() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [term]
             progress = { when = 'always', width = 100 }
@@ -128,7 +128,7 @@ fn never_progress() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [term]
             progress = { when = 'never' }

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1377,7 +1377,7 @@ fn publish_checks_for_token_before_verify() {
 fn publish_with_bad_source() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [source.crates-io]
             replace-with = 'local-registry'
@@ -1400,7 +1400,7 @@ include `--registry crates-io` to use crates.io
         .run();
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
         [source.crates-io]
         replace-with = "vendored-sources"
@@ -2823,7 +2823,7 @@ fn skip_wait_for_publish() {
         )
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             "
                 [publish]
                 timeout = 0

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -2478,7 +2478,7 @@ fn registry_index_rejected() {
 
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [registry]
             index = "https://example.com/"
@@ -3292,7 +3292,7 @@ or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 
     // Test the output with the default.
     cargo_util::paths::append(
-        &cargo_home().join("config"),
+        &cargo_home().join("config.toml"),
         br#"
             [registry]
             default = "alternative"

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -90,7 +90,7 @@ fn quiet_arg_and_verbose_arg() {
 fn quiet_arg_and_verbose_config() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [term]
                 verbose = true
@@ -106,7 +106,7 @@ fn quiet_arg_and_verbose_config() {
 fn verbose_arg_and_quiet_config() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [term]
                 quiet = true
@@ -131,7 +131,7 @@ fn verbose_arg_and_quiet_config() {
 fn quiet_config_alone() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [term]
                 quiet = true
@@ -147,7 +147,7 @@ fn quiet_config_alone() {
 fn verbose_config_alone() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [term]
                 verbose = true
@@ -172,7 +172,7 @@ fn verbose_config_alone() {
 fn quiet_config_and_verbose_config() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [term]
                 verbose = true

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -76,7 +76,7 @@ fn std_docs() {
     }
     let p = basic_project();
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
             [doc.extern-map]
             std = "local"
@@ -90,7 +90,7 @@ fn std_docs() {
     assert!(myfun.contains(r#"share/doc/rust/html/core/option/enum.Option.html""#));
 
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
             [doc.extern-map]
             std = "https://example.com/rust/"
@@ -241,7 +241,7 @@ fn alt_registry() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [doc.extern-map.registries]
                 alternative = "https://example.com/{pkg_name}/{version}/"
@@ -329,7 +329,7 @@ fn rebuilds_when_changing() {
 
     // This also tests that the map for docs.rs can be overridden.
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
             [doc.extern-map.registries]
             crates-io = "https://example.com/"
@@ -396,7 +396,7 @@ fn alt_sparse_registry() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [doc.extern-map.registries]
                 alternative = "https://example.com/{pkg_name}/{version}/"

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -17,7 +17,7 @@ fn parses_config() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 rustdocflags = ["--cfg", "foo"]
@@ -135,7 +135,7 @@ fn not_affected_by_target_rustflags() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.'cfg({cfg})']

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -476,7 +476,7 @@ fn build_rustflags_normal_source() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["-Z", "bogus"]
@@ -528,7 +528,7 @@ fn build_rustflags_build_script() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -560,7 +560,7 @@ fn build_rustflags_build_script_dep() {
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -610,7 +610,7 @@ fn build_rustflags_plugin() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -644,7 +644,7 @@ fn build_rustflags_plugin_dep() {
         )
         .file("src/lib.rs", "fn foo() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -683,7 +683,7 @@ fn build_rustflags_normal_source_with_target() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["-Z", "bogus"]
@@ -743,7 +743,7 @@ fn build_rustflags_build_script_with_target() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -776,7 +776,7 @@ fn build_rustflags_build_script_dep_with_target() {
         .file("src/lib.rs", "")
         .file("build.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -827,7 +827,7 @@ fn build_rustflags_plugin_with_target() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -862,7 +862,7 @@ fn build_rustflags_plugin_dep_with_target() {
         )
         .file("src/lib.rs", "fn foo() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -897,7 +897,7 @@ fn build_rustflags_recompile() {
         [build]
         rustflags = ["-Z", "bogus"]
         "#;
-    let config_file = paths::root().join("foo/.cargo/config");
+    let config_file = paths::root().join("foo/.cargo/config.toml");
     fs::create_dir_all(config_file.parent().unwrap()).unwrap();
     fs::write(config_file, config).unwrap();
 
@@ -918,7 +918,7 @@ fn build_rustflags_recompile2() {
         [build]
         rustflags = ["-Z", "bogus"]
         "#;
-    let config_file = paths::root().join("foo/.cargo/config");
+    let config_file = paths::root().join("foo/.cargo/config.toml");
     fs::create_dir_all(config_file.parent().unwrap()).unwrap();
     fs::write(config_file, config).unwrap();
 
@@ -933,7 +933,7 @@ fn build_rustflags_no_recompile() {
     let p = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -986,7 +986,7 @@ fn target_rustflags_normal_source() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [target.{}]
@@ -1030,7 +1030,7 @@ fn target_rustflags_also_for_build_scripts() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [target.{}]
@@ -1056,7 +1056,7 @@ fn target_rustflags_not_for_build_scripts_with_target() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [target.{}]
@@ -1079,7 +1079,7 @@ fn target_rustflags_not_for_build_scripts_with_target() {
     // Even with the setting, the rustflags from `target.` should not apply, to match the legacy
     // Cargo behavior.
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         &format!(
             "
         target-applies-to-host = true
@@ -1109,7 +1109,7 @@ fn build_rustflags_for_build_scripts() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             "
             [build]
             rustflags = [\"--cfg=foo\"]
@@ -1143,7 +1143,7 @@ fn build_rustflags_for_build_scripts() {
     // When set to false though, the "proper" behavior where host artifacts _only_ pick up on
     // [host] should be applied.
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         "
         target-applies-to-host = false
 
@@ -1179,7 +1179,7 @@ fn host_rustflags_for_build_scripts() {
             "#,
         )
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
                 target-applies-to-host = false
@@ -1209,7 +1209,7 @@ fn target_rustflags_precedence() {
         .file("examples/b.rs", "fn main() {}")
         .file("tests/c.rs", "#[test] fn f() { }")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 "
             [build]
@@ -1253,7 +1253,7 @@ fn cfg_rustflags_normal_source() {
         .file("examples/b.rs", "fn main() {}")
         .file("tests/c.rs", "#[test] fn f() { }")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [target.'cfg({})']
@@ -1337,7 +1337,7 @@ fn cfg_rustflags_precedence() {
         .file("examples/b.rs", "fn main() {}")
         .file("tests/c.rs", "#[test] fn f() { }")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                 [build]
@@ -1420,7 +1420,7 @@ fn target_rustflags_string_and_array_form1() {
     let p1 = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = ["--cfg", "foo"]
@@ -1441,7 +1441,7 @@ fn target_rustflags_string_and_array_form1() {
     let p2 = project()
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [build]
             rustflags = "--cfg foo"
@@ -1464,7 +1464,7 @@ fn target_rustflags_string_and_array_form1() {
 fn target_rustflags_string_and_array_form2() {
     let p1 = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}]
@@ -1488,7 +1488,7 @@ fn target_rustflags_string_and_array_form2() {
 
     let p2 = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}]
@@ -1515,7 +1515,7 @@ fn target_rustflags_string_and_array_form2() {
 fn two_matching_in_config() {
     let p1 = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [target.'cfg(unix)']
                 rustflags = ["--cfg", 'foo="a"']

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -342,7 +342,7 @@ fn use_script_config() {
 
     let p = cargo_test_support::project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
 [build]
 rustc = "non-existent-rustc"

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -13,7 +13,7 @@ fn setup_replacement(config: &str) -> TestRegistry {
 
     let root = paths::root();
     t!(fs::create_dir(&root.join(".cargo")));
-    t!(fs::write(root.join(".cargo/config"), config,));
+    t!(fs::write(root.join(".cargo/config.toml"), config,));
     crates_io
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4358,7 +4358,7 @@ fn cargo_test_doctest_xcompile_runner() {
     let runner_path = paths::root().join("runner");
     fs::copy(&runner.bin("runner"), &runner_path).unwrap();
 
-    let config = paths::root().join(".cargo/config");
+    let config = paths::root().join(".cargo/config.toml");
 
     fs::create_dir_all(config.parent().unwrap()).unwrap();
     // Escape Windows backslashes for TOML config.

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -10,7 +10,7 @@ fn pathless_tools() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}]
@@ -39,7 +39,7 @@ fn custom_linker_cfg() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [target.'cfg(not(target_os = "none"))']
             linker = "nonexistent-linker"
@@ -67,7 +67,7 @@ fn custom_linker_cfg_precedence() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.'cfg(not(target_os = "none"))']
@@ -97,7 +97,7 @@ fn custom_linker_cfg_collision() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [target.'cfg(not(target_arch = "avr"))']
             linker = "nonexistent-linker1"
@@ -112,8 +112,8 @@ fn custom_linker_cfg_collision() {
         .with_stderr(&format!(
             "\
 [ERROR] several matching instances of `target.'cfg(..)'.linker` in configurations
-first match `cfg(not(target_arch = \"avr\"))` located in [..]/foo/.cargo/config
-second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config
+first match `cfg(not(target_arch = \"avr\"))` located in [..]/foo/.cargo/config.toml
+second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config.toml
 ",
         ))
         .run();
@@ -134,7 +134,7 @@ fn absolute_tools() {
         .file("Cargo.toml", &basic_lib_manifest("foo"))
         .file("src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{target}]
@@ -175,7 +175,7 @@ fn relative_tools() {
         .file("bar/Cargo.toml", &basic_lib_manifest("bar"))
         .file("bar/src/lib.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{target}]
@@ -211,7 +211,7 @@ fn custom_runner() {
         .file("tests/test.rs", "")
         .file("benches/bench.rs", "")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.{}]
@@ -265,7 +265,7 @@ fn custom_runner_cfg() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [target.'cfg(not(target_os = "none"))']
             runner = "nonexistent-runner -r"
@@ -293,7 +293,7 @@ fn custom_runner_cfg_precedence() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             &format!(
                 r#"
                     [target.'cfg(not(target_os = "none"))']
@@ -324,7 +324,7 @@ fn custom_runner_cfg_collision() {
     let p = project()
         .file("src/main.rs", "fn main() {}")
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             [target.'cfg(not(target_arch = "avr"))']
             runner = "true"
@@ -340,8 +340,8 @@ fn custom_runner_cfg_collision() {
         .with_stderr(
             "\
 [ERROR] several matching instances of `target.'cfg(..)'.runner` in configurations
-first match `cfg(not(target_arch = \"avr\"))` located in [..]/foo/.cargo/config
-second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config
+first match `cfg(not(target_arch = \"avr\"))` located in [..]/foo/.cargo/config.toml
+second match `cfg(not(target_os = \"none\"))` located in [..]/foo/.cargo/config.toml
 ",
         )
         .run();
@@ -454,7 +454,7 @@ fn cfg_ignored_fields() {
     // Test for some ignored fields in [target.'cfg()'] tables.
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
             # Try some empty tables.
             [target.'cfg(not(foo))']

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -150,7 +150,7 @@ directory = "deps/.vendor"
 
 fn add_vendor_config(p: &Project) {
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         r#"
             [source.crates-io]
             replace-with = 'vendor'
@@ -851,7 +851,7 @@ fn git_complex() {
         .exec_with_output()
         .unwrap();
     let output = String::from_utf8(output.stdout).unwrap();
-    p.change_file(".cargo/config", &output);
+    p.change_file(".cargo/config.toml", &output);
 
     p.cargo("check -v")
         .with_stderr_contains("[..]foo/vendor/a/src/lib.rs[..]")
@@ -973,7 +973,7 @@ fn config_instructions_works() {
         .exec_with_output()
         .unwrap();
     let output = String::from_utf8(output.stdout).unwrap();
-    p.change_file(".cargo/config", &output);
+    p.change_file(".cargo/config.toml", &output);
 
     p.cargo("check -v")
         .with_stderr_contains("[..]foo/vendor/dep/src/lib.rs[..]")
@@ -1132,7 +1132,7 @@ fn vendor_crate_with_ws_inherit() {
 
     p.cargo("vendor --respect-source-config").run();
     p.change_file(
-        ".cargo/config",
+        ".cargo/config.toml",
         &format!(
             r#"
                 [source."{}"]

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -27,7 +27,9 @@ fn version_works_without_rustc() {
 
 #[cargo_test]
 fn version_works_with_bad_config() {
-    let p = project().file(".cargo/config", "this is not toml").build();
+    let p = project()
+        .file(".cargo/config.toml", "this is not toml")
+        .build();
     p.cargo("version").run();
 }
 
@@ -35,7 +37,7 @@ fn version_works_with_bad_config() {
 fn version_works_with_bad_target_dir() {
     let p = project()
         .file(
-            ".cargo/config",
+            ".cargo/config.toml",
             r#"
                 [build]
                 target-dir = 4


### PR DESCRIPTION
### What does this PR try to resolve?

In #7295 (released in 1.39), we said we'd want to warn on use of
`.cargo/config` after about 6 months.  Over 4 years later, we are now
getting that warning.

This is important for addressing user confusion, like in
https://www.reddit.com/r/rust/comments/19fd5q2/cargoconfig/

### How should we test and review this PR?

It'll be important to look at the individual commits as one updates tests from using `.cargo/config` to `.cargo/config.toml` which touches a lot of code.

I added a test for `.cargo/config` in a separate commit so you can see how the output changes.

### Additional information

Discussed on [zulip](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/Deprecating.20credential.20provider.20default.3F)