### PR TITLE
Ensure `nonzero_exit_code` test isn't affected by developers `RUST_BACKTRACE` setting

### DIFF
--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4869,6 +4869,7 @@ error: 2 targets failed:
         .run();
 
     p.cargo("test --no-fail-fast -- --nocapture")
+    .env_remove("RUST_BACKTRACE")
     .with_stderr_does_not_contain("test exited abnormally; to see the full output pass --nocapture to the harness.")
     .with_stderr_contains("[..]thread 't' panicked [..] tests/t1[..]")
     .with_stderr_contains("note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace")


### PR DESCRIPTION
### What does this PR try to resolve?

If testing while having `RUST_BACKTRACE=1` set this test fails as it doesn't contain the expected note about setting it.
