### PR TITLE
Remove `package.documentation` from the “before publishing” list.

### DIFF
--- a/src/doc/src/reference/publishing.md
+++ b/src/doc/src/reference/publishing.md
@@ -50,7 +50,6 @@ you have filled out the following fields:
 - [`license` or `license-file`]
 - [`description`]
 - [`homepage`]
-- [`documentation`]
 - [`repository`]
 - [`readme`]
 


### PR DESCRIPTION
`crates.io` currently automatically links to `docs.rs` if `documentation` is not specified, which is usually a good choice.