### PR TITLE
cargo/init: avoid target.name assignments if possible

### DIFF
--- a/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_binary_when_both_binlib_present/out/Cargo.toml
@@ -10,5 +10,4 @@ name = "case"
 path = "case.rs"
 
 [lib]
-name = "case"
 path = "lib.rs"

--- a/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/creates_library_when_instructed_and_has_bin_file/out/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 
 [lib]
-name = "case"
 path = "case.rs"

--- a/tests/testsuite/cargo_init/inferred_lib_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/inferred_lib_with_git/out/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 
 [lib]
-name = "case"
 path = "lib.rs"

--- a/tests/testsuite/cargo_init/lib_already_exists_nosrc/out/Cargo.toml
+++ b/tests/testsuite/cargo_init/lib_already_exists_nosrc/out/Cargo.toml
@@ -6,5 +6,4 @@ edition = "2021"
 [dependencies]
 
 [lib]
-name = "case"
 path = "lib.rs"


### PR DESCRIPTION
Make `cargo init` skip `target.name` assignments if the default value is suitable.

Currently, all paths of `cargo init` will set target-names to the package-name, ensuring that a suitable target-name is set. This is required for all targets but libraries. Unfortunately, library-names have more restrictions than other targets. For example, creating a library with dashes will lead to errors:

    mkdir foo-bar
    cd foo-bar
    touch foo-bar.rs
    cargo init --lib

Fortunately, target-names for libraries are inferred from the package-name. Hence, by omitting the target-name, a valid configuration will be produced.

Instead of adjusting `SourceFileInformation::target_name` to use `Option<String>`, this commit strips the field completely, since all callers set it to the package-name.

Fixes: #11259