### PR TITLE
Fix publish script due to crates.io CDN change

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -31,11 +31,15 @@ TO_PUBLISH = [
 
 
 def already_published(name, version):
+    url = f'https://static.crates.io/crates/{name}/{version}/download'
     try:
-        urllib.request.urlopen('https://crates.io/api/v1/crates/%s/%s/download' % (name, version))
+        urllib.request.urlopen(url)
     except HTTPError as e:
-        if e.code == 404:
+        # 403 and 404 are common responses to assume it is not published
+        if 400 <= e.code < 500:
             return False
+        print(f'error: failed to check if {name} {version} is already published')
+        print(f'    HTTP response error code {e.code} checking {url}')
         raise
     return True
 


### PR DESCRIPTION
Now that crates.io goes directly to the CDN, this has changed the HTTP response code when a crate is not found (from 404 to 403). This updates the publish script to handle more error codes to assume something isn't published. This also updates it to go directly to the endpoint instead of through the crates.io redirect.

