### PR TITLE
[WIP] Fix: Cargo fails to detect environment variable

### DIFF
--- a/src/cargo/core/compiler/fingerprint/dirty_reason.rs
+++ b/src/cargo/core/compiler/fingerprint/dirty_reason.rs
@@ -29,6 +29,7 @@ pub enum DirtyReason {
     MetadataChanged,
     ConfigSettingsChanged,
     CompileKindChanged,
+    EnvConfigChanged,
     LocalLengthsChanged,
     PrecalculatedComponentsChanged {
         old: String,
@@ -171,6 +172,9 @@ impl DirtyReason {
             }
             DirtyReason::CompileKindChanged => {
                 s.dirty_because(unit, "the rustc compile kind changed")
+            }
+            DirtyReason::EnvConfigChanged => {
+                s.dirty_because(unit, "the environment variable changed")
             }
             DirtyReason::LocalLengthsChanged => {
                 s.dirty_because(unit, "the local lengths changed")?;

--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -190,27 +190,29 @@ fn compile<'gctx>(
     } else {
         let force = exec.force_rebuild(unit) || force_rebuild;
         let mut job = fingerprint::prepare_target(build_runner, unit, force)?;
-        job.before(if job.freshness().is_dirty() {
-            let work = if unit.mode.is_doc() || unit.mode.is_doc_scrape() {
-                rustdoc(build_runner, unit)?
+        job.before(
+            if job.freshness().is_dirty() || env_config_modified(bcx.gctx)? {
+                let work = if unit.mode.is_doc() || unit.mode.is_doc_scrape() {
+                    rustdoc(build_runner, unit)?
+                } else {
+                    rustc(build_runner, unit, exec)?
+                };
+                work.then(link_targets(build_runner, unit, false)?)
             } else {
-                rustc(build_runner, unit, exec)?
-            };
-            work.then(link_targets(build_runner, unit, false)?)
-        } else {
-            // We always replay the output cache,
-            // since it might contain future-incompat-report messages
-            let work = replay_output_cache(
-                unit.pkg.package_id(),
-                PathBuf::from(unit.pkg.manifest_path()),
-                &unit.target,
-                build_runner.files().message_cache_path(unit),
-                build_runner.bcx.build_config.message_format,
-                unit.show_warnings(bcx.gctx),
-            );
-            // Need to link targets on both the dirty and fresh.
-            work.then(link_targets(build_runner, unit, true)?)
-        });
+                // We always replay the output cache,
+                // since it might contain future-incompat-report messages
+                let work = replay_output_cache(
+                    unit.pkg.package_id(),
+                    PathBuf::from(unit.pkg.manifest_path()),
+                    &unit.target,
+                    build_runner.files().message_cache_path(unit),
+                    build_runner.bcx.build_config.message_format,
+                    unit.show_warnings(bcx.gctx),
+                );
+                // Need to link targets on both the dirty and fresh.
+                work.then(link_targets(build_runner, unit, true)?)
+            },
+        );
 
         job
     };
@@ -1924,6 +1926,21 @@ fn apply_env_config(gctx: &crate::GlobalContext, cmd: &mut ProcessBuilder) -> Ca
 /// Checks if there are some scrape units waiting to be processed.
 fn should_include_scrape_units(bcx: &BuildContext<'_, '_>, unit: &Unit) -> bool {
     unit.mode.is_doc() && bcx.scrape_units.len() > 0 && bcx.ws.unit_needs_doc_scrape(unit)
+}
+
+/// Detects if environment variables from config `[env]` is newly modified.
+fn env_config_modified(gctx: &crate::GlobalContext) -> CargoResult<bool> {
+    for (key, value) in gctx.env_config()?.iter() {
+        if !gctx.env().any(|(k, _)| k == key) {
+            continue;
+        }
+
+        if !value.is_force() && gctx.env().find(|(k, _)| k == key).is_some() {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }
 
 /// Gets the file path of function call information output from `rustdoc`.

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -239,3 +239,32 @@ fn env_applied_to_target_info_discovery_rustc() {
         .with_stderr_contains("MAIN ENV_TEST:from-env")
         .run();
 }
+
+#[cargo_test]
+fn env_reset() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file(
+            "src/main.rs",
+            r#"
+        use std::env;
+        fn main() {
+            println!( "{}", env!("ENV_TEST") );
+        }
+        "#,
+        )
+        .file(
+            ".cargo/config.toml",
+            r#"
+                [env]
+                ENV_TEST = "from-config"
+            "#,
+        )
+        .build();
+
+    p.cargo("run").with_stdout_contains("from-config").run();
+    p.cargo("run")
+        .env("ENV_TEST", "from-env")
+        .with_stdout_contains("from-env")
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes: https://github.com/rust-lang/cargo/issues/13280

Cargo fails to detect and rebuild while using environment variable reset environment variable which is set in `config.toml`.

examples:
.cargo/config.toml:
```
[env]
Z = "0"
```
src/main.rs:
```
fn main() {
    println!("{:?}", option_env!("Z"));
}
```
run these commands:
```
cargo run     # first build, output None
Z=1 cargo run # cargo does know the environment variable is set and rebuilds it, output Some("1")
```

### How should we test and review this PR?

checkout and run test:

```
cargo test --package cargo --test testsuite -- cargo_env_config::env_reset
```

### Additional information
Fingerprint code is not able to detect environment variables cause they were removed from Cargo's dep-info. See https://github.com/rust-lang/cargo/issues/13280#issuecomment-1887225691.