### PR TITLE
chore: Fix minor grammar nit in command-line help

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -53,8 +53,8 @@ pub fn cli() -> clap::Command {
         )
         .arg(opt("base-rev", "Git revision to lookup for a baseline"))
         .arg(opt("head-rev", "Git revision with changes"))
-        .arg(flag("frozen", "Require Cargo.lock and cache are up to date").global(true))
-        .arg(flag("locked", "Require Cargo.lock is up to date").global(true))
+        .arg(flag("frozen", "Require Cargo.lock and cache to be up-to-date").global(true))
+        .arg(flag("locked", "Require Cargo.lock to be up-to-date").global(true))
         .arg(flag("offline", "Run without accessing the network").global(true))
         .arg(multi_opt("config", "KEY=VALUE", "Override a configuration value").global(true))
         .arg(

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -640,12 +640,12 @@ See '<cyan,bold>cargo help</> <cyan><<command>></>' for more information on a sp
                 .value_parser(clap::builder::ValueParser::path_buf()),
         )
         .arg(
-            flag("frozen", "Require Cargo.lock and cache are up to date")
+            flag("frozen", "Require Cargo.lock and cache to be up-to-date")
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )
         .arg(
-            flag("locked", "Require Cargo.lock is up to date")
+            flag("locked", "Require Cargo.lock to be up-to-date")
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -172,7 +172,7 @@ OPTIONS
            Add dependencies to only the specified package.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -339,7 +339,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -273,7 +273,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -258,7 +258,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -92,7 +92,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -229,7 +229,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -72,7 +72,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -331,7 +331,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -47,7 +47,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -243,7 +243,7 @@ OPTIONS
 
    Manifest Options
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -405,7 +405,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -159,7 +159,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -85,7 +85,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -129,7 +129,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-remove.txt
+++ b/src/doc/man/generated_txt/cargo-remove.txt
@@ -62,7 +62,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -177,7 +177,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -275,7 +275,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -245,7 +245,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -365,7 +365,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -212,7 +212,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -82,7 +82,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -54,7 +54,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/generated_txt/cargo-verify-project.txt
+++ b/src/doc/man/generated_txt/cargo-verify-project.txt
@@ -50,7 +50,7 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --frozen, --locked
-           Either of these flags requires that the Cargo.lock file is
+           Either of these flags requires that the Cargo.lock file be
            up-to-date. If the lock file is missing, or it needs to be updated,
            Cargo will exit with an error. The --frozen flag also prevents Cargo
            from attempting to access the network to determine if it is

--- a/src/doc/man/includes/options-locked.md
+++ b/src/doc/man/includes/options-locked.md
@@ -1,5 +1,5 @@
 {{#option "`--frozen`" "`--locked`"}}
-Either of these flags requires that the `Cargo.lock` file is
+Either of these flags requires that the `Cargo.lock` file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The `--frozen` flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -193,7 +193,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-add---frozen"><a class="option-anchor" href="#option-cargo-add---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-add---locked"><a class="option-anchor" href="#option-cargo-add---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -379,7 +379,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-bench---frozen"><a class="option-anchor" href="#option-cargo-bench---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-bench---locked"><a class="option-anchor" href="#option-cargo-bench---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -310,7 +310,7 @@ See <a href="https://github.com/rust-lang/cargo/issues/5579">https://github.com/
 
 <dt class="option-term" id="option-cargo-build---frozen"><a class="option-anchor" href="#option-cargo-build---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-build---locked"><a class="option-anchor" href="#option-cargo-build---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -292,7 +292,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-check---frozen"><a class="option-anchor" href="#option-cargo-check---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-check---locked"><a class="option-anchor" href="#option-cargo-check---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -112,7 +112,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-clean---frozen"><a class="option-anchor" href="#option-cargo-clean---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-clean---locked"><a class="option-anchor" href="#option-cargo-clean---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -267,7 +267,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-doc---frozen"><a class="option-anchor" href="#option-cargo-doc---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-doc---locked"><a class="option-anchor" href="#option-cargo-doc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -81,7 +81,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-fetch---frozen"><a class="option-anchor" href="#option-cargo-fetch---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-fetch---locked"><a class="option-anchor" href="#option-cargo-fetch---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -372,7 +372,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-fix---frozen"><a class="option-anchor" href="#option-cargo-fix---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-fix---locked"><a class="option-anchor" href="#option-cargo-fix---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -60,7 +60,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-generate-lockfile---frozen"><a class="option-anchor" href="#option-cargo-generate-lockfile---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-generate-lockfile---locked"><a class="option-anchor" href="#option-cargo-generate-lockfile---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -268,7 +268,7 @@ information about timing information.</li>
 <dl>
 <dt class="option-term" id="option-cargo-install---frozen"><a class="option-anchor" href="#option-cargo-install---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-install---locked"><a class="option-anchor" href="#option-cargo-install---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -430,7 +430,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-metadata---frozen"><a class="option-anchor" href="#option-cargo-metadata---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-metadata---locked"><a class="option-anchor" href="#option-cargo-metadata---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -184,7 +184,7 @@ be specified multiple times, which enables all specified features.</dd>
 
 <dt class="option-term" id="option-cargo-package---frozen"><a class="option-anchor" href="#option-cargo-package---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-package---locked"><a class="option-anchor" href="#option-cargo-package---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -92,7 +92,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-pkgid---frozen"><a class="option-anchor" href="#option-cargo-pkgid---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-pkgid---locked"><a class="option-anchor" href="#option-cargo-pkgid---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -153,7 +153,7 @@ be specified multiple times, which enables all specified features.</dd>
 
 <dt class="option-term" id="option-cargo-publish---frozen"><a class="option-anchor" href="#option-cargo-publish---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-publish---locked"><a class="option-anchor" href="#option-cargo-publish---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -83,7 +83,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-remove---frozen"><a class="option-anchor" href="#option-cargo-remove---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-remove---locked"><a class="option-anchor" href="#option-cargo-remove---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -212,7 +212,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-run---frozen"><a class="option-anchor" href="#option-cargo-run---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-run---locked"><a class="option-anchor" href="#option-cargo-run---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -306,7 +306,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-rustc---frozen"><a class="option-anchor" href="#option-cargo-rustc---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-rustc---locked"><a class="option-anchor" href="#option-cargo-rustc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -287,7 +287,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-rustdoc---frozen"><a class="option-anchor" href="#option-cargo-rustdoc---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-rustdoc---locked"><a class="option-anchor" href="#option-cargo-rustdoc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -408,7 +408,7 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 <dt class="option-term" id="option-cargo-test---frozen"><a class="option-anchor" href="#option-cargo-test---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-test---locked"><a class="option-anchor" href="#option-cargo-test---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -224,7 +224,7 @@ single quotes or double quotes around each pattern.</dd>
 
 <dt class="option-term" id="option-cargo-tree---frozen"><a class="option-anchor" href="#option-cargo-tree---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-tree---locked"><a class="option-anchor" href="#option-cargo-tree---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -101,7 +101,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-update---frozen"><a class="option-anchor" href="#option-cargo-update---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-update---locked"><a class="option-anchor" href="#option-cargo-update---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -70,7 +70,7 @@ only a subset of the packages have changed.</dd>
 
 <dt class="option-term" id="option-cargo-vendor---frozen"><a class="option-anchor" href="#option-cargo-vendor---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-vendor---locked"><a class="option-anchor" href="#option-cargo-vendor---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -65,7 +65,7 @@ terminal.</li>
 
 <dt class="option-term" id="option-cargo-verify-project---frozen"><a class="option-anchor" href="#option-cargo-verify-project---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-verify-project---locked"><a class="option-anchor" href="#option-cargo-verify-project---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file is
+<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
 up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The <code>--frozen</code> flag also prevents Cargo from
 attempting to access the network to determine if it is out-of-date.</p>

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -224,7 +224,7 @@ Add dependencies to only the specified package.
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -420,7 +420,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -338,7 +338,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -319,7 +319,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -118,7 +118,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -286,7 +286,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -86,7 +86,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -414,7 +414,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -65,7 +65,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -305,7 +305,7 @@ information about timing information.
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -439,7 +439,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -201,7 +201,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -124,7 +124,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -157,7 +157,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-remove.1
+++ b/src/etc/man/cargo-remove.1
@@ -84,7 +84,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -223,7 +223,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -337,7 +337,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -305,7 +305,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -447,7 +447,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -269,7 +269,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -108,7 +108,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -65,7 +65,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -75,7 +75,7 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file is
+Either of these flags requires that the \fBCargo.lock\fR file be
 up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
 exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
 attempting to access the network to determine if it is out\-of\-date.

--- a/tests/testsuite/cargo/help/stdout.term.svg
+++ b/tests/testsuite/cargo/help/stdout.term.svg
@@ -45,9 +45,9 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-C</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>            Change to DIRECTORY before doing anything (nightly-only)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>              Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>              Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>              Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>              Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>             Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/help/stdout.term.svg
+++ b/tests/testsuite/cargo_add/help/stdout.term.svg
@@ -181,13 +181,13 @@
 </tspan>
     <tspan x="10px" y="1468px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan>
 </tspan>
-    <tspan x="10px" y="1486px"><tspan>          Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="1486px"><tspan>          Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1504px">
 </tspan>
     <tspan x="10px" y="1522px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan>
 </tspan>
-    <tspan x="10px" y="1540px"><tspan>          Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="1540px"><tspan>          Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1558px">
 </tspan>

--- a/tests/testsuite/cargo_bench/help/stdout.term.svg
+++ b/tests/testsuite/cargo_bench/help/stdout.term.svg
@@ -127,9 +127,9 @@
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_build/help/stdout.term.svg
+++ b/tests/testsuite/cargo_build/help/stdout.term.svg
@@ -125,9 +125,9 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_check/help/stdout.term.svg
+++ b/tests/testsuite/cargo_check/help/stdout.term.svg
@@ -121,9 +121,9 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_clean/help/stdout.term.svg
+++ b/tests/testsuite/cargo_clean/help/stdout.term.svg
@@ -69,9 +69,9 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_config/help/stdout.term.svg
+++ b/tests/testsuite/cargo_config/help/stdout.term.svg
@@ -51,9 +51,9 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_doc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_doc/help/stdout.term.svg
@@ -115,9 +115,9 @@
 </tspan>
     <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_fetch/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fetch/help/stdout.term.svg
@@ -53,9 +53,9 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -129,9 +129,9 @@
 </tspan>
     <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
@@ -47,9 +47,9 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_help/help/stdout.term.svg
+++ b/tests/testsuite/cargo_help/help/stdout.term.svg
@@ -51,9 +51,9 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_init/help/stdout.term.svg
+++ b/tests/testsuite/cargo_init/help/stdout.term.svg
@@ -69,9 +69,9 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -121,9 +121,9 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_locate_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_locate_project/help/stdout.term.svg
@@ -53,9 +53,9 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_login/help/stdout.term.svg
+++ b/tests/testsuite/cargo_login/help/stdout.term.svg
@@ -55,9 +55,9 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_logout/help/stdout.term.svg
+++ b/tests/testsuite/cargo_logout/help/stdout.term.svg
@@ -47,9 +47,9 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_metadata/help/stdout.term.svg
+++ b/tests/testsuite/cargo_metadata/help/stdout.term.svg
@@ -69,9 +69,9 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_new/help/stdout.term.svg
+++ b/tests/testsuite/cargo_new/help/stdout.term.svg
@@ -69,9 +69,9 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_owner/help/stdout.term.svg
+++ b/tests/testsuite/cargo_owner/help/stdout.term.svg
@@ -63,9 +63,9 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -87,9 +87,9 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_pkgid/help/stdout.term.svg
+++ b/tests/testsuite/cargo_pkgid/help/stdout.term.svg
@@ -59,9 +59,9 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_publish/help/stdout.term.svg
+++ b/tests/testsuite/cargo_publish/help/stdout.term.svg
@@ -87,9 +87,9 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
@@ -51,9 +51,9 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/help/stdout.term.svg
+++ b/tests/testsuite/cargo_remove/help/stdout.term.svg
@@ -71,9 +71,9 @@
 </tspan>
     <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_report/help/stdout.term.svg
+++ b/tests/testsuite/cargo_report/help/stdout.term.svg
@@ -51,9 +51,9 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_run/help/stdout.term.svg
+++ b/tests/testsuite/cargo_run/help/stdout.term.svg
@@ -103,9 +103,9 @@
 </tspan>
     <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_rustc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustc/help/stdout.term.svg
@@ -125,9 +125,9 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -123,9 +123,9 @@
 </tspan>
     <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_search/help/stdout.term.svg
+++ b/tests/testsuite/cargo_search/help/stdout.term.svg
@@ -57,9 +57,9 @@
 </tspan>
     <tspan x="10px" y="352px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_test/help/stdout.term.svg
+++ b/tests/testsuite/cargo_test/help/stdout.term.svg
@@ -133,9 +133,9 @@
 </tspan>
     <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_tree/help/stdout.term.svg
+++ b/tests/testsuite/cargo_tree/help/stdout.term.svg
@@ -97,9 +97,9 @@
 </tspan>
     <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_uninstall/help/stdout.term.svg
+++ b/tests/testsuite/cargo_uninstall/help/stdout.term.svg
@@ -65,9 +65,9 @@
 </tspan>
     <tspan x="10px" y="424px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -61,9 +61,9 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_vendor/help/stdout.term.svg
+++ b/tests/testsuite/cargo_vendor/help/stdout.term.svg
@@ -63,9 +63,9 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_verify_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_verify_project/help/stdout.term.svg
@@ -47,9 +47,9 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_version/help/stdout.term.svg
+++ b/tests/testsuite/cargo_version/help/stdout.term.svg
@@ -45,9 +45,9 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_yank/help/stdout.term.svg
+++ b/tests/testsuite/cargo_yank/help/stdout.term.svg
@@ -61,9 +61,9 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache are up to date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock is up to date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>


### PR DESCRIPTION
This change fixes a *very* minor grammar mistake. "Require" used in this way is
typically followed by the infinitive. In addition, since "up-to-date" is used
an adjective now it should be hyphenated.

See https://www.merriam-webster.com/dictionary/up-to-date

### Testing

I have run `cargo test` with `CFG_DISABLE_CROSS_TESTS=1` as well as `cargo
build-man` to regenerate the man pages.

Fixes #13601.
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
