### PR TITLE
[docs]: Clarify vendored sources as read-only and way to modify

### DIFF
--- a/src/doc/man/cargo-vendor.md
+++ b/src/doc/man/cargo-vendor.md
@@ -21,6 +21,12 @@ stdout after `cargo vendor` completes the vendoring process.
 You will need to add or redirect it to your Cargo configuration file,
 which is usually `.cargo/config.toml` locally for the current package.
 
+Cargo treats vendored sources as read-only as it does to registry and git sources.
+If you intend to modify a crate from a remote source,
+use `[patch]` or a `path` dependency pointing to a local copy of that crate.
+Cargo will then correctly handle the crate on incremental rebuilds,
+as it knowns that it is no longer a read-only dependency.
+
 ## OPTIONS
 
 ### Vendor Options

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -18,6 +18,12 @@ DESCRIPTION
        need to add or redirect it to your Cargo configuration file, which is
        usually .cargo/config.toml locally for the current package.
 
+       Cargo treats vendored sources as read-only as it does to registry and
+       git sources. If you intend to modify a crate from a remote source, use
+       [patch] or a path dependency pointing to a local copy of that crate.
+       Cargo will then correctly handle the crate on incremental rebuilds, as
+       it knowns that it is no longer a read-only dependency.
+
 OPTIONS
    Vendor Options
        -s manifest, --sync manifest

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -21,6 +21,12 @@ stdout after `cargo vendor` completes the vendoring process.
 You will need to add or redirect it to your Cargo configuration file,
 which is usually `.cargo/config.toml` locally for the current package.
 
+Cargo treats vendored sources as read-only as it does to registry and git sources.
+If you intend to modify a crate from a remote source,
+use `[patch]` or a `path` dependency pointing to a local copy of that crate.
+Cargo will then correctly handle the crate on incremental rebuilds,
+as it knowns that it is no longer a read-only dependency.
+
 ## OPTIONS
 
 ### Vendor Options

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -18,6 +18,12 @@ The configuration necessary to use the vendored sources would be printed to
 stdout after \fBcargo vendor\fR completes the vendoring process.
 You will need to add or redirect it to your Cargo configuration file,
 which is usually \fB\&.cargo/config.toml\fR locally for the current package.
+.sp
+Cargo treats vendored sources as read\-only as it does to registry and git sources.
+If you intend to modify a crate from a remote source,
+use \fB[patch]\fR or a \fBpath\fR dependency pointing to a local copy of that crate.
+Cargo will then correctly handle the crate on incremental rebuilds,
+as it knowns that it is no longer a read\-only dependency.
 .SH "OPTIONS"
 .SS "Vendor Options"
 .sp


### PR DESCRIPTION
What does this PR try to resolve?

To document that vendored sources are not intended to be modified, and `[patch]` or a `path` dependency is the correct way to modify a vendored crate.

https://github.com/rust-lang/cargo/issues/5805#issuecomment-1868049928