### PR TITLE
Use GITHUB_TOKEN in github_fast_path if available.

### DIFF
--- a/src/cargo/sources/git/utils.rs
+++ b/src/cargo/sources/git/utils.rs
@@ -1413,6 +1413,7 @@ fn github_fast_path(
                 // the branch has moved.
                 if let Some(local_object) = local_object {
                     if is_short_hash_of(rev, local_object) {
+                        debug!("github fast path already has {local_object}");
                         return Ok(FastPathRev::UpToDate);
                     }
                 }
@@ -1452,11 +1453,18 @@ fn github_fast_path(
     handle.get(true)?;
     handle.url(&url)?;
     handle.useragent("cargo")?;
+    handle.follow_location(true)?; // follow redirects
     handle.http_headers({
         let mut headers = List::new();
         headers.append("Accept: application/vnd.github.3.sha")?;
         if let Some(local_object) = local_object {
             headers.append(&format!("If-None-Match: \"{}\"", local_object))?;
+        }
+        if let Ok(token) = gctx.get_env("GITHUB_TOKEN") {
+            if !token.is_empty() {
+                // Avoid API rate limits if possible.
+                headers.append(&format!("Authorization: Bearer {token}"))?;
+            }
         }
         headers
     })?;
@@ -1472,14 +1480,17 @@ fn github_fast_path(
 
     let response_code = handle.response_code()?;
     if response_code == 304 {
+        debug!("github fast path up-to-date");
         Ok(FastPathRev::UpToDate)
     } else if response_code == 200 {
         let oid_to_fetch = str::from_utf8(&response_body)?.parse::<Oid>()?;
+        debug!("github fast path fetch {oid_to_fetch}");
         Ok(FastPathRev::NeedsFetch(oid_to_fetch))
     } else {
         // Usually response_code == 404 if the repository does not exist, and
         // response_code == 422 if exists but GitHub is unable to resolve the
         // requested rev.
+        debug!("github fast path bad response code {response_code}");
         Ok(FastPathRev::Indeterminate)
     }
 }


### PR DESCRIPTION
This changes the GitHub fast-path to include an Authorization header if the GITHUB_TOKEN environment variable is set. This is intended to help with API rate limits, which is not too hard to hit in CI. If it hits the rate limit, then the fetch falls back to fetching all branches which is significantly slower for some repositories. 

This is also a partial solution for #13555, where the user has a `rev="<commit-hash>"` where that commit hash points to a PR. The default refspec of `["+refs/heads/*:refs/remotes/origin/*", "+HEAD:refs/remotes/origin/HEAD"]` will not fetch commits from PRs (unless they are reachable from some branch).

There is some risk that if the user has a GITHUB_TOKEN that is invalid or expired, then this will cause `github_fast_path` to fail where it previously wouldn't. I think that is probably unlikely to happen, though.

This also adds redirect support. Apparently GitHub now issues a redirect for `repos/{org}/{repo}/commits/{commit}` to `/repositories/{id}/commits/{commit}`.

The test `https::github_works` exercises this code path, and will use the token on CI.
