### PR TITLE
fix(doc): Collapse down Generated statuses without --verbose 

### DIFF
--- a/src/cargo/ops/cargo_doc.rs
+++ b/src/cargo/ops/cargo_doc.rs
@@ -1,5 +1,5 @@
 use crate::core::compiler::{Compilation, CompileKind};
-use crate::core::{Shell, Workspace};
+use crate::core::{shell::Verbosity, Shell, Workspace};
 use crate::ops;
 use crate::util::context::{GlobalContext, PathAndArgs};
 use crate::util::CargoResult;
@@ -77,7 +77,7 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
             )?;
             open_docs(&path, &mut shell, config_browser, ws.gctx())?;
         }
-    } else {
+    } else if ws.gctx().shell().verbosity() == Verbosity::Verbose {
         for name in &compilation.root_crate_names {
             for kind in &options.compile_opts.build_config.requested_kinds {
                 let path =
@@ -91,6 +91,36 @@ pub fn doc(ws: &Workspace<'_>, options: &DocOptions) -> CargoResult<()> {
                     )?;
                 }
             }
+        }
+    } else {
+        let mut output = compilation.root_crate_names.iter().flat_map(|name| {
+            options
+                .compile_opts
+                .build_config
+                .requested_kinds
+                .iter()
+                .map(|kind| path_by_output_format(&compilation, kind, name, &options.output_format))
+                .filter(|path| path.exists())
+        });
+        if let Some(first_path) = output.next() {
+            let remaining = output.count();
+            let remaining = match remaining {
+                0 => "".to_owned(),
+                1 => " and 1 other file".to_owned(),
+                n => format!(" and {n} other files"),
+            };
+
+            let mut shell = ws.gctx().shell();
+            let link = shell.err_file_hyperlink(&first_path);
+            shell.status(
+                "Generated",
+                format!(
+                    "{}{}{}{remaining}",
+                    link.open(),
+                    first_path.display(),
+                    link.close()
+                ),
+            )?;
         }
     }
 

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -561,8 +561,7 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [DOCUMENTING] foo-macro v1.0.0 [..]
 [DOCUMENTING] abc v1.0.0 [..]
 [FINISHED] [..]
-[GENERATED] [CWD]/target/doc/abc/index.html
-[GENERATED] [CWD]/target/doc/foo_macro/index.html
+[GENERATED] [CWD]/target/doc/abc/index.html and 1 other file
 ")
         .run();
 }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -309,8 +309,7 @@ the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [DOCUMENTING] bar v0.1.0 ([ROOT]/foo/bar)
 [DOCUMENTING] foo v0.1.0 ([ROOT]/foo/foo)
 [FINISHED] [..]
-[GENERATED] [CWD]/target/doc/foo_lib/index.html
-[GENERATED] [CWD]/target/doc/foo_lib/index.html
+[GENERATED] [CWD]/target/doc/foo_lib/index.html and 1 other file
 ",
         )
         .run();
@@ -658,8 +657,7 @@ fn doc_lib_bin_example_same_name_documents_examples_when_requested() {
 [CHECKING] foo v0.0.1 ([CWD])
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-[GENERATED] [CWD]/target/doc/ex1/index.html
-[GENERATED] [CWD]/target/doc/ex2/index.html
+[GENERATED] [CWD]/target/doc/ex1/index.html and 1 other file
 ",
         )
         .run();
@@ -1189,8 +1187,7 @@ fn doc_all_workspace() {
         .with_stderr_contains("[DOCUMENTING] bar v0.1.0 ([..])")
         .with_stderr_contains("[CHECKING] bar v0.1.0 ([..])")
         .with_stderr_contains("[DOCUMENTING] foo v0.1.0 ([..])")
-        .with_stderr_contains("[GENERATED] [CWD]/target/doc/bar/index.html")
-        .with_stderr_contains("[GENERATED] [CWD]/target/doc/foo/index.html")
+        .with_stderr_contains("[GENERATED] [CWD]/target/doc/bar/index.html and 1 other file")
         .run();
 }
 

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1195,6 +1195,38 @@ fn doc_all_workspace() {
 }
 
 #[cargo_test]
+fn doc_all_workspace_verbose() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [dependencies]
+                bar = { path = "bar" }
+
+                [workspace]
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .file("bar/Cargo.toml", &basic_manifest("bar", "0.1.0"))
+        .file("bar/src/lib.rs", "pub fn bar() {}")
+        .build();
+
+    // The order in which bar is compiled or documented is not deterministic
+    p.cargo("doc --workspace -v")
+        .with_stderr_contains("[DOCUMENTING] bar v0.1.0 ([..])")
+        .with_stderr_contains("[CHECKING] bar v0.1.0 ([..])")
+        .with_stderr_contains("[DOCUMENTING] foo v0.1.0 ([..])")
+        .with_stderr_contains("[GENERATED] [CWD]/target/doc/bar/index.html")
+        .with_stderr_contains("[GENERATED] [CWD]/target/doc/foo/index.html")
+        .run();
+}
+
+#[cargo_test]
 fn doc_all_virtual_manifest() {
     let p = project()
         .file(

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1186,9 +1186,11 @@ fn doc_all_workspace() {
 
     // The order in which bar is compiled or documented is not deterministic
     p.cargo("doc --workspace")
-        .with_stderr_contains("[..] Documenting bar v0.1.0 ([..])")
-        .with_stderr_contains("[..] Checking bar v0.1.0 ([..])")
-        .with_stderr_contains("[..] Documenting foo v0.1.0 ([..])")
+        .with_stderr_contains("[DOCUMENTING] bar v0.1.0 ([..])")
+        .with_stderr_contains("[CHECKING] bar v0.1.0 ([..])")
+        .with_stderr_contains("[DOCUMENTING] foo v0.1.0 ([..])")
+        .with_stderr_contains("[GENERATED] [CWD]/target/doc/bar/index.html")
+        .with_stderr_contains("[GENERATED] [CWD]/target/doc/foo/index.html")
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This is trying to balance
- Overwhelming the user with a lot of paths
- Clarity to the user that the one path is representative of the rest

clap before:
```
    Finished dev [unoptimized + debuginfo] target(s) in 3.81s
   Generated /home/epage/src/personal/clap/target/doc/clap/index.html
   Generated /home/epage/src/personal/clap/target/doc/stdio_fixture/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_bench/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_builder/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_complete/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_complete_fig/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_complete_nushell/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_derive/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_lex/index.html
   Generated /home/epage/src/personal/clap/target/doc/clap_mangen/index.html
```
clap after:
```
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.44s
   Generated /home/epage/src/personal/clap/target/doc/clap/index.html and 9 other files
```

Fixes #13336

### How should we test and review this PR?

Tests were updated in earlier commits to help show the behavior change

### Additional information

