### PR TITLE
Add `docsrs` cfg as a well known `--check-cfg`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1296,8 +1296,15 @@ fn check_cfg_args(cx: &Context<'_, '_>, unit: &Unit) -> Vec<OsString> {
         }
         arg_feature.push("))");
 
+        // We also include the `docsrs` cfg from the docs.rs service. We include it here
+        // (in Cargo) instead of rustc, since there is a much closer relationship between
+        // Cargo and docs.rs than rustc and docs.rs. In particular, all users of docs.rs use
+        // Cargo, but not all users of rustc (like Rust-for-Linux) use docs.rs.
+
         vec![
             OsString::from("-Zunstable-options"),
+            OsString::from("--check-cfg"),
+            OsString::from("cfg(docsrs)"),
             OsString::from("--check-cfg"),
             arg_feature,
         ]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -50,6 +50,7 @@ fn features() {
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -79,6 +80,7 @@ fn features_with_deps() {
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -109,6 +111,7 @@ fn features_with_opt_deps() {
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "bar" "default" "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -138,6 +141,7 @@ fn features_with_namespaced_features() {
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -222,6 +226,7 @@ fn well_known_names_values() {
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -246,6 +251,7 @@ fn features_test() {
     p.cargo("test -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -272,6 +278,8 @@ fn features_doctest() {
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "default" "f_a" "f_b"))
         .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with "default" "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -285,6 +293,7 @@ fn well_known_names_values_test() {
     p.cargo("test -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -299,6 +308,8 @@ fn well_known_names_values_doctest() {
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
         .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -324,6 +335,7 @@ fn features_doc() {
     p.cargo("doc -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustdoc" => "cfg" of "feature" with "default" "f_a" "f_b"))
+        .with_stderr_contains(x!("rustdoc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -350,6 +362,7 @@ fn build_script_feedback() {
     p.cargo("check -v -Zcheck-cfg")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "foo"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 
@@ -423,6 +436,8 @@ fn build_script_override() {
 
     p.cargo("check -v -Zcheck-cfg")
         .with_stderr_contains(x!("rustc" => "cfg" of "foo"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "feature" with))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .run();
 }
@@ -573,6 +588,7 @@ fn config_valid() {
     p.cargo("check -v")
         .masquerade_as_nightly_cargo(&["check-cfg"])
         .with_stderr_contains(x!("rustc" => "cfg" of "feature" with "f_a" "f_b"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "docsrs"))
         .run();
 }
 


### PR DESCRIPTION
Now that https://github.com/rust-lang/docs.rs/pull/2390 has been merged we can add the `docsrs` cfg in Cargo well known --check-cfg "list". The `docsrs` cfg used by at least [3k project on GitHub](https://github.com/search?q=lang%3Atoml+%2Frustdoc-args+%3D+%5C%5B%22--cfg%22%2C+%22docsrs%22%5C%5D%2F+NOT+is%3Afork&type=code&repo=&langOverride=&start_value=1) alone; including the cfg will help reduce the impact of enabling by default this feature.

> We include it here (in Cargo) instead of rustc, since there is a much closer relationship between Cargo and docs.rs than rustc and docs.rs. In particular, all users of docs.rs use Cargo, but not all users of rustc (like Rust-for-Linux) use docs.rs.

This is part of the last remaining bits of the `--check-cfg` feature.

r? @epage