### PR TITLE
Publish test crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,11 +408,11 @@ dependencies = [
 
 [[package]]
 name = "cargo-test-macro"
-version = "0.1.0"
+version = "0.2.0"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ cargo-credential-libsecret = { version = "0.4.2", path = "credential/cargo-crede
 cargo-credential-macos-keychain = { version = "0.4.2", path = "credential/cargo-credential-macos-keychain" }
 cargo-credential-wincred = { version = "0.4.2", path = "credential/cargo-credential-wincred" }
 cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
-cargo-test-macro = { path = "crates/cargo-test-macro" }
-cargo-test-support = { path = "crates/cargo-test-support" }
+cargo-test-macro = { version = "0.2.0", path = "crates/cargo-test-macro" }
+cargo-test-support = { version = "0.2.0", path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.9", path = "crates/cargo-util" }
 cargo-util-schemas = { version = "0.3.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -2,12 +2,11 @@
 name = "cargo-test-macro"
 version = "0.1.0"
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-documentation = "https://github.com/rust-lang/cargo"
 description = "Helper proc-macro for Cargo's testsuite."
-publish = false
 
 [lib]
 proc-macro = true

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-macro"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/cargo-test-macro/Cargo.toml
+++ b/crates/cargo-test-macro/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-test-macro"
 version = "0.2.0"
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.77"  # MSRV:1
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/cargo-test-macro/LICENSE-APACHE
+++ b/crates/cargo-test-macro/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/cargo-test-macro/LICENSE-MIT
+++ b/crates/cargo-test-macro/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/cargo-test-macro/README.md
+++ b/crates/cargo-test-macro/README.md
@@ -1,0 +1,5 @@
+WARNING: You might not want to use this outside of Cargo.
+
+* This is designed for testing Cargo itself. Use at your own risk.
+* No guarantee on any stability across versions.
+* No feature request would be accepted unless proved useful for testing Cargo.

--- a/crates/cargo-test-macro/src/lib.rs
+++ b/crates/cargo-test-macro/src/lib.rs
@@ -1,3 +1,14 @@
+//! # Cargo test macro.
+//!
+//! This is meant to be consumed alongside `cargo-test-support`. See
+//! <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
+//!
+//! WARNING: You might not want to use this outside of Cargo.
+//!
+//! * This is designed for testing Cargo itself. Use at your own risk.
+//! * No guarantee on any stability across versions.
+//! * No feature request would be accepted unless proved useful for testing Cargo.
+
 use proc_macro::*;
 use std::path::Path;
 use std::process::Command;

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-test-support"
 version = "0.2.0"
 edition.workspace = true
-rust-version.workspace = true
+rust-version = "1.77"  # MSRV:1
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "cargo-test-support"
 version = "0.1.0"
-license.workspace = true
 edition.workspace = true
-publish = false
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Testing framework for Cargo's testsuite."
 
 [lib]
 doctest = false

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/cargo-test-support/LICENSE-APACHE
+++ b/crates/cargo-test-support/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/cargo-test-support/LICENSE-MIT
+++ b/crates/cargo-test-support/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/cargo-test-support/README.md
+++ b/crates/cargo-test-support/README.md
@@ -1,0 +1,5 @@
+WARNING: You might not want to use this outside of Cargo.
+
+* This is designed for testing Cargo itself. Use at your own risk.
+* No guarantee on any stability across versions.
+* No feature request would be accepted unless proved useful for testing Cargo.

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1,6 +1,12 @@
 //! # Cargo test support.
 //!
 //! See <https://rust-lang.github.io/cargo/contrib/> for a guide on writing tests.
+//!
+//! WARNING: You might not want to use this outside of Cargo.
+//!
+//! * This is designed for testing Cargo itself. Use at your own risk.
+//! * No guarantee on any stability across versions.
+//! * No feature request would be accepted unless proved useful for testing Cargo.
 
 #![allow(clippy::disallowed_methods)]
 #![allow(clippy::print_stderr)]

--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -168,6 +168,8 @@ fn bump_check(args: &clap::ArgMatches, gctx: &cargo::util::GlobalContext) -> Car
     let mut cmd = ProcessBuilder::new("cargo");
     cmd.arg("semver-checks")
         .arg("check-release")
+        .args(&["--exclude", "cargo-test-macro"]) // FIXME: Remove once 1.79 is stable.
+        .args(&["--exclude", "cargo-test-support"]) // FIXME: Remove once 1.79 is stable.
         .arg("--workspace");
     gctx.shell().status("Running", &cmd)?;
     cmd.exec()?;
@@ -176,6 +178,8 @@ fn bump_check(args: &clap::ArgMatches, gctx: &cargo::util::GlobalContext) -> Car
         let mut cmd = ProcessBuilder::new("cargo");
         cmd.arg("semver-checks")
             .arg("--workspace")
+            .args(&["--exclude", "cargo-test-macro"]) // FIXME: Remove once 1.79 is stable.
+            .args(&["--exclude", "cargo-test-support"]) // FIXME: Remove once 1.79 is stable.
             .arg("--baseline-rev")
             .arg(referenced_commit.id().to_string());
         for krate in crates_not_check_against_channels {

--- a/publish.py
+++ b/publish.py
@@ -26,6 +26,8 @@ TO_PUBLISH = [
     'crates/cargo-util',
     'crates/crates-io',
     'crates/cargo-util-schemas',
+    'crates/cargo-test-macro',
+    'crates/cargo-test-support',
     '.',
 ]
 

--- a/src/doc/contrib/src/process/release.md
+++ b/src/doc/contrib/src/process/release.md
@@ -131,9 +131,9 @@ Cargo's library and its related dependencies (like `cargo-util`) are published
 to [crates.io] as part of the 6-week stable release process by the [Release
 team]. There is a [`publish.py` script] that is used by the Release team's
 automation scripts (see <https://github.com/rust-lang/simpleinfra/>) to handle
-determining which packages to publish. The test and build tool crates aren't
-published. This runs on the specific git commit associated with the cargo
-submodule in the `stable` branch in `rust-lang/rust` at the time of release.
+determining which packages to publish. The build tool crates aren't published.
+This runs on the specific git commit associated with the cargo submodule in the
+`stable` branch in `rust-lang/rust` at the time of release.
 
 On very rare cases, the Cargo team may decide to manually publish a new
 release to [crates.io]. For example, this may be necessary if there is a


### PR DESCRIPTION
### What does this PR try to resolve?

This is an attempt to close #10147. In short, publish the `cargo-test-(macro|support)` crates to crates.io.

Main parts:
* Updating the concerned manifests to make the packages publishable.
* Adding them to `publish.py`: not sure if you want this to be done. I put them after all other packages and in reverse-dependency order to ensure things will work the best, hopefully.
* Updating the contribution documentation to reflect the change. I didn't see any other place where the crates' publication was mentioned.

### How should we test and review this PR?

Sadly, the effective testing could not be done by me as it would require publishing the crates, which would block future publications by Cargo team members and therefore render the whole point of this impossible or cumbersome. Hopefully, the PR is small and readable enough that mistakes can be seen easily. The real testing would need to be done manually by some team member either before by checking the source branch out or after merging.

The only testing I was able to perform was to run `cargo publish --dry-run -p cargo-test-(macro|support)`. The first worked just fine. The second failed on the `crates-io` package not being available on crates.io in version `0.40.0`. However, the package is in this version in the current sources. I therefore suspect that a run of `publish.py` should work since the packages have been added there after `crates-io`.

### Additional information

This is very much tentative and open to discussion. I tried my best to update things as I understood them. Please correct me on anything I would have done wrong or simply not thought of.