### PR TITLE
core/compiler: report executable paths for all binary crates

### DIFF
--- a/src/cargo/core/compiler/build_runner/mod.rs
+++ b/src/cargo/core/compiler/build_runner/mod.rs
@@ -312,11 +312,13 @@ impl<'a, 'gctx> BuildRunner<'a, 'gctx> {
 
     /// Returns the executable for the specified unit (if any).
     pub fn get_executable(&mut self, unit: &Unit) -> CargoResult<Option<PathBuf>> {
-        let is_binary = unit.target.is_executable();
+        let crate_types = unit.target.rustc_crate_types();
+        let is_binary = crate_types.contains(&compiler::CrateType::Bin);
         let is_test = unit.mode.is_any_test();
         if !unit.mode.generates_executable() || !(is_binary || is_test) {
             return Ok(None);
         }
+
         Ok(self
             .outputs(unit)?
             .iter()

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -4266,7 +4266,7 @@ fn compiler_json_error_format() {
                     "overflow_checks": true,
                     "test": false
                 },
-                "executable": null,
+                "executable": "[..]/build-script-build[EXE]",
                 "features": [],
                 "filenames": "{...}",
                 "fresh": $FRESH

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -709,7 +709,7 @@ fn metabuild_json_artifact() {
         .with_json_contains_unordered(
             r#"
             {
-              "executable": null,
+              "executable": "[..]/metabuild-foo[EXE]",
               "features": [],
               "filenames": "{...}",
               "fresh": false,

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -318,7 +318,7 @@ fn pkgid_json_message_metadata_consistency() {
   "profile": "{...}",
   "features": [],
   "filenames": "{...}",
-  "executable": null,
+  "executable": "[..]",
   "fresh": false
 }
 

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -270,6 +270,40 @@ fn build_with_crate_types_for_foo() {
 }
 
 #[cargo_test]
+fn build_lib_with_crate_type_bin() {
+    let p = project().file("src/lib.rs", "fn main() {}").build();
+
+    p.cargo("rustc -v --crate-type bin --message-format=json --jobs=1")
+        .with_json_contains_unordered(
+            r#"
+                {
+                    "executable": "[..]/debug/foo[EXE]",
+                    "features": [],
+                    "filenames": "{...}",
+                    "fresh": false,
+                    "manifest_path": "[..]",
+                    "package_id": "[..]",
+                    "profile": "{...}",
+                    "reason": "compiler-artifact",
+                    "target": {
+                        "crate_types": ["bin"],
+                        "doc": true,
+                        "doctest": false,
+                        "edition": "2015",
+                        "kind": ["bin"],
+                        "name": "foo",
+                        "src_path": "[..]",
+                        "test": true
+                    }
+                }
+
+                {"reason": "build-finished", "success": true}
+            "#,
+        )
+        .run();
+}
+
+#[cargo_test]
 fn build_with_crate_type_to_example() {
     let p = project()
         .file(


### PR DESCRIPTION
Ensure the `compiler-artifact` message reports `executable: "..."` for all builds where the crate-type is set to `bin`.

Currently, only crates with a target-type of `bin` will report the executable path. This is unfortunate, since several other builds produce executables that are otherwise hard to distinguish from other artifacts due to the lack of file extension.

In particular, the following builds now properly report their executables:

 - Library targets built via `cargo rustc --crate-type bin`
 - Build scripts

Before they would report `executable: null` and thus make it very hard for callers to decide whether the produced file is an executable.