### PR TITLE
chore: update pulldown-cmark to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2702,14 +2702,21 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a1a2f1f0a7ecff9c31abbe177637be0e97a0aef46cf8738ece09327985d998"
+checksum = "dce76ce678ffc8e5675b22aa1405de0b7037e2fdf8913fea40d1926c6fe1e6e7"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "memchr",
+ "pulldown-cmark-escape",
  "unicase",
 ]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
 
 [[package]]
 name = "quick-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ pathdiff = "0.2"
 percent-encoding = "2.3"
 pkg-config = "0.3.30"
 proptest = "1.4.0"
-pulldown-cmark = { version = "0.9.3", default-features = false }
+pulldown-cmark = { version = "0.10.0", default-features = false, features = ["html"] }
 rand = "0.8.5"
 regex = "1.10.3"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/crates/mdman/src/util.rs
+++ b/crates/mdman/src/util.rs
@@ -1,7 +1,7 @@
 ///! General utilities.
 use crate::EventIter;
 use anyhow::{bail, format_err, Context, Error};
-use pulldown_cmark::{CowStr, Event, Tag};
+use pulldown_cmark::{CowStr, Event, TagEnd};
 
 /// Splits the text `foo(1)` into "foo" and `1`.
 pub fn parse_name_and_section(text: &str) -> Result<(&str, u8), Error> {
@@ -31,7 +31,7 @@ pub fn header_text<'e>(parser: &mut EventIter<'e>) -> Result<CowStr<'e>, Error> 
         e => bail!("expected plain text in man header, got {:?}", e),
     };
     match parser.next() {
-        Some((Event::End(Tag::Heading(..)), _range)) => {
+        Some((Event::End(TagEnd::Heading(..)), _range)) => {
             return Ok(text);
         }
         e => bail!("expected plain text in man header, got {:?}", e),

--- a/crates/mdman/tests/compare/expected/tables.md
+++ b/crates/mdman/tests/compare/expected/tables.md
@@ -5,7 +5,7 @@
 Testing tables.
 
 | Single col |
---------------
+|------------|
 | Hi! :) |
 
 
@@ -27,7 +27,7 @@ Extra long text 123456789012 with mixed widths. | Extra long text 123456789012 w
 
 
 | Link check |
---------------
+|------------|
 | [foo] |
 | <https://example.com/> |
 

--- a/crates/mdman/tests/compare/tables.md
+++ b/crates/mdman/tests/compare/tables.md
@@ -5,7 +5,7 @@
 Testing tables.
 
 | Single col |
---------------
+|------------|
 | Hi! :) |
 
 
@@ -27,7 +27,7 @@ Extra long text 123456789012 with mixed widths. | Extra long text 123456789012 w
 
 
 | Link check |
---------------
+|------------|
 | [foo] |
 | <https://example.com/> |
 

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -108,13 +108,13 @@ which is defined by the <code>registry.default</code> config key which defaults 
 
 
 <dt class="option-term" id="option-cargo-add---public"><a class="option-anchor" href="#option-cargo-add---public"></a><code>--public</code></dt>
-<dd class="option-desc">Mark the dependency as public. </p>
+<dd class="option-desc">Mark the dependency as public.</p>
 <p>The dependency can be referenced in your library’s public API.</p>
 <p><a href="../reference/unstable.html#public-dependency">Unstable (nightly-only)</a></dd>
 
 
 <dt class="option-term" id="option-cargo-add---no-public"><a class="option-anchor" href="#option-cargo-add---no-public"></a><code>--no-public</code></dt>
-<dd class="option-desc">Mark the dependency as private. </p>
+<dd class="option-desc">Mark the dependency as private.</p>
 <p>While you can use the crate in your implementation, it cannot be referenced in your public API.</p>
 <p><a href="../reference/unstable.html#public-dependency">Unstable (nightly-only)</a></dd>
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -98,7 +98,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-bench---package"><a class="option-anchor" href="#option-cargo-bench---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Benchmark only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -32,7 +32,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-build---package"><a class="option-anchor" href="#option-cargo-build---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Build only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -37,7 +37,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-check---package"><a class="option-anchor" href="#option-cargo-check---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Check only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -54,7 +54,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-doc---package"><a class="option-anchor" href="#option-cargo-doc---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Document only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -117,7 +117,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-fix---package"><a class="option-anchor" href="#option-cargo-fix---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Fix only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -222,7 +222,7 @@ target artifacts are placed in a separate directory. See the
 specified with the <code>CARGO_TARGET_DIR</code> environment variable, or the
 <code>build.target-dir</code> <a href="../reference/config.html">config value</a>.
 Defaults to a new temporary folder located in the
