### PR TITLE
fix(cli): Respect CARGO_TERM_COLOR in '--list' and '-Zhelp'

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -55,14 +55,22 @@ pub fn main(gctx: &mut GlobalContext) -> CliResult {
         .map(String::as_str)
         == Some("help")
     {
+        // Don't let config errors get in the way of parsing arguments
+        let _ = config_configure(gctx, &expanded_args, None, global_args, None);
         print_zhelp(gctx);
     } else if expanded_args.flag("version") {
+        // Don't let config errors get in the way of parsing arguments
+        let _ = config_configure(gctx, &expanded_args, None, global_args, None);
         let version = get_version_string(is_verbose);
         drop_print!(gctx, "{}", version);
     } else if let Some(code) = expanded_args.get_one::<String>("explain") {
+        // Don't let config errors get in the way of parsing arguments
+        let _ = config_configure(gctx, &expanded_args, None, global_args, None);
         let mut procss = gctx.load_global_rustc(None)?.process();
         procss.arg("--explain").arg(code).exec()?;
     } else if expanded_args.flag("list") {
+        // Don't let config errors get in the way of parsing arguments
+        let _ = config_configure(gctx, &expanded_args, None, global_args, None);
         print_list(gctx, is_verbose);
     } else {
         let (cmd, subcommand_args) = match expanded_args.subcommand() {


### PR DESCRIPTION
### What does this PR try to resolve?

Similar to #9012, we aren't respecting `CARGO_TERM_COLOR` for `-Zhelp` and other places.  This corrects that.

### How should we test and review this PR?

#9012 was about initialization order to get the value.  Here, the problem is that we don't update `Shell` with `CARGO_TERM_COLOR`.

In doing this, I was concerned about keeping track of where it is safe to call `config_configure` without running it twice.  To this end, I refactored `main` to make it clear that each call to `config_configure` is in a mutually exclusive path that exists immediately.

### Additional information

Found this with the test for `-Zhelp` in #13461.