### PR TITLE
Update tests for changes in latest nightly

### DIFF
--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -155,7 +155,7 @@ fn cross_custom() {
             r#"
             {
                 "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",
@@ -196,7 +196,7 @@ fn custom_test_framework() {
             r#"
             {
                 "llvm-target": "x86_64-unknown-none-gnu",
-                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+                "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
                 "arch": "x86_64",
                 "target-endian": "little",
                 "target-pointer-width": "64",

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -22,7 +22,7 @@ pub trait Copy {
 const SIMPLE_SPEC: &str = r#"
 {
     "llvm-target": "x86_64-unknown-none-gnu",
-    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
     "arch": "x86_64",
     "target-endian": "little",
     "target-pointer-width": "64",

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -15,7 +15,7 @@ use cargo_test_support::{basic_manifest, project, Project};
 // We use a special flag to force it to generate a report.
 const FUTURE_EXAMPLE: &'static str = "fn main() { let x = 1; }";
 // Some text that will be displayed when the lint fires.
-const FUTURE_OUTPUT: &'static str = "[..]unused_variables[..]";
+const FUTURE_OUTPUT: &'static str = "[..]unused variable[..]";
 
 fn simple_project() -> Project {
     project()


### PR DESCRIPTION
There were two changes that has caused nightly tests to start failing:
* LLVM was updated, and that caused a change in the expected data layout for the target. (https://github.com/rust-lang/rust/pull/120055 update to LLVM 18)
* https://github.com/rust-lang/rust/pull/121049 Do not point at `#[allow(_)]` as the reason for compat lint triggering. The test was looking for the `unused_variables` note, which is no longer printed.