-temporary directory of the platform. </p>
+temporary directory of the platform.</p>
 <p>When using <code>--path</code>, by default it will use <code>target</code> directory in the workspace
 of the local crate unless <code>--target-dir</code>
 is specified.</dd>

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -352,7 +352,7 @@ possible value.</dd>
 
 <dt class="option-term" id="option-cargo-metadata---filter-platform"><a class="option-anchor" href="#option-cargo-metadata---filter-platform"></a><code>--filter-platform</code> <em>triple</em></dt>
 <dd class="option-desc">This filters the <code>resolve</code> output to only include dependencies for the
-given <a href="../appendix/glossary.html#target">target triple</a>. 
+given <a href="../appendix/glossary.html#target">target triple</a>.
 Without this flag, the resolve includes all targets.</p>
 <p>Note that the dependencies listed in the “packages” array still includes all
 dependencies. Each package definition is intended to be an unaltered

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -101,7 +101,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-package---package"><a class="option-anchor" href="#option-cargo-package---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Package only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -106,7 +106,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-test---package"><a class="option-anchor" href="#option-cargo-test---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Test only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -134,7 +134,7 @@ kind given, then it will automatically include the other dependency kinds.</li>
 
 
 <dt class="option-term" id="option-cargo-tree---target"><a class="option-anchor" href="#option-cargo-tree---target"></a><code>--target</code> <em>triple</em></dt>
-<dd class="option-desc">Filter dependencies matching the given <a href="../appendix/glossary.html#target">target triple</a>. 
+<dd class="option-desc">Filter dependencies matching the given <a href="../appendix/glossary.html#target">target triple</a>.
 The default is the host platform. Use the value <code>all</code> to include <em>all</em> targets.</dd>
 
 
