### PR TITLE
Remove build metadata from curl-sys version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ core-foundation = { version = "0.9.4", features = ["mac_os_10_7_support"] }
 crates-io = { version = "0.40.0", path = "crates/crates-io" }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 curl = "0.4.44"
-curl-sys = "0.4.71+curl-8"
+curl-sys = "0.4.71"
 filetime = "0.2.23"
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib"] }
 git2 = "0.18.1"


### PR DESCRIPTION
#13379 added the build metadata to the curl-sys version, but cargo spits a warning that you shouldn't do that. It also didn't add the metadata correctly, as the version is `+curl-8.6.0`. This removes that, since it isn't needed. 
