### PR TITLE
Update annotate snippets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,9 +43,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9b665789884a7e8fb06c84b295e923b03ca51edbb7d08f91a6a50322ecbfe6"
+checksum = "361e18e35c1879cfeba9d8e20c393c84285ac883eaffc71c743c8e9ba023f0f4"
 dependencies = [
  "anstyle",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/rust-lang/cargo"
 repository = "https://github.com/rust-lang/cargo"
 
 [workspace.dependencies]
-annotate-snippets = "0.10.2"
+annotate-snippets = "0.11.0"
 anstream = "0.6.13"
 anstyle = "1.0.6"
 anyhow = "1.0.80"

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Annotation, AnnotationType, Renderer, Slice, Snippet, SourceAnnotation};
+use annotate_snippets::{Level, Renderer, Snippet};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -123,47 +123,39 @@ fn emit_diagnostic(
         return e.into();
     };
 
-    let (line_num, column) = translate_position(&contents, span.start);
+    let line_num = get_line(&contents, span.start);
     let source_start = contents[0..span.start]
-        .rfind('\n')
+        .as_bytes()
+        .iter()
+        .rposition(|b| b == &b'\n')
         .map(|s| s + 1)
         .unwrap_or(0);
     let source_end = contents[span.end.saturating_sub(1)..]
-        .find('\n')
+        .as_bytes()
+        .iter()
+        .position(|b| b == &b'\n')
         .map(|s| s + span.end)
         .unwrap_or(contents.len());
     let source = &contents[source_start..source_end];
+    let highlight_start = span.start - source_start;
     // Make sure we don't try to highlight past the end of the line,
     // but also make sure we are highlighting at least one character
-    let highlight_end = (column + contents[span].chars().count())
-        .min(source.len())
-        .max(column + 1);
+    let highlight_end = (span.end - source_start)
+        .min(source_end - source_start)
+        .max(highlight_start + 1);
     // Get the path to the manifest, relative to the cwd
     let manifest_path = diff_paths(manifest_file, gctx.cwd())
         .unwrap_or_else(|| manifest_file.to_path_buf())
         .display()
         .to_string();
-    let snippet = Snippet {
-        title: Some(Annotation {
-            id: None,
-            label: Some(e.message()),
-            annotation_type: AnnotationType::Error,
-        }),
-        footer: vec![],
-        slices: vec![Slice {
-            source: &source,
-            line_start: line_num + 1,
-            origin: Some(manifest_path.as_str()),
-            annotations: vec![SourceAnnotation {
-                range: (column, highlight_end),
-                label: "",
-                annotation_type: AnnotationType::Error,
-            }],
-            fold: false,
-        }],
-    };
+    let message = Level::Error.title(e.message()).snippet(
+        Snippet::source(&source)
+            .origin(&manifest_path)
+            .line_start(line_num + 1)
+            .annotation(Level::Error.span(highlight_start..highlight_end)),
+    );
     let renderer = Renderer::styled();
-    if let Err(err) = writeln!(gctx.shell().err(), "{}", renderer.render(snippet)) {
+    if let Err(err) = writeln!(gctx.shell().err(), "{}", renderer.render(message)) {
         return err.into();
     }
     return AlreadyPrintedError::new(e.into()).into();
@@ -2367,13 +2359,12 @@ impl ResolveToPath for ConfigRelativePath {
     }
 }
 
-fn translate_position(input: &str, index: usize) -> (usize, usize) {
+fn get_line(input: &str, index: usize) -> usize {
     if input.is_empty() {
-        return (0, index);
+        return 0;
     }
 
     let safe_index = index.min(input.len() - 1);
-    let column_offset = index - safe_index;
 
     let nl = input[0..safe_index]
         .as_bytes()
@@ -2386,13 +2377,9 @@ fn translate_position(input: &str, index: usize) -> (usize, usize) {
         Some(nl) => nl + 1,
         None => 0,
     };
-    let line = input[0..line_start]
+    input[0..line_start]
         .as_bytes()
         .iter()
         .filter(|c| **c == b'\n')
-        .count();
-    let column = input[line_start..=safe_index].chars().count() - 1;
-    let column = column + column_offset;
-
-    (line, column)
+        .count()
 }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -154,7 +154,12 @@ fn emit_diagnostic(
             .line_start(line_num + 1)
             .annotation(Level::Error.span(highlight_start..highlight_end)),
     );
-    let renderer = Renderer::styled();
+    let renderer = Renderer::styled().term_width(
+        gctx.shell()
+            .err_width()
+            .diagnostic_terminal_width()
+            .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
+    );
     if let Err(err) = writeln!(gctx.shell().err(), "{}", renderer.render(message)) {
         return err.into();
     }


### PR DESCRIPTION
This updates `annotate-snippets` to `0.11.0`, which introduces the new builder API as well as a few rendering fixes.