### PR TITLE
feat: Expost host and target sysroot to build scripts.

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -392,6 +392,8 @@ let out_dir = env::var("OUT_DIR").unwrap();
                    changed by editing `.cargo/config.toml`; see the documentation
                    about [cargo configuration][cargo-config] for more
                    information.
+* `RUSTC_HOST_SYSROOT` --- The path to the `rustc` sysroot for the host.
+* `RUSTC_TARGET_SYSROOT` --- The path to the `rustc` sysroot for the target.
 * `CARGO_ENCODED_RUSTFLAGS` --- extra flags that Cargo invokes `rustc` with,
   separated by a `0x1f` character (ASCII Unit Separator). See
   [`build.rustflags`]. Note that since Rust 1.55, `RUSTFLAGS` is removed from


### PR DESCRIPTION
### What does this PR try to resolve?
Currently, when using `-Zbuild-std`, Cargo passes a `--sysroot` argument down to the relevant `rustc` invocations. However, the value of this argument is not exposed to build scripts, so if a build script wishes to mirror the `rustc` configuration of the host, they must somehow discover the sysroot themselves.

This patch exposes the host (`RUSTC_HOST_SYSROOT`) and target (`RUSTC_TARGET_SYSROOT`) sysroots to build scripts through additional environment variables.

Fixes #7501
Related to https://github.com/rust-lang/wg-cargo-std-aware/issues/50

### How should we test and review this PR?
An example build script displaying these environment variables is as follows:
```rust
use std::env;

fn main() {
    println!("host: {}", env::var("RUSTC_HOST_SYSROOT").unwrap());
    println!("target: {}", env::var("RUSTC_TARGET_SYSROOT").unwrap());
}
```

### Additional information
N/A
