### PR TITLE
Fix more redundant imports.

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context as _};
 use cargo::core::shell::Shell;
 use cargo::core::{features, CliUnstable};
-use cargo::{drop_print, drop_println, CargoResult, GlobalContext};
+use cargo::{drop_print, drop_println, CargoResult};
 use clap::builder::UnknownArgumentValueParser;
 use itertools::Itertools;
 use std::collections::HashMap;

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -1,7 +1,7 @@
 use crate::aliased_command;
 use crate::command_prelude::*;
+use cargo::drop_println;
 use cargo::util::errors::CargoResult;
-use cargo::{drop_println, GlobalContext};
 use cargo_util::paths::resolve_executable;
 use flate2::read::GzDecoder;
 use std::ffi::OsStr;

--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -2,7 +2,7 @@
 
 use cargo::util::network::http::http_handle;
 use cargo::util::network::http::needs_custom_http_transport;
-use cargo::util::{self, closest_msg, command_prelude, CargoResult, GlobalContext};
+use cargo::util::{self, closest_msg, command_prelude, CargoResult};
 use cargo_util::{ProcessBuilder, ProcessError};
 use cargo_util_schemas::manifest::StringOrVec;
 use std::collections::BTreeMap;


### PR DESCRIPTION
The latest nightly has started warning about redundant imports. This removes those warnings.

Presumably these were casualties of merging between #13464 and #13409.