### PR TITLE
doc: Replace version with `latest` for jobserver link

### DIFF
--- a/crates/cargo-util/src/process_builder.rs
+++ b/crates/cargo-util/src/process_builder.rs
@@ -176,7 +176,7 @@ impl ProcessBuilder {
     /// Sets the `make` jobserver. See the [jobserver crate][jobserver_docs] for
     /// more information.
     ///
-    /// [jobserver_docs]: https://docs.rs/jobserver/0.1.6/jobserver/
+    /// [jobserver_docs]: https://docs.rs/jobserver/latest/jobserver/
     pub fn inherit_jobserver(&mut self, jobserver: &Client) -> &mut Self {
         self.jobserver = Some(jobserver.clone());
         self


### PR DESCRIPTION
### What does this PR try to resolve?
I prefer the  link with `latest`,  it will always jump to the latest version link for crate. 

There is a bot called renovate to update the version for crate, So it's ok to use `latest` link. 

### How should we test and review this PR?


### Additional information


