### PR TITLE
fix(new): Print a 'Creating', rather than 'Created' status

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -192,6 +192,7 @@ fn substitute_macros(input: &str) -> String {
         ("[CHECKING]", "    Checking"),
         ("[COMPLETED]", "   Completed"),
         ("[CREATED]", "     Created"),
+        ("[CREATING]", "    Creating"),
         ("[CREDENTIAL]", "  Credential"),
         ("[DOWNGRADING]", " Downgrading"),
         ("[FINISHED]", "    Finished"),

--- a/src/bin/cargo/commands/init.rs
+++ b/src/bin/cargo/commands/init.rs
@@ -21,9 +21,6 @@ pub fn cli() -> Command {
 
 pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let opts = args.new_options(config)?;
-    let project_kind = ops::init(&opts, config)?;
-    config
-        .shell()
-        .status("Created", format!("{} package", project_kind))?;
+    ops::init(&opts, config)?;
     Ok(())
 }

--- a/src/bin/cargo/commands/new.rs
+++ b/src/bin/cargo/commands/new.rs
@@ -23,15 +23,5 @@ pub fn exec(config: &mut Config, args: &ArgMatches) -> CliResult {
     let opts = args.new_options(config)?;
 
     ops::new(&opts, config)?;
-    let path = args.get_one::<String>("path").unwrap();
-    let package_name = if let Some(name) = args.get_one::<String>("name") {
-        name
-    } else {
-        path
-    };
-    config.shell().status(
-        "Created",
-        format!("{} `{}` package", opts.kind, package_name),
-    )?;
     Ok(())
 }

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -439,6 +439,7 @@ fn calculate_new_project_kind(
 
 pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     let path = &opts.path;
+
     if path.exists() {
         anyhow::bail!(
             "destination `{}` already exists\n\n\
@@ -446,7 +447,6 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
             path.display()
         )
     }
-
     check_path(path, &mut config.shell())?;
 
     let is_bin = opts.kind.is_bin();
@@ -484,13 +484,11 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<NewProjectKind> {
     if path.join("Cargo.toml").exists() {
         anyhow::bail!("`cargo init` cannot be run on existing Cargo packages")
     }
-
     check_path(path, &mut config.shell())?;
 
     let name = get_name(path, opts)?;
 
     let mut src_paths_types = vec![];
-
     detect_source_paths_and_types(path, name, &mut src_paths_types)?;
 
     let kind = calculate_new_project_kind(opts.kind, opts.auto_detect_kind, &src_paths_types);

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -440,6 +440,9 @@ fn calculate_new_project_kind(
 pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     let path = &opts.path;
     let name = get_name(path, opts)?;
+    config
+        .shell()
+        .status("Creating", format!("{} `{}` package", opts.kind, name))?;
 
     if path.exists() {
         anyhow::bail!(
@@ -484,6 +487,9 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<NewProjectKind> {
     let mut src_paths_types = vec![];
     detect_source_paths_and_types(path, name, &mut src_paths_types)?;
     let kind = calculate_new_project_kind(opts.kind, opts.auto_detect_kind, &src_paths_types);
+    config
+        .shell()
+        .status("Creating", format!("{} package", opts.kind))?;
 
     if path.join("Cargo.toml").exists() {
         anyhow::bail!("`cargo init` cannot be run on existing Cargo packages")

--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -439,6 +439,7 @@ fn calculate_new_project_kind(
 
 pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
     let path = &opts.path;
+    let name = get_name(path, opts)?;
 
     if path.exists() {
         anyhow::bail!(
@@ -451,7 +452,6 @@ pub fn new(opts: &NewOptions, config: &Config) -> CargoResult<()> {
 
     let is_bin = opts.kind.is_bin();
 
-    let name = get_name(path, opts)?;
     check_name(name, opts.name.is_none(), is_bin, &mut config.shell())?;
 
     let mkopts = MkOptions {
@@ -480,18 +480,16 @@ pub fn init(opts: &NewOptions, config: &Config) -> CargoResult<NewProjectKind> {
     }
 
     let path = &opts.path;
+    let name = get_name(path, opts)?;
+    let mut src_paths_types = vec![];
+    detect_source_paths_and_types(path, name, &mut src_paths_types)?;
+    let kind = calculate_new_project_kind(opts.kind, opts.auto_detect_kind, &src_paths_types);
 
     if path.join("Cargo.toml").exists() {
         anyhow::bail!("`cargo init` cannot be run on existing Cargo packages")
     }
     check_path(path, &mut config.shell())?;
 
-    let name = get_name(path, opts)?;
-
-    let mut src_paths_types = vec![];
-    detect_source_paths_and_types(path, name, &mut src_paths_types)?;
-
-    let kind = calculate_new_project_kind(opts.kind, opts.auto_detect_kind, &src_paths_types);
     let has_bin = kind.is_bin();
 
     if src_paths_types.is_empty() {

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -105,6 +105,7 @@ fn bad4() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `foo` package
 [ERROR] Failed to create package `foo` at `[..]`
 
 Caused by:

--- a/tests/testsuite/cargo_init/auto_git/stderr.log
+++ b/tests/testsuite/cargo_init/auto_git/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/cant_create_library_when_both_binlib_present/stderr.log
+++ b/tests/testsuite/cargo_init/cant_create_library_when_both_binlib_present/stderr.log
@@ -1,1 +1,2 @@
+    Creating library package
 error: cannot have a package with multiple libraries, found both `case.rs` and `lib.rs`

--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.log
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.log
+++ b/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.log
@@ -1,2 +1,2 @@
+    Creating binary (application) package
 warning: file `case.rs` seems to be a library file
-     Created binary (application) package

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.log
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.log
@@ -1,2 +1,2 @@
+    Creating library package
 warning: file `case.rs` seems to be a binary (application) file
-     Created library package

--- a/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.log
+++ b/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/formats_source/stderr.log
+++ b/tests/testsuite/cargo_init/formats_source/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/fossil_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/fossil_autodetect/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/git_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/git_autodetect/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.log
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.log
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.log
+++ b/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.log
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.log
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/invalid_dir_name/stderr.log
+++ b/tests/testsuite/cargo_init/invalid_dir_name/stderr.log
@@ -1,3 +1,4 @@
+    Creating binary (application) package
 error: invalid character `.` in package name: `foo.bar`, characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
 If you need a package name to not match the directory name, consider using --name flag.
 If you need a binary with the name "foo.bar", use a valid package name, and set the binary name to be different from the package. This can be done by setting the binary filename to `src/bin/foo.bar.rs` or change the name in Cargo.toml with:

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.log
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/lib_already_exists_src/stderr.log
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/mercurial_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/path_contains_separator/stderr.log
+++ b/tests/testsuite/cargo_init/path_contains_separator/stderr.log
@@ -1,3 +1,3 @@
+    Creating binary (application) package
 warning: the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)
 It is recommended to use a different name to avoid problems.
-     Created binary (application) package

--- a/tests/testsuite/cargo_init/pijul_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/pijul_autodetect/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/reserved_name/stderr.log
+++ b/tests/testsuite/cargo_init/reserved_name/stderr.log
@@ -1,3 +1,4 @@
+    Creating binary (application) package
 error: the name `test` cannot be used as a package name, it conflicts with Rust's built-in test library
 If you need a package name to not match the directory name, consider using --name flag.
 If you need a binary with the name "test", use a valid package name, and set the binary name to be different from the package. This can be done by setting the binary filename to `src/bin/test.rs` or change the name in Cargo.toml with:

--- a/tests/testsuite/cargo_init/simple_bin/stderr.log
+++ b/tests/testsuite/cargo_init/simple_bin/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/simple_git/stderr.log
+++ b/tests/testsuite/cargo_init/simple_git/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.log
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/simple_hg/stderr.log
+++ b/tests/testsuite/cargo_init/simple_hg/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.log
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/simple_lib/stderr.log
+++ b/tests/testsuite/cargo_init/simple_lib/stderr.log
@@ -1,1 +1,1 @@
-     Created library package
+    Creating library package

--- a/tests/testsuite/cargo_init/with_argument/stderr.log
+++ b/tests/testsuite/cargo_init/with_argument/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_init/workspace_add_member/stderr.log
+++ b/tests/testsuite/cargo_init/workspace_add_member/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) package
+    Creating binary (application) package

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `[ROOT]/case/crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/empty_name/stderr.log
+++ b/tests/testsuite/cargo_new/empty_name/stderr.log
@@ -1,1 +1,2 @@
+    Creating binary (application) `` package
 error: package name cannot be empty

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `crates/foo` package
+    Creating binary (application) `foo` package

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.log
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.log
@@ -1,1 +1,1 @@
-     Created binary (application) `bar` package
+    Creating binary (application) `bar` package

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -27,7 +27,7 @@ fn create_default_gitconfig() {
 #[cargo_test]
 fn simple_lib() {
     cargo_process("new --lib foo --vcs none --edition 2015")
-        .with_stderr("[CREATED] library `foo` package")
+        .with_stderr("[CREATING] library `foo` package")
         .run();
 
     assert!(paths::root().join("foo").is_dir());
@@ -62,7 +62,7 @@ mod tests {
 #[cargo_test]
 fn simple_bin() {
     cargo_process("new --bin foo --edition 2015")
-        .with_stderr("[CREATED] binary (application) `foo` package")
+        .with_stderr("[CREATING] binary (application) `foo` package")
         .run();
 
     assert!(paths::root().join("foo").is_dir());
@@ -79,7 +79,10 @@ fn simple_bin() {
 fn both_lib_and_bin() {
     cargo_process("new --lib --bin foo")
         .with_status(101)
-        .with_stderr("[ERROR] can't specify both lib and binary outputs")
+        .with_stderr(
+            "\
+[ERROR] can't specify both lib and binary outputs",
+        )
         .run();
 }
 
@@ -137,8 +140,10 @@ fn existing() {
     cargo_process("new foo")
         .with_status(101)
         .with_stderr(
-            "[ERROR] destination `[CWD]/foo` already exists\n\n\
-             Use `cargo init` to initialize the directory",
+            "\
+[CREATING] binary (application) `foo` package
+[ERROR] destination `[CWD]/foo` already exists\n\n\
+Use `cargo init` to initialize the directory",
         )
         .run();
 }
@@ -149,6 +154,7 @@ fn invalid_characters() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `foo.rs` package
 [ERROR] invalid character `.` in package name: `foo.rs`, [..]
 If you need a package name to not match the directory name, consider using --name flag.
 If you need a binary with the name \"foo.rs\", use a valid package name, \
@@ -171,6 +177,7 @@ fn reserved_name() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `test` package
 [ERROR] the name `test` cannot be used as a package name, it conflicts [..]
 If you need a package name to not match the directory name, consider using --name flag.
 If you need a binary with the name \"test\", use a valid package name, \
@@ -193,6 +200,7 @@ fn reserved_binary_name() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `incremental` package
 [ERROR] the name `incremental` cannot be used as a package name, it conflicts [..]
 If you need a package name to not match the directory name, consider using --name flag.
 ",
@@ -202,9 +210,9 @@ If you need a package name to not match the directory name, consider using --nam
     cargo_process("new --lib incremental")
         .with_stderr(
             "\
+[CREATING] library `incremental` package
 [WARNING] the name `incremental` will not support binary executables with that name, \
 it conflicts with cargo's build directory names
-[CREATED] library `incremental` package
 ",
         )
         .run();
@@ -216,6 +224,7 @@ fn keyword_name() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `pub` package
 [ERROR] the name `pub` cannot be used as a package name, it is a Rust keyword
 If you need a package name to not match the directory name, consider using --name flag.
 If you need a binary with the name \"pub\", use a valid package name, \
@@ -237,6 +246,7 @@ fn std_name() {
     cargo_process("new core")
         .with_stderr(
             "\
+[CREATING] binary (application) `core` package
 [WARNING] the name `core` is part of Rust's standard library
 It is recommended to use a different name to avoid problems.
 If you need a package name to not match the directory name, consider using --name flag.
@@ -249,7 +259,6 @@ or change the name in Cargo.toml with:
     name = \"core\"
     path = \"src/main.rs\"
 
-[CREATED] binary (application) `core` package
 ",
         )
         .run();
@@ -348,6 +357,7 @@ fn explicit_invalid_name_not_suggested() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `10-invalid` package
 [ERROR] invalid character `1` in package name: `10-invalid`, the name cannot start with a digit
 If you need a binary with the name \"10-invalid\", use a valid package name, \
 and set the binary name to be different from the package. \
@@ -366,7 +376,7 @@ or change the name in Cargo.toml with:
 #[cargo_test]
 fn explicit_project_name() {
     cargo_process("new --lib foo --name bar")
-        .with_stderr("[CREATED] library `bar` package")
+        .with_stderr("[CREATING] library `bar` package")
         .run();
 }
 
@@ -425,6 +435,7 @@ fn restricted_windows_name() {
             .with_status(101)
             .with_stderr(
                 "\
+[CREATING] binary (application) `nul` package
 [ERROR] cannot use name `nul`, it is a reserved Windows filename
 If you need a package name to not match the directory name, consider using --name flag.
 ",
@@ -434,9 +445,9 @@ If you need a package name to not match the directory name, consider using --nam
         cargo_process("new nul")
             .with_stderr(
                 "\
+[CREATING] binary (application) `nul` package
 [WARNING] the name `nul` is a reserved Windows filename
 This package will not work on Windows platforms.
-[CREATED] binary (application) `nul` package
 ",
             )
             .run();
@@ -448,10 +459,10 @@ fn non_ascii_name() {
     cargo_process("new Привет")
         .with_stderr(
             "\
+[CREATING] binary (application) `Привет` package
 [WARNING] the name `Привет` contains non-ASCII characters
 Non-ASCII crate names are not supported by Rust.
 [WARNING] the name `Привет` is not snake_case or kebab-case which is recommended for package names, consider `привет`
-[CREATED] binary (application) `Привет` package
 ",
         )
         .run();
@@ -464,6 +475,7 @@ fn non_ascii_name_invalid() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `ⒶⒷⒸ` package
 [ERROR] invalid character `Ⓐ` in package name: `ⒶⒷⒸ`, \
 the first character must be a Unicode XID start character (most letters or `_`)
 If you need a package name to not match the directory name, consider using --name flag.
@@ -484,6 +496,7 @@ or change the name in Cargo.toml with:
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) `a¼` package
 [ERROR] invalid character `¼` in package name: `a¼`, \
 characters must be Unicode XID characters (numbers, `-`, `_`, or most letters)
 If you need a package name to not match the directory name, consider using --name flag.
@@ -506,8 +519,8 @@ fn non_snake_case_name() {
     cargo_process("new UPPERcase_name")
         .with_stderr(
             "\
+[CREATING] binary (application) `UPPERcase_name` package
 [WARNING] the name `UPPERcase_name` is not snake_case or kebab-case which is recommended for package names, consider `uppercase_name`
-[CREATED] binary (application) `UPPERcase_name` package
 ",
         )
         .run();
@@ -518,7 +531,7 @@ fn kebab_case_name_is_accepted() {
     cargo_process("new kebab-case-is-valid")
         .with_stderr(
             "\
-[CREATED] binary (application) `kebab-case-is-valid` package
+[CREATING] binary (application) `kebab-case-is-valid` package
 ",
         )
         .run();
@@ -559,6 +572,7 @@ fn non_utf8_str_in_ignore_file() {
         .with_status(101)
         .with_stderr(
             "\
+[CREATING] binary (application) package
 error: Failed to create package `home` at `[..]`
 
 Caused by:
@@ -574,9 +588,9 @@ fn path_with_invalid_character() {
     cargo_process("new --name testing test:ing")
         .with_stderr(
             "\
+[CREATING] binary (application) `testing` package
 [WARNING] the path `[CWD]/test:ing` contains invalid PATH characters (usually `:`, `;`, or `\"`)
 It is recommended to use a different name to avoid problems.
-[CREATED] binary (application) `testing` package
 ",
         )
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1063,7 +1063,7 @@ fn new_creates_members_list() {
     let p = p.build();
 
     p.cargo("new --lib bar")
-        .with_stderr("     Created library `bar` package")
+        .with_stderr("    Creating library `bar` package")
         .run();
 }
 
@@ -1073,6 +1073,7 @@ fn new_warning_with_corrupt_ws() {
     p.cargo("new bar")
         .with_stderr(
             "\
+[CREATING] binary (application) `bar` package
 [ERROR] expected `.`, `=`
  --> Cargo.toml:1:5
   |
@@ -1081,7 +1082,6 @@ fn new_warning_with_corrupt_ws() {
   |
 [WARNING] compiling this new package may not work due to invalid workspace configuration
 
-[CREATED] binary (application) `bar` package
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This has bothered me about `cargo new` and `cargo init` for a while that
the output is read backwards, for example:
```diff
--- i/tests/testsuite/cargo_init/path_contains_separator/stderr.log
+++ w/tests/testsuite/cargo_init/path_contains_separator/stderr.log
@@ -1,3 +1,3 @@
+    Creating binary (application) package
 warning: the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)
 It is recommended to use a different name to avoid problems.
-     Created binary (application) package
```

### How should we test and review this PR?



### Additional information

