### PR TITLE
Fix redundant imports.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,7 +2859,7 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustfix"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "proptest",

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -20,7 +20,6 @@ use std::time::{self, Duration};
 
 use anyhow::{bail, Result};
 use cargo_util::{is_ci, ProcessBuilder, ProcessError};
-use serde_json;
 use url::Url;
 
 use self::paths::CargoPathExt;

--- a/crates/cargo-test-support/src/paths.rs
+++ b/crates/cargo-test-support/src/paths.rs
@@ -1,4 +1,4 @@
-use filetime::{self, FileTime};
+use filetime::FileTime;
 
 use std::cell::RefCell;
 use std::env;

--- a/crates/resolver-tests/src/lib.rs
+++ b/crates/resolver-tests/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::print_stderr)]
 
 use std::cell::RefCell;
-use std::cmp::PartialEq;
 use std::cmp::{max, min};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt;
@@ -26,7 +25,7 @@ use proptest::collection::{btree_map, vec};
 use proptest::prelude::*;
 use proptest::sample::Index;
 use proptest::string::string_regex;
-use varisat::{self, ExtendFormula};
+use varisat::ExtendFormula;
 
 pub fn resolve(deps: Vec<Dependency>, registry: &[Summary]) -> CargoResult<Vec<PackageId>> {
     resolve_with_config(deps, registry, &Config::default().unwrap())

--- a/crates/rustfix/Cargo.toml
+++ b/crates/rustfix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustfix"
-version = "0.8.1"
+version = "0.8.2"
 authors = [
     "Pascal Hertleif <killercup@gmail.com>",
     "Oliver Schneider <oli-obk@users.noreply.github.com>",

--- a/crates/rustfix/tests/edge_cases.rs
+++ b/crates/rustfix/tests/edge_cases.rs
@@ -1,4 +1,3 @@
-use rustfix;
 use std::collections::HashSet;
 use std::fs;
 

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, Context as _};
 use cargo::core::shell::Shell;
 use cargo::core::{features, CliUnstable};
-use cargo::{self, drop_print, drop_println, CargoResult, CliResult, Config};
-use clap::{builder::UnknownArgumentValueParser, Arg, ArgMatches};
+use cargo::{drop_print, drop_println, CargoResult};
+use clap::builder::UnknownArgumentValueParser;
 use itertools::Itertools;
 use std::collections::HashMap;
 use std::ffi::OsStr;

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -1,7 +1,7 @@
 use crate::aliased_command;
 use crate::command_prelude::*;
+use cargo::drop_println;
 use cargo::util::errors::CargoResult;
-use cargo::{drop_println, Config};
 use cargo_util::paths::resolve_executable;
 use flate2::read::GzDecoder;
 use std::ffi::OsStr;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -2,8 +2,7 @@
 
 use cargo::util::network::http::http_handle;
 use cargo::util::network::http::needs_custom_http_transport;
-use cargo::util::CliError;
-use cargo::util::{self, closest_msg, command_prelude, CargoResult, CliResult, Config};
+use cargo::util::{self, closest_msg, command_prelude, CargoResult};
 use cargo_util::{ProcessBuilder, ProcessError};
 use cargo_util_schemas::manifest::StringOrVec;
 use std::collections::BTreeMap;

--- a/src/cargo/ops/fix.rs
+++ b/src/cargo/ops/fix.rs
@@ -46,7 +46,7 @@ use std::{env, fs, str};
 use anyhow::{bail, Context as _};
 use cargo_util::{exit_status_to_string, is_simple_exit_code, paths, ProcessBuilder};
 use rustfix::diagnostics::Diagnostic;
-use rustfix::{self, CodeFix};
+use rustfix::CodeFix;
 use semver::Version;
 use tracing::{debug, trace, warn};
 

--- a/src/cargo/ops/registry/mod.rs
+++ b/src/cargo/ops/registry/mod.rs
@@ -15,7 +15,7 @@ use std::task::Poll;
 
 use anyhow::{bail, format_err, Context as _};
 use cargo_credential::{Operation, Secret};
-use crates_io::{self, Registry};
+use crates_io::Registry;
 use url::Url;
 
 use crate::core::SourceId;

--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -10,7 +10,7 @@ use crate::util::{human_readable_bytes, network, Config, IntoUrl, MetricsCounter
 use anyhow::{anyhow, Context as _};
 use cargo_util::{paths, ProcessBuilder};
 use curl::easy::List;
-use git2::{self, ErrorClass, ObjectType, Oid};
+use git2::{ErrorClass, ObjectType, Oid};
 use serde::ser;
 use serde::Serialize;
 use std::borrow::Cow;

--- a/src/cargo/util/machine_message.rs
+++ b/src/cargo/util/machine_message.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use cargo_util_schemas::core::PackageIdSpec;
 use serde::ser;
 use serde::Serialize;
-use serde_json::{self, json, value::RawValue};
+use serde_json::{json, value::RawValue};
 
 use crate::core::compiler::CompileMode;
 use crate::core::Target;

--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -948,8 +948,6 @@ impl Display for WorkspaceSource {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
-
     use crate::util::toml_mut::manifest::LocalManifest;
     use cargo_util::paths;
 


### PR DESCRIPTION
The latest nightly has started warning about redundant imports. This removes those warnings.