### PR TITLE
fixed the issue with the link redirecting to a 422: Unprocessable Entity

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # The Rust Code of Conduct
 
-The Code of Conduct for this repository [can be found online](https://www.rust-lang.org/conduct.html).
+The Code of Conduct for this repository [can be found online](https://www.rust-lang.org/policies/code-of-conduct).


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

This PR solves issue #13407 

There is an issue with the readme.md where if you check the Code-of-conduct tab in the readme and click on the `can be found online` link, it redirects to a **422: Unprocessable Entity**.  Fixed this by changing the link to the actual code-of-conduct link.

### How should we test and review this PR?

To test this PR, go to the readme.md file in the PR and click on the link of `can be found online`, it would redirect to the correct webpage.

<!-- homu-ignore:end -->
