### PR TITLE
Clarify warning for using `features` or `default-features` in `patch`

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -312,8 +312,8 @@ impl<'gctx> PackageRegistry<'gctx> {
 
                 if dep.features().len() != 0 || !dep.uses_default_features() {
                     self.source_config.gctx().shell().warn(format!(
-                        "patch for `{}` uses the features mechanism. \
-                        default-features and features will not take effect because the patch dependency does not support this mechanism",
+                        "patch for `{}` attempts to declare features. \
+                        The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `patch` entry.",
                         dep.package_name()
                     ))?;
                 }

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -165,8 +165,8 @@ pub fn resolve_ws_with_opts<'gctx>(
                 ws.gctx()
                 .shell()
                 .warn(format!(
-                    "replacement for `{}` uses the features mechanism. \
-                    default-features and features will not take effect because the replacement dependency does not support this mechanism",
+                    "replacement for `{}` attempts to declare features. \
+                    The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `replace` entry.",
                     dep.package_name()
                 ))?
             }

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -883,8 +883,8 @@ fn add_patch_with_features() {
     p.cargo("check")
         .with_stderr(
             "\
-[WARNING] patch for `bar` uses the features mechanism. \
-default-features and features will not take effect because the patch dependency does not support this mechanism
+[WARNING] patch for `bar` attempts to declare features. \
+The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `patch` entry.
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
@@ -895,8 +895,8 @@ default-features and features will not take effect because the patch dependency 
     p.cargo("check")
         .with_stderr(
             "\
-[WARNING] patch for `bar` uses the features mechanism. \
-default-features and features will not take effect because the patch dependency does not support this mechanism
+[WARNING] patch for `bar` attempts to declare features. \
+The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `patch` entry.
 [FINISHED] [..]
 ",
         )
@@ -932,8 +932,8 @@ fn add_patch_with_setting_default_features() {
     p.cargo("check")
         .with_stderr(
             "\
-[WARNING] patch for `bar` uses the features mechanism. \
-default-features and features will not take effect because the patch dependency does not support this mechanism
+[WARNING] patch for `bar` attempts to declare features. \
+The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `patch` entry.
 [UPDATING] `dummy-registry` index
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
@@ -944,8 +944,8 @@ default-features and features will not take effect because the patch dependency 
     p.cargo("check")
         .with_stderr(
             "\
-[WARNING] patch for `bar` uses the features mechanism. \
-default-features and features will not take effect because the patch dependency does not support this mechanism
+[WARNING] patch for `bar` attempts to declare features. \
+The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `patch` entry.
 [FINISHED] [..]
 ",
         )

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -93,8 +93,8 @@ fn override_with_features() {
             "\
 [UPDATING] [..] index
 [UPDATING] git repository `[..]`
-[WARNING] replacement for `bar` uses the features mechanism. default-features and features \
-will not take effect because the replacement dependency does not support this mechanism
+[WARNING] replacement for `bar` attempts to declare features. \
+The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `replace` entry.
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -143,8 +143,8 @@ fn override_with_setting_default_features() {
             "\
 [UPDATING] [..] index
 [UPDATING] git repository `[..]`
-[WARNING] replacement for `bar` uses the features mechanism. default-features and features \
-will not take effect because the replacement dependency does not support this mechanism
+[WARNING] replacement for `bar` attempts to declare features. \
+The `features` and `default-features` keys need to appear in a `dependencies` entry, not the `replace` entry.
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]


### PR DESCRIPTION
When attempting to substitute a local version of a dependency, since the
`patch` section uses syntax similar to a dependency (and the
documentation even says "The syntax is similar to the `[dependencies]`
section", it's natural to assume that other things from `[dependencies]`
also work, such as `features` or `default-features`. Attempting to use
them produces this warning:

> patch for `crate-name-here` uses the features mechanism.
> default-features and features will not take effect because the patch dependency does not support this mechanism

The phrasing "the patch dependency does not support this mechanism"
makes it seem at first glance like `patch` just doesn't support this at
all. But the actual problem is that the user needs to move the
`features`/`default-features` keys to an entry in `dependencies`
instead.

Modify the message, to make this more obvious.

Modify the corresponding warning for `replace` as well.

Update tests accordingly.

-----

Discovered while trying to help @benwis debug an issue.
