### PR TITLE
feat: index cache in SQLite3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,10 @@ jobs:
     - name: Clear test output
       run: ci/clean-test-output.sh
 
+    - name: Check operability of index cache in SQLite3
+      run: 'cargo test -p cargo --test testsuite -- alt_registry:: global_cache_tracker::'
+      env:
+        __CARGO_TEST_FORCE_SQLITE_INDEX_CACHE: 1
     # This only tests `cargo fix` because fix-proxy-mode is one of the most
     # complicated subprocess management in Cargo.
     - name: Check operability of rustc invocation with argfile

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -762,6 +762,7 @@ unstable_cli_options!(
     git: Option<GitFeatures> = ("Enable support for shallow git fetch operations"),
     gitoxide: Option<GitoxideFeatures> = ("Use gitoxide for the given git interactions, or all of them if no argument is given"),
     host_config: bool = ("Enable the `[host]` section in the .cargo/config.toml file"),
+    index_cache_sqlite: bool,
     minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
     msrv_policy: bool = ("Enable rust-version aware policy within cargo"),
     mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
@@ -1149,6 +1150,7 @@ impl CliUnstable {
                 )?
             }
             "host-config" => self.host_config = parse_empty(k, v)?,
+            "index-cache-sqlite" => self.index_cache_sqlite = parse_empty(k, v)?,
             "next-lockfile-bump" => self.next_lockfile_bump = parse_empty(k, v)?,
             "minimal-versions" => self.minimal_versions = parse_empty(k, v)?,
             "msrv-policy" => self.msrv_policy = parse_empty(k, v)?,

--- a/src/cargo/sources/registry/index/cache.rs
+++ b/src/cargo/sources/registry/index/cache.rs
@@ -248,7 +248,10 @@ impl<'gctx> CacheManager<'gctx> {
     ///
     /// `root` --- The root path where caches are located.
     pub fn new(cache_root: Filesystem, gctx: &'gctx GlobalContext) -> CacheManager<'gctx> {
-        let store: Box<dyn CacheStore> = if gctx.cli_unstable().index_cache_sqlite {
+        #[allow(clippy::disallowed_methods)]
+        let use_sqlite = gctx.cli_unstable().index_cache_sqlite
+            || std::env::var("__CARGO_TEST_FORCE_SQLITE_INDEX_CACHE").is_ok();
+        let store: Box<dyn CacheStore> = if use_sqlite {
             Box::new(LocalDatabase::new(cache_root, gctx))
         } else {
             Box::new(LocalFileSystem::new(cache_root, gctx))

--- a/tests/testsuite/index_cache_sqlite.rs
+++ b/tests/testsuite/index_cache_sqlite.rs
@@ -46,6 +46,7 @@ fn crates_io() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 3 packages
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.0.0 (registry `dummy-registry`)
 [DOWNLOADED] dep2 v0.0.0 (registry `dummy-registry`)
@@ -74,6 +75,8 @@ fn crates_io() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package
+[ADDING] dep3 v0.0.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep3 v0.0.0 (registry `dummy-registry`)
 ",

--- a/tests/testsuite/index_cache_sqlite.rs
+++ b/tests/testsuite/index_cache_sqlite.rs
@@ -1,0 +1,101 @@
+//! Tests for the `-Zindex-cache-sqlite`.
+
+use std::collections::HashSet;
+
+use cargo_test_support::paths;
+use cargo_test_support::project;
+use cargo_test_support::registry;
+use cargo_test_support::registry::Package;
+
+#[cargo_test]
+fn gated() {
+    project()
+        .build()
+        .cargo("fetch")
+        .arg("-Zindex-cache-sqlite")
+        .with_status(101)
+        .with_stderr_contains("[ERROR] the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel")
+        .run();
+}
+
+#[cargo_test]
+fn crates_io() {
+    registry::alt_init();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                edition = "2015"
+
+                [dependencies]
+                dep2 = "0.0.0"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    Package::new("dep1", "0.0.0").publish();
+    Package::new("dep2", "0.0.0").dep("dep1", "0.0.0").publish();
+    Package::new("dep3", "0.0.0").publish();
+
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["index-cache-sqlite"])
+        .arg("-Zindex-cache-sqlite")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep1 v0.0.0 (registry `dummy-registry`)
+[DOWNLOADED] dep2 v0.0.0 (registry `dummy-registry`)
+",
+        )
+        .run();
+
+    assert_rows_inserted(&["dep1", "dep2"]);
+
+    p.change_file(
+        "Cargo.toml",
+        r#"
+            [package]
+            name = "foo"
+            edition = "2015"
+
+            [dependencies]
+            dep2 = "0.0.0"
+            dep3 = "0.0.0"
+        "#,
+    );
+
+    p.cargo("fetch")
+        .masquerade_as_nightly_cargo(&["index-cache-sqlite"])
+        .arg("-Zindex-cache-sqlite")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[DOWNLOADING] crates ...
+[DOWNLOADED] dep3 v0.0.0 (registry `dummy-registry`)
+",
+        )
+        .run();
+
+    assert_rows_inserted(&["dep1", "dep2", "dep3"]);
+}
+
+#[track_caller]
+fn assert_rows_inserted(names: &[&str]) {
+    let pattern = paths::home().join(".cargo/registry/index/*/.cache/index-cache.db");
+    let pattern = pattern.to_str().unwrap();
+    let db_path = glob::glob(pattern).unwrap().next().unwrap().unwrap();
+
+    let set: HashSet<String> = rusqlite::Connection::open(&db_path)
+        .unwrap()
+        .prepare("SELECT name FROM summaries")
+        .unwrap()
+        .query_map([], |row| row.get(0))
+        .unwrap()
+        .collect::<Result<_, _>>()
+        .unwrap();
+    assert_eq!(set, HashSet::from_iter(names.iter().map(|n| n.to_string())));
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -103,6 +103,7 @@ mod glob_targets;
 mod global_cache_tracker;
 mod help;
 mod https;
+mod index_cache_sqlite;
 mod inheritable_workspace_fields;
 mod install;
 mod install_upgrade;


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

<https://github.com/rust-lang/cargo/issues/6908>
<!-- homu-ignore:end -->

Add an unstable feature to store index cache in SQLite3 database.

The flag is undocumented since the schema is just a naive dump.
The implementation can be used as benchmark baseline while we explore other cache/SQL schema design.

<!-- homu-ignore:start -->
### How should we test and review this PR?

Run this to force using SQLite for index cache.

```
__CARGO_TEST_FORCE_SQLITE_INDEX_CACHE=1 cargo test -p cargo --test testsuite
```

You'll find SQLite3 db file at `registry/index/<index-url>/.cache/index-cache.db`.

### Additional information
<!-- homu-ignore:end -->
