### PR TITLE
chore(ci): enable m1 runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,10 @@ jobs:
           os: macos-latest
           rust: nightly
           other: x86_64-apple-ios
+        - name: macOS aarch64 stable
+          os: macos-14
+          rust: stable
+          other: x86_64-apple-darwin
         - name: Windows x86_64 MSVC stable
           os: windows-latest
           rust: stable-msvc


### PR DESCRIPTION
<!-- homu-ignore:start -->


### What does this PR try to resolve?

Enable M1 runner in Cargo's CI pipeline.

In the foreseeable future, aarch64-apple-darwin would be a tier-1 platform. Regardless, it is a major platform people use right now.

* [GitHub Actions: Introducing the new M1 macOS runner available to open source!](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/)
* https://github.com/rust-lang/rust/pull/120509

### How should we test and review this PR?

Is there any other concern?

* Should we pay attention to billing issue?
* Reach out to t-infra?
* Too small the machine is ([7GB RAM right now](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-private-repositories))


### Additional information

<!-- homu-ignore:end -->
