### PR TITLE
refactor(toml): Expose surce/spans for VirtualManifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,7 +470,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "semver",
  "serde",

--- a/crates/cargo-util-schemas/Cargo.toml
+++ b/crates/cargo-util-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-util-schemas"
-version = "0.3.0"
+version = "0.3.1"
 rust-version = "1.76.0"  # MSRV:1
 edition.workspace = true
 license.workspace = true

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -26,7 +26,7 @@ pub use rust_version::RustVersion;
 pub use rust_version::RustVersionError;
 
 /// This type is used to deserialize `Cargo.toml` files.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlManifest {
     // when adding new fields, be sure to check whether `requires_package` should disallow them

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -12,6 +12,7 @@ use crate::util::errors::CargoResult;
 use crate::GlobalContext;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::rc::Rc;
 
 use super::BuildConfig;
 
@@ -103,6 +104,10 @@ pub fn resolve_std<'gctx>(
         /*custom_metadata*/ &None,
     ));
     let virtual_manifest = crate::core::VirtualManifest::new(
+        Rc::default(),
+        Rc::new(toml_edit::ImDocument::parse("".to_owned()).expect("empty is valid TOML")),
+        Rc::default(),
+        Rc::default(),
         /*replace*/ Vec::new(),
         patch,
         ws_config,

--- a/src/cargo/core/compiler/standard_lib.rs
+++ b/src/cargo/core/compiler/standard_lib.rs
@@ -111,7 +111,6 @@ pub fn resolve_std<'gctx>(
         /*replace*/ Vec::new(),
         patch,
         ws_config,
-        /*profiles*/ None,
         crate::core::Features::default(),
         None,
     );

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -546,7 +546,6 @@ impl Features {
         warnings: &mut Vec<String>,
     ) -> CargoResult<()> {
         let nightly_features_allowed = self.nightly_features_allowed;
-        let is_local = self.is_local;
         let Some((slot, feature)) = self.status(feature_name) else {
             bail!("unknown cargo feature `{}`", feature_name)
         };
@@ -567,19 +566,15 @@ impl Features {
 
         match feature.stability {
             Status::Stable => {
-                // The user can't do anything about non-local packages.
-                // Warnings are usually suppressed, but just being cautious here.
-                if is_local {
-                    let warning = format!(
-                        "the cargo feature `{}` has been stabilized in the {} \
+                let warning = format!(
+                    "the cargo feature `{}` has been stabilized in the {} \
                          release and is no longer necessary to be listed in the \
                          manifest\n  {}",
-                        feature_name,
-                        feature.version,
-                        see_docs()
-                    );
-                    warnings.push(warning);
-                }
+                    feature_name,
+                    feature.version,
+                    see_docs()
+                );
+                warnings.push(warning);
             }
             Status::Unstable if !nightly_features_allowed => bail!(
                 "the cargo feature `{}` requires a nightly version of \

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -58,7 +58,6 @@ pub struct Manifest {
     include: Vec<String>,
     metadata: ManifestMetadata,
     custom_metadata: Option<toml::Value>,
-    profiles: Option<TomlProfiles>,
     publish: Option<Vec<String>>,
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
@@ -98,7 +97,6 @@ pub struct VirtualManifest {
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: WorkspaceConfig,
-    profiles: Option<TomlProfiles>,
     warnings: Warnings,
     features: Features,
     resolve_behavior: Option<ResolveBehavior>,
@@ -416,7 +414,6 @@ impl Manifest {
         links: Option<String>,
         metadata: ManifestMetadata,
         custom_metadata: Option<toml::Value>,
-        profiles: Option<TomlProfiles>,
         publish: Option<Vec<String>>,
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
@@ -447,7 +444,6 @@ impl Manifest {
             links,
             metadata,
             custom_metadata,
-            profiles,
             publish,
             replace,
             patch,
@@ -528,7 +524,7 @@ impl Manifest {
         &self.warnings
     }
     pub fn profiles(&self) -> Option<&TomlProfiles> {
-        self.profiles.as_ref()
+        self.resolved_toml.profile.as_ref()
     }
     pub fn publish(&self) -> &Option<Vec<String>> {
         &self.publish
@@ -643,7 +639,6 @@ impl VirtualManifest {
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
-        profiles: Option<TomlProfiles>,
         features: Features,
         resolve_behavior: Option<ResolveBehavior>,
     ) -> VirtualManifest {
@@ -655,7 +650,6 @@ impl VirtualManifest {
             replace,
             patch,
             workspace,
-            profiles,
             warnings: Warnings::new(),
             features,
             resolve_behavior,
@@ -692,7 +686,7 @@ impl VirtualManifest {
     }
 
     pub fn profiles(&self) -> Option<&TomlProfiles> {
-        self.profiles.as_ref()
+        self.resolved_toml.profile.as_ref()
     }
 
     pub fn warnings_mut(&mut self) -> &mut Warnings {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -468,7 +468,7 @@ impl Manifest {
     pub fn document(&self) -> &toml_edit::ImDocument<String> {
         &self.document
     }
-    /// The [`TomlManifest`] with all fields expanded
+    /// The [`TomlManifest`] as parsed from [`Manifest::document`]
     pub fn original_toml(&self) -> &TomlManifest {
         &self.original_toml
     }
@@ -664,7 +664,7 @@ impl VirtualManifest {
     pub fn document(&self) -> &toml_edit::ImDocument<String> {
         &self.document
     }
-    /// The [`TomlManifest`] with all fields expanded
+    /// The [`TomlManifest`] as parsed from [`VirtualManifest::document`]
     pub fn original_toml(&self) -> &TomlManifest {
         &self.original_toml
     }

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -88,6 +88,13 @@ pub struct Warnings(Vec<DelayedWarning>);
 
 #[derive(Clone, Debug)]
 pub struct VirtualManifest {
+    // alternate forms of manifests:
+    contents: Rc<String>,
+    document: Rc<toml_edit::ImDocument<String>>,
+    original_toml: Rc<TomlManifest>,
+    resolved_toml: Rc<TomlManifest>,
+
+    // this form of manifest:
     replace: Vec<(PackageIdSpec, Dependency)>,
     patch: HashMap<Url, Vec<Dependency>>,
     workspace: WorkspaceConfig,
@@ -629,6 +636,10 @@ impl Manifest {
 
 impl VirtualManifest {
     pub fn new(
+        contents: Rc<String>,
+        document: Rc<toml_edit::ImDocument<String>>,
+        original_toml: Rc<TomlManifest>,
+        resolved_toml: Rc<TomlManifest>,
         replace: Vec<(PackageIdSpec, Dependency)>,
         patch: HashMap<Url, Vec<Dependency>>,
         workspace: WorkspaceConfig,
@@ -637,6 +648,10 @@ impl VirtualManifest {
         resolve_behavior: Option<ResolveBehavior>,
     ) -> VirtualManifest {
         VirtualManifest {
+            contents,
+            document,
+            original_toml,
+            resolved_toml,
             replace,
             patch,
             workspace,
@@ -645,6 +660,23 @@ impl VirtualManifest {
             features,
             resolve_behavior,
         }
+    }
+
+    /// The raw contents of the original TOML
+    pub fn contents(&self) -> &str {
+        self.contents.as_str()
+    }
+    /// Collection of spans for the original TOML
+    pub fn document(&self) -> &toml_edit::ImDocument<String> {
+        &self.document
+    }
+    /// The [`TomlManifest`] with all fields expanded
+    pub fn original_toml(&self) -> &TomlManifest {
+        &self.original_toml
+    }
+    /// The [`TomlManifest`] with all fields expanded
+    pub fn resolved_toml(&self) -> &TomlManifest {
+        &self.resolved_toml
     }
 
     pub fn replace(&self) -> &[(PackageIdSpec, Dependency)] {

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -44,6 +44,7 @@ pub struct Manifest {
     // alternate forms of manifests:
     contents: Rc<String>,
     document: Rc<toml_edit::ImDocument<String>>,
+    original_toml: Rc<TomlManifest>,
     resolved_toml: Rc<TomlManifest>,
     summary: Summary,
 
@@ -396,6 +397,7 @@ impl Manifest {
     pub fn new(
         contents: Rc<String>,
         document: Rc<toml_edit::ImDocument<String>>,
+        original_toml: Rc<TomlManifest>,
         resolved_toml: Rc<TomlManifest>,
         summary: Summary,
 
@@ -425,6 +427,7 @@ impl Manifest {
         Manifest {
             contents,
             document,
+            original_toml,
             resolved_toml,
             summary,
 
@@ -461,6 +464,10 @@ impl Manifest {
     /// Collection of spans for the original TOML
     pub fn document(&self) -> &toml_edit::ImDocument<String> {
         &self.document
+    }
+    /// The [`TomlManifest`] with all fields expanded
+    pub fn original_toml(&self) -> &TomlManifest {
+        &self.original_toml
     }
     /// The [`TomlManifest`] with all fields expanded
     pub fn resolved_toml(&self) -> &TomlManifest {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1108,8 +1108,7 @@ pub fn to_real_manifest(
         .as_ref()
         .map(|_| manifest::InheritableField::Value(include.clone()));
 
-    let profiles = original_toml.profile.clone();
-    if let Some(profiles) = &profiles {
+    if let Some(profiles) = &original_toml.profile {
         let cli_unstable = gctx.cli_unstable();
         validate_profiles(profiles, cli_unstable, &features, &mut warnings)?;
     }
@@ -1211,7 +1210,6 @@ pub fn to_real_manifest(
         package.links.clone(),
         metadata,
         custom_metadata,
-        profiles,
         publish,
         replace,
         patch,
@@ -1328,8 +1326,7 @@ fn to_virtual_manifest(
             patch(&original_toml, &mut manifest_ctx)?,
         )
     };
-    let profiles = original_toml.profile.clone();
-    if let Some(profiles) = &profiles {
+    if let Some(profiles) = &original_toml.profile {
         validate_profiles(profiles, gctx.cli_unstable(), &features, &mut warnings)?;
     }
     let resolve_behavior = original_toml
@@ -1374,7 +1371,6 @@ fn to_virtual_manifest(
         replace,
         patch,
         workspace_config,
-        profiles,
         features,
         resolve_behavior,
     );

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -524,24 +524,20 @@ pub fn to_real_manifest(
 
     let mut package = match (&me.package, &me.project) {
         (Some(_), Some(project)) => {
-            if source_id.is_path() {
-                gctx.shell().warn(format!(
-                    "manifest at `{}` contains both `project` and `package`, \
+            warnings.push(format!(
+                "manifest at `{}` contains both `project` and `package`, \
                     this could become a hard error in the future",
-                    package_root.display()
-                ))?;
-            }
+                package_root.display()
+            ));
             project.clone()
         }
         (Some(package), None) => package.clone(),
         (None, Some(project)) => {
-            if source_id.is_path() {
-                gctx.shell().warn(format!(
-                    "manifest at `{}` contains `[project]` instead of `[package]`, \
+            warnings.push(format!(
+                "manifest at `{}` contains `[project]` instead of `[package]`, \
                                 this could become a hard error in the future",
-                    package_root.display()
-                ))?;
-            }
+                package_root.display()
+            ));
             project.clone()
         }
         (None, None) => bail!("no `package` section found"),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -52,15 +52,15 @@ pub fn read_manifest(
         read_toml_string(path, gctx).map_err(|err| ManifestError::new(err, path.into()))?;
     let document =
         parse_document(&contents).map_err(|e| emit_diagnostic(e.into(), &contents, path, gctx))?;
-    let toml = deserialize_toml(&document)
+    let original_toml = deserialize_toml(&document)
         .map_err(|e| emit_diagnostic(e.into(), &contents, path, gctx))?;
 
     (|| {
-        if toml.package().is_some() {
-            to_real_manifest(contents, document, toml, source_id, path, gctx)
+        if original_toml.package().is_some() {
+            to_real_manifest(contents, document, original_toml, source_id, path, gctx)
                 .map(EitherManifest::Real)
         } else {
-            to_virtual_manifest(toml, source_id, path, gctx).map(EitherManifest::Virtual)
+            to_virtual_manifest(original_toml, source_id, path, gctx).map(EitherManifest::Virtual)
         }
     })()
     .map_err(|err| {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -60,7 +60,8 @@ pub fn read_manifest(
             to_real_manifest(contents, document, original_toml, source_id, path, gctx)
                 .map(EitherManifest::Real)
         } else {
-            to_virtual_manifest(original_toml, source_id, path, gctx).map(EitherManifest::Virtual)
+            to_virtual_manifest(contents, document, original_toml, source_id, path, gctx)
+                .map(EitherManifest::Virtual)
         }
     })()
     .map_err(|err| {
@@ -1276,6 +1277,8 @@ fn load_inheritable_fields(
 }
 
 fn to_virtual_manifest(
+    contents: String,
+    document: toml_edit::ImDocument<String>,
     original_toml: manifest::TomlManifest,
     source_id: SourceId,
     manifest_file: &Path,
@@ -1362,7 +1365,12 @@ fn to_virtual_manifest(
             bail!("virtual manifests must be configured with [workspace]");
         }
     };
+    let resolved_toml = original_toml.clone();
     let mut manifest = VirtualManifest::new(
+        Rc::new(contents),
+        Rc::new(document),
+        Rc::new(original_toml),
+        Rc::new(resolved_toml),
         replace,
         patch,
         workspace_config,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1199,6 +1199,7 @@ pub fn to_real_manifest(
     let mut manifest = Manifest::new(
         Rc::new(contents),
         Rc::new(document),
+        Rc::new(original_toml),
         Rc::new(resolved_toml),
         summary,
         default_kind,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1246,14 +1246,14 @@ pub fn to_real_manifest(
         embedded,
     );
     if package.license_file.is_some() && package.license.is_some() {
-        manifest.warnings_mut().add_warning(
+        warnings.push(
             "only one of `license` or `license-file` is necessary\n\
                  `license` should be used if the package license can be expressed \
                  with a standard SPDX expression.\n\
                  `license-file` should be used if the package uses a non-standard license.\n\
                  See https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields \
                  for more information."
-                .to_string(),
+                .to_owned(),
         );
     }
     for warning in warnings {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -585,7 +585,7 @@ pub fn to_real_manifest(
         ),
     };
 
-    let package_name = package.name.trim();
+    let package_name = &package.name;
     if package_name.contains(':') {
         features.require(Feature::open_namespaces())?;
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -594,11 +594,9 @@ pub fn to_real_manifest(
         features.require(Feature::open_namespaces())?;
     }
 
-    let resolved_path = package_root.join("Cargo.toml");
-
     let inherit_cell: LazyCell<InheritableFields> = LazyCell::new();
     let inherit =
-        || inherit_cell.try_borrow_with(|| get_ws(gctx, &resolved_path, &workspace_config));
+        || inherit_cell.try_borrow_with(|| get_ws(gctx, manifest_file, &workspace_config));
 
     let version = package
         .version


### PR DESCRIPTION
### What does this PR try to resolve?

This is a follow up to #13593, expanding support from `Manifest` to `VirtualManifest` as well.

This also does other clean up along the way in preparation for making a more explicit `resolve_toml` phase.

### How should we test and review this PR?


### Additional information

