### PR TITLE
Fix markdown line break in cargo-add

### DIFF
--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -11,7 +11,7 @@ cargo-add --- Add dependencies to a Cargo.toml manifest file
 
 `cargo add` [_options_] _crate_...\
 `cargo add` [_options_] `--path` _path_\
-`cargo add` [_options_] `--git` _url_ [_crate_...]\
+`cargo add` [_options_] `--git` _url_ [_crate_...]
 
 
 ## DESCRIPTION

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -7,7 +7,7 @@ cargo-add --- Add dependencies to a Cargo.toml manifest file
 
 `cargo add` [_options_] _crate_...\
 `cargo add` [_options_] `--path` _path_\
-`cargo add` [_options_] `--git` _url_ [_crate_...]\
+`cargo add` [_options_] `--git` _url_ [_crate_...]
 
 
 ## DESCRIPTION


### PR DESCRIPTION
This fixes a backslash line break in the cargo-add documentation. A future version of mdbook will adhere to the commonmark spec more closely, and this will end up showing as a literal backslash.
