### PR TITLE
fix(new): Print a note, rather than a comment, for more information

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -784,8 +784,7 @@ fn mk(config: &Config, opts: &MkOptions<'_>) -> CargoResult<()> {
         array.push(registry);
         manifest["package"]["publish"] = toml_edit::value(array);
     }
-    let mut dep_table = toml_edit::Table::default();
-    dep_table.decor_mut().set_prefix("\n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\n\n");
+    let dep_table = toml_edit::Table::default();
     manifest["dependencies"] = toml_edit::Item::Table(dep_table);
 
     // Calculate what `[lib]` and `[[bin]]`s we need to append to `Cargo.toml`.
@@ -910,6 +909,10 @@ mod tests {
             &mut config.shell(),
         );
     }
+
+    config.shell().note(
+        "see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html",
+    )?;
 
     Ok(())
 }

--- a/tests/testsuite/cargo_init/auto_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/auto_git/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/auto_git/stderr.log
+++ b/tests/testsuite/cargo_init/auto_git/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_explicit_nosrc/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namenosrc/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_namesrc/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.log
+++ b/tests/testsuite/cargo_init/bin_already_exists_implicit_nosrc/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.log
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.log
+++ b/tests/testsuite/cargo_init/creates_binary_when_instructed_and_has_lib_file/stderr.log
@@ -1,2 +1,3 @@
     Creating binary (application) package
 warning: file `case.rs` seems to be a library file
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [lib]

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.log
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/stderr.log
@@ -1,2 +1,3 @@
     Creating library package
 warning: file `case.rs` seems to be a binary (application) file
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/explicit_bin_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/explicit_bin_with_git/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.log
+++ b/tests/testsuite/cargo_init/explicit_bin_with_git/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/formats_source/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/formats_source/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/formats_source/stderr.log
+++ b/tests/testsuite/cargo_init/formats_source/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/fossil_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/fossil_autodetect/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/fossil_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/fossil_autodetect/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/git_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/git_autodetect/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/git_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/git_autodetect/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.log
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.log
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/inferred_bin_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/inferred_bin_with_git/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [[bin]]

--- a/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.log
+++ b/tests/testsuite/cargo_init/inferred_bin_with_git/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [lib]

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.log
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/out/crates/foo/Cargo.toml
@@ -16,6 +16,4 @@ publish.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.log
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/out/Cargo.toml
@@ -3,8 +3,6 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [lib]

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.log
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/lib_already_exists_src/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/lib_already_exists_src/stderr.log
+++ b/tests/testsuite/cargo_init/lib_already_exists_src/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/mercurial_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/mercurial_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/path_contains_separator/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/path_contains_separator/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "testing"
 version = "0.1.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/path_contains_separator/stderr.log
+++ b/tests/testsuite/cargo_init/path_contains_separator/stderr.log
@@ -1,3 +1,4 @@
     Creating binary (application) package
 warning: the path `[ROOT]/case/test:ing/.` contains invalid PATH characters (usually `:`, `;`, or `"`)
 It is recommended to use a different name to avoid problems.
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/pijul_autodetect/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/pijul_autodetect/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/pijul_autodetect/stderr.log
+++ b/tests/testsuite/cargo_init/pijul_autodetect/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/simple_bin/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_bin/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/simple_bin/stderr.log
+++ b/tests/testsuite/cargo_init/simple_bin/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/simple_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_git/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/simple_git/stderr.log
+++ b/tests/testsuite/cargo_init/simple_git/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.log
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/simple_hg/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_hg/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/simple_hg/stderr.log
+++ b/tests/testsuite/cargo_init/simple_hg/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.log
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/simple_lib/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/simple_lib/out/Cargo.toml
@@ -3,6 +3,4 @@ name = "case"
 version = "0.1.0"
 edition = "2015"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/simple_lib/stderr.log
+++ b/tests/testsuite/cargo_init/simple_lib/stderr.log
@@ -1,1 +1,2 @@
     Creating library package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/with_argument/out/foo/Cargo.toml
+++ b/tests/testsuite/cargo_init/with_argument/out/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/with_argument/stderr.log
+++ b/tests/testsuite/cargo_init/with_argument/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_init/workspace_add_member/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_init/workspace_add_member/out/crates/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_init/workspace_add_member/stderr.log
+++ b/tests/testsuite/cargo_init/workspace_add_member/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/out/crates/foo/Cargo.toml
@@ -4,6 +4,4 @@ version = "0.1.0"
 edition = "2021"
 authors.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_previous_items/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/out/crates/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_format_sorted/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/out/crates/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_absolute_package_path/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/out/crates/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_empty_members/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/out/crates/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/out/crates/foo/Cargo.toml
