### PR TITLE
fix: remove unused `sysroot_host_libdir`

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -74,9 +74,6 @@ pub struct Compilation<'gctx> {
     /// May be for the host or for a specific target.
     pub deps_output: HashMap<CompileKind, PathBuf>,
 
-    /// The path to the host libdir for the compiler used
-    sysroot_host_libdir: PathBuf,
-
     /// The path to libstd for each target
     sysroot_target_libdir: HashMap<CompileKind, PathBuf>,
 
@@ -128,11 +125,6 @@ impl<'gctx> Compilation<'gctx> {
             native_dirs: BTreeSet::new(),
             root_output: HashMap::new(),
             deps_output: HashMap::new(),
-            sysroot_host_libdir: bcx
-                .target_data
-                .info(CompileKind::Host)
-                .sysroot_host_libdir
-                .clone(),
             sysroot_target_libdir: get_sysroot_target_libdir(bcx)?,
             tests: Vec::new(),
             binaries: Vec::new(),
@@ -282,7 +274,6 @@ impl<'gctx> Compilation<'gctx> {
         let mut search_path = Vec::new();
         if is_rustc_tool {
             search_path.push(self.deps_output[&CompileKind::Host].clone());
-            search_path.push(self.sysroot_host_libdir.clone());
         } else {
             search_path.extend(super::filter_dynamic_search_path(
                 self.native_dirs.iter(),


### PR DESCRIPTION


<!-- homu-ignore:start -->
### What does this PR try to resolve?

Copy from <https://github.com/rust-lang/cargo/pull/10469#issuecomment-1079503079>:

> I've never been entirely clear why it does this. #4006 didn't really
> explain why it added the corresponding host_dylib_path. I can't envision
> a scenario where it matters. I think compiler plugins and proc-macros
> should load just fine, since libstd.so should already be loaded by the
> compiler. Also, rustc uses rpath these days, and on Windows libstd.so is
> placed in the bin directory which will be searched first anyways.
>
> On balance, I think it should be safe to just remove sysroot_host_libdir.
> I can't come up with a scenario where it matters, at least on
> windows/macos/linux. One issue is that this is most likely to affect
> plugins, but those are deprecated and I think only Servo was the real
> holdout. A concern is that nobody is going to test this use case before
> it hits stable.

Also,

* compiler plugins were removed https://github.com/rust-lang/rust/pull/116412
* servo has moved off from plugins: https://github.com/servo/servo/pull/30508

So should generally be fine.

### How should we test and review this PR?

There might be some edge case like <https://github.com/rust-lang/cargo/pull/7798> passing `--sysroot`, though I would also expect rustc to load sysroot from provided path. Hence safe?

### Additional information
<!-- homu-ignore:end -->
