### PR TITLE
Apply `-Zpanic-abort-tests` to doctests too

### DIFF
--- a/src/cargo/ops/cargo_test.rs
+++ b/src/cargo/ops/cargo_test.rs
@@ -1,4 +1,5 @@
 use crate::core::compiler::{Compilation, CompileKind, Doctest, Metadata, Unit, UnitOutput};
+use crate::core::profiles::PanicStrategy;
 use crate::core::shell::Verbosity;
 use crate::core::{TargetKind, Workspace};
 use crate::ops;
@@ -242,6 +243,10 @@ fn run_doc_tests(
                 joined.push(linker);
                 p.arg("-C").arg(joined);
             }
+        }
+
+        if unit.profile.panic != PanicStrategy::Unwind {
+            p.arg("-C").arg(format!("panic={}", unit.profile.panic));
         }
 
         for &rust_dep in &[

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -4489,6 +4489,37 @@ fn panic_abort_tests() {
         .run();
 }
 
+#[cargo_test] // Unlike with rustc, `rustdoc --test -Cpanic=abort` already works on stable
+fn panic_abort_doc_tests() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = 'foo'
+                version = '0.1.0'
+
+                [profile.dev]
+                panic = 'abort'
+            "#,
+        )
+        .file(
+            "src/lib.rs",
+            r#"
+                //! ```should_panic
+                //! panic!();
+                //! ```
+            "#,
+        )
+        .build();
+
+    p.cargo("test --doc -Z panic-abort-tests -v")
+        .with_stderr_contains("[..]rustc[..]--crate-name foo [..]-C panic=abort[..]")
+        .with_stderr_contains("[..]rustdoc[..]--crate-name foo [..]--test[..]-C panic=abort[..]")
+        .masquerade_as_nightly_cargo(&["panic-abort-tests"])
+        .run();
+}
+
 #[cargo_test(nightly, reason = "-Zpanic-abort-tests in rustc is unstable")]
 fn panic_abort_only_test() {
     let p = project()


### PR DESCRIPTION
### What does this PR try to resolve?

`cranelift` doesn't support unwinding, which causes issues with `should_panic` tests. Attempting to use `-Zpanic-abort-tests` to fix that still fails with doctests because they attempt to use unwinding. `rustdoc` already supports specifying `-Cpanic=abort` and correctly handles ` ```should_panic` tests with it enabled, so we can just start passing it when `-Zpanic-abort-tests` is set.

Fixes https://github.com/rust-lang/rust/issues/120578 (when using `-Zbuild-std=std,panic_abort` too)