@@ -193,7 +193,7 @@ virtual workspace will include all workspace members (equivalent to passing
 <dt class="option-term" id="option-cargo-tree---package"><a class="option-anchor" href="#option-cargo-tree---package"></a><code>--package</code> <em>spec</em>…</dt>
 <dd class="option-desc">Display only the specified packages. See <a href="cargo-pkgid.html">cargo-pkgid(1)</a> for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally 
+glob patterns like <code>*</code>, <code>?</code> and <code>[]</code>. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.</dd>
 

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -123,7 +123,7 @@ Mark the dependency as \fIrequired\fR <https://doc.rust\-lang.org/cargo/referenc
 .sp
 \fB\-\-public\fR
 .RS 4
-Mark the dependency as public. 
+Mark the dependency as public.
 .sp
 The dependency can be referenced in your library\[cq]s public API.
 .sp
@@ -132,7 +132,7 @@ The dependency can be referenced in your library\[cq]s public API.
 .sp
 \fB\-\-no\-public\fR
 .RS 4
-Mark the dependency as private. 
+Mark the dependency as private.
 .sp
 While you can use the crate in your implementation, it cannot be referenced in your public API.
 .sp

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -58,10 +58,10 @@ benchmark, you can use the \fB\-\-profile=dev\fR command\-line option to switch 
 the dev profile. You can then run the debug\-enabled benchmark within a
 debugger.
 .SS "Working directory of benchmarks"
-The working directory of every benchmark is set to the root directory of the 
+The working directory of every benchmark is set to the root directory of the
 package the benchmark belongs to.
-Setting the working directory of benchmarks to the package\[cq]s root directory 
-makes it possible for benchmarks to reliably access the package\[cq]s files using 
+Setting the working directory of benchmarks to the package\[cq]s root directory
+makes it possible for benchmarks to reliably access the package\[cq]s files using
 relative paths, regardless from where \fBcargo bench\fR was executed from.
 .SH "OPTIONS"
 .SS "Benchmark Options"
@@ -95,7 +95,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Benchmark only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE
@@ -158,7 +158,7 @@ for more information on per\-target settings.
 .sp
 Binary targets are automatically built if there is an integration test or
 benchmark being selected to benchmark. This allows an integration
-test to execute the binary to exercise and test its behavior. 
+test to execute the binary to exercise and test its behavior.
 The \fBCARGO_BIN_EXE_<name>\fR
 \fIenvironment variable\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#environment\-variables\-cargo\-sets\-for\-crates>
 is set when the integration test is built so that it can use the
@@ -166,11 +166,11 @@ is set when the integration test is built so that it can use the
 executable.
 .sp
 Passing target selection flags will benchmark only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -27,7 +27,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Build only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE
@@ -57,7 +57,7 @@ they have \fBrequired\-features\fR that are missing.
 .sp
 Binary targets are automatically built if there is an integration test or
 benchmark being selected to build. This allows an integration
-test to execute the binary to exercise and test its behavior. 
+test to execute the binary to exercise and test its behavior.
 The \fBCARGO_BIN_EXE_<name>\fR
 \fIenvironment variable\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#environment\-variables\-cargo\-sets\-for\-crates>
 is set when the integration test is built so that it can use the
@@ -65,11 +65,11 @@ is set when the integration test is built so that it can use the
 executable.
 .sp
 Passing target selection flags will build only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -32,7 +32,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Check only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE
@@ -61,11 +61,11 @@ binary and library targets of the selected packages. Binaries are skipped if
 they have \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will check only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -47,7 +47,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Document only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -127,7 +127,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Fix only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE
@@ -156,11 +156,11 @@ When no target selection options are given, \fBcargo fix\fR will fix all targets
 \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will fix only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -104,8 +104,8 @@ available.
 .SS "Configuration Discovery"
 This command operates on system or user level, not project level.
 This means that the local \fIconfiguration discovery\fR <https://doc.rust\-lang.org/cargo/reference/config.html#hierarchical\-structure> is ignored.
-Instead, the configuration discovery begins at \fB$CARGO_HOME/config.toml\fR\&. 
-If the package is installed with \fB\-\-path $PATH\fR, the local configuration 
+Instead, the configuration discovery begins at \fB$CARGO_HOME/config.toml\fR\&.
+If the package is installed with \fB\-\-path $PATH\fR, the local configuration
 will be used, beginning discovery at \fB$PATH/.cargo/config.toml\fR\&.
 .SH "OPTIONS"
 .SS "Install Options"
@@ -254,7 +254,7 @@ Directory for all generated artifacts and intermediate files. May also be
 specified with the \fBCARGO_TARGET_DIR\fR environment variable, or the
 \fBbuild.target\-dir\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
 Defaults to a new temporary folder located in the
-temporary directory of the platform. 
+temporary directory of the platform.
 .sp
 When using \fB\-\-path\fR, by default it will use \fBtarget\fR directory in the workspace
 of the local crate unless \fB\-\-target\-dir\fR

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -357,7 +357,7 @@ possible value.
 \fB\-\-filter\-platform\fR \fItriple\fR
 .RS 4
 This filters the \fBresolve\fR output to only include dependencies for the
-given \fItarget triple\fR <https://doc.rust\-lang.org/cargo/appendix/glossary.html#target>\&. 
+given \fItarget triple\fR <https://doc.rust\-lang.org/cargo/appendix/glossary.html#target>\&.
 Without this flag, the resolve includes all targets.
 .sp
 Note that the dependencies listed in the \[lq]packages\[rq] array still includes all

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -124,7 +124,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Package only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -28,7 +28,7 @@ which registries you are allowed to publish to.
 .sp
 .RS 4
 \h'-04' 3.\h'+01'Upload the crate to the registry. The server will perform additional
-checks on the crate. 
+checks on the crate.
 .RE
 .sp
 .RS 4

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -14,8 +14,8 @@ All the arguments following the two dashes (\fB\-\-\fR) are passed to the binary
 run. If you\[cq]re passing arguments to both Cargo and the binary, the ones after
 \fB\-\-\fR go to the binary, the ones before go to Cargo.
 .sp
-Unlike \fBcargo\-test\fR(1) and \fBcargo\-bench\fR(1), \fBcargo run\fR sets the 
-working directory of the binary executed to the current working directory, same 
+Unlike \fBcargo\-test\fR(1) and \fBcargo\-bench\fR(1), \fBcargo run\fR sets the
+working directory of the binary executed to the current working directory, same
 as if it was executed in the shell directly.
 .SH "OPTIONS"
 .SS "Package Selection"

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -43,7 +43,7 @@ binary and library targets of the selected package.
 .sp
 Binary targets are automatically built if there is an integration test or
 benchmark being selected to build. This allows an integration
-test to execute the binary to exercise and test its behavior. 
+test to execute the binary to exercise and test its behavior.
 The \fBCARGO_BIN_EXE_<name>\fR
 \fIenvironment variable\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#environment\-variables\-cargo\-sets\-for\-crates>
 is set when the integration test is built so that it can use the
@@ -51,11 +51,11 @@ is set when the integration test is built so that it can use the
 executable.
 .sp
 Passing target selection flags will build only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -53,11 +53,11 @@ if its name is the same as the lib target. Binaries are skipped if they have
 \fBrequired\-features\fR that are missing.
 .sp
 Passing target selection flags will document only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -98,7 +98,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Test only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE
@@ -172,7 +172,7 @@ for more information on per\-target settings.
 .sp
 Binary targets are automatically built if there is an integration test or
 benchmark being selected to test. This allows an integration
-test to execute the binary to exercise and test its behavior. 
+test to execute the binary to exercise and test its behavior.
 The \fBCARGO_BIN_EXE_<name>\fR
 \fIenvironment variable\fR <https://doc.rust\-lang.org/cargo/reference/environment\-variables.html#environment\-variables\-cargo\-sets\-for\-crates>
 is set when the integration test is built so that it can use the
@@ -180,11 +180,11 @@ is set when the integration test is built so that it can use the
 executable.
 .sp
 Passing target selection flags will test only the specified
-targets. 
+targets.
 .sp
-Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also 
-support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your 
-shell accidentally expanding glob patterns before Cargo handles them, you must 
+Note that \fB\-\-bin\fR, \fB\-\-example\fR, \fB\-\-test\fR and \fB\-\-bench\fR flags also
+support common Unix glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your
+shell accidentally expanding glob patterns before Cargo handles them, you must
 use single quotes or double quotes around each glob pattern.
 .sp
 \fB\-\-lib\fR

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -167,7 +167,7 @@ The default is \fBnormal,build,dev\fR\&.
 .sp
 \fB\-\-target\fR \fItriple\fR
 .RS 4
-Filter dependencies matching the given \fItarget triple\fR <https://doc.rust\-lang.org/cargo/appendix/glossary.html#target>\&. 
+Filter dependencies matching the given \fItarget triple\fR <https://doc.rust\-lang.org/cargo/appendix/glossary.html#target>\&.
 The default is the host platform. Use the value \fBall\fR to include \fIall\fR targets.
 .RE
 .SS "Tree Formatting Options"
@@ -240,7 +240,7 @@ virtual workspace will include all workspace members (equivalent to passing
 .RS 4
 Display only the specified packages. See \fBcargo\-pkgid\fR(1) for the
 SPEC format. This flag may be specified multiple times and supports common Unix
-glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally 
+glob patterns like \fB*\fR, \fB?\fR and \fB[]\fR\&. However, to avoid your shell accidentally
 expanding glob patterns before Cargo handles them, you must use single quotes or
 double quotes around each pattern.
 .RE


### PR DESCRIPTION
### What does this PR try to resolve?

Update a dependency and address its breaking changes.
`pulldown-cmark: 0.9.3 -> 0.10.0`

Fixes: https://github.com/rust-lang/cargo/issues/13509

### How should we test and review this PR?

The `.md` and `.1` docs are updated as part of this commit, you can see there that nothing changes except for removal of some trailing whitespace.