@@ -3,6 +3,4 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.log
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_members_glob/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/crates/foo/Cargo.toml
@@ -3,8 +3,6 @@ name = "foo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 
 [lints]

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/out/crates/foo/Cargo.toml
@@ -16,6 +16,4 @@ publish.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/crates/foo/Cargo.toml
@@ -16,6 +16,4 @@ publish.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/crates/foo/Cargo.toml
@@ -16,6 +16,4 @@ license.workspace = true
 repository.workspace = true
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/out/crates/foo/Cargo.toml
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/out/crates/foo/Cargo.toml
@@ -16,6 +16,4 @@ license.workspace = true
 publish.workspace = true
 repository.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.log
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `foo` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/out/bar/Cargo.toml
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/out/bar/Cargo.toml
@@ -3,6 +3,4 @@ name = "bar"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.log
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/stderr.log
@@ -1,1 +1,2 @@
     Creating binary (application) `bar` package
+note: see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -27,7 +27,10 @@ fn create_default_gitconfig() {
 #[cargo_test]
 fn simple_lib() {
     cargo_process("new --lib foo --vcs none --edition 2015")
-        .with_stderr("[CREATING] library `foo` package")
+        .with_stderr("\
+[CREATING] library `foo` package
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+")
         .run();
 
     assert!(paths::root().join("foo").is_dir());
@@ -62,7 +65,10 @@ mod tests {
 #[cargo_test]
 fn simple_bin() {
     cargo_process("new --bin foo --edition 2015")
-        .with_stderr("[CREATING] binary (application) `foo` package")
+        .with_stderr("\
+[CREATING] binary (application) `foo` package
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+")
         .run();
 
     assert!(paths::root().join("foo").is_dir());
@@ -213,6 +219,7 @@ If you need a package name to not match the directory name, consider using --nam
 [CREATING] library `incremental` package
 [WARNING] the name `incremental` will not support binary executables with that name, \
 it conflicts with cargo's build directory names
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();
@@ -259,6 +266,7 @@ or change the name in Cargo.toml with:
     name = \"core\"
     path = \"src/main.rs\"
 
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();
@@ -376,7 +384,10 @@ or change the name in Cargo.toml with:
 #[cargo_test]
 fn explicit_project_name() {
     cargo_process("new --lib foo --name bar")
-        .with_stderr("[CREATING] library `bar` package")
+        .with_stderr("\
+[CREATING] library `bar` package
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+")
         .run();
 }
 
@@ -410,14 +421,6 @@ fn new_with_bad_edition() {
 }
 
 #[cargo_test]
-fn new_with_reference_link() {
-    cargo_process("new foo").run();
-
-    let contents = fs::read_to_string(paths::root().join("foo/Cargo.toml")).unwrap();
-    assert!(contents.contains("# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html"))
-}
-
-#[cargo_test]
 fn lockfile_constant_during_new() {
     cargo_process("new foo").run();
 
@@ -448,6 +451,7 @@ If you need a package name to not match the directory name, consider using --nam
 [CREATING] binary (application) `nul` package
 [WARNING] the name `nul` is a reserved Windows filename
 This package will not work on Windows platforms.
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
             )
             .run();
@@ -463,6 +467,7 @@ fn non_ascii_name() {
 [WARNING] the name `Привет` contains non-ASCII characters
 Non-ASCII crate names are not supported by Rust.
 [WARNING] the name `Привет` is not snake_case or kebab-case which is recommended for package names, consider `привет`
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();
@@ -521,6 +526,7 @@ fn non_snake_case_name() {
             "\
 [CREATING] binary (application) `UPPERcase_name` package
 [WARNING] the name `UPPERcase_name` is not snake_case or kebab-case which is recommended for package names, consider `uppercase_name`
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();
@@ -532,6 +538,7 @@ fn kebab_case_name_is_accepted() {
         .with_stderr(
             "\
 [CREATING] binary (application) `kebab-case-is-valid` package
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();
@@ -591,6 +598,7 @@ fn path_with_invalid_character() {
 [CREATING] binary (application) `testing` package
 [WARNING] the path `[CWD]/test:ing` contains invalid PATH characters (usually `:`, `;`, or `\"`)
 It is recommended to use a different name to avoid problems.
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1063,7 +1063,10 @@ fn new_creates_members_list() {
     let p = p.build();
 
     p.cargo("new --lib bar")
-        .with_stderr("    Creating library `bar` package")
+        .with_stderr("\
+[CREATING] library `bar` package
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+")
         .run();
 }
 
@@ -1082,6 +1085,7 @@ fn new_warning_with_corrupt_ws() {
   |
 [WARNING] compiling this new package may not work due to invalid workspace configuration
 
+[NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

For myself, I find it frustrating when tools add boilerplate that I have to remove after every use.  A `note:` on the command-line is more ephemeral, helping people who need it while not interfering with those that don't.

Fixes #12210

### How should we test and review this PR?


### Additional information
