### PR TITLE
Change tests to support changes to suggestion

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1502,6 +1502,7 @@ fn fix_shared_cross_workspace() {
     //     [FIXED] bar/src/../../foo/src/shared.rs (2 fixes)
     //     [FIXED] foo/src/shared.rs (2 fixes)
     p.cargo("fix --allow-no-vcs")
+        .env("__CARGO_FIX_YOLO", "1")
         .with_stderr_unordered(
             "\
 [CHECKING] foo v0.1.0 [..]

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -60,7 +60,7 @@ fn deduplicate_messages_basic() {
     let rustc_message = raw_rustc_output(&p, "src/lib.rs", &[]);
     let expected_output = format!(
         "{}\
-warning: `foo` (lib) generated 1 warning (run `cargo fix --lib -p foo` to apply 1 suggestion)
+warning: `foo` (lib) generated 1 warning[..]
 warning: `foo` (lib test) generated 1 warning (1 duplicate)
 [FINISHED] [..]
 [EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[..][EXE])
@@ -103,7 +103,7 @@ fn deduplicate_messages_mismatched_warnings() {
     let expected_output = format!(
         "\
 {}\
-warning: `foo` (lib) generated 1 warning (run `cargo fix --lib -p foo` to apply 1 suggestion)
+warning: `foo` (lib) generated 1 warning[..]
 {}\
 warning: `foo` (lib test) generated 2 warnings (1 duplicate)
 [FINISHED] [..]


### PR DESCRIPTION
`rustc` will start marking the suggestions for prefacing unused bindings with underscores as "maybe incorrect", which makes them no longer auto applicable by `rustfix`.

Change done at https://github.com/rust-lang/rust/pull/120470.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
