### PR TITLE
test: relax help text assertion

### DIFF
--- a/tests/testsuite/cargo/help/stdout.term.svg
+++ b/tests/testsuite/cargo/help/stdout.term.svg
@@ -23,9 +23,9 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[+toolchain] [OPTIONS] [COMMAND]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">Usage:</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[..][OPTIONS] [COMMAND]</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[+toolchain] [OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">-Zscript</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;MANIFEST_RS&gt; [ARGS]...</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">       </tspan><tspan class="fg-cyan bold">cargo</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">[..][OPTIONS]</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">-Zscript</tspan><tspan class="bold"> </tspan><tspan class="fg-cyan bold">&lt;MANIFEST_RS&gt; [ARGS]...</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

When running test in rust-lang/rust via `./x test src/tool/cargo`, there is no rustup integrated.

### How should we test and review this PR?

Update the submodule and run `./x test src/tool/cargo` in rust-lang/rust repo.

See also <https://github.com/rust-lang/cargo/pull/12416>
<!-- homu-ignore:end -->
