### PR TITLE
[beta-1.77.0] Fix panic on empty spans when parsing Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,9 +3036,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
  "serde",
 ]
@@ -3354,9 +3354,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,8 +96,8 @@ tar = { version = "0.4.40", default-features = false }
 tempfile = "3.9.0"
 thiserror = "1.0.56"
 time = { version = "0.3", features = ["parsing", "formatting", "serde"] }
-toml = "0.8.8"
-toml_edit = { version = "0.21.0", features = ["serde"] }
+toml = "0.8.9"
+toml_edit = { version = "0.21.1", features = ["serde"] }
 tracing = "0.1.37" # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 unicase = "2.7.0"

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -121,7 +121,7 @@ fn read_manifest_from_str(
                 .rfind('\n')
                 .map(|s| s + 1)
                 .unwrap_or(0);
-            let source_end = contents[span.end - 1..]
+            let source_end = contents[span.end.saturating_sub(1)..]
                 .find('\n')
                 .map(|s| s + span.end)
                 .unwrap_or(contents.len());

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -155,7 +155,7 @@ fn cross_custom() {
             r#"
             {
                 "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",
@@ -196,7 +196,7 @@ fn custom_test_framework() {
             r#"
             {
                 "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -22,7 +22,7 @@ pub trait Copy {
 const SIMPLE_SPEC: &str = r#"
 {
     "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/tests/testsuite/diagnostics.rs
+++ b/tests/testsuite/diagnostics.rs
@@ -21,9 +21,11 @@ edition = "2021"
         .with_stderr(
             "\
 error: invalid type: map, expected a sequence
---> Cargo.toml:1:1
- |
- |
+ --> Cargo.toml:6:3
+  |
+6 | [[bench.foo]]
+  |   ^^^^^
+  |
 ",
         )
         .run();

--- a/tests/testsuite/diagnostics.rs
+++ b/tests/testsuite/diagnostics.rs
@@ -1,0 +1,30 @@
+use cargo_test_support::project;
+
+#[cargo_test]
+fn dont_panic_on_render() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+[[bench.foo]]
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: invalid type: map, expected a sequence
+--> Cargo.toml:1:1
+ |
+ |
+",
+        )
+        .run();
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -79,6 +79,7 @@ mod cross_publish;
 mod custom_target;
 mod death;
 mod dep_info;
+mod diagnostics;
 mod direct_minimal_versions;
 mod directory;
 mod doc;


### PR DESCRIPTION
Beta backports:

- <https://github.com/rust-lang/cargo/pull/13375>
- <https://github.com/rust-lang/cargo/pull/13376>

In order to make CI pass, the following PRs are also cherry-picked:

- <https://github.com/rust-lang/cargo/pull/13362>