### PR TITLE
Silently ignore `cargo::rustc-check-cfg` to avoid MSRV annoyance when stabilizing `-Zcheck-cfg`

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -916,10 +916,8 @@ impl BuildOutput {
                     if extra_check_cfg {
                         check_cfgs.push(value.to_string());
                     } else {
-                        warnings.push(format!(
-                            "{}{} requires -Zcheck-cfg flag",
-                            syntax_prefix, key
-                        ));
+                        // silently ignoring the instruction to try to
+                        // minimise MSRV annoyance when stabilizing -Zcheck-cfg
                     }
                 }
                 "rustc-env" => {

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -208,10 +208,8 @@ fn parse_links_overrides(
                         let list = value.list(key)?;
                         output.check_cfgs.extend(list.iter().map(|v| v.0.clone()));
                     } else {
-                        gctx.shell().warn(format!(
-                            "target config `{}.{}` requires -Zcheck-cfg flag",
-                            target_key, key
-                        ))?;
+                        // silently ignoring the instruction to try to
+                        // minimise MSRV annoyance when stabilizing -Zcheck-cfg
                     }
                 }
                 "rustc-env" => {

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -471,9 +471,7 @@ fn build_script_override_feature_gate() {
         .build();
 
     p.cargo("check")
-        .with_stderr_contains(
-            "warning: target config[..]rustc-check-cfg[..] requires -Zcheck-cfg flag",
-        )
+        .with_stderr_does_not_contain("warning: [..]rustc-check-cfg[..]")
         .run();
 }
 
@@ -555,7 +553,7 @@ fn build_script_feature_gate() {
         .build();
 
     p.cargo("check")
-        .with_stderr_contains("warning[..]cargo::rustc-check-cfg requires -Zcheck-cfg flag")
+        .with_stderr_does_not_contain("warning: [..]rustc-check-cfg[..]")
         .with_status(0)
         .run();
 }


### PR DESCRIPTION
This PR, removes the warning when trying to use `cargo::rustc-check-cfg` on stable or nightly (without the nightly-only `-Zcheck-cfg` flag) to avoid MSRV annoyance when stabilizing `-Zcheck-cfg`.

See this [Zulip thread](https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/check-cfg.20backwards.20compatible.20warnings) for more information and context.

cc @ehuss 