### PR TITLE
test: data layout fix for `x86_64-unknown-none-gnu`

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -155,7 +155,7 @@ fn cross_custom() {
             r#"
             {
                 "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",
@@ -196,7 +196,7 @@ fn custom_test_framework() {
             r#"
             {
                 "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -22,7 +22,7 @@ pub trait Copy {
 const SIMPLE_SPEC: &str = r#"
 {
     "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",


### PR DESCRIPTION
Tests are broken due to LLVM target layout check in rustc. See <https://github.com/rust-lang/rust/pull/120062>.