### PR TITLE
chore(bump-check): include rustfix and cargo-util-schemas

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -176,8 +176,6 @@ fn bump_check(args: &clap::ArgMatches, config: &cargo::util::Config) -> CargoRes
         let mut cmd = ProcessBuilder::new("cargo");
         cmd.arg("semver-checks")
             .arg("--workspace")
-            .args(&["--exclude", "rustfix"]) // FIXME: Remove once 1.76 is stable
-            .args(&["--exclude", "cargo-util-schemas"]) // FIXME: Remove once 1.76 is stable
             .arg("--baseline-rev")
             .arg(referenced_commit.id().to_string());
         for krate in crates_not_check_against_channels {


### PR DESCRIPTION
The workspace now has these two crates in stable, beta, and nightly channels.
Checking semver compatibility against them should work now.