### PR TITLE
chore(deps): update openssl to 3.2.1 again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2329,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2361,18 +2361,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.28.1+1.1.1w"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.92"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ libloading = "0.8.1"
 memchr = "2.7.1"
 miow = "0.6.0"
 opener = "0.6.1"
-openssl = "0.10.57"
+openssl = "0.10.63"
 os_info = "3.7.0"
 pasetors = { version = "0.6.8", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/13159 had updated to 3.2.0 and https://github.com/rust-lang/cargo/pull/13179 reverted to 1.1.1 for riscv64 build.

riscv64 build issue fixed and released in openssl-src 300.2.3+3.2.1: https://github.com/alexcrichton/openssl-src-rs/pull/230

Update to 3.2.1 from 3.2.0 should be safe.