### PR TITLE
util/network/http: Use `cargo/1.2.3` user-agent header

### DIFF
--- a/src/cargo/util/network/http.rs
+++ b/src/cargo/util/network/http.rs
@@ -74,7 +74,7 @@ pub fn configure_http_handle(gctx: &GlobalContext, handle: &mut Easy) -> CargoRe
     if let Some(user_agent) = &http.user_agent {
         handle.useragent(user_agent)?;
     } else {
-        handle.useragent(&format!("cargo {}", version()))?;
+        handle.useragent(&format!("cargo/{}", version()))?;
     }
 
     fn to_ssl_version(s: &str) -> CargoResult<SslVersion> {

--- a/src/doc/src/reference/registry-web-api.md
+++ b/src/doc/src/reference/registry-web-api.md
@@ -42,7 +42,7 @@ Cargo sets the following headers for all requests:
 
 - `Content-Type`: `application/json` (for requests with a body payload)
 - `Accept`: `application/json`
-- `User-Agent`: The Cargo version such as `cargo 1.32.0 (8610973aa
+- `User-Agent`: The Cargo version such as `cargo/1.32.0 (8610973aa
   2019-01-02)`. This may be modified by the user in a configuration value.
   Added in 1.29.
 


### PR DESCRIPTION
... instead of `cargo 1.2.3`.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#syntax declares that the product and product version are usually separated by a slash. This commit changes the cargo `User-Agent` header to follow that syntax instead of using whitespace for the separator.
