### PR TITLE
test: Verify build-std final crate graph against library lock file. 

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -406,6 +406,10 @@ impl EncodableResolve {
             HashMap::new(),
         ))
     }
+
+    pub fn package(&self) -> Option<&Vec<EncodableDependency>> {
+        self.package.as_ref()
+    }
 }
 
 fn build_path_deps(ws: &Workspace<'_>) -> CargoResult<HashMap<String, SourceId>> {
@@ -487,6 +491,20 @@ pub struct EncodableDependency {
     checksum: Option<String>,
     dependencies: Option<Vec<EncodablePackageId>>,
     replace: Option<EncodablePackageId>,
+}
+
+impl EncodableDependency {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn dependencies(&self) -> Option<&Vec<EncodablePackageId>> {
+        self.dependencies.as_ref()
+    }
 }
 
 /// Pretty much equivalent to [`SourceId`] with a different serialization method.
@@ -572,6 +590,16 @@ pub struct EncodablePackageId {
     name: String,
     version: Option<String>,
     source: Option<EncodableSourceId>,
+}
+
+impl EncodablePackageId {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_ref().map(|x| x.as_str())
+    }
 }
 
 impl fmt::Display for EncodablePackageId {


### PR DESCRIPTION
### What does this PR try to resolve?

Adds a test to the build-std test suite which checks whether the resolved standard library unit graph accurately describes a subset of the dependencies listed in the standard library's `Cargo.lock`, as mentioned in an issue from wg-cargo-std-aware:

> It might be a good idea to do the equivalent of --locked for the standard library to ensure that the Cargo.lock isn't modified, and that it is correct.
Source: https://github.com/rust-lang/wg-cargo-std-aware/issues/38

This PR implements this as part of the build-std test suite, as suggested by @adamgemmell in the above linked issue, however I also have a version of this patch implemented which can perform this check at runtime, if that would be a more appropriate place to perform the check.

Fixes https://github.com/rust-lang/wg-cargo-std-aware/issues/38

### How should we test and review this PR?

The test can be run as follows:
```
CARGO_RUN_BUILD_STD_TESTS=1 cargo test validate_std_crate_graph
```

### Additional information
N/A