### PR TITLE
Enable edition migration for 2024

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -275,7 +275,7 @@ impl Edition {
             Edition2015 => false,
             Edition2018 => true,
             Edition2021 => true,
-            Edition2024 => false,
+            Edition2024 => true,
         }
     }
 


### PR DESCRIPTION
This enables `cargo fix --edition` to migrate to the 2024 edition. The lint group is now available in rustc.
