### PR TITLE
feat: Use consistent colors when testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,7 @@ features = [
 ]
 
 [dev-dependencies]
+annotate-snippets = { workspace = true, features = ["testing-colors"] }
 cargo-test-macro.workspace = true
 cargo-test-support.workspace = true
 same-file.workspace = true

--- a/tests/testsuite/cargo_add/invalid_manifest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/invalid_manifest/stderr.term.svg
@@ -19,19 +19,19 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="[..]">invalid string</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">invalid string</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="[..]">expected `"`, `'`</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">expected `"`, `'`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan> </tspan><tspan class="fg-bright-[..] bold">--&gt;</tspan><tspan> Cargo.toml:9:7</tspan>
+    <tspan x="10px" y="64px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:9:7</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-bright-[..] bold">  |</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-bright-[..] bold">9 |</tspan><tspan> key = invalid-value</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> key = invalid-value</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-bright-[..] bold">  |</tspan><tspan class="fg-bright-red bold">       ^</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-bright-red bold">       ^</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="fg-bright-[..] bold">  |</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>


### PR DESCRIPTION
In cargo#13461, it was [noted that `annotate-snippets`](https://github.com/rust-lang/cargo/pull/13461#discussion_r1501136340) made testing hard as it outputs platform specific colors. To fix this I created [annotate-snippets-rs#82](https://github.com/rust-lang/annotate-snippets-rs/pull/82), which added a feature to make the output platform agnostic when enabled. This makes it so glob syntax does not need to be used when matching colored output.