### PR TITLE
fix(compiler): Clarify Finished message

### DIFF
--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -806,8 +806,14 @@ impl<'cfg> DrainState<'cfg> {
             // `display_error` inside `handle_error`.
             Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
         } else if self.queue.is_empty() && self.pending_queue.is_empty() {
-            let message =
-                format!("`{profile_name}` profile [{opt_type}] target(s) in {time_elapsed}",);
+            let profile_link = cx.bcx.config.shell().err_hyperlink(
+                "https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles",
+            );
+            let message = format!(
+                "{}`{profile_name}` profile [{opt_type}]{} target(s) in {time_elapsed}",
+                profile_link.open(),
+                profile_link.close()
+            );
             if !cx.bcx.build_config.build_plan {
                 // It doesn't really matter if this fails.
                 let _ = cx.bcx.config.shell().status("Finished", message);

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -806,7 +806,8 @@ impl<'cfg> DrainState<'cfg> {
             // `display_error` inside `handle_error`.
             Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
         } else if self.queue.is_empty() && self.pending_queue.is_empty() {
-            let message = format!("{profile_name} [{opt_type}] target(s) in {time_elapsed}",);
+            let message =
+                format!("`{profile_name}` profile [{opt_type}] target(s) in {time_elapsed}",);
             if !cx.bcx.build_config.build_plan {
                 // It doesn't really matter if this fails.
                 let _ = cx.bcx.config.shell().status("Finished", message);

--- a/src/cargo/core/compiler/job_queue/mod.rs
+++ b/src/cargo/core/compiler/job_queue/mod.rs
@@ -806,10 +806,7 @@ impl<'cfg> DrainState<'cfg> {
             // `display_error` inside `handle_error`.
             Some(anyhow::Error::new(AlreadyPrintedError::new(error)))
         } else if self.queue.is_empty() && self.pending_queue.is_empty() {
-            let message = format!(
-                "{} [{}] target(s) in {}",
-                profile_name, opt_type, time_elapsed
-            );
+            let message = format!("{profile_name} [{opt_type}] target(s) in {time_elapsed}",);
             if !cx.bcx.build_config.build_plan {
                 // It doesn't really matter if this fails.
                 let _ = cx.bcx.config.shell().status("Finished", message);

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -114,7 +114,7 @@ fn basic() {
         // There have been multiple bugs where every build triggers and update.
         .with_stderr(
             "[COMPILING] foo v0.0.1 [..]\n\
-             [FINISHED] dev [..]",
+             [FINISHED] `dev` profile [..]",
         )
         .run();
     p.cargo("run").build_std().target_host().run();
@@ -262,7 +262,7 @@ fn remap_path_scope() {
         .with_status(101)
         .with_stderr_contains(
             "\
-[FINISHED] release [optimized + debuginfo] [..]
+[FINISHED] `release` profile [optimized + debuginfo] [..]
 [RUNNING] [..]
 [..]thread '[..]' panicked at [..]src/main.rs:3:[..]",
         )

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -36,7 +36,7 @@ fn depend_on_alt_registry() {
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -49,7 +49,7 @@ fn depend_on_alt_registry() {
             "\
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -91,7 +91,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
 [CHECKING] baz v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -133,7 +133,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
 [CHECKING] baz v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -176,7 +176,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
 [CHECKING] baz v0.0.1
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -210,7 +210,7 @@ fn registry_and_path_dep_works() {
             "\
 [CHECKING] bar v0.0.1 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -413,7 +413,7 @@ fn alt_registry_and_crates_io_deps() {
 [CHECKING] alt_reg_dep v0.1.0 (registry `alternative`)
 [CHECKING] crates_io_dep v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -683,7 +683,7 @@ fn patch_alt_reg() {
 [UPDATING] `alternative` index
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -775,7 +775,7 @@ fn no_api() {
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1334,7 +1334,7 @@ fn registries_index_relative_url() {
 [DOWNLOADED] bar v0.0.1 (registry `relative`)
 [CHECKING] bar v0.0.1 (registry `relative`)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -316,7 +316,7 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
 [COMPILING] d2 v0.0.1 ([CWD]/d2)
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -568,7 +568,9 @@ fn build_script_with_bin_artifacts() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[COMPILING] foo [..]")
         .with_stderr_contains("[COMPILING] bar v0.5.0 ([CWD]/bar)")
-        .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr_contains(
+            "[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
+        )
         .run();
 
     let build_script_output = build_script_output_string(&p, "foo");
@@ -752,7 +754,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
             "\
 [COMPILING] bar-baz v0.5.0 ([CWD]/bar)
 [COMPILING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 
@@ -849,7 +851,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
             "\
 [COMPILING] bar-baz v0.5.0 ([CWD]/bar)
 [COMPILING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 
@@ -895,7 +897,9 @@ fn allow_artifact_and_no_artifact_dep_to_same_package_within_different_dep_categ
     p.cargo("test -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_contains("[COMPILING] bar v0.5.0 ([CWD]/bar)")
-        .with_stderr_contains("[FINISHED] test [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr_contains(
+            "[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]",
+        )
         .run();
 }
 
@@ -1229,7 +1233,7 @@ fn no_cross_doctests_works_with_artifacts() {
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/{triple}/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ",
@@ -1251,7 +1255,7 @@ fn no_cross_doctests_works_with_artifacts() {
 [RUNNING] `rustc --crate-name bar bar/src/main.rs [..]--target {triple} [..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]",
             triple = target
         ))
         .run();
@@ -1268,7 +1272,7 @@ fn no_cross_doctests_works_with_artifacts() {
             "[FRESH] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]--test[..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[CWD]/target/{triple}/debug/deps/foo-[..][EXE]`",
             triple = target
         ))
@@ -1702,7 +1706,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate_if_these_are_not_the
             "\
 [COMPILING] bar [..]
 [COMPILING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1737,7 +1741,7 @@ fn prevent_no_lib_warning_with_artifact_dependencies() {
             "\
             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
             [CHECKING] foo v0.0.0 ([CWD])\n\
-            [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+            [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -1771,7 +1775,7 @@ fn show_no_lib_warning_with_artifact_dependencies_that_have_no_lib_but_lib_true(
         .with_stderr_contains("[WARNING] foo v0.0.0 ([CWD]) ignoring invalid dependency `bar` which is missing a lib target")
         .with_stderr_contains("[COMPILING] bar v0.5.0 ([CWD]/bar)")
         .with_stderr_contains("[CHECKING] foo [..]")
-        .with_stderr_contains("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr_contains("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }
 
@@ -1977,7 +1981,7 @@ fn env_vars_and_build_products_for_various_build_targets() {
             "\
 [COMPILING] bar [..]
 [COMPILING] foo [..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] unittests [..]
 [RUNNING] tests/main.rs [..]
 [DOCTEST] foo
@@ -2151,7 +2155,7 @@ fn doc_lib_true() {
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -2230,7 +2234,7 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -2433,7 +2437,7 @@ fn calc_bin_artifact_fingerprint() {
             "\
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2450,7 +2454,7 @@ fn calc_bin_artifact_fingerprint() {
 [DIRTY] foo v0.1.0 ([CWD]): the dependency bar was rebuilt
 [CHECKING] foo v0.1.0 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2462,7 +2466,7 @@ fn calc_bin_artifact_fingerprint() {
             "\
 [FRESH] bar v0.5.0 ([CWD]/bar)
 [FRESH] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2516,7 +2520,7 @@ fn with_target_and_optional() {
 [RUNNING] `rustc --crate-name d1 [..]--crate-type bin[..]
 [CHECKING] foo v0.0.1 [..]
 [RUNNING] `rustc --crate-name foo [..]--cfg[..]d1[..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -2567,7 +2571,7 @@ fn with_assumed_host_target_and_optional_build_dep() {
 [RUNNING] `rustc --crate-name d1 [..]--crate-type bin[..]
 [RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]--cfg[..]d1[..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -2690,7 +2694,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
 [COMPILING] a v0.1.0 ([CWD]/a)
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2790,7 +2794,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
 [COMPILING] a v0.1.0 ([CWD]/a)
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2915,7 +2919,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
 [COMPILING] c v0.1.0 ([CWD]/c)
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2974,7 +2978,7 @@ fn same_target_artifact_dep_sharing() {
 [COMPILING] a v0.1.0 ([CWD]/a)
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -674,7 +674,7 @@ fn unused_keys() {
             "\
 warning: unused manifest key: target.foo.bar
 [CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -698,7 +698,7 @@ warning: unused manifest key: target.foo.bar
             "\
 warning: unused manifest key: package.bulid
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -725,7 +725,7 @@ warning: unused manifest key: package.bulid
             "\
 warning: unused manifest key: lib.build
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -750,7 +750,7 @@ fn unused_keys_in_virtual_manifest() {
             "\
 [WARNING] [..]/foo/Cargo.toml: unused manifest key: workspace.bulid
 [CHECKING] bar [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -39,7 +39,7 @@ fn cargo_bench_simple() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench_hello ... bench: [..]")
@@ -81,7 +81,7 @@ fn bench_bench_implicit() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 [RUNNING] [..] (target/release/deps/mybench-[..][EXE])
 ",
@@ -125,7 +125,7 @@ fn bench_bin_implicit() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 ",
         )
@@ -158,7 +158,7 @@ fn bench_tarname() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/bin2-[..][EXE])
 ",
         )
@@ -223,7 +223,7 @@ fn cargo_bench_verbose() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] src/main.rs [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE] hello --bench`",
         )
         .with_stdout_contains("test bench_hello ... bench: [..]")
@@ -310,7 +310,7 @@ fn cargo_bench_failing_test() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.5.0 ([CWD])[..]
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("[..]thread '[..]' panicked at[..]")
@@ -377,7 +377,7 @@ fn bench_with_lib_dep() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 [RUNNING] [..] (target/release/deps/baz-[..][EXE])",
         )
@@ -438,7 +438,7 @@ fn bench_with_deep_lib_dep() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/bar-[..][EXE])",
         )
         .with_stdout_contains("test bar_bench ... bench: [..]")
@@ -491,7 +491,7 @@ fn external_bench_explicit() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 [RUNNING] [..] (target/release/deps/bench-[..][EXE])",
         )
@@ -534,7 +534,7 @@ fn external_bench_implicit() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 [RUNNING] [..] (target/release/deps/external-[..][EXE])",
         )
@@ -609,7 +609,7 @@ automatically infer them to be a target, such as in subfolders.
 For more information on this warning you can consult
 https://github.com/rust-lang/cargo/issues/5330
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 ",
         )
@@ -648,7 +648,7 @@ fn pass_through_command_line() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bar ... bench: [..]")
@@ -656,7 +656,7 @@ fn pass_through_command_line() {
 
     p.cargo("bench foo")
         .with_stderr(
-            "[FINISHED] bench [optimized] target(s) in [..]
+            "[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test foo ... bench: [..]")
@@ -733,7 +733,7 @@ fn lib_bin_same_name() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
@@ -778,7 +778,7 @@ fn lib_with_standard_name() {
         .with_stderr(
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/syntax-[..][EXE])
 [RUNNING] [..] (target/release/deps/bench-[..][EXE])",
         )
@@ -826,7 +826,7 @@ fn lib_with_standard_name2() {
         .with_stderr(
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/syntax-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
@@ -902,7 +902,7 @@ fn bench_dylib() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE] --bench`
 [RUNNING] `[..]target/release/deps/bench-[..][EXE] --bench`",
         )
@@ -915,7 +915,7 @@ fn bench_dylib() {
             "\
 [FRESH] bar v0.0.1 ([CWD]/bar)
 [FRESH] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE] --bench`
 [RUNNING] `[..]target/release/deps/bench-[..][EXE] --bench`",
         )
@@ -953,7 +953,7 @@ fn bench_twice_with_build_cmd() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test foo ... bench: [..]")
@@ -961,7 +961,7 @@ fn bench_twice_with_build_cmd() {
 
     p.cargo("bench")
         .with_stderr(
-            "[FINISHED] bench [optimized] target(s) in [..]
+            "[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test foo ... bench: [..]")
@@ -1042,7 +1042,7 @@ fn bench_with_examples() {
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[CWD]/target/release/deps/foo-[..][EXE] --bench`
 [RUNNING] `[CWD]/target/release/deps/testb1-[..][EXE] --bench`",
         )
@@ -1080,7 +1080,7 @@ fn test_a_bench() {
         .with_stderr(
             "\
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/b-[..][EXE])",
         )
         .with_stdout_contains("test foo ... ok")
@@ -1110,7 +1110,7 @@ fn test_bench_no_run() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [EXECUTABLE] benches src/lib.rs (target/release/deps/foo-[..][EXE])
 [EXECUTABLE] benches/bbaz.rs (target/release/deps/bbaz-[..][EXE])
 ",
@@ -1141,7 +1141,7 @@ fn test_bench_no_run_emit_json() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -1192,7 +1192,7 @@ fn test_bench_no_fail_fast() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 [..]
-[FINISHED] bench [..]
+[FINISHED] `bench` profile [..]
 [RUNNING] unittests src/main.rs (target/release/deps/foo[..])
 [ERROR] bench failed, to rerun pass `--bin foo`
 [RUNNING] benches/b1.rs (target/release/deps/b1[..])
@@ -1702,7 +1702,7 @@ fn cargo_bench_print_env_verbose() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc[..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] [CWD]/target/release/deps/foo-[..][EXE] --bench`",
         )
         .run();

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -178,7 +178,7 @@ fn binary_name2() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test tests::check_crabs ... ok")

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1440,7 +1440,7 @@ fn cargo_default_env_metadata_env_var() {
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps \
         --extern bar=[CWD]/target/debug/deps/{prefix}bar{suffix}`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
             prefix = env::consts::DLL_PREFIX,
             suffix = env::consts::DLL_SUFFIX,
         ))
@@ -1468,7 +1468,7 @@ fn cargo_default_env_metadata_env_var() {
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps \
         --extern bar=[CWD]/target/debug/deps/{prefix}bar-[..]{suffix}`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             prefix = env::consts::DLL_PREFIX,
             suffix = env::consts::DLL_SUFFIX,
@@ -2331,7 +2331,7 @@ fn lto_build() {
         -C opt-level=3 \
         -C lto \
         [..]
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -2349,7 +2349,7 @@ fn verbose_build() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2368,7 +2368,7 @@ fn verbose_release_build() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/release/deps`
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -2387,7 +2387,7 @@ fn verbose_release_build_short() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/release/deps`
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -2447,7 +2447,7 @@ fn verbose_release_build_deps() {
         -L dependency=[CWD]/target/release/deps \
         --extern foo=[CWD]/target/release/deps/{prefix}foo{suffix} \
         --extern foo=[CWD]/target/release/deps/libfoo.rlib`
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
             prefix = env::consts::DLL_PREFIX,
             suffix = env::consts::DLL_SUFFIX
@@ -3034,7 +3034,7 @@ fn lib_with_standard_name() {
         .with_stderr(
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3150,7 +3150,7 @@ fn freshness_ignores_excluded() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3204,7 +3204,7 @@ fn rebuild_preserves_out_dir() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3214,7 +3214,7 @@ fn rebuild_preserves_out_dir() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4405,7 +4405,7 @@ fn no_warn_about_package_metadata() {
     p.cargo("build")
         .with_stderr(
             "[..] foo v0.0.1 ([..])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -4442,7 +4442,7 @@ fn no_warn_about_workspace_metadata() {
     p.cargo("build")
         .with_stderr(
             "[..] foo v0.0.1 ([..])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -4511,7 +4511,7 @@ fn build_all_workspace() {
             "\
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4544,7 +4544,7 @@ fn build_all_exclude() {
             "\
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4613,7 +4613,7 @@ fn build_all_exclude_not_found() {
 [WARNING] excluded package(s) `baz` not found in workspace [..]
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4646,7 +4646,7 @@ fn build_all_exclude_glob() {
             "\
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4678,7 +4678,7 @@ fn build_all_exclude_glob_not_found() {
 [WARNING] excluded package pattern(s) `*z` not found in workspace [..]
 [COMPILING] [..] v0.1.0 ([..])
 [COMPILING] [..] v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4727,7 +4727,7 @@ fn build_all_workspace_implicit_examples() {
         .with_stderr(
             "[..] Compiling bar v0.1.0 ([..])\n\
              [..] Compiling foo v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
     assert!(!p.bin("a").is_file());
@@ -4762,7 +4762,7 @@ fn build_all_virtual_manifest() {
             "\
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4790,7 +4790,7 @@ fn build_virtual_manifest_all_implied() {
             "\
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4817,7 +4817,7 @@ fn build_virtual_manifest_one_project() {
         .with_stderr(
             "\
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4844,7 +4844,7 @@ fn build_virtual_manifest_glob() {
         .with_stderr(
             "\
 [COMPILING] baz v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4920,7 +4920,7 @@ fn build_all_virtual_manifest_implicit_examples() {
             "\
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4967,7 +4967,7 @@ fn build_all_member_dependency_same_name() {
              [DOWNLOADED] a v0.1.0 ([..])\n\
              [COMPILING] a v0.1.0\n\
              [COMPILING] a v0.1.0 ([..])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -5323,7 +5323,7 @@ fn deterministic_cfg_flags() {
 --cfg[..]default[..]--cfg[..]f_a[..]--cfg[..]f_b[..]\
 --cfg[..]f_c[..]--cfg[..]f_d[..] \
 --cfg cfg_a --cfg cfg_b --cfg cfg_c --cfg cfg_d --cfg cfg_e`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -6276,7 +6276,7 @@ fn build_lib_only() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -890,7 +890,7 @@ fn custom_build_script_rustc_flags() {
     -L dependency=[CWD]/target/debug/deps \
     --extern foo=[..]libfoo-[..] \
     -L /dummy/path1 -L /dummy/path2`
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -949,7 +949,7 @@ fn custom_build_script_rustc_flags_no_space() {
     -L dependency=[CWD]/target/debug/deps \
     --extern foo=[..]libfoo-[..] \
     -L /dummy/path1 -L /dummy/path2`
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -1221,7 +1221,7 @@ fn overrides_and_links() {
 [..]
 [..]
 [RUNNING] `rustc --crate-name foo [..] -L foo -L bar`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1348,7 +1348,7 @@ fn only_rerun_build_script() {
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1456,7 +1456,7 @@ fn testing_and_such() {
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--test [..]`",
@@ -1470,7 +1470,7 @@ fn testing_and_such() {
             "\
 [DOCUMENTING] foo v0.5.0 ([CWD])
 [RUNNING] `rustdoc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -1482,7 +1482,7 @@ fn testing_and_such() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
         )
@@ -1672,7 +1672,7 @@ fn build_deps_simple() {
 [RUNNING] `rustc [..] build.rs [..] --extern a=[..]`
 [RUNNING] `[..]/foo-[..]/build-script-build`
 [RUNNING] `rustc --crate-name foo [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1797,7 +1797,7 @@ fn build_cmd_with_a_build_cmd() {
     -C metadata=[..] \
     --out-dir [..] \
     -L [..]target/debug/deps`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2012,7 +2012,7 @@ fn code_generation() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("Hello, World!")
@@ -2575,7 +2575,7 @@ fn cfg_test() {
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
 [RUNNING] [..] --cfg foo[..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`
 [RUNNING] `[..]/test-[..][EXE]`
 [DOCTEST] foo
@@ -2686,7 +2686,7 @@ fn cfg_override_test() {
 [RUNNING] `[..]`
 [RUNNING] `[..]`
 [RUNNING] `[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`
 [RUNNING] `[..]/test-[..][EXE]`
 [DOCTEST] foo
@@ -2822,7 +2822,7 @@ fn env_test() {
 [RUNNING] [..] --crate-name foo[..]
 [RUNNING] [..] --crate-name foo[..]
 [RUNNING] [..] --crate-name test[..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`
 [RUNNING] `[..]/test-[..][EXE]`
 [DOCTEST] foo
@@ -2923,7 +2923,7 @@ fn flags_go_into_tests() {
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] src/lib.rs [..] -L test[..]`
 [RUNNING] `rustc [..] tests/foo.rs [..] -L test[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/foo-[..][EXE]`",
         )
         .with_stdout_contains("running 0 tests")
@@ -2935,7 +2935,7 @@ fn flags_go_into_tests() {
 [FRESH] a v0.5.0 ([..]
 [COMPILING] b v0.5.0 ([..]
 [RUNNING] `rustc [..] b/src/lib.rs [..] -L test[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]/b-[..][EXE]`",
         )
         .with_stdout_contains("running 0 tests")
@@ -3019,7 +3019,7 @@ fn diamond_passes_args_only_once() {
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `[..]rmeta -L native=test`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3059,7 +3059,7 @@ fn adding_an_override_invalidates() {
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
 [RUNNING] `rustc [..] -L native=foo`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3080,7 +3080,7 @@ fn adding_an_override_invalidates() {
             "\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3120,7 +3120,7 @@ fn changing_an_override_invalidates() {
             "\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=foo`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3142,7 +3142,7 @@ fn changing_an_override_invalidates() {
 [DIRTY] foo v0.5.0 ([..]): the precalculated components changed
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..] -L native=bar`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3185,7 +3185,7 @@ fn fresh_builds_possible_with_link_libs() {
             "\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3194,7 +3194,7 @@ fn fresh_builds_possible_with_link_libs() {
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3239,7 +3239,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
             "\
 [COMPILING] foo v0.5.0 ([..]
 [RUNNING] `rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3248,7 +3248,7 @@ fn fresh_builds_possible_with_multiple_metadata_overrides() {
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3433,7 +3433,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3452,7 +3452,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3462,7 +3462,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3476,7 +3476,7 @@ fn rebuild_only_on_explicit_paths() {
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3491,7 +3491,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3506,7 +3506,7 @@ fn rebuild_only_on_explicit_paths() {
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3781,7 +3781,7 @@ fn warnings_emitted() {
 warning: foo@0.5.0: foo
 warning: foo@0.5.0: bar
 [RUNNING] `rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3873,7 +3873,7 @@ fn warnings_hidden_for_upstream() {
 [RUNNING] `rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3934,7 +3934,7 @@ warning: bar@0.1.0: bar
 [RUNNING] `[..] rustc [..]`
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..] rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3976,7 +3976,7 @@ fn output_shows_on_vv() {
 [RUNNING] `[..]`
 [foo 0.5.0] stderr
 [RUNNING] `[..] rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -4647,7 +4647,7 @@ fn optional_build_dep_and_required_normal_dep() {
             "\
 [COMPILING] bar v0.5.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]foo[EXE]`",
         )
         .run();
@@ -4658,7 +4658,7 @@ fn optional_build_dep_and_required_normal_dep() {
             "\
 [COMPILING] bar v0.5.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]foo[EXE]`",
         )
         .run();
@@ -4975,7 +4975,7 @@ fn rerun_if_published_directory() {
             "\
 [FRESH] mylib-sys v1.0.0
 [FRESH] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -266,7 +266,7 @@ fn link_arg_transitive_not_allowed() {
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo v0.1.0 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .with_stderr_does_not_contain("--bogus")

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -347,7 +347,7 @@ fn replay_non_json() {
 [CHECKING] foo [..]
 line 1
 line 2
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -358,7 +358,7 @@ line 2
             "\
 line 1
 line 2
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -407,7 +407,7 @@ fn caching_large_output() {
             "\
 [CHECKING] foo [..]
 {}warning: `foo` (lib) generated 250 warnings
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
             expected
         ))
@@ -418,7 +418,7 @@ fn caching_large_output() {
         .with_stderr(&format!(
             "\
 {}warning: `foo` (lib) generated 250 warnings
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
             expected
         ))

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -164,7 +164,7 @@ fn builtin_alias_shadowing_external_subcommand() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 [..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] unittests src/main.rs [..]
 ",
         )
@@ -197,7 +197,7 @@ fn alias_shadowing_external_subcommand() {
 This was previously accepted but is being phased out; it will become a hard error in a future release.
 For more information, see issue #10049 <https://github.com/rust-lang/cargo/issues/10049>.
 [COMPILING] foo v0.5.0 [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -254,7 +254,7 @@ error: alias test-1 has unresolvable recursive definition: test-1 -> echo -> ech
             "\
 [WARNING] user-defined alias `build` is ignored, because it is shadowed by a built-in command
 [COMPILING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -350,7 +350,7 @@ fn alias_cannot_shadow_builtin_command() {
             "\
 [WARNING] user-defined alias `build` is ignored, because it is shadowed by a built-in command
 [COMPILING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -374,7 +374,7 @@ fn alias_override_builtin_alias() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
         )
@@ -405,7 +405,7 @@ fn global_options_with_alias() {
             "\
 [CHECKING] foo [..]
 [RUNNING] `rustc [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -55,7 +55,7 @@ fn dont_include() {
         .with_stderr(
             "\
 [CHECKING] a v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -98,7 +98,7 @@ fn works_through_the_registry() {
 [CHECKING] baz v0.1.0
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -144,7 +144,7 @@ fn ignore_version_from_other_platform() {
 [DOWNLOADED] [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -302,7 +302,7 @@ fn dylib_check_preserves_build_cache() {
         .with_stderr(
             "\
 [..]Compiling foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -310,7 +310,7 @@ fn dylib_check_preserves_build_cache() {
     p.cargo("check").run();
 
     p.cargo("build")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }
 
@@ -438,7 +438,7 @@ fn check_all_exclude() {
         .with_stderr(
             "\
 [CHECKING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -465,7 +465,7 @@ fn check_all_exclude_glob() {
         .with_stderr(
             "\
 [CHECKING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -514,7 +514,7 @@ fn check_virtual_manifest_one_project() {
         .with_stderr(
             "\
 [CHECKING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -541,7 +541,7 @@ fn check_virtual_manifest_glob() {
         .with_stderr(
             "\
 [CHECKING] baz v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -556,7 +556,7 @@ fn exclude_warns_on_non_existing_package() {
             "\
 [WARNING] excluded package(s) `bar` not found in workspace `[CWD]`
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1049,7 +1049,7 @@ fn warn_manifest_package_and_project() {
             "\
 [WARNING] manifest at `[CWD]` contains both `project` and `package`, this could become a hard error in the future
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1100,7 +1100,7 @@ fn git_manifest_package_and_project() {
 [UPDATING] git repository `[..]`
 [CHECKING] bar v0.0.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1125,7 +1125,7 @@ fn warn_manifest_with_project() {
             "\
 [WARNING] manifest at `[CWD]` contains `[project]` instead of `[package]`, this could become a hard error in the future
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1172,7 +1172,7 @@ fn git_manifest_with_project() {
 [UPDATING] git repository `[..]`
 [CHECKING] bar v0.0.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1492,7 +1492,7 @@ fn check_unused_manifest_keys() {
 [CHECKING] [..]
 [CHECKING] [..]
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1515,7 +1515,7 @@ fn versionless_package() {
         .with_stderr(
             "\
 [CHECKING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1556,7 +1556,7 @@ fn pkgid_querystring_works() {
         .with_stderr(
             "\
 [COMPILING] gitdep v1.0.0 (file:///[..]/gitdep?branch=master#[..])
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
         )
         .run();
 }

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -396,7 +396,7 @@ fn build_script_doc() {
 [RUNNING] `[..]/build-script-build`
 [DOCUMENTING] foo [..]
 [RUNNING] `rustdoc [..] src/main.rs [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -239,7 +239,7 @@ fn clean_release() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -326,7 +326,7 @@ fn build_script() {
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -434,7 +434,7 @@ fn debug_release_ok() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run_output(&a);
@@ -442,7 +442,7 @@ fn debug_release_ok() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run_output(&b);

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -464,7 +464,7 @@ fn cross_tests() {
         .with_stderr(&format!(
             "\
 [COMPILING] foo v0.0.0 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/{triple}/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/{triple}/debug/deps/bar-[..][EXE])",
             triple = target
@@ -494,7 +494,7 @@ fn no_cross_doctests() {
 
     let host_output = "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ";
@@ -512,7 +512,7 @@ fn no_cross_doctests() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]--crate-type lib[..]
 [RUNNING] `rustc --crate-name foo [..]--test[..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[CWD]/target/{target}/debug/deps/foo-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]--target {target}[..]`
@@ -545,7 +545,7 @@ test result: ok. 1 passed[..]
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [NOTE] skipping doctests for foo v0.0.1 ([ROOT]/foo) (lib), \
 cross-compilation doctests are not yet supported
 See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#doctest-xcompile \
@@ -565,7 +565,7 @@ for more information.
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]--test[..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[CWD]/target/{triple}/debug/deps/foo-[..][EXE]`
 [NOTE] skipping doctests for foo v0.0.1 ([ROOT]/foo) (lib), \
 cross-compilation doctests are not yet supported
@@ -657,7 +657,7 @@ fn cross_with_a_build_script() {
 [RUNNING] `rustc [..] build.rs [..] --out-dir [CWD]/target/debug/build/foo-[..]`
 [RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..] --target {target} [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             target = target,
         ))
@@ -902,7 +902,7 @@ fn plugin_build_script_right_arch() {
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -974,7 +974,7 @@ fn build_script_with_platform_specific_dependencies() {
 [RUNNING] `rustc [..] build.rs [..]`
 [RUNNING] `[CWD]/target/debug/build/foo-[..]/build-script-build`
 [RUNNING] `rustc [..] src/lib.rs [..] --target {target} [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             target = target
         ))
@@ -1209,7 +1209,7 @@ fn cross_test_dylib() {
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/{arch}/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/{arch}/debug/deps/test-[..][EXE])",
             arch = cross_compile::alternate()

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -45,7 +45,7 @@ fn simple_cross_package() {
 [PACKAGING] foo v0.0.0 ([CWD])
 [VERIFYING] foo v0.0.0 ([CWD])
 [COMPILING] foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -109,7 +109,7 @@ fn publish_with_target() {
 [PACKAGING] foo v0.0.0 ([CWD])
 [VERIFYING] foo v0.0.0 ([CWD])
 [COMPILING] foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.0 ([CWD])
 [UPLOADED] foo v0.0.0 to registry `crates-io`

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -244,13 +244,13 @@ fn custom_target_ignores_filepath() {
         .with_stderr(
             "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
 
     // But not the second time, even though the path to the custom target is dfferent.
     p.cargo("build --lib --target b/custom-target.json")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -357,7 +357,7 @@ fn relative_depinfo_paths_ws() {
     p.cargo("build -Z binary-dep-depinfo --target")
         .arg(&host)
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
-        .with_stderr("[FINISHED] dev [..]")
+        .with_stderr("[FINISHED] `dev` profile [..]")
         .run();
 }
 
@@ -479,7 +479,7 @@ fn relative_depinfo_paths_no_ws() {
     // Make sure it stays fresh.
     p.cargo("build -Z binary-dep-depinfo")
         .masquerade_as_nightly_cargo(&["binary-dep-depinfo"])
-        .with_stderr("[FINISHED] dev [..]")
+        .with_stderr("[FINISHED] `dev` profile [..]")
         .run();
 }
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -147,7 +147,7 @@ fn simple_install() {
 [INSTALLING] bar v0.1.0
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
-[FINISHED] release [optimized] target(s) in [..]s
+[FINISHED] `release` profile [optimized] target(s) in [..]s
 [INSTALLING] [..]bar[..]
 [INSTALLED] package `bar v0.1.0` (executable `bar[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -240,7 +240,7 @@ fn install_without_feature_dep() {
 [INSTALLING] bar v0.1.0
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
-[FINISHED] release [optimized] target(s) in [..]s
+[FINISHED] `release` profile [optimized] target(s) in [..]s
 [INSTALLING] [..]bar[..]
 [INSTALLED] package `bar v0.1.0` (executable `bar[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -30,7 +30,7 @@ fn simple() {
             "\
 [..] foo v0.0.1 ([CWD])
 [..] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -69,7 +69,7 @@ fn doc_twice() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -111,7 +111,7 @@ fn doc_deps() {
 [..] bar v0.0.1 ([CWD]/bar)
 [..] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -165,7 +165,7 @@ fn doc_no_deps() {
             "\
 [CHECKING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -415,7 +415,7 @@ fn doc_lib_bin_same_name_documents_lib() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -451,7 +451,7 @@ fn doc_lib_bin_same_name_documents_lib_when_requested() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -497,7 +497,7 @@ This is a known bug where multiple crates with the same name use
 the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -543,7 +543,7 @@ This is a known bug where multiple crates with the same name use
 the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -589,7 +589,7 @@ fn doc_lib_bin_example_same_name_documents_named_example_when_requested() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/ex1/index.html
 ",
         )
@@ -644,7 +644,7 @@ fn doc_lib_bin_example_same_name_documents_examples_when_requested() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/ex1/index.html
 [GENERATED] [CWD]/target/doc/ex2/index.html
 ",
@@ -703,7 +703,7 @@ fn doc_dash_p() {
 [..] b v0.0.1 ([CWD]/b)
 [..] b v0.0.1 ([CWD]/b)
 [DOCUMENTING] a v0.0.1 ([CWD]/a)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/a/index.html
 ",
         )
@@ -731,7 +731,7 @@ fn doc_all_exclude() {
         .with_stderr(
             "\
 [DOCUMENTING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
@@ -759,7 +759,7 @@ fn doc_all_exclude_glob() {
         .with_stderr(
             "\
 [DOCUMENTING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
@@ -947,7 +947,7 @@ fn doc_release() {
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
 [RUNNING] `rustdoc [..] src/lib.rs [..]`
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -1235,7 +1235,7 @@ fn doc_virtual_manifest_one_project() {
         .with_stderr(
             "\
 [DOCUMENTING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
@@ -1263,7 +1263,7 @@ fn doc_virtual_manifest_glob() {
         .with_stderr(
             "\
 [DOCUMENTING] baz v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/baz/index.html
 ",
         )
@@ -1675,7 +1675,7 @@ fn doc_cap_lints() {
 [DOCUMENTING] a v0.5.0 ([..])
 [CHECKING] a v0.5.0 ([..])
 [DOCUMENTING] foo v0.0.1 ([..])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -1941,7 +1941,7 @@ fn bin_private_items() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -2002,7 +2002,7 @@ fn bin_private_items_deps() {
 [DOCUMENTING] bar v0.0.1 ([..])
 [CHECKING] bar v0.0.1 ([..])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -25,7 +25,7 @@ fn basic() {
 [CHECKING] foo v0.0.1 ([CWD])
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -393,7 +393,7 @@ fn cache() {
 [CHECKING] foo v0.0.1 ([CWD])
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -403,7 +403,7 @@ fn cache() {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr(
             "\
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -446,7 +446,7 @@ warning: failed to scan example \"ex2\" in package `foo` for example code usage
     If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex2\") generated 1 warning
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
     )
@@ -512,7 +512,7 @@ warning: failed to scan example \"ex1\" in package `foo` for example code usage
     If an example should not be scanned, then consider adding `doc-scrape-examples = false` to its `[[example]]` definition in Cargo.toml
 warning: `foo` (example \"ex1\") generated 1 warning
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -537,7 +537,7 @@ error: expected one of `!` or `::`, found `NOT`
   |      ^^^ expected one of `!` or `::`
 
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -590,7 +590,7 @@ warning: Rustdoc did not scrape the following examples because they require dev-
     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
     to the [[example]] target configuration of at least one example.
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -606,7 +606,7 @@ warning: Rustdoc did not scrape the following examples because they require dev-
 [DOCUMENTING] a v0.0.1 ([CWD]/a)
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/ex/index.html
 ",
         )
@@ -655,7 +655,7 @@ fn use_dev_deps_if_explicitly_enabled() {
 [CHECKING] a v0.0.1 ([CWD]/a)
 [SCRAPING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -507,7 +507,7 @@ fn no_feature_doesnt_build() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -521,7 +521,7 @@ fn no_feature_doesnt_build() {
 [DIRTY-MSVC] foo v0.0.1 ([CWD]): the list of features changed
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -567,7 +567,7 @@ fn default_feature_pulled_in() {
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -579,7 +579,7 @@ fn default_feature_pulled_in() {
 [DIRTY-MSVC] foo v0.0.1 ([CWD]): the list of features changed
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -691,7 +691,7 @@ fn groups_on_groups_on_groups() {
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -740,7 +740,7 @@ fn many_cli_features() {
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -823,7 +823,7 @@ fn union_features() {
 [CHECKING] d2 v0.0.1 ([CWD]/d2)
 [CHECKING] d1 v0.0.1 ([CWD]/d1)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -868,7 +868,7 @@ fn many_features_no_rebuilds() {
             "\
 [CHECKING] a v0.1.0 ([CWD]/a)
 [CHECKING] b v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -879,7 +879,7 @@ fn many_features_no_rebuilds() {
             "\
 [FRESH] a v0.1.0 ([..]/a)
 [FRESH] b v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1137,7 +1137,7 @@ fn optional_and_dev_dep() {
         .with_stderr(
             "\
 [CHECKING] test v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1409,7 +1409,7 @@ fn many_cli_features_comma_delimited() {
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1476,7 +1476,7 @@ fn many_cli_features_comma_and_space_delimited() {
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1637,7 +1637,7 @@ fn warn_if_default_features() {
             r#"
 [WARNING] `default-features = [".."]` was found in [features]. Did you mean to use `default = [".."]`?
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
             "#.trim(),
         ).run();
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1109,7 +1109,7 @@ fn proc_macro_ws() {
             "\
 [FRESH] foo v0.1.0 [..]
 [FRESH] pm v0.1.0 [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -2583,7 +2583,7 @@ fn dep_with_optional_host_deps_activated() {
 [COMPILING] serde_derive v0.1.0 ([CWD]/serde_derive)
 [COMPILING] serde v0.1.0 ([CWD]/serde)
 [CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -909,7 +909,7 @@ fn fix_overlapping() {
 [CHECKING] foo [..]
 [MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (2 fixes)
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -1093,7 +1093,7 @@ fn doesnt_rebuild_dependencies() {
             "\
 [CHECKING] bar v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1104,7 +1104,7 @@ fn doesnt_rebuild_dependencies() {
         .with_stderr(
             "\
 [CHECKING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1194,7 +1194,7 @@ fn only_warn_for_relevant_crates() {
 [CHECKING] a v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
 [MIGRATING] src/lib.rs from 2015 edition to 2018
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -29,7 +29,7 @@ fn modifying_and_moving() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -45,7 +45,7 @@ fn modifying_and_moving() {
 [DIRTY] foo v0.0.1 ([CWD]): the file `src/a.rs` has changed ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -71,7 +71,7 @@ fn modify_only_some_files() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -92,7 +92,7 @@ fn modify_only_some_files() {
 [DIRTY] foo v0.0.1 ([CWD]): the file `src/b.rs` has changed ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -139,7 +139,7 @@ fn rebuild_sub_package_then_while_package() {
 [COMPILING] b [..]
 [COMPILING] a [..]
 [COMPILING] foo [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -155,7 +155,7 @@ fn rebuild_sub_package_then_while_package() {
 [DIRTY] b v0.0.1 ([..]): the file `b/src/lib.rs` has changed ([..])
 [COMPILING] b [..]
 [RUNNING] `rustc --crate-name b [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -175,7 +175,7 @@ fn rebuild_sub_package_then_while_package() {
 [DIRTY] foo [..]: the dependency b was rebuilt ([..])
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -203,7 +203,7 @@ fn changing_lib_features_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -212,7 +212,7 @@ fn changing_lib_features_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -220,13 +220,13 @@ fn changing_lib_features_caches_targets() {
     /* Targets should be cached from the first build */
 
     p.cargo("build")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 
     p.cargo("build").with_stderr("[FINISHED] [..]").run();
 
     p.cargo("build --features foo")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }
 
@@ -252,7 +252,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -261,7 +261,7 @@ fn changing_profiles_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling foo v0.0.1 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target[..]debug[..]deps[..]foo-[..][EXE])
 [DOCTEST] foo
 ",
@@ -271,13 +271,13 @@ fn changing_profiles_caches_targets() {
     /* Targets should be cached from the first build */
 
     p.cargo("build")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 
     p.cargo("test foo")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target[..]debug[..]deps[..]foo-[..][EXE])
 ",
         )
@@ -377,7 +377,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
             "\
 [..]Compiling dep_crate v0.0.1 ([..])
 [..]Compiling a v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/a[EXE]`
 ",
         )
@@ -389,7 +389,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling a v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/a[EXE]`
 ",
         )
@@ -403,7 +403,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
             "\
 [..]Compiling dep_crate v0.0.1 ([..])
 [..]Compiling b v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/b[EXE]`
 ",
         )
@@ -415,7 +415,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling b v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/b[EXE]`
 ",
         )
@@ -430,7 +430,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling a v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/a[EXE]`
 ",
         )
@@ -445,7 +445,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .with_stderr(
             "\
 [..]Compiling b v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]target/debug/b[EXE]`
 ",
         )
@@ -482,7 +482,7 @@ fn changing_bin_features_caches_targets() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -492,7 +492,7 @@ fn changing_bin_features_caches_targets() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -509,10 +509,10 @@ fn changing_bin_features_caches_targets() {
 [DIRTY] foo v0.0.1 ([..]): the list of features changed
 [COMPILING] foo[..]
 [RUNNING] `rustc [..]
-[FINISHED] dev[..]",
+[FINISHED] `dev`[..]",
         );
     } else {
-        e.with_stderr("[FRESH] foo v0.0.1 ([..])\n[FINISHED] dev[..]");
+        e.with_stderr("[FRESH] foo v0.0.1 ([..])\n[FINISHED] `dev`[..]");
     }
     e.run();
     p.rename_run("foo", "off2").with_stdout("feature off").run();
@@ -524,13 +524,13 @@ fn changing_bin_features_caches_targets() {
 [DIRTY] foo v0.0.1 ([..]): the list of features changed
 [COMPILING] foo[..]
 [RUNNING] `rustc [..]
-[FINISHED] dev[..]",
+[FINISHED] `dev`[..]",
         );
     } else {
         e.with_stderr(
             "\
 [FRESH] foo v0.0.1 ([..])
-[FINISHED] dev[..]",
+[FINISHED] `dev`[..]",
         );
     }
     e.run();
@@ -620,7 +620,7 @@ fn no_rebuild_transitive_target_deps() {
 [COMPILING] c v0.0.1 ([..])
 [COMPILING] b v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[..][EXE])
 [EXECUTABLE] tests/foo.rs (target/debug/deps/foo-[..][EXE])
 ",
@@ -740,7 +740,7 @@ fn same_build_dir_cached_packages() {
 [COMPILING] c v0.0.1 ({dir}/c)
 [COMPILING] b v0.0.1 ({dir}/b)
 [COMPILING] a1 v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             dir = p.url().to_file_path().unwrap().to_str().unwrap()
         ))
@@ -750,7 +750,7 @@ fn same_build_dir_cached_packages() {
         .with_stderr(
             "\
 [COMPILING] a2 v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -851,7 +851,7 @@ fn rebuild_if_environment_changes() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
         )
@@ -875,7 +875,7 @@ fn rebuild_if_environment_changes() {
 [DIRTY] foo v0.0.1 ([CWD]): the metadata changed
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
         )
@@ -920,7 +920,7 @@ fn no_rebuild_when_rename_dir() {
 
     p.cargo("build")
         .cwd(&new)
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }
 
@@ -1217,7 +1217,7 @@ fn changing_rustflags_is_cached() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
     p.cargo("build -v")
@@ -1227,7 +1227,7 @@ fn changing_rustflags_is_cached() {
 [DIRTY] foo v0.0.1 ([..]): the rustflags changed
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 
@@ -1237,7 +1237,7 @@ fn changing_rustflags_is_cached() {
 [DIRTY] foo v0.0.1 ([..]): the rustflags changed
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
     p.cargo("build -v")
@@ -1247,7 +1247,7 @@ fn changing_rustflags_is_cached() {
 [DIRTY] foo v0.0.1 ([..]): the rustflags changed
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -1278,20 +1278,20 @@ fn update_dependency_mtime_does_not_rebuild() {
             "\
 [COMPILING] bar v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
     // This does not make new files, but it does update the mtime of the dependency.
     p.cargo("build -p bar -Z mtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
     // This should not recompile!
     p.cargo("build -Z mtime-on-use")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
         .env("RUSTFLAGS", "-C linker=cc")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }
 
@@ -1357,7 +1357,7 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
     if is_coarse_mtime() {
@@ -1370,13 +1370,13 @@ fn fingerprint_cleaner_does_not_rebuild() {
     // This does not make new files, but it does update the mtime.
     p.cargo("build -Z mtime-on-use --features a")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
     fingerprint_cleaner(p.target_debug_dir(), timestamp);
     // This should not recompile!
     p.cargo("build -Z mtime-on-use --features a")
         .masquerade_as_nightly_cargo(&["mtime-on-use"])
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
     // But this should be cleaned and so need a rebuild
     p.cargo("build -Z mtime-on-use")
@@ -1384,7 +1384,7 @@ fn fingerprint_cleaner_does_not_rebuild() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -1646,7 +1646,7 @@ fn rebuild_on_mid_build_file_modification() {
             "\
 [COMPILING] proc_macro_dep v0.1.0 ([..]/proc_macro_dep)
 [COMPILING] root v0.1.0 ([..]/root)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1658,7 +1658,7 @@ fn rebuild_on_mid_build_file_modification() {
 [DIRTY] root v0.1.0 ([..]/root): the file `root/src/lib.rs` has changed ([..])
 [COMPILING] root v0.1.0 ([..]/root)
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2792,7 +2792,7 @@ fn verify_source_before_recompile() {
             "\
 [FRESH] bar v0.1.0
 [FRESH] foo v0.1.0 ([CWD])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -2831,7 +2831,7 @@ fn skip_mtime_check_in_selected_cargo_home_subdirs() {
             "\
 [CHECKING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
         )
         .run();
     p.change_file("src/lib.rs", "illegal syntax");
@@ -2840,7 +2840,7 @@ fn skip_mtime_check_in_selected_cargo_home_subdirs() {
         .with_stderr(
             "\
 [FRESH] foo v0.5.0 ([CWD])
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
         )
         .run();
 }
@@ -2860,7 +2860,7 @@ fn use_mtime_cache_in_cargo_home() {
             "\
 [CHECKING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
         )
         .run();
     p.change_file("src/lib.rs", "illegal syntax");

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -63,7 +63,7 @@ fn cargo_compile_simple_git_dep() {
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}#[..])\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
         ))
@@ -133,7 +133,7 @@ fn cargo_compile_git_dep_branch() {
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
         ))
@@ -208,7 +208,7 @@ fn cargo_compile_git_dep_tag() {
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
         ))
@@ -277,7 +277,7 @@ fn cargo_compile_git_dep_pull_request() {
             "[UPDATING] git repository `{}`\n\
              [COMPILING] dep1 v0.5.0 ({}?rev=refs/pull/330/head#[..])\n\
              [COMPILING] foo v0.0.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
         ))
@@ -583,7 +583,7 @@ fn recompilation() {
             "[UPDATING] git repository `{}`\n\
              [CHECKING] bar v0.5.0 ({}#[..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
             git_project.url(),
             git_project.url(),
@@ -631,7 +631,7 @@ fn recompilation() {
         .with_stderr(&format!(
             "[CHECKING] bar v0.5.0 ({}#[..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
             git_project.url(),
         ))
@@ -642,7 +642,7 @@ fn recompilation() {
     p.cargo("check")
         .with_stderr(
             "[CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]",
         )
         .run();
@@ -726,7 +726,7 @@ fn update_with_shared_deps() {
 [CHECKING] [..] v0.5.0 ([..])
 [CHECKING] [..] v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             git = git_project.url(),
         ))
         .run();
@@ -794,7 +794,7 @@ Caused by:
 [CHECKING] [..] v0.5.0 ([CWD][..]dep[..])
 [CHECKING] [..] v0.5.0 ([CWD][..]dep[..])
 [CHECKING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             git = git_project.url(),
         ))
         .run();
@@ -853,7 +853,7 @@ fn dep_with_submodule() {
 [UPDATING] git submodule `file://[..]/dep2`
 [CHECKING] dep1 [..]
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -920,7 +920,7 @@ fn dep_with_relative_submodule() {
 [CHECKING] deployment [..]
 [CHECKING] base [..]
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -1054,7 +1054,7 @@ fn dep_with_skipped_submodule() {
 [SKIPPING] git submodule `file://[..]/qux` [..]
 [CHECKING] bar [..]
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -1115,7 +1115,7 @@ fn ambiguous_published_deps() {
         .with_stderr(
             "\
 [WARNING] skipping duplicate package `bar` found at `[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`
 ",
         )
@@ -1178,7 +1178,7 @@ fn two_deps_only_update_one() {
              [CHECKING] [..] v0.5.0 ([..])\n\
              [CHECKING] [..] v0.5.0 ([..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 
@@ -1276,7 +1276,7 @@ fn stale_cached_version() {
 [UPDATING] git repository `{bar}`
 [COMPILING] bar v0.0.0 ({bar}#[..])
 [COMPILING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = bar.url(),
         ))
@@ -1334,7 +1334,7 @@ fn dep_with_changed_submodule() {
              [UPDATING] git submodule `file://[..]/dep2`\n\
              [COMPILING] dep1 v0.5.0 ([..])\n\
              [COMPILING] foo v0.5.0 ([..])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in \
              [..]\n\
              [RUNNING] `target/debug/foo[EXE]`\n",
         )
@@ -1388,7 +1388,7 @@ fn dep_with_changed_submodule() {
         .with_stderr(
             "[COMPILING] dep1 v0.5.0 ([..])\n\
              [COMPILING] foo v0.5.0 ([..])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in \
              [..]\n\
              [RUNNING] `target/debug/foo[EXE]`\n",
         )
@@ -1448,7 +1448,7 @@ fn dev_deps_with_testing() {
             "\
 [UPDATING] git repository `{bar}`
 [CHECKING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = p2.url()
         ))
@@ -1461,7 +1461,7 @@ fn dev_deps_with_testing() {
             "\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test tests::foo ... ok")
@@ -1494,7 +1494,7 @@ fn git_build_cmd_freshness() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1553,7 +1553,7 @@ fn git_name_not_always_needed() {
             "\
 [UPDATING] git repository `{bar}`
 [CHECKING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = p2.url()
         ))
@@ -1596,7 +1596,7 @@ fn git_repo_changing_no_rebuild() {
 [UPDATING] git repository `{bar}`
 [COMPILING] [..]
 [CHECKING] [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = bar.url()
         ))
@@ -1633,7 +1633,7 @@ fn git_repo_changing_no_rebuild() {
 [UPDATING] git repository `{bar}`
 [CHECKING] [..]
 [CHECKING] [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             bar = bar.url()
         ))
@@ -1825,7 +1825,7 @@ fn warnings_in_git_dep() {
             "[UPDATING] git repository `{}`\n\
              [CHECKING] bar v0.5.0 ({}#[..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             bar.url(),
             bar.url(),
         ))
@@ -2010,7 +2010,7 @@ fn switch_deps_does_not_update_transitive() {
 [CHECKING] transitive [..]
 [CHECKING] dep [..]
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             dep1.url(),
             transitive.url()
@@ -2040,7 +2040,7 @@ fn switch_deps_does_not_update_transitive() {
 [UPDATING] git repository `{}`
 [CHECKING] dep [..]
 [CHECKING] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             dep2.url()
         ))
@@ -2156,7 +2156,7 @@ fn switch_sources() {
 [CHECKING] a v0.5.0 ([..]a1#[..]
 [CHECKING] b v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2183,7 +2183,7 @@ fn switch_sources() {
 [CHECKING] a v0.5.1 ([..]a2#[..]
 [CHECKING] b v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2311,7 +2311,7 @@ fn lints_are_suppressed() {
 [UPDATING] git repository `[..]`
 [CHECKING] a v0.5.0 ([..])
 [CHECKING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2354,7 +2354,7 @@ fn denied_lints_are_allowed() {
 [UPDATING] git repository `[..]`
 [CHECKING] a v0.5.0 ([..])
 [CHECKING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2492,7 +2492,7 @@ fn include_overrides_gitignore() {
 [COMPILING] foo v0.5.0 ([..])
 [RUNNING] `[..]build-script-build[..]`
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -3034,7 +3034,7 @@ fn default_not_master() {
 [UPDATING] git repository `[..]`
 [CHECKING] dep1 v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -3677,7 +3677,7 @@ fn different_user_relative_submodules() {
 [UPDATING] git submodule `{}`
 [COMPILING] dep1 v0.5.0 ({}#[..])
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             path2url(&user1_git_project.root()),
             path2url(&user2_git_project.root()),

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -10,7 +10,7 @@ fn build_example() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -24,7 +24,7 @@ fn build_bin() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -45,7 +45,7 @@ fn build_bench() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -66,7 +66,7 @@ fn build_test() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -80,7 +80,7 @@ fn check_example() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -94,7 +94,7 @@ fn check_bin() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -108,7 +108,7 @@ fn check_bench() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name bench1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -122,7 +122,7 @@ fn check_test() {
             "\
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name test1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -136,7 +136,7 @@ fn doc_bin() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name bin1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bin1/index.html
 ",
         )
@@ -152,7 +152,7 @@ fn fix_example() {
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name example1 [..]`
 [FIXING] examples/example1.rs
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -167,7 +167,7 @@ fn fix_bin() {
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name bin1 [..]`
 [FIXING] src/bin/bin1.rs
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -182,7 +182,7 @@ fn fix_bench() {
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name bench1 [..]`
 [FIXING] benches/bench1.rs
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -197,7 +197,7 @@ fn fix_test() {
 [CHECKING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] rustc --crate-name test1 [..]`
 [FIXING] tests/test1.rs
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -225,7 +225,7 @@ fn test_example() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]example1[..]
 ",
         )
@@ -240,7 +240,7 @@ fn test_bin() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]bin1[..]
 ",
         )
@@ -262,7 +262,7 @@ fn test_bench() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]bench1[..]
 ",
         )
@@ -284,7 +284,7 @@ fn test_test() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]test1[..]
 ",
         )
@@ -299,7 +299,7 @@ fn bench_example() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]example1[..] --bench`
 ",
         )
@@ -314,7 +314,7 @@ fn bench_bin() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]bin1[..] --bench`
 ",
         )
@@ -336,7 +336,7 @@ fn bench_bench() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]bench1[..] --bench`
 ",
         )
@@ -358,7 +358,7 @@ fn bench_test() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `[..]test1[..] --bench`
 ",
         )
@@ -373,7 +373,7 @@ fn install_example() {
             "\
 [INSTALLING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/home/.cargo/bin/example1[EXE]
 [INSTALLED] package `foo v0.0.1 ([CWD])` (executable `example1[EXE]`)
 [WARNING] be sure to add [..]
@@ -390,7 +390,7 @@ fn install_bin() {
             "\
 [INSTALLING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/home/.cargo/bin/bin1[EXE]
 [INSTALLED] package `foo v0.0.1 ([CWD])` (executable `bin1[EXE]`)
 [WARNING] be sure to add [..]
@@ -407,7 +407,7 @@ fn rustdoc_example() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name example1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/example1/index.html
 ",
         )
@@ -422,7 +422,7 @@ fn rustdoc_bin() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name bin1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bin1/index.html
 ",
         )
@@ -437,7 +437,7 @@ fn rustdoc_bench() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name bench1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bench1/index.html
 ",
         )
@@ -452,7 +452,7 @@ fn rustdoc_test() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc --crate-type bin --crate-name test1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/test1/index.html
 ",
         )
@@ -467,7 +467,7 @@ fn rustc_example() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name example1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -481,7 +481,7 @@ fn rustc_bin() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name bin1 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -502,7 +502,7 @@ fn rustc_bench() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -523,7 +523,7 @@ fn rustc_test() {
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
 [RUNNING] `rustc --crate-name [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -55,7 +55,7 @@ fn permit_additional_workspace_fields() {
         .with_stderr(
             "\
 [CHECKING] bar v0.1.0 ([CWD]/bar)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -296,7 +296,7 @@ fn inherit_own_dependencies() {
 [DOWNLOADED] dep-build v0.8.2 ([..])
 [CHECKING] dep v0.1.2
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -444,7 +444,7 @@ fn inherit_own_detailed_dependencies() {
 [DOWNLOADED] dep v0.1.2 ([..])
 [CHECKING] dep v0.1.2
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -614,7 +614,7 @@ fn inherited_dependencies_union_features() {
 [CHECKING] [..]
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -839,7 +839,7 @@ fn inherit_dependencies() {
 [DOWNLOADED] dep-build v0.8.2 ([..])
 [CHECKING] dep v0.1.2
 [CHECKING] bar v0.2.0 ([CWD]/bar)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -990,7 +990,7 @@ fn inherit_target_dependencies() {
 [DOWNLOADED] dep v0.1.2 ([..])
 [CHECKING] dep v0.1.2
 [CHECKING] bar v0.2.0 ([CWD]/bar)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1033,7 +1033,7 @@ fn inherit_dependency_override_optional() {
             "\
 [UPDATING] `[..]` index
 [CHECKING] bar v0.2.0 ([CWD]/bar)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1080,7 +1080,7 @@ fn inherit_dependency_features() {
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1147,7 +1147,7 @@ fn inherit_detailed_dependencies() {
 [UPDATING] git repository `{}`\n\
 [CHECKING] detailed v0.5.0 ({}?branch=branchy#[..])\n\
 [CHECKING] bar v0.2.0 ([CWD]/bar)\n\
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
             path2url(&git_root),
             path2url(&git_root),
         ))
@@ -1188,7 +1188,7 @@ fn inherit_path_dependencies() {
             "\
 [CHECKING] dep v0.9.0 ([CWD]/dep)
 [CHECKING] bar v0.2.0 ([CWD]/bar)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1458,7 +1458,7 @@ true for `workspace.dependencies.dep`, this could become a hard error in the fut
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1506,7 +1506,7 @@ not specified for `workspace.dependencies.dep`, this could become a hard error i
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1552,7 +1552,7 @@ fn inherit_def_feat_false_member_def_feat_true() {
 [CHECKING] fancy_dep v0.2.4
 [CHECKING] dep v0.1.0
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1640,7 +1640,7 @@ fn warn_inherit_unused_manifest_key_dep() {
 [DOWNLOADED] dep v0.1.0 ([..])
 [CHECKING] [..]
 [CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1671,7 +1671,7 @@ fn warn_unused_workspace_package_field() {
             "\
 [WARNING] [CWD]/Cargo.toml: unused manifest key: workspace.package.name
 [CHECKING] foo v0.0.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1746,7 +1746,7 @@ fn warn_inherit_unused_manifest_key_package() {
 [WARNING] [CWD]/Cargo.toml: unused manifest key: package.rust-version.xyz
 [WARNING] [CWD]/Cargo.toml: unused manifest key: package.version.xyz
 [CHECKING] bar v1.2.3 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -43,7 +43,7 @@ fn simple() {
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -70,7 +70,7 @@ fn install_the_same_version_twice() {
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -118,7 +118,7 @@ fn simple_with_message_format() {
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -197,7 +197,7 @@ fn with_index() {
 [DOWNLOADED] foo v0.0.1 (registry `{reg}`)
 [INSTALLING] foo v0.0.1 (registry `{reg}`)
 [COMPILING] foo v0.0.1 (registry `{reg}`)
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1 (registry `{reg}`)` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -230,12 +230,12 @@ fn multiple_pkgs() {
 [ERROR] could not find `baz` in registry `[..]` with version `*`
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [INSTALLING] bar v0.0.2
 [COMPILING] bar v0.0.2
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/bar[EXE]
 [INSTALLED] package `bar v0.0.2` (executable `bar[EXE]`)
 [SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
@@ -290,12 +290,12 @@ fn multiple_pkgs_path_set() {
 [ERROR] could not find `baz` in registry `[..]` with version `*`
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [INSTALLING] bar v0.0.2
 [COMPILING] bar v0.0.2
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/bar[EXE]
 [INSTALLED] package `bar v0.0.2` (executable `bar[EXE]`)
 [SUMMARY] Successfully installed foo, bar! Failed to install baz (see error(s) above).
@@ -336,7 +336,7 @@ fn pick_max_version() {
 [DOWNLOADED] foo v0.2.1 (registry [..])
 [INSTALLING] foo v0.2.1
 [COMPILING] foo v0.2.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.2.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -489,7 +489,7 @@ fn install_path() {
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 [..]
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 [REPLACING] [..]/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v0.0.1 [..]` with `foo v0.0.1 [..]` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -508,7 +508,7 @@ fn install_target_dir() {
 [WARNING] Using `cargo install` [..]
 [INSTALLING] foo v0.0.1 [..]
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 [INSTALLING] [..]foo[EXE]
 [INSTALLED] package `foo v0.0.1 [..]foo[..]` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -585,7 +585,7 @@ fn install_relative_path_outside_current_ws() {
             "\
 [INSTALLING] foo v0.0.1 ([..]/bar/foo)
 [COMPILING] foo v0.0.1 ([..]/bar/foo)
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 [INSTALLING] {home}/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1 ([..]/bar/foo)` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -898,7 +898,7 @@ fn install_force() {
             "\
 [INSTALLING] foo v0.2.0 ([..])
 [COMPILING] foo v0.2.0 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v0.0.1 ([..]/foo)` with `foo v0.2.0 ([..]/foo2)` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -938,7 +938,7 @@ fn install_force_partial_overlap() {
             "\
 [INSTALLING] foo v0.2.0 ([..])
 [COMPILING] foo v0.2.0 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo-bin3[EXE]
 [REPLACING] [CWD]/home/.cargo/bin/foo-bin2[EXE]
 [REMOVING] executable `[..]/bin/foo-bin1[EXE]` from previous version foo v0.0.1 [..]
@@ -982,7 +982,7 @@ fn install_force_bin() {
             "\
 [INSTALLING] foo v0.2.0 ([..])
 [COMPILING] foo v0.2.0 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [CWD]/home/.cargo/bin/foo-bin2[EXE]
 [REPLACED] package `foo v0.0.1 ([..]/foo)` with `foo v0.2.0 ([..]/foo2)` (executable `foo-bin2[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -1036,7 +1036,7 @@ fn git_repo() {
 [WARNING] no Cargo.lock file published in foo v0.1.0 ([..])
 [INSTALLING] foo v0.1.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.1.0 ([..]/foo#[..])` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -1240,7 +1240,7 @@ fn uninstall_cwd() {
             "\
 [INSTALLING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] {home}/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1 ([..]/foo)` (executable `foo[EXE]`)
 [WARNING] be sure to add `{home}/bin` to your PATH to be able to run the installed binaries",
@@ -1295,7 +1295,7 @@ fn do_not_rebuilds_on_local_install() {
         .with_stderr(
             "\
 [INSTALLING] [..]
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]
 [INSTALLED] package `foo v0.0.1 ([..]/foo)` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -1928,7 +1928,7 @@ fn workspace_uses_workspace_target_dir() {
         .arg(p.root().join("bar"))
         .with_stderr(
             "[INSTALLING] [..]
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]
 [INSTALLED] package `bar v0.1.0 ([..]/bar)` (executable `bar[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2169,7 +2169,7 @@ workspace: [..]/foo/Cargo.toml
 [DOWNLOADED] foo v0.1.0 (registry [..])
 [INSTALLING] foo v0.1.0
 [COMPILING] foo v0.1.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]foo[EXE]
 [INSTALLED] package `foo v0.1.0` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2271,7 +2271,7 @@ fn no_auto_fix_note() {
 [DOWNLOADED] auto_fix v0.0.1 (registry [..])
 [INSTALLING] auto_fix v0.0.1
 [COMPILING] auto_fix v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/auto_fix[EXE]
 [INSTALLED] package `auto_fix v0.0.1` (executable `auto_fix[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2343,7 +2343,7 @@ fn sparse_install() {
 [INSTALLING] foo v0.0.1 (registry `dummy-registry`)
 [UPDATING] `dummy-registry` index
 [COMPILING] foo v0.0.1 (registry `dummy-registry`)
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [ROOT]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1 (registry `dummy-registry`)` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2414,7 +2414,7 @@ fn self_referential() {
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [COMPILING] foo v0.0.1
 [COMPILING] foo v0.0.2
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.2` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2459,7 +2459,7 @@ fn ambiguous_registry_vs_local_package() {
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [COMPILING] foo v0.0.1
 [COMPILING] foo v0.1.0 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.1.0 ([..])` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2559,7 +2559,7 @@ fn uninstall_running_binary() {
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries
@@ -2615,7 +2615,7 @@ fn uninstall_running_binary() {
 [UPDATING] `[..]` index
 [INSTALLING] foo v0.0.1
 [COMPILING] foo v0.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]` to your PATH to be able to run the installed binaries

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -133,7 +133,7 @@ fn registry_upgrade() {
 [DOWNLOADED] foo v1.0.0 (registry [..])
 [INSTALLING] foo v1.0.0
 [COMPILING] foo v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v1.0.0` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -163,7 +163,7 @@ fn registry_upgrade() {
 [DOWNLOADED] foo v1.0.1 (registry [..])
 [INSTALLING] foo v1.0.1
 [COMPILING] foo v1.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -213,7 +213,7 @@ fn upgrade_force() {
 [UPDATING] `[..]` index
 [INSTALLING] foo v1.0.0
 [COMPILING] foo v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [..]/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v1.0.0` with `foo v1.0.0` (executable `foo[EXE]`)
 [WARNING] be sure to add `[..]/.cargo/bin` to your PATH [..]
@@ -603,17 +603,17 @@ fn multiple_report() {
 [DOWNLOADED] three v1.0.0 (registry `[..]`)
 [INSTALLING] one v1.0.0
 [COMPILING] one v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/.cargo/bin/one[EXE]
 [INSTALLED] package `one v1.0.0` (executable `one[EXE]`)
 [INSTALLING] two v1.0.0
 [COMPILING] two v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/.cargo/bin/two[EXE]
 [INSTALLED] package `two v1.0.0` (executable `two[EXE]`)
 [INSTALLING] three v1.0.0
 [COMPILING] three v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/.cargo/bin/three[EXE]
 [INSTALLING] [..]/.cargo/bin/x[EXE]
 [INSTALLING] [..]/.cargo/bin/y[EXE]
@@ -636,7 +636,7 @@ fn multiple_report() {
 [DOWNLOADED] three v1.0.1 (registry `[..]`)
 [INSTALLING] three v1.0.1
 [COMPILING] three v1.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [..]/.cargo/bin/three[EXE]
 [REPLACING] [..]/.cargo/bin/x[EXE]
 [REPLACING] [..]/.cargo/bin/y[EXE]
@@ -661,7 +661,7 @@ fn multiple_report() {
 [UPDATING] `[..]` index
 [INSTALLING] three v1.0.1
 [COMPILING] three v1.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/.cargo/bin/x[EXE]
 [INSTALLED] package `three v1.0.1` (executable `x[EXE]`)
 [WARNING] be sure to add `[..]/.cargo/bin` to your PATH [..]
@@ -674,7 +674,7 @@ fn multiple_report() {
 [UPDATING] `[..]` index
 [INSTALLING] three v1.0.1
 [COMPILING] three v1.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/.cargo/bin/three[EXE]
 [INSTALLING] [..]/.cargo/bin/y[EXE]
 [REPLACING] [..]/.cargo/bin/x[EXE]
@@ -739,7 +739,7 @@ fn deletes_orphaned() {
             "\
 [INSTALLING] foo v0.2.0 [..]
 [COMPILING] foo v0.2.0 [..]
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 [INSTALLING] [..]/.cargo/bin/ex2[EXE]
 [REPLACING] [..]/.cargo/bin/ex1[EXE]
 [REPLACING] [..]/.cargo/bin/foo[EXE]
@@ -787,7 +787,7 @@ fn already_installed_exact_does_not_update() {
 [DOWNLOADED] foo v1.0.1 (registry [..])
 [INSTALLING] foo v1.0.1
 [COMPILING] foo v1.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -822,7 +822,7 @@ fn already_installed_updates_yank_status_on_upgrade() {
 [DOWNLOADED] foo v1.0.1 (registry [..])
 [INSTALLING] foo v1.0.1
 [COMPILING] foo v1.0.1
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [CWD]/home/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v1.0.0` with `foo v1.0.1` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -848,12 +848,12 @@ fn partially_already_installed_does_one_update() {
 [DOWNLOADED] baz v1.0.0 (registry [..])
 [INSTALLING] bar v1.0.0
 [COMPILING] bar v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/bar[EXE]
 [INSTALLED] package `bar v1.0.0` (executable `bar[EXE]`)
 [INSTALLING] baz v1.0.0
 [COMPILING] baz v1.0.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [CWD]/home/.cargo/bin/baz[EXE]
 [INSTALLED] package `baz v1.0.0` (executable `baz[EXE]`)
 [SUMMARY] Successfully installed foo, bar, baz!

--- a/tests/testsuite/lints.rs
+++ b/tests/testsuite/lints.rs
@@ -169,7 +169,7 @@ fn warn_on_unused_key() {
 [WARNING] [CWD]/Cargo.toml: unused manifest key: lints.rust.rust-2018-idioms.unused
 [WARNING] [CWD]/Cargo.toml: unused manifest key: workspace.lints.rust.rust-2018-idioms.unused
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -714,7 +714,7 @@ pub const Ĕ: i32 = 2;
         .with_stderr(
             "\
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -723,7 +723,7 @@ pub const Ĕ: i32 = 2;
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]s
 [DOCTEST] foo
 ",
         )

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -1036,7 +1036,7 @@ dependencies = [
 [UPDATING] git repository `{url}`
 [CHECKING] dep1 v0.5.0 ({url}?{ref_kind}={git_ref}#[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 "
         ))
         .run();
@@ -1051,7 +1051,7 @@ dependencies = [
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 "
         ))
         .run();
@@ -1128,7 +1128,7 @@ dependencies = [
 [UPDATING] git repository `{url}`
 [CHECKING] dep1 v0.5.0 ({url}?{ref_kind}={git_ref}#[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 "
         ))
         .run();
@@ -1138,7 +1138,9 @@ dependencies = [
 
     // Unlike v3_and_git_url_encoded, v4 encodes URL parameters so no git
     // repository re-clone happen.
-    p.cargo("check").with_stderr("[FINISHED] dev [..]").run();
+    p.cargo("check")
+        .with_stderr("[FINISHED] `dev` profile [..]")
+        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -733,7 +733,7 @@ fn doctest() {
             "\
 [FRESH] bar v0.1.0 [..]
 [FRESH] foo v0.1.0 [..]
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 [DOCTEST] foo
 [RUNNING] `rustdoc [..]-C lto[..]
 ",

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -278,7 +278,7 @@ fn metabuild_fresh() {
             "\
 [FRESH] mb [..]
 [FRESH] foo [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -131,7 +131,7 @@ fn simple_doc_open() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v1.0.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [ERROR] only one `--target` argument is supported",
         )
         .with_status(101)

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -141,7 +141,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
             "\
 [CHECKING] present_dep v1.2.3
 [CHECKING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -247,7 +247,7 @@ fn main(){
             "\
 [COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
      Running `[..]`",
         )
         .with_stdout("1.2.3")
@@ -489,7 +489,7 @@ fn compile_offline_with_cached_git_dep(shallow: bool) {
         "\
 [COMPILING] dep1 v0.5.0 ({}#[..])
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         path2url(git_root),
     ));
     maybe_use_shallow(cargo).run();
@@ -666,7 +666,7 @@ fn main(){
             "\
 [COMPILING] present_dep v1.2.9
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -688,7 +688,7 @@ fn main(){
             "\
 [COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -39,7 +39,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -63,7 +63,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -90,7 +90,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -117,7 +117,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -144,7 +144,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -257,7 +257,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -728,7 +728,7 @@ fn ignore_nested() {
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -750,7 +750,7 @@ src/main.rs
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -806,7 +806,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 5 files, [..] ([..] compressed)
 ",
         )
@@ -2540,14 +2540,14 @@ See [..]
 [PACKAGING] bar v0.0.1 ([CWD]/bar)
 [VERIFYING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] bar v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [WARNING] manifest has no documentation, [..]
 See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -2592,7 +2592,7 @@ fn workspace_noconflict_readme() {
 [PACKAGING] bar v0.0.1 ([CWD]/bar)
 [VERIFYING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] bar v0.0.1 ([CWD]/[..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -2635,7 +2635,7 @@ warning: readme `../README.md` appears to be a path outside of the package, but 
 [PACKAGING] bar v0.0.1 ([CWD]/bar)
 [VERIFYING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] bar v0.0.1 ([CWD]/[..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -3073,7 +3073,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -3097,7 +3097,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -3139,7 +3139,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -3163,7 +3163,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..] ([..] compressed)
 ",
         )
@@ -3200,7 +3200,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
    Packaging foo v0.0.0 ([CWD])
    Verifying foo v0.0.0 ([CWD])
    Compiling foo v0.0.0 ([CWD]/target/package/foo-0.0.0)
-    Finished dev [unoptimized + debuginfo] target(s) in [..]s
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]s
     Packaged 4 files, [..]B ([..]B compressed)
 ",
         )

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -58,7 +58,7 @@ fn replace() {
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] baz v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -101,7 +101,7 @@ fn from_config() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -142,7 +142,7 @@ fn from_config_relative() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -186,7 +186,7 @@ fn from_config_precedence() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -226,7 +226,7 @@ fn nonexistent() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -273,7 +273,7 @@ fn patch_git() {
 [UPDATING] git repository `file://[..]`
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -321,7 +321,7 @@ fn patch_to_git() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -366,7 +366,7 @@ version. [..]
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -442,7 +442,7 @@ version. [..]
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -479,7 +479,7 @@ fn prefer_patch_version() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -539,7 +539,7 @@ version. [..]
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -612,7 +612,7 @@ version. [..]
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -660,7 +660,7 @@ fn add_patch() {
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -687,7 +687,7 @@ fn add_patch() {
             "\
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -724,7 +724,7 @@ fn add_patch_from_config() {
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -743,7 +743,7 @@ fn add_patch_from_config() {
             "\
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -780,7 +780,7 @@ fn add_ignored_patch() {
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -810,7 +810,7 @@ Check that [..]
 with the [..]
 what is [..]
 version. [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
     p.cargo("check")
@@ -831,7 +831,7 @@ version. [..]
             "\
 [CHECKING] bar v0.1.1 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -870,7 +870,7 @@ default-features and features will not take effect because the patch dependency 
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -918,7 +918,7 @@ default-features and features will not take effect because the patch dependency 
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1008,7 +1008,7 @@ fn new_minor() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.1 [..]
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1059,7 +1059,7 @@ fn transitive_new_minor() {
 [CHECKING] baz v0.1.1 [..]
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1096,7 +1096,7 @@ fn new_major() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.2.0 [..]
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1104,7 +1104,7 @@ fn new_major() {
     Package::new("bar", "0.2.0").publish();
     p.cargo("update").run();
     p.cargo("check")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 
     p.change_file(
@@ -1127,7 +1127,7 @@ fn new_major() {
 [DOWNLOADED] bar v0.2.0 [..]
 [CHECKING] bar v0.2.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1178,7 +1178,7 @@ fn transitive_new_major() {
 [CHECKING] baz v0.2.0 [..]
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1235,7 +1235,7 @@ fn shared_by_transitive() {
 [CHECKING] baz v0.1.2 [..]
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -73,7 +73,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
             "[COMPILING] baz v0.5.0 ([CWD]/bar/baz)\n\
              [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -93,7 +93,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
     p.cargo("build -p baz")
         .with_stderr(
             "[COMPILING] baz v0.5.0 ([CWD]/bar/baz)\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -102,7 +102,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
         .with_stderr(
             "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -191,7 +191,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
             "\
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
@@ -249,7 +249,7 @@ fn cargo_compile_with_transitive_dev_deps() {
         .with_stderr(
             "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in \
              [..]\n",
         )
         .run();
@@ -284,7 +284,7 @@ fn no_rebuild_dependency() {
         .with_stderr(
             "[CHECKING] bar v0.5.0 ([CWD]/bar)\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -301,7 +301,7 @@ fn no_rebuild_dependency() {
     p.cargo("check")
         .with_stderr(
             "[CHECKING] foo v0.5.0 ([..])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -351,7 +351,7 @@ fn deep_dependencies_trigger_rebuild() {
             "[CHECKING] baz v0.5.0 ([CWD]/baz)\n\
              [CHECKING] bar v0.5.0 ([CWD]/bar)\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -369,7 +369,7 @@ fn deep_dependencies_trigger_rebuild() {
             "[CHECKING] baz v0.5.0 ([CWD]/baz)\n\
              [CHECKING] bar v0.5.0 ([CWD]/bar)\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -388,7 +388,7 @@ fn deep_dependencies_trigger_rebuild() {
         .with_stderr(
             "[CHECKING] bar v0.5.0 ([CWD]/bar)\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -437,7 +437,7 @@ fn no_rebuild_two_deps() {
             "[COMPILING] baz v0.5.0 ([CWD]/baz)\n\
              [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -473,7 +473,7 @@ fn nested_deps_recompile() {
         .with_stderr(
             "[CHECKING] bar v0.5.0 ([CWD]/src/bar)\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -485,7 +485,7 @@ fn nested_deps_recompile() {
     p.cargo("check")
         .with_stderr(
             "[CHECKING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -714,7 +714,7 @@ fn path_dep_build_cmd() {
         .with_stderr(
             "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in \
              [..]\n",
         )
         .run();
@@ -730,7 +730,7 @@ fn path_dep_build_cmd() {
         .with_stderr(
             "[COMPILING] bar v0.5.0 ([CWD]/bar)\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) in \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in \
              [..]\n",
         )
         .run();
@@ -771,7 +771,7 @@ fn dev_deps_no_rebuild_lib() {
         .env("FOO", "bar")
         .with_stderr(
             "[COMPILING] foo v0.5.0 ([CWD])\n\
-             [FINISHED] dev [unoptimized + debuginfo] target(s) \
+             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
              in [..]\n",
         )
         .run();
@@ -781,7 +781,7 @@ fn dev_deps_no_rebuild_lib() {
             "\
 [COMPILING] [..] v0.5.0 ([CWD][..])
 [COMPILING] [..] v0.5.0 ([CWD][..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
@@ -825,7 +825,7 @@ fn custom_target_no_rebuild() {
             "\
 [CHECKING] a v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -839,7 +839,7 @@ fn custom_target_no_rebuild() {
         .with_stderr(
             "\
 [CHECKING] b v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -886,7 +886,7 @@ fn override_and_depend() {
 [CHECKING] a2 v0.5.0 ([..])
 [CHECKING] a1 v0.5.0 ([..])
 [CHECKING] b v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -272,7 +272,7 @@ fn profile_config_all_options() {
             -C overflow-checks=off [..]\
             -C rpath [..]\
             -C incremental=[..]
-[FINISHED] release [optimized + debuginfo] [..]
+[FINISHED] `release` profile [optimized + debuginfo] [..]
 ",
         )
         .run();
@@ -318,7 +318,7 @@ fn profile_config_override_precedence() {
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=2[..]-C codegen-units=2 [..]
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name foo [..]-C codegen-units=2 [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
         )
         .run();
 }

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -331,7 +331,7 @@ fn overrides_with_custom() {
 [RUNNING] `rustc --crate-name xxx [..] -C codegen-units=5 [..]`
 [RUNNING] `rustc --crate-name yyy [..] -C codegen-units=3 [..]`
 [RUNNING] `rustc --crate-name foo [..] -C codegen-units=7 [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -346,7 +346,7 @@ fn overrides_with_custom() {
 [RUNNING] `rustc --crate-name xxx [..] -C codegen-units=5 [..]`
 [RUNNING] `rustc --crate-name yyy [..] -C codegen-units=6 [..]`
 [RUNNING] `rustc --crate-name foo [..] -C codegen-units=2 [..]`
-[FINISHED] other [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `other` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -396,7 +396,7 @@ warning: the `--release` flag should not be specified with the `--profile` flag
 The `--release` flag will be ignored.
 This was historically accepted, but will become an error in a future release.
 [COMPILING] foo [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -419,7 +419,7 @@ warning: the `--release` flag should not be specified with the `--profile` flag
 The `--release` flag will be ignored.
 This was historically accepted, but will become an error in a future release.
 [CHECKING] foo [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 ",
         )
         .run();
@@ -429,7 +429,7 @@ This was historically accepted, but will become an error in a future release.
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 ",
         )
         .run();
@@ -437,7 +437,7 @@ This was historically accepted, but will become an error in a future release.
     p.cargo("build --profile=release --release")
         .with_stderr(
             "\
-[FINISHED] release [..]
+[FINISHED] `release` profile [..]
 ",
         )
         .run();
@@ -446,7 +446,7 @@ This was historically accepted, but will become an error in a future release.
         .with_stderr(
             "\
 [INSTALLING] foo [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [INSTALLING] [..]
 [INSTALLED] [..]
 [WARNING] be sure to add [..]
@@ -489,7 +489,7 @@ fn clean_custom_dirname() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -500,7 +500,7 @@ fn clean_custom_dirname() {
         .with_stdout("")
         .with_stderr(
             "\
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -511,7 +511,7 @@ fn clean_custom_dirname() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -521,7 +521,7 @@ fn clean_custom_dirname() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -530,7 +530,7 @@ fn clean_custom_dirname() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] other [optimized] target(s) in [..]
+[FINISHED] `other` profile [optimized] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -35,7 +35,7 @@ fn profile_override_basic() {
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=3 [..]`
 [CHECKING] foo [..]
 [RUNNING] `rustc --crate-name foo [..] -C opt-level=1 [..]`
-[FINISHED] dev [optimized + debuginfo] target(s) in [..]",
+[FINISHED] `dev` profile [optimized + debuginfo] target(s) in [..]",
         )
         .run();
 }
@@ -226,7 +226,7 @@ fn profile_override_hierarchy() {
 [RUNNING] `rustc --crate-name m2 m2/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=2 [..]
 [COMPILING] m1 [..]
 [RUNNING] `rustc --crate-name m1 m1/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=1 [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 ",
         )
         .run();

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -97,7 +97,7 @@ fn profile_selection_build() {
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 "
         )
         .with_stderr_does_not_contain("[..] -C debuginfo=0[..]")
@@ -108,7 +108,7 @@ fn profile_selection_build() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 ",
         )
         .run();
@@ -131,7 +131,7 @@ fn profile_selection_build_release() {
 [foo 0.0.1] foo custom build PROFILE=release DEBUG=false OPT_LEVEL=3
 [RUNNING] `[..] rustc --crate-name foo src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 ").run();
     p.cargo("build --release -vv")
         .with_stderr_unordered(
@@ -139,7 +139,7 @@ fn profile_selection_build_release() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 ",
         )
         .run();
@@ -198,7 +198,7 @@ fn profile_selection_build_all_targets() {
 [RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs [..]--emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]--test [..]`
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]`
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 "
         )
         .with_stderr_does_not_contain("[..] -C debuginfo=0[..]")
@@ -209,7 +209,7 @@ fn profile_selection_build_all_targets() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 ",
         )
         .run();
@@ -267,7 +267,7 @@ fn profile_selection_build_all_targets_release() {
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=2 --test [..]`
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]`
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 ").run();
     p.cargo("build --all-targets --release -vv")
         .with_stderr_unordered(
@@ -275,7 +275,7 @@ fn profile_selection_build_all_targets_release() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 ",
         )
         .run();
@@ -323,7 +323,7 @@ fn profile_selection_test() {
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C panic=abort[..]-C codegen-units=3 -C debuginfo=2 [..]
-[FINISHED] test [unoptimized + debuginfo] [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
@@ -336,7 +336,7 @@ fn profile_selection_test() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] test [unoptimized + debuginfo] [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
@@ -390,7 +390,7 @@ fn profile_selection_test_release() {
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=2 --test [..]
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=[..]link -C opt-level=3[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
@@ -403,7 +403,7 @@ fn profile_selection_test_release() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/foo-[..]`
 [RUNNING] `[..]/deps/test1-[..]`
@@ -455,7 +455,7 @@ fn profile_selection_bench() {
 [RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=4 --test [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=[..]link -C opt-level=3[..]-C codegen-units=4 --test [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=4 [..]
-[FINISHED] bench [optimized] [..]
+[FINISHED] `bench` profile [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..] --bench`
 [RUNNING] `[..]/deps/foo-[..] --bench`
 [RUNNING] `[..]/deps/bench1-[..] --bench`
@@ -466,7 +466,7 @@ fn profile_selection_bench() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] bench [optimized] [..]
+[FINISHED] `bench` profile [optimized] [..]
 [RUNNING] `[..]/deps/foo-[..] --bench`
 [RUNNING] `[..]/deps/foo-[..] --bench`
 [RUNNING] `[..]/deps/bench1-[..] --bench`
@@ -522,7 +522,7 @@ fn profile_selection_check_all_targets() {
 [RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs [..]--emit=[..]metadata[..]-C codegen-units=1 -C debuginfo=2 [..]--test [..]
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]metadata -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 ").run();
     // Starting with Rust 1.27, rustc emits `rmeta` files for bins, so
     // everything should be completely fresh. Previously, bins were being
@@ -534,7 +534,7 @@ fn profile_selection_check_all_targets() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 ",
         )
         .run();
@@ -567,7 +567,7 @@ fn profile_selection_check_all_targets_release() {
 [RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs [..]--emit=[..]metadata -C opt-level=3[..]-C codegen-units=2 --test [..]
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--crate-type bin --emit=[..]metadata -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--crate-type bin --emit=[..]metadata -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 ").run();
 
     p.cargo("check --all-targets --release -vv")
@@ -576,7 +576,7 @@ fn profile_selection_check_all_targets_release() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] release [optimized] [..]
+[FINISHED] `release` profile [optimized] [..]
 ",
         )
         .run();
@@ -623,7 +623,7 @@ fn profile_selection_check_all_targets_test() {
 [RUNNING] `[..] rustc --crate-name foo src/main.rs [..]--emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]
 [RUNNING] `[..] rustc --crate-name bench1 benches/bench1.rs [..]--emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]
 [RUNNING] `[..] rustc --crate-name ex1 examples/ex1.rs [..]--emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]--test [..]
-[FINISHED] test [unoptimized + debuginfo] [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] [..]
 ").run();
 
     p.cargo("check --all-targets --profile=test -vv")
@@ -632,7 +632,7 @@ fn profile_selection_check_all_targets_test() {
 [FRESH] bar [..]
 [FRESH] bdep [..]
 [FRESH] foo [..]
-[FINISHED] test [unoptimized + debuginfo] [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] [..]
 ",
         )
         .run();
@@ -666,7 +666,7 @@ fn profile_selection_doc() {
 [foo 0.0.1] foo custom build PROFILE=debug DEBUG=true OPT_LEVEL=0
 [DOCUMENTING] foo [..]
 [RUNNING] `rustdoc [..]--crate-name foo src/lib.rs [..]
-[FINISHED] dev [unoptimized + debuginfo] [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ").run();
 }

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -87,7 +87,7 @@ fn release_profile_default_to_object() {
     -Zremap-path-scope=object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] release [..]",
+[FINISHED] `release` profile [..]",
         )
         .run();
 }
@@ -125,7 +125,7 @@ fn one_option() {
     -Zremap-path-scope={option} \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
             ))
             .run();
     }
@@ -162,7 +162,7 @@ fn multiple_options() {
     -Zremap-path-scope=diagnostics,macro,object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
         )
         .run();
 }
@@ -197,7 +197,7 @@ fn profile_merge_works() {
     -Zremap-path-scope=diagnostics \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] custom [..]",
+[FINISHED] `custom` profile [..]",
         )
         .run();
 }
@@ -247,7 +247,7 @@ fn registry_dependency() {
     -Zremap-path-scope=object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
         .run();
@@ -301,7 +301,7 @@ fn git_dependency() {
     -Zremap-path-scope=object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
         .run();
@@ -347,7 +347,7 @@ fn path_dependency() {
     -Zremap-path-scope=object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
         .run();
@@ -396,7 +396,7 @@ fn path_dependency_outside_workspace() {
     -Zremap-path-scope=object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [RUNNING] `target/debug/foo[EXE]`"
         ))
         .run();
@@ -578,7 +578,7 @@ fn object_works_helper(split_debuginfo: &str, run: impl Fn(&std::path::Path) -> 
     -Zremap-path-scope=object \
     --remap-path-prefix=[CWD]=. \
     --remap-path-prefix=[..]/lib/rustlib/src/rust=/rustc/[..]
-[FINISHED] dev [..]",
+[FINISHED] `dev` profile [..]",
         ))
         .run();
 

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -36,7 +36,7 @@ fn profile_overrides() {
         -C rpath \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
-[FINISHED] dev [optimized] target(s) in [..]
+[FINISHED] `dev` profile [optimized] target(s) in [..]
 ",
         )
         .run();
@@ -226,7 +226,7 @@ fn top_level_overrides_deps() {
         --extern foo=[CWD]/target/release/deps/\
                      {prefix}foo[..]{suffix} \
         --extern foo=[CWD]/target/release/deps/libfoo.rlib`
-[FINISHED] release [optimized + debuginfo] target(s) in [..]
+[FINISHED] `release` profile [optimized + debuginfo] target(s) in [..]
 ",
             prefix = env::consts::DLL_PREFIX,
             suffix = env::consts::DLL_SUFFIX
@@ -278,7 +278,7 @@ package:   [..]
 workspace: [..]
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] dev [unoptimized] target(s) in [..]",
+[FINISHED] `dev` profile [unoptimized] target(s) in [..]",
         )
         .run();
 }
@@ -317,7 +317,7 @@ fn profile_in_virtual_manifest_works() {
             "\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] dev [optimized] target(s) in [..]",
+[FINISHED] `dev` profile [optimized] target(s) in [..]",
         )
         .run();
 }
@@ -468,7 +468,7 @@ fn debug_0_report() {
             "\
 [COMPILING] foo v0.1.0 [..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]
-[FINISHED] dev [unoptimized] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized] target(s) in [..]
 ",
         )
         .with_stderr_does_not_contain("-C debuginfo")

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -80,7 +80,7 @@ fn exported_pub_dep() {
 [DOWNLOADED] pub_dep v0.1.0 ([..])
 [CHECKING] pub_dep v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -294,7 +294,7 @@ fn allow_priv_in_tests() {
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -338,7 +338,7 @@ fn allow_priv_in_benchs() {
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -383,7 +383,7 @@ fn allow_priv_in_bins() {
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -428,7 +428,7 @@ fn allow_priv_in_examples() {
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -474,7 +474,7 @@ fn allow_priv_in_custom_build() {
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [COMPILING] priv_dep v0.1.0
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()
@@ -529,7 +529,7 @@ fn publish_package_with_public_dependency() {
 [CHECKING] pub_bar v0.1.0
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run()

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -725,7 +725,7 @@ See [..]
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 [UPLOADING] foo v0.0.1 ([CWD])
 [WARNING] aborting upload due to dry run

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -76,7 +76,7 @@ fn package_lockfile() {
 [PACKAGING] foo v0.0.1 ([CWD])
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] [..] files, [..] ([..] compressed)
 ",
         )
@@ -145,7 +145,7 @@ src/main.rs
 [VERIFYING] foo v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc --crate-name foo src/main.rs [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 5 files, [..] ([..] compressed)
 ",
         )
@@ -397,7 +397,7 @@ dependencies = [
 [DOWNLOADED] bar v0.1.0 (registry `[..]`)
 [COMPILING] bar v0.1.0
 [COMPILING] foo v0.1.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [INSTALLING] [..]/.cargo/bin/foo[EXE]
 [INSTALLED] package `foo v0.1.0` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -415,7 +415,7 @@ dependencies = [
 [DOWNLOADED] bar v0.1.1 (registry `[..]`)
 [COMPILING] bar v0.1.1
 [COMPILING] foo v0.1.0
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [REPLACING] [..]/.cargo/bin/foo[EXE]
 [REPLACED] package `foo v0.1.0` with `foo v0.1.0` (executable `foo[EXE]`)
 [WARNING] be sure to add [..]
@@ -469,7 +469,7 @@ src/main.rs
 [VERIFYING] foo v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc --crate-name foo src/main.rs [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 5 files, [..] ([..] compressed)
 ",
         )
@@ -566,7 +566,7 @@ See [..]
 [DOWNLOADED] serde v0.2.0 ([..])
 [COMPILING] serde v0.2.0
 [COMPILING] bar v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..]
 [WARNING] manifest has no documentation, [..]
 See [..]
@@ -574,7 +574,7 @@ See [..]
 [VERIFYING] foo v0.0.1 ([CWD])
 [COMPILING] serde v0.2.0
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [PACKAGED] 4 files, [..]
 ",
         )

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -63,7 +63,7 @@ fn simple() {
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -78,7 +78,7 @@ fn simple() {
             "\
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -125,7 +125,7 @@ fn deps() {
 [CHECKING] baz v0.0.1
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -426,7 +426,7 @@ required by package `foo v0.0.1 ([..])`
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [CHECKING] notyet v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -496,7 +496,7 @@ Caused by:
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [COMPILING] notyet v0.0.1
 [COMPILING] foo v0.0.1 ([CWD][..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [PACKAGED] [..]
 ",
         )
@@ -541,7 +541,7 @@ fn lockfile_locks() {
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -593,7 +593,7 @@ fn lockfile_locks_transitively() {
 [CHECKING] baz v0.0.1
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -651,7 +651,7 @@ fn yanks_are_not_used() {
 [CHECKING] baz v0.0.1
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -921,7 +921,7 @@ fn update_with_lockfile_if_packages_missing() {
 [UPDATING] `[..]` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -980,7 +980,7 @@ fn update_lockfile() {
 [DOWNLOADED] [..] v0.0.2 (registry `dummy-registry`)
 [CHECKING] bar v0.0.2
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1003,7 +1003,7 @@ fn update_lockfile() {
 [DOWNLOADED] [..] v0.0.3 (registry `dummy-registry`)
 [CHECKING] bar v0.0.3
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1073,7 +1073,7 @@ fn dev_dependency_not_used() {
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1167,7 +1167,7 @@ fn updating_a_dep() {
 [CHECKING] bar v0.0.1
 [CHECKING] a v0.0.1 ([CWD]/a)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1203,7 +1203,7 @@ fn updating_a_dep() {
 [CHECKING] bar v0.1.0
 [CHECKING] a v0.0.1 ([CWD]/a)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1276,7 +1276,7 @@ fn git_and_registry_dep() {
 [CHECKING] a v0.0.1
 [CHECKING] b v0.0.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1362,7 +1362,7 @@ fn update_publish_then_update() {
 [DOWNLOADED] a v0.1.1 (registry `dummy-registry`)
 [COMPILING] a v0.1.1
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1461,7 +1461,7 @@ fn update_transitive_dependency() {
 [CHECKING] b v0.1.1
 [CHECKING] a v0.1.0
 [CHECKING] foo v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1823,7 +1823,7 @@ fn only_download_relevant() {
 [DOWNLOADED] baz v0.1.0 ([..])
 [CHECKING] baz v0.1.0
 [CHECKING] bar v0.5.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -2748,7 +2748,7 @@ Caused by:
             "\
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([..])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();
@@ -2802,7 +2802,7 @@ internal server error
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -3608,7 +3608,7 @@ fn differ_only_by_metadata() {
 [DOWNLOADED] [..] v0.0.1+b (registry `dummy-registry`)
 [CHECKING] baz v0.0.1+b
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -3659,7 +3659,7 @@ fn differ_only_by_metadata_with_lockfile() {
 [DOWNLOADED] [..] v0.0.1+b (registry `dummy-registry`)
 [CHECKING] baz v0.0.1+b
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -42,7 +42,7 @@ static SUCCESS_OUTPUT: &'static str = "\
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ";
 
 #[cargo_test]

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -46,7 +46,7 @@ fn override_simple() {
 [UPDATING] git repository `[..]`
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -95,7 +95,7 @@ fn override_with_features() {
 will not take effect because the replacement dependency does not support this mechanism
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -144,7 +144,7 @@ fn override_with_setting_default_features() {
 will not take effect because the replacement dependency does not support this mechanism
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -300,7 +300,7 @@ fn transitive() {
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] baz v0.2.0
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -349,7 +349,7 @@ fn persists_across_rebuilds() {
 [UPDATING] git repository `file://[..]`
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -395,7 +395,7 @@ fn replace_registry_with_path() {
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([ROOT][..]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -466,7 +466,7 @@ fn use_a_spec_to_select() {
 [CHECKING] [..]
 [CHECKING] [..]
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -525,7 +525,7 @@ fn override_adds_some_deps() {
 [CHECKING] baz v0.1.1
 [CHECKING] bar v0.1.0 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1449,7 +1449,7 @@ fn override_spec_metadata_is_optional() {
 [UPDATING] git repository `[..]`
 [CHECKING] bar v0.1.0+a (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -293,21 +293,21 @@ fn test_default_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
         .run();
 
     p.cargo("test --no-default-features")
-        .with_stderr("[FINISHED] test [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]")
         .with_stdout("")
         .run();
 
     p.cargo("test --test=foo")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
@@ -350,7 +350,7 @@ fn test_arg_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
@@ -391,7 +391,7 @@ fn test_multiple_required_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo_2-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
@@ -401,7 +401,7 @@ fn test_multiple_required_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo_1-[..][EXE])
 [RUNNING] [..] (target/debug/deps/foo_2-[..][EXE])",
         )
@@ -409,7 +409,7 @@ fn test_multiple_required_features() {
         .run();
 
     p.cargo("test --no-default-features")
-        .with_stderr("[FINISHED] test [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]")
         .with_stdout("")
         .run();
 }
@@ -451,21 +451,21 @@ fn bench_default_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
         .run();
 
     p.cargo("bench --no-default-features")
-        .with_stderr("[FINISHED] bench [optimized] target(s) in [..]".to_string())
+        .with_stderr("[FINISHED] `bench` profile [optimized] target(s) in [..]".to_string())
         .with_stdout("")
         .run();
 
     p.cargo("bench --bench=foo")
         .with_stderr(
             "\
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
@@ -518,7 +518,7 @@ fn bench_arg_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
@@ -579,7 +579,7 @@ fn bench_multiple_required_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo_2-[..][EXE])",
         )
         .with_stdout_contains("test bench ... bench: [..]")
@@ -589,7 +589,7 @@ fn bench_multiple_required_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo_1-[..][EXE])
 [RUNNING] [..] (target/release/deps/foo_2-[..][EXE])",
         )
@@ -597,7 +597,7 @@ fn bench_multiple_required_features() {
         .run();
 
     p.cargo("bench --no-default-features")
-        .with_stderr("[FINISHED] bench [optimized] target(s) in [..]")
+        .with_stderr("[FINISHED] `bench` profile [optimized] target(s) in [..]")
         .with_stdout("")
         .run();
 }
@@ -638,7 +638,7 @@ fn install_default_features() {
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo\" requires the features: `a`
   example \"foo\" requires the features: `a`
@@ -796,7 +796,7 @@ fn install_multiple_required_features() {
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo_1\" requires the features: `b`, `c`
   bin \"foo_2\" requires the features: `a`
@@ -811,7 +811,7 @@ Consider enabling some of the needed features by passing, e.g., `--features=\"b 
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [WARNING] target filter `bins` specified, but no targets matched; this is a no-op
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo_1\" requires the features: `b`, `c`
   bin \"foo_2\" requires the features: `a`
@@ -826,7 +826,7 @@ Consider enabling some of the needed features by passing, e.g., `--features=\"b 
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [WARNING] target filter `examples` specified, but no targets matched; this is a no-op
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo_1\" requires the features: `b`, `c`
   bin \"foo_2\" requires the features: `a`
@@ -841,7 +841,7 @@ Consider enabling some of the needed features by passing, e.g., `--features=\"b 
             "\
 [INSTALLING] foo v0.0.1 ([..])
 [WARNING] target filters `bins`, `examples` specified, but no targets matched; this is a no-op
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo_1\" requires the features: `b`, `c`
   bin \"foo_2\" requires the features: `a`
@@ -932,7 +932,7 @@ fn dep_feature_in_toml() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
@@ -945,7 +945,7 @@ fn dep_feature_in_toml() {
                 "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
             )
             .with_stdout_contains("test bench ... bench: [..]")
@@ -1029,7 +1029,9 @@ fn dep_feature_in_cmd_line() {
         .build();
 
     // This is a no-op
-    p.cargo("build").with_stderr("[FINISHED] dev [..]").run();
+    p.cargo("build")
+        .with_stderr("[FINISHED] `dev` profile [..]")
+        .run();
     assert!(!p.bin("foo").is_file());
 
     // bin
@@ -1063,7 +1065,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
     // test
     // This is a no-op, since no tests are enabled
     p.cargo("test")
-        .with_stderr("[FINISHED] test [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]")
         .with_stdout("")
         .run();
 
@@ -1074,7 +1076,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test bin_is_built ... ok")
@@ -1083,7 +1085,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
     // bench
     if is_nightly() {
         p.cargo("bench")
-            .with_stderr("[FINISHED] bench [optimized] target(s) in [..]")
+            .with_stderr("[FINISHED] `bench` profile [optimized] target(s) in [..]")
             .with_stdout("")
             .run();
 
@@ -1092,7 +1094,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
                 "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
             )
             .with_stdout_contains("test bench ... bench: [..]")
@@ -1104,7 +1106,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo\" requires the features: `bar/a`
   example \"foo\" requires the features: `bar/a`
@@ -1148,7 +1150,7 @@ fn test_skips_compiling_bin_with_missing_required_features() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
@@ -1168,7 +1170,7 @@ error[E0463]: can't find crate for `bar`",
             .with_stderr(
                 "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] [..] (target/release/deps/foo-[..][EXE])",
             )
             .with_stdout_contains("running 0 tests")
@@ -1441,7 +1443,7 @@ fn truncated_install_warning_message() {
 
     p.cargo("install --path .").with_stderr("\
 [INSTALLING] foo v0.1.0 ([..])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo1\" requires the features: `feature1`, `feature2`, `feature3`
   bin \"foo2\" requires the features: `feature2`

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -15,7 +15,7 @@ fn simple() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("hello")
@@ -120,7 +120,7 @@ fn verbose_arg_and_quiet_config() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("hello")
@@ -161,7 +161,7 @@ fn verbose_config_alone() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("hello")
@@ -240,7 +240,7 @@ fn exit_code() {
     let mut output = String::from(
         "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 ",
     );
@@ -262,7 +262,7 @@ fn exit_code_verbose() {
         "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target[..]`
 ",
     );
@@ -336,7 +336,7 @@ fn specify_name() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..] src/lib.rs [..]`
 [RUNNING] `rustc [..] src/bin/a.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/a[EXE]`",
         )
         .with_stdout("hello a.rs")
@@ -347,7 +347,7 @@ fn specify_name() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] src/bin/b.rs [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/b[EXE]`",
         )
         .with_stdout("hello b.rs")
@@ -421,7 +421,7 @@ fn run_example() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`",
         )
         .with_stdout("example")
@@ -475,7 +475,7 @@ fn run_bin_example() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/bar[EXE]`",
         )
         .with_stdout("example")
@@ -558,7 +558,7 @@ fn run_example_autodiscover_2015_with_autoexamples_enabled() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`",
         )
         .with_stdout("example")
@@ -588,7 +588,7 @@ fn run_example_autodiscover_2018() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`",
         )
         .with_stdout("example")
@@ -728,7 +728,7 @@ fn one_bin_multiple_examples() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/main[EXE]`",
         )
         .with_stdout("hello main.rs")
@@ -801,7 +801,7 @@ fn example_with_release_flag() {
         -C strip=debuginfo \
         -L dependency=[CWD]/target/release/deps \
          --extern bar=[CWD]/target/release/deps/libbar-[..].rlib`
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [RUNNING] `target/release/examples/a[EXE]`
 ",
         )
@@ -830,7 +830,7 @@ fast2",
         --out-dir [CWD]/target/debug/examples \
         -L dependency=[CWD]/target/debug/deps \
          --extern bar=[CWD]/target/debug/deps/libbar-[..].rlib`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/examples/a[EXE]`
 ",
         )
@@ -915,7 +915,7 @@ fn run_with_bin_dep() {
             "\
 [WARNING] foo v0.0.1 ([CWD]) ignoring invalid dependency `bar` which is missing a lib target
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("hello")
@@ -973,7 +973,7 @@ fn run_with_bin_deps() {
 [WARNING] foo v0.0.1 ([CWD]) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo v0.0.1 ([CWD]) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo[EXE]`",
         )
         .with_stdout("hello")
@@ -1063,7 +1063,7 @@ available binaries: bar1, bar2, foo1, foo2",
 [WARNING] foo1 v0.0.1 ([CWD]/foo1) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo2 v0.0.1 ([CWD]/foo2) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo1 v0.0.1 ([CWD]/foo1)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `target/debug/foo1[EXE]`",
         )
         .with_stdout("hello")
@@ -1085,7 +1085,7 @@ fn release_works() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [RUNNING] `target/release/foo[EXE]`
 ",
         )
@@ -1108,7 +1108,7 @@ fn release_short_works() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [RUNNING] `target/release/foo[EXE]`
 ",
         )
@@ -1169,7 +1169,7 @@ fn run_from_executable_folder() {
     p.cargo("run")
         .cwd(cwd)
         .with_stderr(
-            "[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]\n\
+            "[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n\
              [RUNNING] `./foo[EXE]`",
         )
         .with_stdout("hello")
@@ -1469,7 +1469,7 @@ fn print_env_verbose() {
             "\
 [COMPILING] a v0.0.1 ([CWD])
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc --crate-name a[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] target/debug/a[EXE]`",
         )
         .run();

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -22,7 +22,7 @@ fn build_lib_for_foo() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -45,7 +45,7 @@ fn lib() {
         -C metadata=[..] \
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -74,7 +74,7 @@ fn build_main_and_allow_unstable_options() {
         --out-dir [..] \
         -L dependency=[CWD]/target/debug/deps \
         --extern {name}=[CWD]/target/debug/deps/lib{name}-[..].rlib`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             name = "foo",
             version = "0.0.1"
@@ -113,7 +113,7 @@ fn build_with_args_to_one_of_multiple_binaries() {
         --out-dir [..]`
 [RUNNING] `rustc --crate-name bar src/bin/bar.rs [..]--crate-type bin --emit=[..]link[..]\
         -C debuginfo=2 [..]-C debug-assertions [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -207,7 +207,7 @@ fn build_with_crate_type_for_foo() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type cdylib [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -246,7 +246,7 @@ fn build_with_crate_type_for_foo_with_deps() {
 [RUNNING] `rustc --crate-name a a/src/lib.rs [..]--crate-type lib [..]
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type cdylib [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -261,7 +261,7 @@ fn build_with_crate_types_for_foo() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib,cdylib [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -293,7 +293,7 @@ fn build_with_crate_type_to_example() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib [..]
 [RUNNING] `rustc --crate-name ex examples/ex.rs [..]--crate-type cdylib [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -325,7 +325,7 @@ fn build_with_crate_types_to_example() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib [..]
 [RUNNING] `rustc --crate-name ex examples/ex.rs [..]--crate-type lib,cdylib [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -361,7 +361,7 @@ fn build_with_crate_types_to_one_of_multi_examples() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc --crate-name foo src/lib.rs [..]--crate-type lib [..]
 [RUNNING] `rustc --crate-name ex1 examples/ex1.rs [..]--crate-type lib,cdylib [..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -385,7 +385,7 @@ fn build_with_args_to_one_of_multiple_tests() {
         --out-dir [..]`
 [RUNNING] `rustc --crate-name bar tests/bar.rs [..]--emit=[..]link[..]-C debuginfo=2 [..]\
         -C debug-assertions [..]--test[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -421,7 +421,7 @@ fn build_foo_with_bar_dependency() {
 [RUNNING] `[..] -C debuginfo=2 [..]`
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `[..] -C debuginfo=2 [..]-C debug-assertions [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -455,7 +455,7 @@ fn build_only_bar_dependency() {
             "\
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..] -C debug-assertions [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -14,7 +14,7 @@ fn rustdoc_simple() {
         -o [CWD]/target/doc \
         [..] \
         -L dependency=[CWD]/target/debug/deps [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -47,7 +47,7 @@ fn rustdoc_simple_json() {
             "\
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [RUNNING] `rustdoc [..]--crate-name foo [..]-o [CWD]/target/doc [..]--output-format=json[..]
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo.json
 ",
         )
@@ -118,7 +118,7 @@ fn rustdoc_args() {
         --cfg=foo \
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -172,7 +172,7 @@ fn rustdoc_foo_with_bar_dependency() {
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps \
         --extern [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -212,7 +212,7 @@ fn rustdoc_only_bar_dependency() {
         --cfg=foo \
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
 ",
         )
@@ -236,7 +236,7 @@ fn rustdoc_same_name_documents_lib() {
         --cfg=foo \
         -C metadata=[..] \
         -L dependency=[CWD]/target/debug/deps [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )
@@ -313,7 +313,7 @@ fn rustdoc_target() {
     [..] \
     -L dependency=[CWD]/target/{target}/debug/deps \
     -L dependency=[CWD]/target/debug/deps[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/[..]/doc/foo/index.html",
             target = cross_compile::alternate()
         ))

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -49,7 +49,7 @@ fn rerun() {
     p.cargo("doc")
         .env("RUSTDOCFLAGS", "--cfg=foo")
         .with_stderr(
-            "[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+            "[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html",
         )
         .run();
@@ -58,7 +58,7 @@ fn rerun() {
         .with_stderr(
             "\
 [DOCUMENTING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/foo/index.html
 ",
         )

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1273,7 +1273,7 @@ fn cfg_rustflags_normal_source() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1283,7 +1283,7 @@ fn cfg_rustflags_normal_source() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1293,7 +1293,7 @@ fn cfg_rustflags_normal_source() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1305,7 +1305,7 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 [EXECUTABLE] `[..]/target/debug/deps/a-[..][EXE]`
 [EXECUTABLE] `[..]/target/debug/deps/c-[..][EXE]`
@@ -1320,7 +1320,7 @@ fn cfg_rustflags_normal_source() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [EXECUTABLE] `[..]/target/release/deps/foo-[..][EXE]`
 [EXECUTABLE] `[..]/target/release/deps/a-[..][EXE]`
 ",
@@ -1360,7 +1360,7 @@ fn cfg_rustflags_precedence() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1370,7 +1370,7 @@ fn cfg_rustflags_precedence() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1380,7 +1380,7 @@ fn cfg_rustflags_precedence() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1392,7 +1392,7 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 [EXECUTABLE] `[..]/target/debug/deps/a-[..][EXE]`
 [EXECUTABLE] `[..]/target/debug/deps/c-[..][EXE]`
@@ -1407,7 +1407,7 @@ fn cfg_rustflags_precedence() {
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
 [RUNNING] `rustc [..] --cfg bar[..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [EXECUTABLE] `[..]/target/release/deps/foo-[..][EXE]`
 [EXECUTABLE] `[..]/target/release/deps/a-[..][EXE]`
 ",
@@ -1433,7 +1433,7 @@ fn target_rustflags_string_and_array_form1() {
             "\
 [CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1454,7 +1454,7 @@ fn target_rustflags_string_and_array_form1() {
             "\
 [CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1481,7 +1481,7 @@ fn target_rustflags_string_and_array_form2() {
             "\
 [CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1505,7 +1505,7 @@ fn target_rustflags_string_and_array_form2() {
             "\
 [CHECKING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] --cfg foo[..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -37,7 +37,7 @@ args: []
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/echo[EXE]`
 ",
         )
@@ -61,7 +61,7 @@ args: []
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/echo[EXE]`
 ",
         )
@@ -84,7 +84,7 @@ args: []
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `target/debug/foo[EXE]`
 ",
         )
@@ -140,7 +140,7 @@ args: []
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] echo v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/echo[EXE]`
 ",
         )
@@ -231,7 +231,7 @@ fn main() {
         .with_stderr(
             "\
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )
@@ -262,7 +262,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )
@@ -291,7 +291,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )
@@ -307,7 +307,7 @@ fn main() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )
@@ -325,7 +325,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )
@@ -437,7 +437,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )
@@ -462,7 +462,7 @@ args: ["-NotAnArg"]
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] -NotAnArg`
 ",
         )
@@ -487,7 +487,7 @@ args: ["-NotAnArg"]
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] -NotAnArg`
 ",
         )
@@ -512,7 +512,7 @@ args: ["--help"]
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
@@ -536,7 +536,7 @@ args: []
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] s-h-w-c- v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/s-h-w-c-[EXE]`
 "#,
         )
@@ -560,7 +560,7 @@ args: []
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] answer v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/answer[EXE]`
 "#,
         )
@@ -582,7 +582,7 @@ args: []
         .with_stderr(
             r#"[WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] package v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/package[EXE]`
 "#,
         )
@@ -740,7 +740,7 @@ fn main() {
 [DOWNLOADED] script v1.0.0 (registry `dummy-registry`)
 [COMPILING] script v1.0.0
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
@@ -776,7 +776,7 @@ fn main() {
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
@@ -805,7 +805,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
@@ -834,7 +834,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE] --help`
 ",
         )
@@ -859,7 +859,7 @@ args: []
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[ROOT]/home/.cargo/target/[..]/debug/script[EXE]`
 ",
         )
@@ -887,7 +887,7 @@ args: []
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[ROOT]/home/.cargo/target/[..]/debug/script[EXE]`
 ",
         )
@@ -950,7 +950,7 @@ fn cmd_check_with_embedded() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [CHECKING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1011,7 +1011,7 @@ fn cmd_build_with_embedded() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();
@@ -1039,7 +1039,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fini
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] unittests script.rs ([..])
 ",
         )
@@ -1252,7 +1252,7 @@ args: []
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [COMPILING] script v0.0.0 ([ROOT]/foo)
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]s
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 [RUNNING] `[..]/debug/script[EXE]`
 ",
         )

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -217,7 +217,7 @@ See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for
 [DOWNLOADED] bar v1.0.0 (registry `alternative`)
 [COMPILING] bar v1.0.0
 [COMPILING] foo v0.0.1 ([..]foo-0.0.1)
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [PACKAGED] [..]
 [UPLOADING] foo v0.0.1 ([..])
 [UPLOADED] foo v0.0.1 to registry `crates-io`
@@ -288,7 +288,7 @@ fn source_replacement_with_registry_url() {
 [DOWNLOADED] bar v0.0.1 (registry `using-registry-url`)
 [CHECKING] bar v0.0.1
 [CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 ",
         )
         .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -41,7 +41,7 @@ fn cargo_test_simple() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("test test_hello ... ok")
@@ -95,7 +95,7 @@ fn cargo_test_release() {
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
 [RUNNING] [..] -C opt-level=3 [..]
-[FINISHED] release [optimized] target(s) in [..]
+[FINISHED] `release` profile [optimized] target(s) in [..]
 [RUNNING] `[..]target/release/deps/foo-[..][EXE]`
 [RUNNING] `[..]target/release/deps/test-[..][EXE]`
 [DOCTEST] foo
@@ -301,7 +301,7 @@ fn cargo_test_verbose() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] src/main.rs [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[CWD]/target/debug/deps/foo-[..] hello`
 ",
         )
@@ -375,7 +375,7 @@ fn cargo_test_failing_test_in_bin() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [ERROR] test failed, to rerun pass `--bin foo`",
         )
@@ -424,7 +424,7 @@ fn cargo_test_failing_test_in_test() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/footest-[..][EXE])
 [ERROR] test failed, to rerun pass `--test footest`",
@@ -463,7 +463,7 @@ fn cargo_test_failing_test_in_lib() {
         .with_stderr(
             "\
 [COMPILING] foo v0.5.0 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [ERROR] test failed, to rerun pass `--lib`",
         )
@@ -537,7 +537,7 @@ fn test_with_lib_dep() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/baz-[..][EXE])
 [DOCTEST] foo",
@@ -591,7 +591,7 @@ fn test_with_deep_lib_dep() {
             "\
 [COMPILING] bar v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target[..])
 [DOCTEST] foo",
         )
@@ -640,7 +640,7 @@ fn external_test_explicit() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/test-[..][EXE])
 [DOCTEST] foo",
@@ -700,7 +700,7 @@ fn external_test_implicit() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/external-[..][EXE])
 [DOCTEST] foo",
@@ -759,7 +759,7 @@ fn pass_through_escaped() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ",
@@ -771,7 +771,7 @@ fn pass_through_escaped() {
     p.cargo("test -- foo")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ",
@@ -783,7 +783,7 @@ fn pass_through_escaped() {
     p.cargo("test -- foo bar")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo
 ",
@@ -829,7 +829,7 @@ fn pass_through_testname() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
@@ -840,7 +840,7 @@ fn pass_through_testname() {
     p.cargo("test foo")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
@@ -851,7 +851,7 @@ fn pass_through_testname() {
     p.cargo("test foo -- bar")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 ",
         )
@@ -917,7 +917,7 @@ fn lib_bin_same_name() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
@@ -958,7 +958,7 @@ fn lib_with_standard_name() {
         .with_stderr(
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/syntax-[..][EXE])
 [RUNNING] [..] (target/debug/deps/test-[..][EXE])
 [DOCTEST] syntax",
@@ -1004,7 +1004,7 @@ fn lib_with_standard_name2() {
         .with_stderr(
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/syntax-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
@@ -1045,7 +1045,7 @@ fn lib_without_name() {
         .with_stderr(
             "\
 [COMPILING] syntax v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/syntax-[..][EXE])",
         )
         .with_stdout_contains("test test ... ok")
@@ -1357,7 +1357,7 @@ fn test_dylib() {
             "\
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/test-[..][EXE])",
         )
@@ -1368,7 +1368,7 @@ fn test_dylib() {
     p.cargo("test")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [RUNNING] [..] (target/debug/deps/test-[..][EXE])",
         )
@@ -1397,7 +1397,7 @@ fn test_twice_with_build_cmd() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
@@ -1408,7 +1408,7 @@ fn test_twice_with_build_cmd() {
     p.cargo("test")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
@@ -1425,7 +1425,7 @@ fn test_then_build() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])
 [DOCTEST] foo",
         )
@@ -1446,7 +1446,7 @@ fn test_no_run() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] unittests src/lib.rs (target/debug/deps/foo-[..][EXE])
 ",
         )
@@ -1463,7 +1463,7 @@ fn test_no_run_emit_json() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1497,7 +1497,7 @@ fn test_run_specific_bin_target() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/bin2-[..][EXE])",
         )
         .with_stdout_contains("test test2 ... ok")
@@ -1538,7 +1538,7 @@ fn test_run_implicit_bin_target() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/mybin-[..][EXE])",
         )
         .with_stdout_contains("test test_in_bin ... ok")
@@ -1558,7 +1558,7 @@ fn test_run_specific_test_target() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/b-[..][EXE])",
         )
         .with_stdout_contains("test test_b ... ok")
@@ -1598,7 +1598,7 @@ fn test_run_implicit_test_target() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/mybin-[..][EXE])
 [RUNNING] [..] (target/debug/deps/mytest-[..][EXE])",
         )
@@ -1639,7 +1639,7 @@ fn test_run_implicit_bench_target() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/mybin-[..][EXE])
 [RUNNING] [..] (target/debug/deps/mybench-[..][EXE])",
         )
@@ -1781,7 +1781,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]
 [RUNNING] `rustc --crate-name foo src/lib.rs [..] --test [..]`
 [RUNNING] `rustc --crate-name mybin src/bin/mybin.rs [..] --crate-type bin [..]`
 [RUNNING] `rustc --crate-name mytest tests/mytest.rs [..] --test [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[CWD]/target/debug/deps/foo-[..] test_in_`
 [RUNNING] `[CWD]/target/debug/deps/mytest-[..] test_in_`
 ",
@@ -1820,7 +1820,7 @@ fn test_no_harness() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/bar-[..][EXE])
 ",
         )
@@ -1892,7 +1892,7 @@ fn selective_testing() {
         .with_stderr(
             "\
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/d1-[..][EXE])
 [RUNNING] [..] (target/debug/deps/d1-[..][EXE])",
         )
@@ -1904,7 +1904,7 @@ fn selective_testing() {
         .with_stderr(
             "\
 [COMPILING] d2 v0.0.1 ([CWD]/d2)
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/d2-[..][EXE])
 [RUNNING] [..] (target/debug/deps/d2-[..][EXE])",
         )
@@ -1916,7 +1916,7 @@ fn selective_testing() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
@@ -2097,7 +2097,7 @@ fn selective_testing_with_docs() {
         .with_stderr(
             "\
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/d1[..][EXE])
 [DOCTEST] d1",
         )
@@ -2118,7 +2118,7 @@ fn example_bin_same_name() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 ",
         )
@@ -2135,7 +2135,7 @@ fn example_bin_same_name() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..]",
         )
         .with_stdout("bin")
@@ -2195,7 +2195,7 @@ fn example_with_dev_dep() {
 [..]
 [..]
 [RUNNING] `rustc --crate-name ex [..] --extern a=[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2271,7 +2271,7 @@ fn doctest_feature() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo[..][EXE])
 [DOCTEST] foo",
         )
@@ -2348,7 +2348,7 @@ fn filter_no_doc_tests() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo[..][EXE])",
         )
         .with_stdout_contains("running 0 tests")
@@ -2387,7 +2387,7 @@ fn dylib_doctest() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [DOCTEST] foo",
         )
         .with_stdout_contains("test [..] ... ok")
@@ -2474,7 +2474,7 @@ fn cyclic_dev_dep_doc_test() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo[..][EXE])
 [DOCTEST] foo",
         )
@@ -2570,7 +2570,7 @@ fn no_fail_fast() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] unittests src/lib.rs (target/debug/deps/foo[..])
 [RUNNING] tests/test_add_one.rs (target/debug/deps/test_add_one[..])
 [ERROR] test failed, to rerun pass `--test test_add_one`
@@ -2666,7 +2666,7 @@ fn bin_does_not_rebuild_tests() {
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..] src/main.rs [..]`
 [RUNNING] `rustc [..] src/main.rs [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 [EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
 [EXECUTABLE] `[..]/target/debug/deps/foo-[..][EXE]`
@@ -2727,7 +2727,7 @@ fn selective_test_optional_dep() {
 [COMPILING] a v0.0.1 ([..])
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [EXECUTABLE] `[..]/target/debug/deps/a-[..][EXE]`
 ",
         )
@@ -2760,7 +2760,7 @@ fn only_test_docs() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [DOCTEST] foo",
         )
         .with_stdout_contains("test [..] ... ok")
@@ -2827,7 +2827,7 @@ fn cfg_test_even_with_no_harness() {
             "\
 [COMPILING] foo v0.0.1 ([..])
 [RUNNING] `rustc [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]`
 ",
         )
@@ -3796,7 +3796,7 @@ fn test_hint_workspace_virtual() {
 [COMPILING] c v0.1.0 [..]
 [COMPILING] a v0.1.0 [..]
 [COMPILING] b v0.1.0 [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] unittests src/lib.rs (target/debug/deps/a[..])
 [RUNNING] unittests src/lib.rs (target/debug/deps/b[..])
 [ERROR] test failed, to rerun pass `-p b --lib`
@@ -3808,7 +3808,7 @@ fn test_hint_workspace_virtual() {
         .cwd("b")
         .with_stderr(
             "\
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] unittests src/lib.rs ([ROOT]/foo/target/debug/deps/b[..])
 [ERROR] test failed, to rerun pass `--lib`
 ",
@@ -3818,7 +3818,7 @@ fn test_hint_workspace_virtual() {
     p.cargo("test --no-fail-fast")
         .with_stderr(
             "\
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] unittests src/lib.rs (target/debug/deps/a[..])
 [RUNNING] unittests src/lib.rs (target/debug/deps/b[..])
 [ERROR] test failed, to rerun pass `-p b --lib`
@@ -3845,7 +3845,7 @@ fn test_hint_workspace_virtual() {
         .with_stderr(
             "\
 [COMPILING] c v0.1.0 [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] unittests src/lib.rs (target/debug/deps/c[..])
 [RUNNING] unittests src/main.rs (target/debug/deps/c[..])
 [ERROR] test failed, to rerun pass `-p c --bin c`
@@ -4082,7 +4082,7 @@ fn doctest_skip_staticlib() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] [..] (target/debug/deps/foo-[..])",
         )
         .run();
@@ -4110,7 +4110,7 @@ pub fn foo() -> u8 { 1 }
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..])
 [DOCTEST] foo
 ",
@@ -4134,7 +4134,7 @@ test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out[..]
     p.cargo("test --lib")
         .with_stderr(
             "\
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/foo-[..])\n",
         )
         .with_stdout(
@@ -4200,7 +4200,7 @@ fn test_all_targets_lib() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] [..]foo[..]
 ",
         )
@@ -4800,7 +4800,7 @@ fn execution_error() {
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] tests/t1.rs (target/debug/deps/t1[..])
 error: test failed, to rerun pass `--test t1`
 
@@ -4839,7 +4839,7 @@ fn nonzero_exit_status() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] tests/t1.rs (target/debug/deps/t1[..])
 error: test failed, to rerun pass `--test t1`
 ",
@@ -4852,7 +4852,7 @@ error: test failed, to rerun pass `--test t1`
         .with_stderr(
             "\
 [COMPILING] foo v0.0.1 [..]
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] tests/t2.rs (target/debug/deps/t2[..])
 error: test failed, to rerun pass `--test t2`
 
@@ -4867,7 +4867,7 @@ note: test exited abnormally; to see the full output pass --nocapture to the har
     p.cargo("test --test t2 -- --nocapture")
         .with_stderr(
             "\
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] tests/t2.rs (target/debug/deps/t2[..])
 error: test failed, to rerun pass `--test t2`
 
@@ -4882,7 +4882,7 @@ Caused by:
     p.cargo("test --no-fail-fast")
         .with_stderr(
             "\
-[FINISHED] test [..]
+[FINISHED] `test` profile [..]
 [RUNNING] tests/t1.rs (target/debug/deps/t1[..])
 error: test failed, to rerun pass `--test t1`
 [RUNNING] tests/t2.rs (target/debug/deps/t2[..])
@@ -4922,7 +4922,7 @@ fn cargo_test_print_env_verbose() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc --crate-name foo[..]`
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustc --crate-name foo[..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] [CWD]/target/debug/deps/foo-[..][EXE]`
 [DOCTEST] foo
 [RUNNING] `[..]CARGO_MANIFEST_DIR=[CWD][..] rustdoc --crate-type lib --crate-name foo[..]",

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -26,7 +26,7 @@ fn pathless_tools() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C linker=nonexistent-linker [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -52,7 +52,7 @@ fn custom_linker_cfg() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C linker=nonexistent-linker [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -85,7 +85,7 @@ fn custom_linker_cfg_precedence() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C linker=nonexistent-linker [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -151,7 +151,7 @@ fn absolute_tools() {
             "\
 [COMPILING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C linker=[..]bogus/nonexistent-linker [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -195,7 +195,7 @@ fn relative_tools() {
             "\
 [COMPILING] bar v0.5.0 ([CWD])
 [RUNNING] `rustc [..] -C linker={prefix}/./tools/nonexistent-linker [..]`
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
             prefix = prefix,
         ))
@@ -227,7 +227,7 @@ fn custom_runner() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
         )
@@ -239,7 +239,7 @@ fn custom_runner() {
             "\
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
-[FINISHED] test [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r [..]/target/debug/deps/test-[..][EXE] --param`
 ",
         )
@@ -252,7 +252,7 @@ fn custom_runner() {
 [COMPILING] foo v0.0.1 ([CWD])
 [RUNNING] `rustc [..]`
 [RUNNING] `rustc [..]`
-[FINISHED] bench [optimized] target(s) in [..]
+[FINISHED] `bench` profile [optimized] target(s) in [..]
 [RUNNING] `nonexistent-runner -r [..]/target/release/deps/bench-[..][EXE] --param --bench`
 ",
         )
@@ -278,7 +278,7 @@ fn custom_runner_cfg() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
         )
@@ -312,7 +312,7 @@ fn custom_runner_cfg_precedence() {
         .with_stderr_contains(
             "\
 [COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] `nonexistent-runner -r target/debug/foo[EXE] --param`
 ",
         )
@@ -362,7 +362,7 @@ fn custom_runner_env() {
         .with_stderr(&format!(
             "\
 [COMPILING] foo [..]
-[FINISHED] dev [..]
+[FINISHED] `dev` profile [..]
 [RUNNING] `nonexistent-runner --foo target/debug/foo[EXE]`
 [ERROR] could not execute process `nonexistent-runner --foo target/debug/foo[EXE]` (never executed)
 

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -68,7 +68,7 @@ fn no_warning_on_success() {
 [DOWNLOADED] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -107,14 +107,14 @@ fn non_virtual_default_members_build_other_member() {
     p.cargo("check")
         .with_stderr(
             "[CHECKING] baz v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 
     p.cargo("check --manifest-path bar/Cargo.toml")
         .with_stderr(
             "[CHECKING] bar v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -143,7 +143,7 @@ fn non_virtual_default_members_build_root_project() {
     p.cargo("check")
         .with_stderr(
             "[CHECKING] foo v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -668,7 +668,7 @@ fn share_dependencies() {
 [DOWNLOADED] dep1 v0.1.3 ([..])
 [CHECKING] dep1 v0.1.3
 [CHECKING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -769,7 +769,7 @@ fn lock_works_for_everyone() {
 [DOWNLOADED] dep2 v0.1.0 ([..])
 [CHECKING] dep2 v0.1.0
 [CHECKING] foo v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -782,7 +782,7 @@ fn lock_works_for_everyone() {
 [DOWNLOADED] dep1 v0.1.0 ([..])
 [CHECKING] dep1 v0.1.0
 [CHECKING] bar v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -937,7 +937,7 @@ fn virtual_default_members_build_other_member() {
     p.cargo("check --manifest-path bar/Cargo.toml")
         .with_stderr(
             "[CHECKING] bar v0.1.0 ([..])\n\
-             [..] Finished dev [unoptimized + debuginfo] target(s) in [..]\n",
+             [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
         )
         .run();
 }
@@ -1982,7 +1982,7 @@ fn dep_used_with_separate_features() {
 [..]Compiling feat_lib v0.1.0 ([..])
 [..]Compiling caller1 v0.1.0 ([..])
 [..]Compiling caller2 v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -1999,7 +1999,7 @@ fn dep_used_with_separate_features() {
             "\
 [..]Compiling feat_lib v0.1.0 ([..])
 [..]Compiling caller1 v0.1.0 ([..])
-[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
         .run();
@@ -2008,15 +2008,15 @@ fn dep_used_with_separate_features() {
     // features are being built separately. Should not rebuild anything.
     p.cargo("build")
         .cwd("caller2")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
     p.cargo("build")
         .cwd("caller1")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
     p.cargo("build")
         .cwd("caller2")
-        .with_stderr("[FINISHED] dev [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

As highlighted on [zulip](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/cargo.20build.20default.20profile/near/418316528), many users think "Rust is slow" because of the `dev` profile.

While a perfect solution is still being worked out, this attempts what will hopefully be smaller, incremental step that hopefully maintains balance of the different needs.

We are changing the message from:
```
Finished dev [unoptimized + debuginfo] target(s) in [..]s
```
to
```
Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]s
```
where `dev profile` is a link to [the Cargo book](https://doc.rust-lang.org/cargo/reference/profiles.html#profiles).

The intent is
- Clarify what `dev` even means
  - Add `profile` to give it context
  - Quote it to highlight this is something mutable
- Make the profile content stand out on hover by being a link
- Help people learn more by following the link

For now, this leaves the profile description alone.

### How should we test and review this PR?



### Additional information

