### PR TITLE
fix(cli): Control clap colors through config

### DIFF
--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -39,7 +39,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             }
         }
     } else {
-        let mut cmd = crate::cli::cli();
+        let mut cmd = crate::cli::cli(gctx);
         let _ = cmd.print_help();
     }
     Ok(())

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -20,6 +20,7 @@ fn main() {
     setup_logger();
 
     let mut lazy_gctx = cli::LazyContext::new();
+    lazy_gctx.get();
 
     let result = if let Some(lock_addr) = cargo::ops::fix_get_proxy_lock_addr() {
         cargo::ops::fix_exec_rustc(lazy_gctx.get(), &lock_addr).map_err(|e| CliError::from(e))

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::self_named_module_files)] // false positive in `commands/build.rs`
 
+use cargo::core::shell::Shell;
 use cargo::util::network::http::http_handle;
 use cargo::util::network::http::needs_custom_http_transport;
 use cargo::util::{self, closest_msg, command_prelude, CargoResult};
@@ -19,18 +20,23 @@ use crate::command_prelude::*;
 fn main() {
     setup_logger();
 
-    let mut lazy_gctx = cli::LazyContext::new();
-    lazy_gctx.get();
+    let mut gctx = match GlobalContext::default() {
+        Ok(gctx) => gctx,
+        Err(e) => {
+            let mut shell = Shell::new();
+            cargo::exit_with_error(e.into(), &mut shell)
+        }
+    };
 
     let result = if let Some(lock_addr) = cargo::ops::fix_get_proxy_lock_addr() {
-        cargo::ops::fix_exec_rustc(lazy_gctx.get(), &lock_addr).map_err(|e| CliError::from(e))
+        cargo::ops::fix_exec_rustc(&gctx, &lock_addr).map_err(|e| CliError::from(e))
     } else {
         let _token = cargo::util::job::setup();
-        cli::main(&mut lazy_gctx)
+        cli::main(&mut gctx)
     };
 
     match result {
-        Err(e) => cargo::exit_with_error(e, &mut lazy_gctx.get_mut().shell()),
+        Err(e) => cargo::exit_with_error(e, &mut *gctx.shell()),
         Ok(()) => {}
     }
 }

--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -236,18 +236,10 @@ impl Shell {
             ..
         } = self.output
         {
-            let cfg = match color {
-                Some("always") => ColorChoice::Always,
-                Some("never") => ColorChoice::Never,
-
-                Some("auto") | None => ColorChoice::CargoAuto,
-
-                Some(arg) => anyhow::bail!(
-                    "argument for --color must be auto, always, or \
-                     never, but found `{}`",
-                    arg
-                ),
-            };
+            let cfg = color
+                .map(|c| c.parse())
+                .transpose()?
+                .unwrap_or(ColorChoice::CargoAuto);
             *color_choice = cfg;
             let stdout_choice = cfg.to_anstream_color_choice();
             let stderr_choice = cfg.to_anstream_color_choice();
@@ -496,6 +488,25 @@ impl ColorChoice {
             ColorChoice::Never => anstream::ColorChoice::Never,
             ColorChoice::CargoAuto => anstream::ColorChoice::Auto,
         }
+    }
+}
+
+impl std::str::FromStr for ColorChoice {
+    type Err = anyhow::Error;
+    fn from_str(color: &str) -> Result<Self, Self::Err> {
+        let cfg = match color {
+            "always" => ColorChoice::Always,
+            "never" => ColorChoice::Never,
+
+            "auto" => ColorChoice::CargoAuto,
+
+            arg => anyhow::bail!(
+                "argument for --color must be auto, always, or \
+                     never, but found `{}`",
+                arg
+            ),
+        };
+        Ok(cfg)
     }
 }
 

--- a/src/cargo/util/config/mod.rs
+++ b/src/cargo/util/config/mod.rs
@@ -2636,14 +2636,14 @@ impl BuildTargetConfig {
 }
 
 #[derive(Deserialize, Default)]
-struct TermConfig {
-    verbose: Option<bool>,
-    quiet: Option<bool>,
-    color: Option<String>,
-    hyperlinks: Option<bool>,
+pub struct TermConfig {
+    pub verbose: Option<bool>,
+    pub quiet: Option<bool>,
+    pub color: Option<String>,
+    pub hyperlinks: Option<bool>,
     #[serde(default)]
     #[serde(deserialize_with = "progress_or_string")]
-    progress: Option<ProgressConfig>,
+    pub progress: Option<ProgressConfig>,
 }
 
 #[derive(Debug, Default, Deserialize)]


### PR DESCRIPTION
### What does this PR try to resolve?

Part of #9012

### How should we test and review this PR?

To accomplish this, I pivoted in how we handle `-C`.  In #11029, I made the config lazily loaded.  Instead, we are now reloading the config for `-C` like we do for "cargo script" and `cargo install`.  If there is any regression, it will be felt by those commands as well and we can fix all together.  As this is unstable, if there is a regression, the impact is less.  This allowed us access to the full config for getting the color setting, rather than taking more limited approaches like checking only `CARGO_TERM_CONFIG`.

### Additional information

