### PR TITLE
fix(cli): Add traces to clarify where time is going

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -637,6 +637,7 @@ impl<'de> de::Deserialize<'de> for EncodablePackageId {
 }
 
 impl ser::Serialize for Resolve {
+    #[tracing::instrument(skip_all)]
     fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
     where
         S: ser::Serializer,

--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -31,6 +31,7 @@ struct Inner {
 }
 
 impl Summary {
+    #[tracing::instrument(skip_all)]
     pub fn new(
         pkg_id: PackageId,
         dependencies: Vec<Dependency>,

--- a/src/cargo/ops/lockfile.rs
+++ b/src/cargo/ops/lockfile.rs
@@ -112,6 +112,7 @@ fn resolve_to_string_orig(
     (orig.ok(), out, lock_root)
 }
 
+#[tracing::instrument(skip_all)]
 fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
     let toml = toml::Table::try_from(resolve).unwrap();
 
@@ -194,6 +195,7 @@ fn serialize_resolve(resolve: &Resolve, orig: Option<&str>) -> String {
     out
 }
 
+#[tracing::instrument(skip_all)]
 fn are_equal_lockfiles(orig: &str, current: &str, ws: &Workspace<'_>) -> bool {
     // If we want to try and avoid updating the lock file, parse both and
     // compare them; since this is somewhat expensive, don't do it in the

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -424,6 +424,7 @@ pub fn prepare_for_publish(
     }
 }
 
+#[tracing::instrument(skip_all)]
 pub fn to_real_manifest(
     me: manifest::TomlManifest,
     embedded: bool,
@@ -723,6 +724,7 @@ pub fn to_real_manifest(
         root: package_root,
     };
 
+    #[tracing::instrument(skip(manifest_ctx, new_deps, workspace_config, inherit_cell))]
     fn process_dependencies(
         manifest_ctx: &mut ManifestContext<'_, '_>,
         new_deps: Option<&BTreeMap<manifest::PackageName, manifest::InheritableDependency>>,
@@ -1531,6 +1533,7 @@ fn default_readme_from_package_root(package_root: &Path) -> Option<String> {
 
 /// Checks a list of build targets, and ensures the target names are unique within a vector.
 /// If not, the name of the offending build target is returned.
+#[tracing::instrument(skip_all)]
 fn unique_build_targets(
     targets: &[Target],
     package_root: &Path,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -32,6 +32,7 @@ const DEFAULT_BENCH_DIR_NAME: &'static str = "benches";
 const DEFAULT_EXAMPLE_DIR_NAME: &'static str = "examples";
 const DEFAULT_BIN_DIR_NAME: &'static str = "bin";
 
+#[tracing::instrument(skip_all)]
 pub(super) fn targets(
     features: &Features,
     manifest: &TomlManifest,


### PR DESCRIPTION
In looking at the traces, I had a couple of questions of where the time is going, like
- Why does writing a package file take so long
- How much of manifest parsing is TOML parsing vs target discovery vs other stuff


This adds traces to help answer those.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
