### PR TITLE
feat(update): Tell users when they are still behind

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -208,6 +208,7 @@ fn substitute_macros(input: &str) -> String {
         ("[ADDING]", "      Adding"),
         ("[REMOVING]", "    Removing"),
         ("[REMOVED]", "     Removed"),
+        ("[UNCHANGED]", "   Unchanged"),
         ("[DOCTEST]", "   Doc-tests"),
         ("[PACKAGING]", "   Packaging"),
         ("[PACKAGED]", "    Packaged"),

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -281,12 +281,12 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     }
     if opts.config.shell().verbosity() == Verbosity::Verbose {
         opts.config.shell().note(
-            "To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`",
+            "to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`",
         )?;
     } else {
         if 0 < unchanged_behind {
             opts.config.shell().note(format!(
-                "Pass `--verbose` to see {unchanged_behind} unchanged dependencies behind latest"
+                "pass `--verbose` to see {unchanged_behind} unchanged dependencies behind latest"
             ))?;
         }
     }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -212,21 +212,22 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
         .unwrap_or_default();
 
         if removed.len() == 1 && added.len() == 1 {
-            let msg = if removed[0].source_id().is_git() {
+            let added = added.into_iter().next().unwrap();
+            let removed = removed.into_iter().next().unwrap();
+            let msg = if removed.source_id().is_git() {
                 format!(
-                    "{} -> #{}",
-                    removed[0],
-                    &added[0].source_id().precise_git_fragment().unwrap()[..8],
+                    "{removed} -> #{}",
+                    &added.source_id().precise_git_fragment().unwrap()[..8],
                 )
             } else {
-                format!("{} -> v{}{latest}", removed[0], added[0].version())
+                format!("{removed} -> v{}{latest}", added.version())
             };
 
             // If versions differ only in build metadata, we call it an "update"
             // regardless of whether the build metadata has gone up or down.
             // This metadata is often stuff like git commit hashes, which are
             // not meaningfully ordered.
-            if removed[0].version().cmp_precedence(added[0].version()) == Ordering::Greater {
+            if removed.version().cmp_precedence(added.version()) == Ordering::Greater {
                 print_change("Downgrading", msg, &style::WARN)?;
             } else {
                 print_change("Updating", msg, &style::GOOD)?;

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -255,7 +255,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             (dep.name().as_str(), dep.source_id())
         }
 
-        fn vec_subtract(a: &[PackageId], b: &[PackageId]) -> Vec<PackageId> {
+        fn vec_subset(a: &[PackageId], b: &[PackageId]) -> Vec<PackageId> {
             a.iter().filter(|a| !contains_id(b, a)).cloned().collect()
         }
 
@@ -308,8 +308,8 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             let (ref mut old, ref mut new) = *v;
             old.sort();
             new.sort();
-            let removed = vec_subtract(old, new);
-            let added = vec_subtract(new, old);
+            let removed = vec_subset(old, new);
+            let added = vec_subset(new, old);
             *old = removed;
             *new = added;
         }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -184,6 +184,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
             possibilities
                 .iter()
                 .map(|s| s.as_summary())
+                .filter(|s| s.version().pre.is_empty())
                 .map(|s| s.version().clone())
                 .max()
                 .filter(|v| added.version() < v)

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -166,6 +166,11 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     };
     let mut unchanged_behind = 0;
     for (removed, added, unchanged) in compare_dependency_graphs(&previous_resolve, &resolve) {
+        fn format_latest(version: semver::Version) -> String {
+            let warn = style::WARN;
+            format!(" {warn}(latest: v{version}){warn:#}")
+        }
+
         let highest_present = [added.iter().rev().next(), unchanged.iter().rev().next()]
             .into_iter()
             .flatten()
@@ -185,7 +190,6 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                     std::task::Poll::Pending => registry.block_until_ready()?,
                 }
             };
-            let warn = style::WARN;
             let present_version = present.version();
             possibilities
                 .iter()
@@ -201,7 +205,7 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                 .map(|s| s.version().clone())
                 .max()
                 .filter(|v| present.version() < v)
-                .map(|v| format!(" {warn}(latest: v{v}){warn:#}"))
+                .map(format_latest)
         } else {
             None
         }

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -244,17 +244,20 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                         &anstyle::Style::new().bold(),
                     )?;
                 }
-            } else {
-                if !unchanged.is_empty() {
-                    unchanged_behind += 1;
-                }
             }
+            unchanged_behind += unchanged.len();
         }
     }
