### PR TITLE
Remove unnecessary `use` statement in metabuild

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1077,9 +1077,6 @@ fn prepare_metabuild(cx: &Context<'_, '_>, unit: &Unit, deps: &[String]) -> Carg
                 .map(|d| d.unit.target.crate_name())
         })
         .collect();
-    for dep in &meta_deps {
-        output.push(format!("use {};\n", dep));
-    }
     output.push("fn main() {\n".to_string());
     for dep in &meta_deps {
         output.push(format!("    {}::metabuild();\n", dep));


### PR DESCRIPTION
Check this situation in PR [#117772](https://github.com/rust-lang/rust/pull/117772)  in rustc.

This blocks the merge of that PR. Details in [CI log](https://github.com/rust-lang-ci/rust/actions/runs/7886502990/job/21519873414). 


```bash
2024-02-13T13:22:45.9857459Z failures:
2024-02-13T13:22:45.9857706Z 
2024-02-13T13:22:45.9858644Z ---- metabuild::metabuild_fresh stdout ----
2024-02-13T13:22:45.9881590Z running `/checkout/obj/build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-linux-gnu/release/cargo check -vv`
2024-02-13T13:22:45.9883611Z running `/checkout/obj/build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-linux-gnu/release/cargo check -vv`
2024-02-13T13:22:45.9884693Z thread 'metabuild::metabuild_fresh' panicked at tests/testsuite/metabuild.rs:284:10:
2024-02-13T13:22:45.9885493Z �[1m�[31merror�[0m�[1m:�[0m test failed, to rerun pass `--test testsuite`
2024-02-13T13:22:45.9885887Z 
2024-02-13T13:22:45.9886990Z test failed running `/checkout/obj/build/x86_64-unknown-linux-gnu/stage2-tools/x86_64-unknown-linux-gnu/release/cargo check -vv`
2024-02-13T13:22:45.9888275Z error: stderr did not match:
2024-02-13T13:22:45.9888777Z 1   1            Fresh mb [..]
2024-02-13T13:22:45.9889189Z     2    +warning: the item `mb` is imported redundantly
2024-02-13T13:22:45.9889820Z     3    + --> target/.metabuild/metabuild-foo-0e2ce73c8cda338a.rs:1:5
2024-02-13T13:22:45.9890297Z     4    +  |
2024-02-13T13:22:45.9890545Z     5    +1 | use mb;
2024-02-13T13:22:45.9890899Z     6    +  |     ^^ the item `mb` is already defined here
2024-02-13T13:22:45.9891299Z     7    +  |
2024-02-13T13:22:45.9891623Z     8    +  = note: `#[warn(unused_imports)]` on by default
2024-02-13T13:22:45.9927602Z     9    +
2024-02-13T13:22:45.9928248Z     10   +warning: `foo` (build script) generated 1 warning
2024-02-13T13:22:45.9930583Z 2   11           Fresh foo [..]
2024-02-13T13:22:45.9931176Z 3   12        Finished `dev` profile [..]
2024-02-13T13:22:45.9931653Z 
2024-02-13T13:22:45.9931665Z 
2024-02-13T13:22:45.9932104Z other output:
2024-02-13T13:22:45.9932291Z 
2024-02-13T13:22:45.9932297Z 
2024-02-13T13:22:45.9932309Z 
2024-02-13T13:22:45.9932316Z 
2024-02-13T13:22:45.9932417Z failures:
2024-02-13T13:22:45.9932695Z     metabuild::metabuild_fresh

```


<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
