### PR TITLE
refactor(toml): Flatten manifest parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3418,9 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.6"
+version = "0.22.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1b5fd4128cc8d3e0cb74d4ed9a9cc7c7284becd4df68f5f940e1ad123606f6"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tempfile = "3.10.1"
 thiserror = "1.0.57"
 time = { version = "0.3", features = ["parsing", "formatting", "serde"] }
 toml = "0.8.10"
-toml_edit = { version = "0.22.6", features = ["serde"] }
+toml_edit = { version = "0.22.7", features = ["serde"] }
 tracing = "0.1.40" # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ cargo-platform = { path = "crates/cargo-platform", version = "0.1.5" }
 cargo-test-macro = { path = "crates/cargo-test-macro" }
 cargo-test-support = { path = "crates/cargo-test-support" }
 cargo-util = { version = "0.2.9", path = "crates/cargo-util" }
-cargo-util-schemas = { version = "0.2.1", path = "crates/cargo-util-schemas" }
+cargo-util-schemas = { version = "0.3.0", path = "crates/cargo-util-schemas" }
 cargo_metadata = "0.18.1"
 clap = "4.5.1"
 color-print = "0.3.5"

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.2.1"
+version = "0.3.0"
 rust-version = "1.76.0"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -6,6 +6,7 @@
 //! - Keys that exist for bookkeeping but don't correspond to the schema have a `_` prefix
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::fmt::{self, Display, Write};
 use std::path::PathBuf;
 use std::str;
