### PR TITLE
fix(alias): dont panic when resolving an empty alias

### DIFF
--- a/src/bin/cargo/main.rs
+++ b/src/bin/cargo/main.rs
@@ -148,6 +148,13 @@ fn aliased_command(gctx: &GlobalContext, command: &str) -> CargoResult<Option<Ve
     let result = user_alias.or_else(|| {
         builtin_aliases_execs(command).map(|command_str| vec![command_str.1.to_string()])
     });
+    if result
+        .as_ref()
+        .map(|alias| alias.is_empty())
+        .unwrap_or_default()
+    {
+        anyhow::bail!("subcommand is required, but `{alias_name}` is empty");
+    }
     Ok(result)
 }
 

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -429,3 +429,29 @@ To pass the arguments to the subcommand, remove `--`
         )
         .run();
 }
+
+#[cargo_test]
+fn empty_alias() {
+    let p = project()
+        .file("Cargo.toml", &basic_bin_manifest("foo"))
+        .file("src/main.rs", "fn main() {}")
+        .file(
+            ".cargo/config.toml",
+            r#"
+               [alias]
+               string = ""
+               array = []
+            "#,
+        )
+        .build();
+
+    p.cargo("string")
+        .with_status(101)
+        .with_stderr_contains("[..]panicked at[..]")
+        .run();
+
+    p.cargo("array")
+        .with_status(101)
+        .with_stderr_contains("[..]panicked at[..]")
+        .run();
+}

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -447,11 +447,19 @@ fn empty_alias() {
 
     p.cargo("string")
         .with_status(101)
-        .with_stderr_contains("[..]panicked at[..]")
+        .with_stderr(
+            "\
+[ERROR] subcommand is required, but `alias.string` is empty
+",
+        )
         .run();
 
     p.cargo("array")
         .with_status(101)
-        .with_stderr_contains("[..]panicked at[..]")
+        .with_stderr(
+            "\
+[ERROR] subcommand is required, but `alias.array` is empty
+",
+        )
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Previously Cargo panicked when resolving empty aliases like these:

```toml
[alias]
buidthis = ""
buildthat = []
````

This PR fixes it.

### How should we test and review this PR?

The first commit with a test demonstrates the panic, followed by a commit fixing that.
<!-- homu-ignore:end -->
