### PR TITLE
Remove `rustc-check-cfg=` from the reserved directive prefixes

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -716,7 +716,6 @@ impl BuildOutput {
             "rustc-link-arg-examples=",
             "rustc-link-arg=",
             "rustc-cfg=",
-            "rustc-check-cfg=",
             "rustc-env=",
             "warning=",
             "rerun-if-changed=",


### PR DESCRIPTION
While `rustc-check-cfg=` is still nightly-only we can still remove it from the old build script reserved prefixes. I think we should do it, so let's remove it (while we still can).

r? @epage