### PR TITLE
fix(toml): Don't warn on unset Edition if only 2015 is compatible

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -616,16 +616,20 @@ pub fn to_real_manifest(
         let default_edition = Edition::default();
         let latest_edition = Edition::LATEST_STABLE;
 
-        let tip = if msrv_edition == default_edition {
-            String::new()
-        } else if msrv_edition == latest_edition {
-            format!(" while the latest is {latest_edition}")
-        } else {
-            format!(" while {msrv_edition} is compatible with `rust-version`")
-        };
-        warnings.push(format!(
-            "no edition set: defaulting to the {default_edition} edition{tip}",
-        ));
+        // We're trying to help the user who might assume they are using a new edition,
+        // so if they can't use a new edition, don't bother to tell them to set it.
+        // This also avoids having to worry about whether `package.edition` is compatible with
+        // their MSRV.
+        if msrv_edition != default_edition {
+            let tip = if msrv_edition == latest_edition {
+                format!(" while the latest is {latest_edition}")
+            } else {
+                format!(" while {msrv_edition} is compatible with `rust-version`")
+            };
+            warnings.push(format!(
+                "no edition set: defaulting to the {default_edition} edition{tip}",
+            ));
+        }
         default_edition
     };
     // Add these lines if start a new unstable edition.

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -141,7 +141,6 @@ fn unset_edition_works_with_no_newer_compatible_edition() {
     p.cargo("check -v")
         .with_stderr(
             "\
-[WARNING] no edition set: defaulting to the 2015 edition
 [CHECKING] foo [..]
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] [..]


### PR DESCRIPTION
### What does this PR try to resolve?

The warning doesn't help towards the stated goal if the only MSRV-compatible Edition is 2015 (plus, if you're MSRV is that old, you likely know better).

This also fixes a problem in #13505 where we were suggesting to set a field that might require an MSRV bump which may be unactionable to silence and we avoid warnings without an actionable way of silencing until #12235 gives us a general means.

### How should we test and review this PR?



### Additional information

This was discussed in
- #13505
- https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/warn.20on.20missing.20.60edition.60.20field.20in.20Cargo.2Etoml