### PR TITLE
refactor: Expose source/spans to Manifest for emitting lints

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -445,6 +445,7 @@ impl Manifest {
         }
     }
 
+    /// The [`TomlManifest`] with all fields expanded
     pub fn resolved_toml(&self) -> &TomlManifest {
         &self.resolved_toml
     }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -445,6 +445,16 @@ impl Manifest {
         }
     }
 
+    pub fn resolved_toml(&self) -> &TomlManifest {
+        &self.resolved_toml
+    }
+    pub fn summary(&self) -> &Summary {
+        &self.summary
+    }
+    pub fn summary_mut(&mut self) -> &mut Summary {
+        &mut self.summary
+    }
+
     pub fn dependencies(&self) -> &[Dependency] {
         self.summary.dependencies()
     }
@@ -468,12 +478,6 @@ impl Manifest {
     }
     pub fn package_id(&self) -> PackageId {
         self.summary.package_id()
-    }
-    pub fn summary(&self) -> &Summary {
-        &self.summary
-    }
-    pub fn summary_mut(&mut self) -> &mut Summary {
-        &mut self.summary
     }
     pub fn targets(&self) -> &[Target] {
         &self.targets
@@ -499,9 +503,6 @@ impl Manifest {
     }
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] {
         &self.replace
-    }
-    pub fn resolved_toml(&self) -> &TomlManifest {
-        &self.resolved_toml
     }
     pub fn patch(&self) -> &HashMap<Url, Vec<Dependency>> {
         &self.patch

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -42,6 +42,8 @@ impl EitherManifest {
 #[derive(Clone, Debug)]
 pub struct Manifest {
     // alternate forms of manifests:
+    contents: Rc<String>,
+    document: Rc<toml_edit::ImDocument<String>>,
     resolved_toml: Rc<TomlManifest>,
     summary: Summary,
 
@@ -389,6 +391,8 @@ compact_debug! {
 
 impl Manifest {
     pub fn new(
+        contents: Rc<String>,
+        document: Rc<toml_edit::ImDocument<String>>,
         resolved_toml: Rc<TomlManifest>,
         summary: Summary,
 
@@ -416,6 +420,8 @@ impl Manifest {
         embedded: bool,
     ) -> Manifest {
         Manifest {
+            contents,
+            document,
             resolved_toml,
             summary,
 
@@ -445,6 +451,14 @@ impl Manifest {
         }
     }
 
+    /// The raw contents of the original TOML
+    pub fn contents(&self) -> &str {
+        self.contents.as_str()
+    }
+    /// Collection of spans for the original TOML
+    pub fn document(&self) -> &toml_edit::ImDocument<String> {
+        &self.document
+    }
     /// The [`TomlManifest`] with all fields expanded
     pub fn resolved_toml(&self) -> &TomlManifest {
         &self.resolved_toml

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -453,10 +453,19 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
     let orig_resolve = ops::load_pkg_lockfile(ws)?;
 
     // Convert Package -> TomlManifest -> Manifest -> Package
+    let contents = orig_pkg.manifest().contents();
+    let document = orig_pkg.manifest().document();
     let toml_manifest =
         prepare_for_publish(orig_pkg.manifest().resolved_toml(), ws, orig_pkg.root())?;
     let source_id = orig_pkg.package_id().source_id();
-    let manifest = to_real_manifest(toml_manifest, source_id, orig_pkg.manifest_path(), gctx)?;
+    let manifest = to_real_manifest(
+        contents.to_owned(),
+        document.clone(),
+        toml_manifest,
+        source_id,
+        orig_pkg.manifest_path(),
+        gctx,
+    )?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 
     // Regenerate Cargo.lock using the old one as a guide.

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -57,7 +57,8 @@ pub fn read_manifest(
 
     (|| {
         if toml.package().is_some() {
-            to_real_manifest(toml, source_id, path, gctx).map(EitherManifest::Real)
+            to_real_manifest(contents, document, toml, source_id, path, gctx)
+                .map(EitherManifest::Real)
         } else {
             to_virtual_manifest(toml, source_id, path, gctx).map(EitherManifest::Virtual)
         }
@@ -443,6 +444,8 @@ pub fn prepare_for_publish(
 
 #[tracing::instrument(skip_all)]
 pub fn to_real_manifest(
+    contents: String,
+    document: toml_edit::ImDocument<String>,
     me: manifest::TomlManifest,
     source_id: SourceId,
     manifest_file: &Path,
@@ -1208,6 +1211,8 @@ pub fn to_real_manifest(
         _unused_keys: Default::default(),
     };
     let mut manifest = Manifest::new(
+        Rc::new(contents),
+        Rc::new(document),
         Rc::new(resolved_toml),
         summary,
         default_kind,


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #13589.

This does nothing on its own.

This is meant to short-circuit some of my refactorings so Muscraft can
start on their work on adding lints while I work to move out existing
warnings into being able to be converted to lints.

### How should we test and review this PR?

This includes documentation changes suggested in #13589

### Additional information

