### PR TITLE
fix: reduce failing to open a git repo to a tracing warning

### DIFF
--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -217,9 +217,13 @@ impl<'gctx> PathSource<'gctx> {
                 return Ok(None);
             }
         };
-        let index = repo
-            .index()
-            .with_context(|| format!("failed to open git index at {}", repo.path().display()))?;
+        let index = match repo.index() {
+            Ok(index) => index,
+            Err(e) => {
+                tracing::warn!("failed to open git index at {}: {e}", repo.path().display());
+                return Ok(None);
+            }
+        };
         let repo_root = repo.workdir().ok_or_else(|| {
             anyhow::format_err!(
                 "did not expect repo at {} to be bare",


### PR DESCRIPTION
When listing files in a path source, Cargo attempts to open the path source as a git repository with a fallback to walking the filesystem if path source isn't a git repository or fails for various reasons.

### What does this PR try to resolve?

If the path source *is* part of a git repository, but that git repository uses features that `cargo` (via `libgit2`) doesn't understand, Cargo will error out. This PR changes the error to tracing warning, similar to other failures on this path.

Fixes #10150

### How should we test and review this PR?

Manually validated on the repro repo linked in the issue.