### PR TITLE
Relax a test to permit warnings to be emitted, too.

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -29,7 +29,7 @@ fn do_not_fix_broken_builds() {
     p.cargo("fix --allow-no-vcs")
         .env("__CARGO_FIX_YOLO", "1")
         .with_status(101)
-        .with_stderr_contains("[ERROR] could not compile `foo` (lib) due to 1 previous error")
+        .with_stderr_contains("[ERROR] could not compile `foo` (lib) due to 1 previous error[..]")
         .run();
     assert!(p.read_file("src/lib.rs").contains("let mut x = 3;"));
 }


### PR DESCRIPTION
This change is necessary to allow rustc to actually start emitting the warning about the unused `mut`

See the test failure in https://github.com/rust-lang/rust/pull/120550#issuecomment-1931802095 for where this happens.