### PR TITLE
refactor: remove unnecessary Option in `Freshness::Dirty`

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -34,6 +34,7 @@
 use super::{fingerprint, Context, Job, Unit, Work};
 use crate::core::compiler::artifact;
 use crate::core::compiler::context::Metadata;
+use crate::core::compiler::fingerprint::DirtyReason;
 use crate::core::compiler::job_queue::JobState;
 use crate::core::{profiles::ProfileRoot, PackageId, Target};
 use crate::util::errors::CargoResult;
@@ -608,7 +609,7 @@ fn build_work(cx: &mut Context<'_, '_>, unit: &Unit) -> CargoResult<Job> {
     });
 
     let mut job = if cx.bcx.build_config.build_plan {
-        Job::new_dirty(Work::noop(), None)
+        Job::new_dirty(Work::noop(), DirtyReason::FreshBuild)
     } else {
         fingerprint::prepare_target(cx, unit, false)?
     };

--- a/src/cargo/core/compiler/fingerprint/dirty_reason.rs
+++ b/src/cargo/core/compiler/fingerprint/dirty_reason.rs
@@ -77,6 +77,8 @@ pub enum DirtyReason {
     FsStatusOutdated(FsStatus),
     NothingObvious,
     Forced,
+    /// First time to build something.
+    FreshBuild,
 }
 
 trait ShellExt {
@@ -131,6 +133,11 @@ impl fmt::Display for After {
 }
 
 impl DirtyReason {
+    /// Whether a build is dirty because it is a fresh build being kicked off.
+    pub fn is_fresh_build(&self) -> bool {
+        matches!(self, DirtyReason::FreshBuild)
+    }
+
     fn after(old_time: FileTime, new_time: FileTime, what: &'static str) -> After {
         After {
             old_time,
@@ -257,6 +264,7 @@ impl DirtyReason {
                 s.dirty_because(unit, "the fingerprint comparison turned up nothing obvious")
             }
             DirtyReason::Forced => s.dirty_because(unit, "forced"),
+            DirtyReason::FreshBuild => s.dirty_because(unit, "fresh build"),
         }
     }
 }

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1750,7 +1750,25 @@ fn compare_old_fingerprint(
     }
 
     let compare = _compare_old_fingerprint(old_hash_path, new_fingerprint);
-    log_compare(unit, &compare);
+
+    match compare.as_ref() {
+        Ok(None) => {}
+        Ok(Some(reason)) => {
+            info!(
+                "fingerprint dirty for {}/{:?}/{:?}",
+                unit.pkg, unit.mode, unit.target,
+            );
+            info!("    dirty: {reason:?}");
+        }
+        Err(e) => {
+            info!(
+                "fingerprint error for {}/{:?}/{:?}",
+                unit.pkg, unit.mode, unit.target,
+            );
+            info!("    err: {e:?}");
+        }
+    }
+
     match compare {
         Ok(None) if forced => Some(DirtyReason::Forced),
         Ok(reason) => reason,
@@ -1782,29 +1800,6 @@ fn _compare_old_fingerprint(
     }
 
     Ok(Some(new_fingerprint.compare(&old_fingerprint)))
-}
-
-/// Logs the result of fingerprint comparison.
-///
-/// TODO: Obsolete and mostly superseded by [`DirtyReason`]. Could be removed.
-fn log_compare(unit: &Unit, compare: &CargoResult<Option<DirtyReason>>) {
-    match compare {
-        Ok(None) => {}
-        Ok(Some(reason)) => {
-            info!(
-                "fingerprint dirty for {}/{:?}/{:?}",
-                unit.pkg, unit.mode, unit.target,
-            );
-            info!("    dirty: {reason:?}");
-        }
-        Err(e) => {
-            info!(
-                "fingerprint error for {}/{:?}/{:?}",
-                unit.pkg, unit.mode, unit.target,
-            );
-            info!("    err: {e:?}");
-        }
-    }
 }
 
 /// Parses Cargo's internal [`EncodedDepInfo`] structure that was previously

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -415,8 +415,7 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
     // information about failed comparisons to aid in debugging.
     let fingerprint = calculate(cx, unit)?;
     let mtime_on_use = cx.bcx.config.cli_unstable().mtime_on_use;
-    let compare = compare_old_fingerprint(&loc, &*fingerprint, mtime_on_use);
-    log_compare(unit, &compare);
+    let compare = compare_old_fingerprint(unit, &loc, &*fingerprint, mtime_on_use);
 
     // If our comparison failed or reported dirty (e.g., we're going to trigger
     // a rebuild of this crate), then we also ensure the source of the crate
@@ -1752,6 +1751,17 @@ fn target_root(cx: &Context<'_, '_>) -> PathBuf {
 /// If dirty, it then restores the detailed information
 /// from the fingerprint JSON file, and provides an rich dirty reason.
 fn compare_old_fingerprint(
+    unit: &Unit,
+    old_hash_path: &Path,
+    new_fingerprint: &Fingerprint,
+    mtime_on_use: bool,
+) -> CargoResult<Option<DirtyReason>> {
+    let compare = _compare_old_fingerprint(old_hash_path, new_fingerprint, mtime_on_use);
+    log_compare(unit, &compare);
+    compare
+}
+
+fn _compare_old_fingerprint(
     old_hash_path: &Path,
     new_fingerprint: &Fingerprint,
     mtime_on_use: bool,

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -506,7 +506,7 @@ pub fn prepare_target(cx: &mut Context<'_, '_>, unit: &Unit, force: bool) -> Car
         Work::new(move |_| write_fingerprint(&loc, &fingerprint))
     };
 
-    Ok(Job::new_dirty(write_fingerprint, Some(dirty_reason)))
+    Ok(Job::new_dirty(write_fingerprint, dirty_reason))
 }
 
 /// Dependency edge information for fingerprints. This is generated for each

--- a/src/cargo/core/compiler/job_queue/job.rs
+++ b/src/cargo/core/compiler/job_queue/job.rs
@@ -60,7 +60,7 @@ impl Job {
     }
 
     /// Creates a new job representing a unit of work.
-    pub fn new_dirty(work: Work, dirty_reason: Option<DirtyReason>) -> Job {
+    pub fn new_dirty(work: Work, dirty_reason: DirtyReason) -> Job {
         Job {
             work,
             fresh: Freshness::Dirty(dirty_reason),
@@ -100,7 +100,7 @@ impl fmt::Debug for Job {
 #[derive(Debug, Clone)]
 pub enum Freshness {
     Fresh,
-    Dirty(Option<DirtyReason>),
+    Dirty(DirtyReason),
 }
 
 impl Freshness {

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1110,12 +1110,10 @@ impl<'cfg> DrainState<'cfg> {
             // Any dirty stage which runs at least one command gets printed as
             // being a compiled package.
             Dirty(dirty_reason) => {
-                if let Some(reason) = dirty_reason {
-                    if !reason.is_fresh_build() {
-                        config
-                            .shell()
-                            .verbose(|shell| reason.present_to(shell, unit, ws_root))?;
-                    }
+                if !dirty_reason.is_fresh_build() {
+                    config
+                        .shell()
+                        .verbose(|shell| dirty_reason.present_to(shell, unit, ws_root))?;
                 }
 
                 if unit.mode.is_doc() {

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -1111,9 +1111,11 @@ impl<'cfg> DrainState<'cfg> {
             // being a compiled package.
             Dirty(dirty_reason) => {
                 if let Some(reason) = dirty_reason {
-                    config
-                        .shell()
-                        .verbose(|shell| reason.present_to(shell, unit, ws_root))?;
+                    if !reason.is_fresh_build() {
+                        config
+                            .shell()
+                            .verbose(|shell| reason.present_to(shell, unit, ws_root))?;
+                    }
                 }
 
                 if unit.mode.is_doc() {

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -183,7 +183,7 @@ fn compile<'cfg>(
         // We run these targets later, so this is just a no-op for now.
         Job::new_fresh()
     } else if build_plan {
-        Job::new_dirty(rustc(cx, unit, &exec.clone())?, None)
+        Job::new_dirty(rustc(cx, unit, &exec.clone())?, DirtyReason::FreshBuild)
     } else {
         let force = exec.force_rebuild(unit) || force_rebuild;
         let mut job = fingerprint::prepare_target(cx, unit, force)?;

--- a/src/cargo/ops/common_for_install_and_uninstall.rs
+++ b/src/cargo/ops/common_for_install_and_uninstall.rs
@@ -175,7 +175,7 @@ impl InstallTracker {
         // Check if any tracked exe's are already installed.
         let duplicates = self.find_duplicates(dst, &exes);
         if force || duplicates.is_empty() {
-            return Ok((Freshness::Dirty(Some(DirtyReason::Forced)), duplicates));
+            return Ok((Freshness::Dirty(DirtyReason::Forced), duplicates));
         }
         // Check if all duplicates come from packages of the same name. If
         // there are duplicates from other packages, then --force will be
@@ -205,7 +205,7 @@ impl InstallTracker {
             let source_id = pkg.package_id().source_id();
             if source_id.is_path() {
                 // `cargo install --path ...` is always rebuilt.
-                return Ok((Freshness::Dirty(Some(DirtyReason::Forced)), duplicates));
+                return Ok((Freshness::Dirty(DirtyReason::Forced), duplicates));
             }
             let is_up_to_date = |dupe_pkg_id| {
                 let info = self
@@ -229,7 +229,7 @@ impl InstallTracker {
             if matching_duplicates.iter().all(is_up_to_date) {
                 Ok((Freshness::Fresh, duplicates))
             } else {
-                Ok((Freshness::Dirty(Some(DirtyReason::Forced)), duplicates))
+                Ok((Freshness::Dirty(DirtyReason::Forced), duplicates))
             }
         } else {
             // Format the error message.


### PR DESCRIPTION
### What does this PR try to resolve?

This encodes `Freshness::Dirty(None)` better with a new variant `DirtyReason::FreshBuild`.

<!-- homu-ignore:start -->
### How should we test and review this PR?

The only behavior change in this PR is that source verification is
also performed for `DirtyReason::Forced` rebuild.

### Additional information
<!-- homu-ignore:end -->
