### PR TITLE
fix(cli): Skip tracing-chrome for platforms without 64bit atomics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,12 +199,14 @@ time.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
 tracing.workspace = true
-tracing-chrome.workspace = true
 tracing-subscriber.workspace = true
 unicase.workspace = true
 unicode-width.workspace = true
 url.workspace = true
 walkdir.workspace = true
+
+[target.'cfg(target_has_atomic = "64")'.dependencies]
+tracing-chrome.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cargo-credential-libsecret.workspace = true


### PR DESCRIPTION
See rust-lang/rust#122054

I also created thoren-d/tracing-chrome#27