### PR TITLE
feat(add): Stabilize MSRV-aware version req selection

### DIFF
--- a/src/bin/cargo/commands/add.rs
+++ b/src/bin/cargo/commands/add.rs
@@ -87,7 +87,7 @@ Example uses:
 - Depend on crates with the same name from different registries"),
             flag(
                 "ignore-rust-version",
-                "Ignore `rust-version` specification in packages (unstable)"
+                "Ignore `rust-version` specification in packages"
             ),
         ])
         .arg_manifest_path_without_unsupported_path_tip()
@@ -206,14 +206,6 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     let dependencies = parse_dependencies(gctx, args)?;
 
     let ignore_rust_version = args.flag("ignore-rust-version");
-    if ignore_rust_version && !gctx.cli_unstable().msrv_policy {
-        return Err(CliError::new(
-            anyhow::format_err!(
-                "`--ignore-rust-version` is unstable; pass `-Zmsrv-policy` to enable support for it"
-            ),
-            101,
-        ));
-    }
     let honor_rust_version = !ignore_rust_version;
 
     let options = AddOptions {

--- a/src/cargo/ops/cargo_add/mod.rs
+++ b/src/cargo/ops/cargo_add/mod.rs
@@ -608,7 +608,7 @@ fn get_latest_dependency(
                 )
             })?;
 
-            if gctx.cli_unstable().msrv_policy && honor_rust_version {
+            if honor_rust_version {
                 let (req_msrv, is_msrv) = spec
                     .rust_version()
                     .cloned()

--- a/src/doc/man/cargo-add.md
+++ b/src/doc/man/cargo-add.md
@@ -141,11 +141,6 @@ which enables all specified features.
 
 {{#option "`--ignore-rust-version`" }}
 Ignore `rust-version` specification in packages.
-
-This option is unstable and available only on the
-[nightly channel](https://doc.rust-lang.org/book/appendix-07-nightly-rust.html)
-and requires the `-Z unstable-options` flag to enable.
-See <https://github.com/rust-lang/cargo/issues/5579> for more information.
 {{/option}}
 
 {{/options}}

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -131,12 +131,6 @@ OPTIONS
        --ignore-rust-version
            Ignore rust-version specification in packages.
 
-           This option is unstable and available only on the nightly channel
-           <https://doc.rust-lang.org/book/appendix-07-nightly-rust.html> and
-           requires the -Z unstable-options flag to enable. See
-           <https://github.com/rust-lang/cargo/issues/5579> for more
-           information.
-
    Display Options
        -v, --verbose
            Use verbose output. May be specified twice for “very verbose”

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -137,11 +137,7 @@ which enables all specified features.</dd>
 
 
 <dt class="option-term" id="option-cargo-add---ignore-rust-version"><a class="option-anchor" href="#option-cargo-add---ignore-rust-version"></a><code>--ignore-rust-version</code></dt>
-<dd class="option-desc">Ignore <code>rust-version</code> specification in packages.</p>
-<p>This option is unstable and available only on the
-<a href="https://doc.rust-lang.org/book/appendix-07-nightly-rust.html">nightly channel</a>
-and requires the <code>-Z unstable-options</code> flag to enable.
-See <a href="https://github.com/rust-lang/cargo/issues/5579">https://github.com/rust-lang/cargo/issues/5579</a> for more information.</dd>
+<dd class="option-desc">Ignore <code>rust-version</code> specification in packages.</dd>
 
 
 </dl>

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -326,8 +326,6 @@ Documentation updates:
 
 ## msrv-policy
 - [#9930](https://github.com/rust-lang/cargo/issues/9930) (MSRV-aware resolver)
-- [#10653](https://github.com/rust-lang/cargo/issues/10653) (MSRV-aware cargo-add)
-- [#10903](https://github.com/rust-lang/cargo/issues/10903) (MSRV-aware cargo-install)
 
 The `msrv-policy` feature enables experiments in MSRV-aware policy for cargo in
 preparation for an upcoming RFC.

--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -87,6 +87,7 @@ _cargo() {
                         '--path=[local filesystem path to crate to add]: :_directories' \
                         '--rev=[specific commit to use when adding from git]:commit' \
                         '--tag=[tag to use when adding from git]:tag' \
+                        '--ignore-rust-version[Ignore rust-version specification in packages]' \
                         '1: :_guard "^-*" "crate name"' \
                         '*:args:_default'
                         ;;

--- a/src/etc/cargo.bashcomp.sh
+++ b/src/etc/cargo.bashcomp.sh
@@ -49,7 +49,7 @@ _cargo()
 	local opt_targets="--lib --bin --bins --example --examples --test --tests --bench --benches --all-targets"
 
 	local opt___nocmd="$opt_common -V --version --list --explain"
-	local opt__add="$opt_common -p --package --features --default-features --no-default-features $opt_mani --optional --no-optional --rename --dry-run --path --git --branch --tag --rev --registry --dev --build --target"
+	local opt__add="$opt_common -p --package --features --default-features --no-default-features $opt_mani --optional --no-optional --rename --dry-run --path --git --branch --tag --rev --registry --dev --build --target --ignore-rust-version"
 	local opt__bench="$opt_common $opt_pkg_spec $opt_feat $opt_mani $opt_lock $opt_jobs $opt_targets --message-format --target --no-run --no-fail-fast --target-dir --ignore-rust-version"
 	local opt__build="$opt_common $opt_pkg_spec $opt_feat $opt_mani $opt_lock $opt_parallel $opt_targets --message-format --target --release --profile --target-dir --ignore-rust-version"
 	local opt__b="$opt__build"

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -162,11 +162,6 @@ which enables all specified features.
 \fB\-\-ignore\-rust\-version\fR
 .RS 4
 Ignore \fBrust\-version\fR specification in packages.
-.sp
-This option is unstable and available only on the
-\fInightly channel\fR <https://doc.rust\-lang.org/book/appendix\-07\-nightly\-rust.html>
-and requires the \fB\-Z unstable\-options\fR flag to enable.
-See <https://github.com/rust\-lang/cargo/issues/5579> for more information.
 .RE
 .SS "Display Options"
 .sp

--- a/tests/testsuite/cargo_add/help/stdout.term.svg
+++ b/tests/testsuite/cargo_add/help/stdout.term.svg
@@ -125,7 +125,7 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>          Ignore `rust-version` specification in packages (unstable)</tspan>
+    <tspan x="10px" y="982px"><tspan>          Ignore `rust-version` specification in packages</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #9930 for rust-lang/rfcs#3537

This will make it easier to maintain an MSRV-compliant `Cargo.toml` but leaves validation up to the user as the resolver will pick newer versions.
This helps the MSRV-aware workflows enumerated in
rust-lang/rfcs#3537

### How should we test and review this PR?

As for determining if this is ready for stabilization:

By stabilizing this without the MSRV-aware resolver, this could be confusing to the workflow with an MSRV-compatible lockfile.
PR #13561 at least raises awareness of that discrepancy.
In general there was interest in the RFC discussions to stabilize this ASAP, regardless of what resolver direction we went.

There is an unresolved question on differences in the resolver vs `cargo add` for dealing with an unset `rust-version` (noted in the tracking issue). However, we are only stabilizing the `cargo add` side which is a very light two-way door as this is a UX-focused command and not a programmatic command. 

This hasn't gotten much end-user acceptance testing but, as its UX focused, that seems fine (light, two way door)

As such, this seems like it is ready to stabilize.

### Additional information

