### PR TITLE
[beta-1.77] Backport ignore `cargo::rustc-check-cfg`

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -1074,9 +1074,6 @@ fn prepare_metabuild(cx: &Context<'_, '_>, unit: &Unit, deps: &[String]) -> Carg
                 .map(|d| d.unit.target.crate_name())
         })
         .collect();
-    for dep in &meta_deps {
-        output.push(format!("use {};\n", dep));
-    }
     output.push("fn main() {\n".to_string());
     for dep in &meta_deps {
         output.push(format!("    {}::metabuild();\n", dep));

--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -915,10 +915,8 @@ impl BuildOutput {
                     if extra_check_cfg {
                         check_cfgs.push(value.to_string());
                     } else {
-                        warnings.push(format!(
-                            "{}{} requires -Zcheck-cfg flag",
-                            syntax_prefix, key
-                        ));
+                        // silently ignoring the instruction to try to
+                        // minimise MSRV annoyance when stabilizing -Zcheck-cfg
                     }
                 }
                 "rustc-env" => {

--- a/src/cargo/util/config/target.rs
+++ b/src/cargo/util/config/target.rs
@@ -207,10 +207,8 @@ fn parse_links_overrides(
                         let list = value.list(key)?;
                         output.check_cfgs.extend(list.iter().map(|v| v.0.clone()));
                     } else {
-                        config.shell().warn(format!(
-                            "target config `{}.{}` requires -Zcheck-cfg flag",
-                            target_key, key
-                        ))?;
+                        // silently ignoring the instruction to try to
+                        // minimise MSRV annoyance when stabilizing -Zcheck-cfg
                     }
                 }
                 "rustc-env" => {

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -456,9 +456,7 @@ fn build_script_override_feature_gate() {
         .build();
 
     p.cargo("check")
-        .with_stderr_contains(
-            "warning: target config[..]rustc-check-cfg[..] requires -Zcheck-cfg flag",
-        )
+        .with_stderr_does_not_contain("warning: [..]rustc-check-cfg[..]")
         .run();
 }
 
@@ -540,7 +538,7 @@ fn build_script_feature_gate() {
         .build();
 
     p.cargo("check")
-        .with_stderr_contains("warning[..]cargo::rustc-check-cfg requires -Zcheck-cfg flag")
+        .with_stderr_does_not_contain("warning: [..]rustc-check-cfg[..]")
         .with_status(0)
         .run();
 }


### PR DESCRIPTION
This is a beta backport of https://github.com/rust-lang/cargo/pull/13438#event-11953691715 to disable the warning when `cargo::rustc-check-cfg` is used in a build script on stable in order to provide a broader window where we can stabilize check-cfg, and allow developers to avoid the warning when they use a range of different Rust versions (such as stable and nightly).

Also backports to fix CI:
* https://github.com/rust-lang/cargo/pull/13455 — Remove unnecessary use statement in metabuild