### PR TITLE
doc: `[package]` doesn't require `version` field

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -65,10 +65,10 @@ version = "0.1.0"    # the current version, obeying semver
 authors = ["Alice <a@example.com>", "Bob <b@example.com>"]
 ```
 
-The only fields required by Cargo are [`name`](#the-name-field) and
-[`version`](#the-version-field). If publishing to a registry, the registry may
-require additional fields. See the notes below and [the publishing
-chapter][publishing] for requirements for publishing to [crates.io].
+The only field required by Cargo is [`name`](#the-name-field). If publishing to
+a registry, the registry may require additional fields. See the notes below and
+[the publishing chapter][publishing] for requirements for publishing to
+[crates.io].
 
 ### The `name` field
 


### PR DESCRIPTION
Since #12786 (in 1.75) cargo doesn't require the version field as it defaults to 0.0.0. A bin crate with the following toml builds successfully with `cargo build`:

```toml
[package]
name = "foo"
```

This PR slightly rewords the `[package]` section of `src/doc/src/reference/manifest.md` to reflect this.