### PR TITLE
fix(msrv): Report all incompatible packages, not just a random one

### DIFF
--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -179,8 +179,10 @@ fn rust_version_too_high() {
     p.cargo("check")
         .with_status(101)
         .with_stderr(
-            "error: package `foo v0.0.1 ([..])` cannot be built because it requires \
-             rustc 1.9876.0 or newer, while the currently active rustc version is [..]\n\n",
+            "\
+[ERROR] package `foo v0.0.1 ([..])` cannot be built because it requires rustc 1.9876.0 or newer, while the currently active rustc version is [..]
+
+",
         )
         .run();
     p.cargo("check --ignore-rust-version").run();
@@ -212,14 +214,14 @@ fn dependency_rust_version_newer_than_rustc() {
     p.cargo("check")
         .with_status(101)
         .with_stderr(
-            "    Updating `[..]` index\n \
-             Downloading crates ...\n  \
-             Downloaded bar v0.0.1 (registry `[..]`)\n\
-             error: package `bar v0.0.1` cannot be built because it requires \
-             rustc 1.2345.0 or newer, while the currently active rustc version is [..]\n\
-             Either upgrade to rustc 1.2345.0 or newer, or use\n\
-             cargo update bar@0.0.1 --precise ver\n\
-             where `ver` is the latest version of `bar` supporting rustc [..]",
+            "\
+[UPDATING] `[..]` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `[..]`)
+[ERROR] package `bar v0.0.1` cannot be built because it requires rustc 1.2345.0 or newer, while the currently active rustc version is [..]
+Either upgrade to rustc 1.2345.0 or newer, or use
+cargo update bar@0.0.1 --precise ver
+where `ver` is the latest version of `bar` supporting rustc [..]",
         )
         .run();
     p.cargo("check --ignore-rust-version").run();


### PR DESCRIPTION
### What does this PR try to resolve?

In #9930, it recommended improving the error for incompatible packages
so people can better get to the root of the problem.
For example, you might get an error about `clap_lex` but resolving the
error for the higher level `clap` could make the problem with `clap_lex`
go away.

Because I generally saw earlier packages in the graph reported, I
assumed we were reporting these errors bottom up.
It turns out, we are reporting them in the `UnitGraph`s order, which is
non-deterministic because it is built on a `HashMap`.

So this adds determinism and shows all incompatible dependencies
(not just the bottom or the root).


### How should we test and review this PR?

This is a first step.
We might find that we still want to only include the shallowest units,
rather than all.
At that point, we can add the complexity to address this by walking the
unit graph.

We could also further improve this by querying the index to suggest
compatible versions of packages.

The multi-package test wasn't split out into its own commit because hat would have required fixing the non-determinism one way to then just revert it when we fix it this way.

### Additional information
