### PR TITLE
Error messages when collecting workspace members now mention the workspace root location

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -724,8 +724,8 @@ impl<'gctx> Workspace<'gctx> {
                         continue;
                     }
                     bail!(
-                        "package `{}` is listed in default-members\n\
-                        for workspace at {} but is not a member.",
+                        "package `{}` is listed in default-members but is not a member\n\
+                        for workspace at {}.",
                         path.display(),
                         root_manifest_path.display()
                     )

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -697,8 +697,10 @@ impl<'gctx> Workspace<'gctx> {
             self.find_path_deps(&path.join("Cargo.toml"), &root_manifest_path, false)
                 .with_context(|| {
                     format!(
-                        "failed to load manifest for workspace member `{}`",
-                        path.display()
+                        "failed to load manifest for workspace member `{}`\n\
+                        referenced by workspace at `{}`",
+                        path.display(),
+                        root_manifest_path.display()
                     )
                 })?;
         }
@@ -722,9 +724,10 @@ impl<'gctx> Workspace<'gctx> {
                         continue;
                     }
                     bail!(
-                        "package `{}` is listed in workspace’s default-members \
-                         but is not a member.",
-                        path.display()
+                        "package `{}` is listed in default-members\n\
+                        for workspace at {} but is not a member.",
+                        path.display(),
+                        root_manifest_path.display()
                     )
                 }
                 self.default_members.push(manifest_path)

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -911,8 +911,8 @@ fn virtual_default_member_is_not_a_member() {
         .with_status(101)
         .with_stderr(
             "\
-error: package `[..]something-else` is listed in default-members\n\
-for workspace at [..]Cargo.toml but is not a member.
+error: package `[..]something-else` is listed in default-members but is not a member\n\
+for workspace at [..]Cargo.toml.
 ",
         )
         .run();
@@ -1673,8 +1673,8 @@ fn excluded_default_members_still_must_be_members() {
         .with_status(101)
         .with_stderr(
             "\
-error: package `[..]bar` is listed in default-members\n\
-for workspace at [..]foo/Cargo.toml but is not a member.
+error: package `[..]bar` is listed in default-members but is not a member\n\
+for workspace at [..]foo/Cargo.toml.
 ",
         )
         .run();

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -438,6 +438,7 @@ fn invalid_members() {
         .with_stderr(
             "\
 [ERROR] failed to load manifest for workspace member `[..]/foo`
+referenced by workspace at `[..]/foo/Cargo.toml`
 
 Caused by:
   failed to read `[..]foo/foo/Cargo.toml`
@@ -910,8 +911,8 @@ fn virtual_default_member_is_not_a_member() {
         .with_status(101)
         .with_stderr(
             "\
-error: package `[..]something-else` is listed in workspace’s default-members \
-but is not a member.
+error: package `[..]something-else` is listed in default-members\n\
+for workspace at [..]Cargo.toml but is not a member.
 ",
         )
         .run();
@@ -1672,8 +1673,8 @@ fn excluded_default_members_still_must_be_members() {
         .with_status(101)
         .with_stderr(
             "\
-error: package `[..]bar` is listed in workspace’s default-members \
-but is not a member.
+error: package `[..]bar` is listed in default-members\n\
+for workspace at [..]foo/Cargo.toml but is not a member.
 ",
         )
         .run();
@@ -1902,6 +1903,7 @@ fn glob_syntax_invalid_members() {
         .with_stderr(
             "\
 [ERROR] failed to load manifest for workspace member `[..]/crates/bar`
+referenced by workspace at `[..]/Cargo.toml`
 
 Caused by:
   failed to read `[..]foo/crates/bar/Cargo.toml`
@@ -2388,6 +2390,7 @@ fn member_dep_missing() {
         .with_stderr(
             "\
 [ERROR] failed to load manifest for workspace member `[..]/bar`
+referenced by workspace at `[..]/Cargo.toml`
 
 Caused by:
   failed to load manifest for dependency `baz`


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/13394

### What does this PR try to resolve?

This is a small tweak in error messages for workspaces, with intention to make it easier for users who accidentally created some unwanted workspace and then was surprised by the error coming seemingly out of nowhere. The exact inspiration for the change was [this comment](https://users.rust-lang.org/t/cargo-using-wrong-directory/107126/9?u=cerber-ursi) in discussion on URLO.

### How should we test and review this PR?

This is a simple change in error messages, so the existing test suite should probably be enough. Requests for changing the text further are welcome, of course.