-    if 0 < unchanged_behind {
-        opts.config.shell().note(format!(
-            "Pass `--verbose` to see {unchanged_behind} unchanged dependencies behind latest"
-        ))?;
+    if opts.config.shell().verbosity() == Verbosity::Verbose {
+        opts.config.shell().note(
+            "To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`",
+        )?;
+    } else {
+        if 0 < unchanged_behind {
+            opts.config.shell().note(format!(
+                "Pass `--verbose` to see {unchanged_behind} unchanged dependencies behind latest"
+            ))?;
+        }
     }
     if opts.dry_run {
         opts.config

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -186,10 +186,18 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
                 }
             };
             let warn = style::WARN;
+            let present_version = present.version();
             possibilities
                 .iter()
                 .map(|s| s.as_summary())
-                .filter(|s| s.version().pre.is_empty())
+                .filter(|s| {
+                    let s_version = s.version();
+                    s_version.pre.is_empty()
+                        // Only match pre-release if major.minor.patch are the same
+                        || (s_version.major == present_version.major
+                            && s_version.minor == present_version.minor
+                            && s_version.patch == present_version.patch)
+                })
                 .map(|s| s.version().clone())
                 .max()
                 .filter(|v| present.version() < v)

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1372,7 +1372,7 @@ fn dep_with_changed_submodule() {
     sleep_ms(1000);
     // Update the dependency and carry on!
     println!("update");
-    p.cargo("update -v")
+    p.cargo("update")
         .with_stderr("")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -183,7 +183,7 @@ fn multiple_versions() {
         .file("src/lib.rs", "pub fn bar() {}")
         .publish();
 
-    p.cargo("update -v")
+    p.cargo("update")
         .with_stderr("[UPDATING] bar v0.1.0 -> v0.2.0")
         .run();
 }

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2430,7 +2430,7 @@ fn can_update_with_alt_reg() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2430,6 +2430,7 @@ fn can_update_with_alt_reg() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1572,6 +1572,7 @@ fn update_multiple_packages() {
 [UPDATING] `[..]` index
 [UPDATING] a v0.1.0 -> v0.1.1
 [UPDATING] b v0.1.0 -> v0.1.1
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1572,7 +1572,7 @@ fn update_multiple_packages() {
 [UPDATING] `[..]` index
 [UPDATING] a v0.1.0 -> v0.1.1
 [UPDATING] b v0.1.0 -> v0.1.1
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -539,7 +539,7 @@ fn override_adds_some_deps() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -547,7 +547,7 @@ fn override_adds_some_deps() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -539,6 +539,7 @@ fn override_adds_some_deps() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -546,6 +547,7 @@ fn override_adds_some_deps() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1478,6 +1478,7 @@ fn precise_yanked_multiple_presence() {
 fn report_behind() {
     Package::new("breaking", "0.1.0").publish();
     Package::new("breaking", "0.2.0").publish();
+    Package::new("breaking", "0.2.1-alpha.0").publish();
     let p = project()
         .file(
             "Cargo.toml",
@@ -1499,7 +1500,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
+[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.1-alpha.0)
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -109,6 +109,7 @@ fn transitive_minor_update() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[NOTE] Pass `--verbose` to see 2 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -160,6 +161,7 @@ fn conservative() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] serde v0.1.0 -> v0.1.1
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -520,6 +522,7 @@ fn update_precise_do_not_force_update_deps() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] serde v0.2.1 -> v0.2.2
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -898,6 +901,7 @@ fn dry_run_update() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] serde v0.1.0 -> v0.1.1
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1522,6 +1526,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1531,6 +1536,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1566,6 +1572,7 @@ fn update_with_missing_feature() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -109,7 +109,7 @@ fn transitive_minor_update() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[NOTE] Pass `--verbose` to see 2 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -161,7 +161,7 @@ fn conservative() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] serde v0.1.0 -> v0.1.1
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -388,7 +388,7 @@ fn update_precise() {
             "\
 [UPDATING] `[..]` index
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -523,7 +523,7 @@ fn update_precise_do_not_force_update_deps() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] serde v0.2.1 -> v0.2.2
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -902,7 +902,7 @@ fn dry_run_update() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] serde v0.1.0 -> v0.1.1
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1513,7 +1513,7 @@ fn report_behind() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
-[NOTE] Pass `--verbose` to see 2 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1526,7 +1526,7 @@ fn report_behind() {
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
-[NOTE] To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
+[NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1538,7 +1538,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[NOTE] Pass `--verbose` to see 3 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 3 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1551,7 +1551,7 @@ fn report_behind() {
 [UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
-[NOTE] To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
+[NOTE] to see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1587,7 +1587,7 @@ fn update_with_missing_feature() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1496,11 +1496,42 @@ fn report_behind() {
     p.cargo("generate-lockfile").run();
     Package::new("breaking", "0.1.1").publish();
 
-    p.cargo("update")
+    p.cargo("update --dry-run")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
+[WARNING] not updating lockfile due to dry run
+",
+        )
+        .run();
+
+    p.cargo("update --dry-run --verbose")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
+[WARNING] not updating lockfile due to dry run
+",
+        )
+        .run();
+
+    p.cargo("update").run();
+
+    p.cargo("update --dry-run")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[WARNING] not updating lockfile due to dry run
+",
+        )
+        .run();
+
+    p.cargo("update --dry-run --verbose")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[WARNING] not updating lockfile due to dry run
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1499,7 +1499,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[UPDATING] breaking v0.1.0 -> v0.1.1
+[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -388,6 +388,7 @@ fn update_precise() {
             "\
 [UPDATING] `[..]` index
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
         .run();
@@ -1512,7 +1513,7 @@ fn report_behind() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] Pass `--verbose` to see 2 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1524,6 +1525,7 @@ fn report_behind() {
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
+[UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
 [NOTE] To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 ",
@@ -1536,7 +1538,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[NOTE] Pass `--verbose` to see 2 unchanged dependencies behind latest
+[NOTE] Pass `--verbose` to see 3 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1548,6 +1550,7 @@ fn report_behind() {
 [UPDATING] `dummy-registry` index
 [UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
+[UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
 [NOTE] To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 ",

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1500,7 +1500,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.1-alpha.0)
+[UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 ",
         )
         .run();

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1480,6 +1480,8 @@ fn precise_yanked_multiple_presence() {
 
 #[cargo_test]
 fn report_behind() {
+    Package::new("two-ver", "0.1.0").publish();
+    Package::new("two-ver", "0.2.0").publish();
     Package::new("pre", "1.0.0-alpha.0").publish();
     Package::new("pre", "1.0.0-alpha.1").publish();
     Package::new("breaking", "0.1.0").publish();
@@ -1495,6 +1497,8 @@ fn report_behind() {
                 [dependencies]
                 breaking = "0.1"
                 pre = "=1.0.0-alpha.0"
+                two-ver = "0.2.0"
+                two-ver-one = { version = "0.1.0", package = "two-ver" }
             "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1520,6 +1520,7 @@ fn report_behind() {
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
+[NOTE] To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1543,6 +1544,7 @@ fn report_behind() {
 [UPDATING] `dummy-registry` index
 [UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
+[NOTE] To see how you depend on a package, run `cargo tree --invert --package <dep>@<ver>`
 [WARNING] not updating lockfile due to dry run
 ",
         )

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1480,6 +1480,8 @@ fn precise_yanked_multiple_presence() {
 
 #[cargo_test]
 fn report_behind() {
+    Package::new("pre", "1.0.0-alpha.0").publish();
+    Package::new("pre", "1.0.0-alpha.1").publish();
     Package::new("breaking", "0.1.0").publish();
     Package::new("breaking", "0.2.0").publish();
     Package::new("breaking", "0.2.1-alpha.0").publish();
@@ -1492,6 +1494,7 @@ fn report_behind() {
 
                 [dependencies]
                 breaking = "0.1"
+                pre = "=1.0.0-alpha.0"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1505,6 +1508,7 @@ fn report_behind() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
+[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1515,6 +1519,7 @@ fn report_behind() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
+[UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1526,7 +1531,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[NOTE] Pass `--verbose` to see 1 unchanged dependencies behind latest
+[NOTE] Pass `--verbose` to see 2 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
         )
@@ -1537,6 +1542,7 @@ fn report_behind() {
             "\
 [UPDATING] `dummy-registry` index
 [UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
+[UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
 [WARNING] not updating lockfile due to dry run
 ",
         )


### PR DESCRIPTION
### What does this PR try to resolve?

Part of this is an offshoot of #12425 which is about pulling  some of `cargo upgrade`s behavior into `cargo update`.  One of the "'Potential related `cargo update` improvements" is informing the user when they are behind.

Part of this is to help close the gap of users being behind on their dependencies unaware.  This is commonly raised when discussing an MSRV-aware resolver (see rust-lang/rfcs#3537) but breaking changes are just as big of a deal so I'm starting this now.

See also #7167, #4309

Compared to `cargo upgrade` / `cargo outdated`, I'm taking a fairly conservative approach and tweaking the existing output as a starting point / MVP.  We can experiment with a richer or easier-to-consume way of expressing this over time.

I view us telling people they aren't on the latest as a warning, so I made that text yellow.

`clap $ cargo update --dry-run` 
![image](https://github.com/rust-lang/cargo/assets/60961/4bf151e3-6b57-4073-8822-9140dd731d5e)

`clap $ cargo update --dry-run --verbose`
![image](https://github.com/rust-lang/cargo/assets/60961/fbf802fb-3a6a-4e8b-a6ec-4ce49fb505f6)

### How should we test and review this PR?

This sets up the minimal implementation and slowly adds bits at a time, with a test first that demonstrates it.

### Additional information

I'm expecting that the `cargo upgrade` integration will extend the notes to say something like "X dependencies may be updated with `--breaking`"