### PR TITLE
chore: downgrade to openssl v1.1.1 (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,9 +2361,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2393,18 +2393,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.3+3.2.1"
+version = "111.28.1+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ libloading = "0.8.1"
 memchr = "2.7.1"
 miow = "0.6.0"
 opener = "0.6.1"
-openssl = "0.10.64"
+openssl = "0.10.57"
 os_info = "3.7.0"
 pasetors = { version = "0.6.8", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Revert OpenSSL v3 upgrade in <https://github.com/rust-lang/cargo/pull/13449>, as

See rust-lang/cargo#13546 and sfackler/rust-openssl#2163

### How should we test and review this PR?

### Additional information

Fixes rust-lang/cargo#13546

<!-- homu-ignore:end -->
