### PR TITLE
Update git2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf97ba92db08df386e10c8ede66a2a0369bd277090afd8710e19e38de9ec0cd"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
 dependencies = [
  "bitflags 2.4.1",
  "libc",
@@ -2072,9 +2072,9 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.16.1+1.7.1"
+version = "0.16.2+1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ curl = "0.4.44"
 curl-sys = "0.4.71"
 filetime = "0.2.23"
 flate2 = { version = "1.0.28", default-features = false, features = ["zlib"] }
-git2 = "0.18.1"
+git2 = "0.18.2"
 git2-curl = "0.19.0"
 gix = { version = "0.58.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree", "revision"] }
 gix-features-for-configuration-only = { version = "0.38.0", package = "gix-features", features = [ "parallel" ] }
@@ -62,7 +62,7 @@ itertools = "0.12.1"
 jobserver = "0.1.27"
 lazycell = "1.3.0"
 libc = "0.2.153"
-libgit2-sys = "0.16.1"
+libgit2-sys = "0.16.2"
 libloading = "0.8.1"
 memchr = "2.7.1"
 miow = "0.6.0"


### PR DESCRIPTION
This updates git2 primarily to pull in the update for libgit2 1.7.2 which fixes three security issues. @weihanglo did some investigation, and it looks like cargo may be susceptible to one of them with rev parsing. I am uncertain of the severity, but the CVE seems to imply that it is mainly a denial-of-service with an infinite loop from a well-crafted spec.

See https://github.com/libgit2/libgit2/releases/tag/v1.7.2 for more information.