@@ -28,6 +29,7 @@ pub use rust_version::RustVersionError;
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlManifest {
+    // when adding new fields, be sure to check whether `requires_package` should disallow them
     pub cargo_features: Option<Vec<String>>,
     pub package: Option<Box<TomlPackage>>,
     pub project: Option<Box<TomlPackage>>,
@@ -51,7 +53,11 @@ pub struct TomlManifest {
     pub workspace: Option<TomlWorkspace>,
     pub badges: Option<InheritableBtreeMap>,
     pub lints: Option<InheritableLints>,
-    // when adding new fields, be sure to check whether `requires_package` should disallow them
+
+    /// Report unused keys (see also nested `_unused_keys`)
+    /// Note: this is populated by the caller, rather than automatically
+    #[serde(skip)]
+    pub _unused_keys: BTreeSet<String>,
 }
 
 impl TomlManifest {

--- a/crates/xtask-stale-label/src/main.rs
+++ b/crates/xtask-stale-label/src/main.rs
@@ -15,7 +15,7 @@
 use std::fmt::Write as _;
 use std::path::PathBuf;
 use std::process;
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 fn main() {
     let pkg_root = std::env!("CARGO_MANIFEST_DIR");
@@ -31,7 +31,7 @@ fn main() {
     let mut passed = 0;
 
     let toml = std::fs::read_to_string(path).expect("read from file");
-    let doc = toml.parse::<Document>().expect("a toml");
+    let doc = toml.parse::<DocumentMut>().expect("a toml");
     let autolabel = doc["autolabel"].as_table().expect("a toml table");
 
     for (label, value) in autolabel.iter() {

--- a/src/bin/cargo/commands/remove.rs
+++ b/src/bin/cargo/commands/remove.rs
@@ -160,7 +160,7 @@ fn parse_section(args: &ArgMatches) -> DepTable {
 /// Clean up the workspace.dependencies, profile, patch, and replace sections of the root manifest
 /// by removing dependencies which no longer have a reference to them.
 fn gc_workspace(workspace: &Workspace<'_>) -> CargoResult<()> {
-    let mut manifest: toml_edit::Document =
+    let mut manifest: toml_edit::DocumentMut =
         cargo_util::paths::read(workspace.root_manifest())?.parse()?;
     let mut is_modified = true;
 
@@ -315,7 +315,7 @@ fn spec_has_match(
 
 /// Removes unused patches from the manifest
 fn gc_unused_patches(workspace: &Workspace<'_>, resolve: &Resolve) -> CargoResult<bool> {
-    let mut manifest: toml_edit::Document =
+    let mut manifest: toml_edit::DocumentMut =
         cargo_util::paths::read(workspace.root_manifest())?.parse()?;
     let mut modified = false;
 

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -42,7 +42,7 @@ impl EitherManifest {
 #[derive(Clone, Debug)]
 pub struct Manifest {
     // alternate forms of manifests:
-    original: Rc<TomlManifest>,
+    resolved_toml: Rc<TomlManifest>,
     summary: Summary,
 
     // this form of manifest:
@@ -389,7 +389,7 @@ compact_debug! {
 
 impl Manifest {
     pub fn new(
-        original: Rc<TomlManifest>,
+        resolved_toml: Rc<TomlManifest>,
         summary: Summary,
 
         default_kind: Option<CompileKind>,
@@ -416,7 +416,7 @@ impl Manifest {
         embedded: bool,
     ) -> Manifest {
         Manifest {
-            original,
+            resolved_toml,
             summary,
 
             default_kind,
@@ -500,8 +500,8 @@ impl Manifest {
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] {
         &self.replace
     }
-    pub fn original(&self) -> &TomlManifest {
-        &self.original
+    pub fn resolved_toml(&self) -> &TomlManifest {
+        &self.resolved_toml
     }
     pub fn patch(&self) -> &HashMap<Url, Vec<Dependency>> {
         &self.patch

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -41,7 +41,11 @@ impl EitherManifest {
 /// This is deserialized using the [`TomlManifest`] type.
 #[derive(Clone, Debug)]
 pub struct Manifest {
+    // alternate forms of manifests:
+    original: Rc<TomlManifest>,
     summary: Summary,
+
+    // this form of manifest:
     targets: Vec<Target>,
     default_kind: Option<CompileKind>,
     forced_kind: Option<CompileKind>,
@@ -56,7 +60,6 @@ pub struct Manifest {
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: WorkspaceConfig,
-    original: Rc<TomlManifest>,
     unstable_features: Features,
     edition: Edition,
     rust_version: Option<RustVersion>,
@@ -386,7 +389,9 @@ compact_debug! {
 
 impl Manifest {
     pub fn new(
+        original: Rc<TomlManifest>,
         summary: Summary,
+
         default_kind: Option<CompileKind>,
         forced_kind: Option<CompileKind>,
         targets: Vec<Target>,
@@ -405,14 +410,15 @@ impl Manifest {
         rust_version: Option<RustVersion>,
         im_a_teapot: Option<bool>,
         default_run: Option<String>,
-        original: Rc<TomlManifest>,
         metabuild: Option<Vec<String>>,
         resolve_behavior: Option<ResolveBehavior>,
         lint_rustflags: Vec<String>,
         embedded: bool,
     ) -> Manifest {
         Manifest {
+            original,
             summary,
+
             default_kind,
             forced_kind,
             targets,
@@ -430,7 +436,6 @@ impl Manifest {
             unstable_features,
             edition,
             rust_version,
-            original,
             im_a_teapot,
             default_run,
             metabuild,

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -198,7 +198,7 @@ impl Package {
     }
 
     pub fn to_registry_toml(&self, ws: &Workspace<'_>) -> CargoResult<String> {
-        let manifest = prepare_for_publish(self.manifest().original(), ws, self.root())?;
+        let manifest = prepare_for_publish(self.manifest().resolved_toml(), ws, self.root())?;
         let toml = toml::to_string_pretty(&manifest)?;
         Ok(format!("{}\n{}", MANIFEST_PREAMBLE, toml))
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -420,7 +420,6 @@ impl<'gctx> Workspace<'gctx> {
         let source = SourceId::for_path(self.root())?;
 
         let mut warnings = Vec::new();
-        let mut nested_paths = Vec::new();
 
         let mut patch = HashMap::new();
         for (url, deps) in config_patch.into_iter().flatten() {
@@ -442,7 +441,6 @@ impl<'gctx> Workspace<'gctx> {
                             dep,
                             name,
                             source,
-                            &mut nested_paths,
                             self.gctx,
                             &mut warnings,
                             /* platform */ None,
@@ -1063,7 +1061,7 @@ impl<'gctx> Workspace<'gctx> {
             return Ok(p);
         }
         let source_id = SourceId::for_path(manifest_path.parent().unwrap())?;
-        let (package, _nested_paths) = ops::read_package(manifest_path, source_id, self.gctx)?;
+        let package = ops::read_package(manifest_path, source_id, self.gctx)?;
         loaded.insert(manifest_path.to_path_buf(), package.clone());
         Ok(package)
     }
@@ -1596,7 +1594,7 @@ impl<'gctx> Packages<'gctx> {
             Entry::Occupied(e) => Ok(e.into_mut()),
             Entry::Vacant(v) => {
                 let source_id = SourceId::for_path(key)?;
-                let (manifest, _nested_paths) = read_manifest(manifest_path, source_id, self.gctx)?;
+                let manifest = read_manifest(manifest_path, source_id, self.gctx)?;
                 Ok(v.insert(match manifest {
                     EitherManifest::Real(manifest) => {
                         MaybePackage::Package(Package::new(manifest, manifest_path))
@@ -1746,7 +1744,7 @@ pub fn find_workspace_root(
     find_workspace_root_with_loader(manifest_path, gctx, |self_path| {
         let key = self_path.parent().unwrap();
         let source_id = SourceId::for_path(key)?;
-        let (manifest, _nested_paths) = read_manifest(self_path, source_id, gctx)?;
+        let manifest = read_manifest(self_path, source_id, gctx)?;
         Ok(manifest
             .workspace_config()
             .get_ws_root(self_path, manifest_path))

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1006,7 +1006,7 @@ impl<'gctx> Workspace<'gctx> {
                     );
                     self.gctx.shell().warn(&msg)
                 };
-                if manifest.original().has_profiles() {
+                if manifest.resolved_toml().has_profiles() {
                     emit_warning("profiles")?;
                 }
                 if !manifest.replace().is_empty() {

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -455,10 +455,9 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
     // Convert Package -> TomlManifest -> Manifest -> Package
     let toml_manifest =
         prepare_for_publish(orig_pkg.manifest().resolved_toml(), ws, orig_pkg.root())?;
-    let package_root = orig_pkg.root();
     let source_id = orig_pkg.package_id().source_id();
     let (manifest, _nested_paths) =
-        to_real_manifest(toml_manifest, false, source_id, package_root, gctx)?;
+        to_real_manifest(toml_manifest, source_id, orig_pkg.manifest_path(), gctx)?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 
     // Regenerate Cargo.lock using the old one as a guide.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -456,8 +456,7 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
     let toml_manifest =
         prepare_for_publish(orig_pkg.manifest().resolved_toml(), ws, orig_pkg.root())?;
     let source_id = orig_pkg.package_id().source_id();
-    let (manifest, _nested_paths) =
-        to_real_manifest(toml_manifest, source_id, orig_pkg.manifest_path(), gctx)?;
+    let manifest = to_real_manifest(toml_manifest, source_id, orig_pkg.manifest_path(), gctx)?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 
     // Regenerate Cargo.lock using the old one as a guide.

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -453,7 +453,8 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
     let orig_resolve = ops::load_pkg_lockfile(ws)?;
 
     // Convert Package -> TomlManifest -> Manifest -> Package
-    let toml_manifest = prepare_for_publish(orig_pkg.manifest().original(), ws, orig_pkg.root())?;
+    let toml_manifest =
+        prepare_for_publish(orig_pkg.manifest().resolved_toml(), ws, orig_pkg.root())?;
     let package_root = orig_pkg.root();
     let source_id = orig_pkg.package_id().source_id();
     let (manifest, _nested_paths) =

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -420,7 +420,7 @@ fn transmit(
         .map(|dep| dep.name.clone())
         .collect::<BTreeSet<String>>();
 
-    let string_features = match manifest.original().features() {
+    let string_features = match manifest.resolved_toml().features() {
         Some(features) => features
             .iter()
             .map(|(feat, values)| {

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -363,7 +363,7 @@ fn cp_sources(
         let cksum = if dst.file_name() == Some(OsStr::new("Cargo.toml"))
             && pkg.package_id().source_id().is_git()
         {
-            let original_toml = toml::to_string_pretty(pkg.manifest().original())?;
+            let original_toml = toml::to_string_pretty(pkg.manifest().resolved_toml())?;
             let contents = format!("{}\n{}", MANIFEST_PREAMBLE, original_toml);
             copy_and_checksum(
                 &dst,

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -110,7 +110,7 @@ impl<'gctx> PathSource<'gctx> {
             ops::read_packages(&self.path, self.source_id, self.gctx)
         } else {
             let path = self.path.join("Cargo.toml");
-            let (pkg, _) = ops::read_package(&path, self.source_id, self.gctx)?;
+            let pkg = ops::read_package(&path, self.source_id, self.gctx)?;
             Ok(vec![pkg])
         }
     }

--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -1365,9 +1365,9 @@ impl GlobalContext {
                 // We only want to allow "dotted key" (see https://toml.io/en/v1.0.0#keys)
                 // expressions followed by a value that's not an "inline table"
                 // (https://toml.io/en/v1.0.0#inline-table). Easiest way to check for that is to
-                // parse the value as a toml_edit::Document, and check that the (single)
+                // parse the value as a toml_edit::DocumentMut, and check that the (single)
                 // inner-most table is set via dotted keys.
-                let doc: toml_edit::Document = arg.parse().with_context(|| {
+                let doc: toml_edit::DocumentMut = arg.parse().with_context(|| {
                     format!("failed to parse value from --config argument `{arg}` as a dotted key expression")
                 })?;
                 fn non_empty(d: Option<&toml_edit::RawString>) -> bool {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -14,7 +14,6 @@ use cargo_util_schemas::manifest::{self, TomlManifest};
 use itertools::Itertools;
 use lazycell::LazyCell;
 use pathdiff::diff_paths;
-use tracing::trace;
 use url::Url;
 
 use crate::core::compiler::{CompileKind, CompileTarget};
@@ -49,11 +48,6 @@ pub fn read_manifest(
     source_id: SourceId,
     gctx: &GlobalContext,
 ) -> CargoResult<(EitherManifest, Vec<PathBuf>)> {
-    trace!(
-        "read_manifest; path={}; source-id={}",
-        path.display(),
-        source_id
-    );
     let contents = read_toml_string(path, gctx)?;
     let document =
         parse_document(&contents).map_err(|e| emit_diagnostic(e.into(), &contents, path, gctx))?;

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -175,20 +175,6 @@ fn convert_toml(
     source_id: SourceId,
     gctx: &GlobalContext,
 ) -> CargoResult<(EitherManifest, Vec<PathBuf>)> {
-    if let Some(deps) = manifest
-        .workspace
-        .as_ref()
-        .and_then(|ws| ws.dependencies.as_ref())
-    {
-        for (name, dep) in deps {
-            if dep.is_optional() {
-                bail!("{name} is optional, but workspace dependencies cannot be optional",);
-            }
-            if dep.is_public() {
-                bail!("{name} is public, but workspace dependencies cannot be public",);
-            }
-        }
-    }
     return if manifest.package().is_some() {
         let (manifest, paths) = to_real_manifest(manifest, source_id, manifest_file, gctx)?;
         Ok((EitherManifest::Real(manifest), paths))
@@ -514,6 +500,21 @@ pub fn to_real_manifest(
             package_root.display()
         );
     };
+
+    if let Some(deps) = me
+        .workspace
+        .as_ref()
+        .and_then(|ws| ws.dependencies.as_ref())
+    {
+        for (name, dep) in deps {
+            if dep.is_optional() {
+                bail!("{name} is optional, but workspace dependencies cannot be optional",);
+            }
+            if dep.is_public() {
+                bail!("{name} is public, but workspace dependencies cannot be public",);
+            }
+        }
+    }
 
     let mut nested_paths = vec![];
     let mut warnings = vec![];
@@ -1281,6 +1282,21 @@ fn to_virtual_manifest(
     gctx: &GlobalContext,
 ) -> CargoResult<(VirtualManifest, Vec<PathBuf>)> {
     let root = manifest_file.parent().unwrap();
+
+    if let Some(deps) = me
+        .workspace
+        .as_ref()
+        .and_then(|ws| ws.dependencies.as_ref())
+    {
+        for (name, dep) in deps {
+            if dep.is_optional() {
+                bail!("{name} is optional, but workspace dependencies cannot be optional",);
+            }
+            if dep.is_public() {
+                bail!("{name} is public, but workspace dependencies cannot be public",);
+            }
+        }
+    }
 
     for field in me.requires_package() {
         bail!("this virtual manifest specifies a `{field}` section, which is not allowed");

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1345,17 +1345,19 @@ fn to_virtual_manifest(
             bail!("virtual manifests must be configured with [workspace]");
         }
     };
-    Ok((
-        VirtualManifest::new(
-            replace,
-            patch,
-            workspace_config,
-            profiles,
-            features,
-            resolve_behavior,
-        ),
-        nested_paths,
-    ))
+    let mut manifest = VirtualManifest::new(
+        replace,
+        patch,
+        workspace_config,
+        profiles,
+        features,
+        resolve_behavior,
+    );
+    for warning in warnings {
+        manifest.warnings_mut().add_warning(warning);
+    }
+
+    Ok((manifest, nested_paths))
 }
 
 fn replace(

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1214,6 +1214,7 @@ pub fn to_real_manifest(
         }),
     };
     let mut manifest = Manifest::new(
+        Rc::new(resolved_toml),
         summary,
         default_kind,
         forced_kind,
@@ -1233,7 +1234,6 @@ pub fn to_real_manifest(
         rust_version,
         package.im_a_teapot,
         package.default_run.clone(),
-        Rc::new(resolved_toml),
         package.metabuild.clone().map(|sov| sov.0),
         resolve_behavior,
         rustflags,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -209,7 +209,7 @@ fn convert_toml(
             }
         }
     }
-    return if manifest.project.is_some() || manifest.package.is_some() {
+    return if manifest.package().is_some() {
         let embedded = is_embedded(manifest_file);
         let (mut manifest, paths) =
             to_real_manifest(manifest, embedded, source_id, package_root, gctx)?;

--- a/src/cargo/util/toml_mut/manifest.rs
+++ b/src/cargo/util/toml_mut/manifest.rs
@@ -82,7 +82,7 @@ impl From<DepKind> for DepTable {
 #[derive(Debug, Clone)]
 pub struct Manifest {
     /// Manifest contents as TOML data.
-    pub data: toml_edit::Document,
+    pub data: toml_edit::DocumentMut,
 }
 
 impl Manifest {
@@ -225,7 +225,7 @@ impl str::FromStr for Manifest {
 
     /// Read manifest data from string
     fn from_str(input: &str) -> ::std::result::Result<Self, Self::Err> {
-        let d: toml_edit::Document = input.parse().context("Manifest not valid TOML")?;
+        let d: toml_edit::DocumentMut = input.parse().context("Manifest not valid TOML")?;
 
         Ok(Manifest { data: d })
     }

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -711,6 +711,7 @@ fn cargo_compile_with_invalid_non_numeric_dep_version() {
                 crossbeam = "y"
             "#,
         )
+        .file("src/lib.rs", "")
         .build();
 
     p.cargo("build")


### PR DESCRIPTION
### What does this PR try to resolve?

This is just a clean up but the goals are
- Support diagnostics that show source by tracking `&str`, `ImDocument`, etc in `Manifest` by making each accessible in the creation of a `Manifest`
- Defer warning analysis until we know what is a local vs non-local workspace by refactoring warnings out into a dedicated step
- Centralize the logic for `cargo publish` stripping of dev-dependencies and their feature activations by allowing a `Summary` to be created from any "resolved" `TomlManifest`
- Enumerate all build targets in the "resolved" `TomlManifest` so they get included in `cargo publish`, reducing the work done on registry dependencies and resolving problems like #13456

Along the way, this fixed a bug where we were not reporting warnings from virtual manifests

### How should we test and review this PR?


### Additional information
