### PR TITLE
refactor(vendor): tiny not important refactors

### DIFF
--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -133,7 +133,7 @@ fn sync(
                 continue;
             }
             if let Ok(pkg) = packages.get_one(pkg) {
-                drop(fs::remove_dir_all(pkg.manifest_path().parent().unwrap()));
+                drop(fs::remove_dir_all(pkg.root()));
             }
         }
     }
@@ -192,10 +192,7 @@ fn sync(
     let mut tmp_buf = [0; 64 * 1024];
     for (id, pkg) in ids.iter() {
         // Next up, copy it to the vendor directory
-        let src = pkg
-            .manifest_path()
-            .parent()
-            .expect("manifest_path should point to a file");
+        let src = pkg.root();
         let max_version = *versions[&id.name()].iter().rev().next().unwrap().0;
         let dir_has_version_suffix = opts.versioned_dirs || id.version() != max_version;
         let dst_name = if dir_has_version_suffix {

--- a/src/cargo/ops/vendor.rs
+++ b/src/cargo/ops/vendor.rs
@@ -326,7 +326,7 @@ fn cp_sources(
             // the time and if we respect them (e.g.  in git) then it'll
             // probably mess with the checksums when a vendor dir is checked
             // into someone else's source control
-            Some(".gitattributes") | Some(".gitignore") | Some(".git") => continue,
+            Some(".gitattributes" | ".gitignore" | ".git") => continue,
 
             // Temporary Cargo files
             Some(".cargo-ok") => continue,


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Did some tiny refactors in cargo vendor I found when working on other stuff.

### How should we test and review this PR?

~~I believe `std::path::Path` should be quite cross-platform compatible, as [it calls into something like [`GetFullPathNameW`](
https://github.com/rust-lang/rust/blob/e760daa6a729b3d52a38804e9766f7d89dc27357/library/std/src/sys/path/windows.rs#L280-L287) eventually when being used. I might be wrong though.~~

See https://github.com/rust-lang/cargo/pull/13610#discussion_r1532741537

### Additional information
<!-- homu-ignore:end -->
