### PR TITLE
chore: bump baseline version requirement of sub crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,11 +29,11 @@ cargo-credential = { version = "0.4.2", path = "credential/cargo-credential" }
 cargo-credential-libsecret = { version = "0.4.2", path = "credential/cargo-credential-libsecret" }
 cargo-credential-macos-keychain = { version = "0.4.2", path = "credential/cargo-credential-macos-keychain" }
 cargo-credential-wincred = { version = "0.4.2", path = "credential/cargo-credential-wincred" }
-cargo-platform = { path = "crates/cargo-platform", version = "0.1.4" }
+cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
-cargo-util = { version = "0.2.6", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.2.0", path = "crates/cargo-util-schemas" }
+cargo-util = { version = "0.2.9", path = "crates/cargo-util" }
+cargo-util-schemas = { version = "0.2.1", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"
 clap = "4.5.1"
 color-print = "0.3.5"
@@ -78,7 +78,7 @@ pulldown-cmark = { version = "0.9.3", default-features = false }
 rand = "0.8.5"
 regex = "1.10.3"
 rusqlite = { version = "0.30.0", features = ["bundled"] }
-rustfix = { version = "0.8.0", path = "crates/rustfix" }
+rustfix = { version = "0.8.2", path = "crates/rustfix" }
 same-file = "1.0.6"
 security-framework = "2.9.2"
 semver = { version = "1.0.21", features = ["serde"] }


### PR DESCRIPTION


<!-- homu-ignore:start -->
### What does this PR try to resolve?

Closes https://github.com/rust-lang/cargo/issues/13493

While we can just bump to the latest versions, this time we do a conservative one for some crates.

* `cargo-util` --- 0.2.10 to 0.2.11 contain only comment changes.
* `cargo-platform` --- 0.1.6 to 0.1.8 contain only lint and metadata changes.
* `rustfix` and `cargo-util-schemas` contain actual behavior changes.

### How should we test and review this PR?

Currently, there is no Cargo-native way to dry-run `cargo publish`.
Cargo itself can benefit from <https://github.com/rust-lang/cargo/issues/1169> to avoid issues like <https://github.com/rust-lang/cargo/issues/13493> from happening.


### Additional information
<!-- homu-ignore:end -->
