### PR TITLE
Don't print rustdoc command lines on failure by default

### DIFF
--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -2640,3 +2640,24 @@ fn link_to_private_item() {
         )
         .run();
 }
+
+#[cargo_test]
+fn rustdoc_failure_hides_command_line_by_default() {
+    let p = project().file("src/lib.rs", "invalid rust code").build();
+
+    let string_to_test = "\
+Caused by:
+  process didn't exit successfully[..]rustdoc[..]";
+
+    // `cargo doc` doesn't print the full command line on failures by default
+    p.cargo("doc")
+        .with_stderr_does_not_contain(string_to_test)
+        .with_status(101)
+        .run();
+
+    // ... but it still does so if requested with `--verbose`.
+    p.cargo("doc --verbose")
+        .with_stderr_contains(string_to_test)
+        .with_status(101)
+        .run();
+}


### PR DESCRIPTION
This commit lifts a helper function from invoking rustc to additionally being used for invoking rustdoc. This enables hiding the command line invocation of `rustdoc` by default when it fails, although it's still available to see with `--verbose`. The intention here is to match the behavior of `cargo build` for rustc failures here and was inspired by recently running `cargo doc` and not being able to see the actual failure as the command line ended up taking the whole screen (afterwards I made the screen bigger and that helped too).

Fixes #13386

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
