### PR TITLE
feat: Add a basic linting system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3428,9 +3428,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tempfile = "3.10.1"
 thiserror = "1.0.57"
 time = { version = "0.3", features = ["parsing", "formatting", "serde"] }
 toml = "0.8.10"
-toml_edit = { version = "0.22.7", features = ["serde"] }
+toml_edit = { version = "0.22.9", features = ["serde"] }
 tracing = "0.1.40" # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-chrome = "0.7.1"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -750,6 +750,7 @@ unstable_cli_options!(
     #[serde(deserialize_with = "deserialize_build_std")]
     build_std: Option<Vec<String>>  = ("Enable Cargo to compile the standard library itself as part of a crate graph compilation"),
     build_std_features: Option<Vec<String>>  = ("Configure features enabled for the standard library itself when building the standard library"),
+    cargo_lints: bool = ("Enable the `[lints.cargo]` table"),
     check_cfg: bool = ("Enable compile-time checking of `cfg` names/values/features"),
     codegen_backend: bool = ("Enable the `codegen-backend` option in profiles in .cargo/config.toml file"),
     config_include: bool = ("Enable the `include` key in config files"),
@@ -1117,6 +1118,7 @@ impl CliUnstable {
                 self.build_std = Some(crate::core::compiler::standard_lib::parse_unstable_flag(v))
             }
             "build-std-features" => self.build_std_features = Some(parse_features(v)),
+            "cargo-lints" => self.cargo_lints = parse_empty(k, v)?,
             "check-cfg" => {
                 self.check_cfg = parse_empty(k, v)?;
             }

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -1,0 +1,226 @@
+use crate::core::FeatureValue::Dep;
+use crate::core::{Edition, FeatureValue, Package};
+use crate::util::interning::InternedString;
+use crate::{CargoResult, GlobalContext};
+use annotate_snippets::{Level, Renderer, Snippet};
+use cargo_util_schemas::manifest::{TomlLintLevel, TomlToolLints};
+use pathdiff::diff_paths;
+use std::collections::HashSet;
+use std::ops::Range;
+use std::path::Path;
+use toml_edit::ImDocument;
+
+fn get_span(document: &ImDocument<String>, path: &[&str], get_value: bool) -> Option<Range<usize>> {
+    let mut table = document.as_item().as_table_like().unwrap();
+    let mut iter = path.into_iter().peekable();
+    while let Some(key) = iter.next() {
+        let (key, item) = table.get_key_value(key).unwrap();
+        if iter.peek().is_none() {
+            return if get_value {
+                item.span()
+            } else {
+                let leaf_decor = key.dotted_decor();
+                let leaf_prefix_span = leaf_decor.prefix().and_then(|p| p.span());
+                let leaf_suffix_span = leaf_decor.suffix().and_then(|s| s.span());
+                if let (Some(leaf_prefix_span), Some(leaf_suffix_span)) =
+                    (leaf_prefix_span, leaf_suffix_span)
+                {
+                    Some(leaf_prefix_span.start..leaf_suffix_span.end)
+                } else {
+                    key.span()
+                }
+            };
+        }
+        if item.is_table_like() {
+            table = item.as_table_like().unwrap();
+        }
+        if item.is_array() && iter.peek().is_some() {
+            let array = item.as_array().unwrap();
+            let next = iter.next().unwrap();
+            return array.iter().find_map(|item| {
+                if next == &item.to_string() {
+                    item.span()
+                } else {
+                    None
+                }
+            });
+        }
+    }
+    None
+}
+
+/// Gets the relative path to a manifest from the current working directory, or
+/// the absolute path of the manifest if a relative path cannot be constructed
+fn rel_cwd_manifest_path(path: &Path, gctx: &GlobalContext) -> String {
+    diff_paths(path, gctx.cwd())
+        .unwrap_or_else(|| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
+#[derive(Copy, Clone, Debug)]
+pub struct LintGroup {
+    pub name: &'static str,
+    pub default_level: LintLevel,
+    pub desc: &'static str,
+    pub edition_lint_opts: Option<(Edition, LintLevel)>,
+}
+
+const RUST_2024_COMPATIBILITY: LintGroup = LintGroup {
+    name: "rust-2024-compatibility",
+    default_level: LintLevel::Allow,
+    desc: "warn about compatibility with Rust 2024",
+    edition_lint_opts: Some((Edition::Edition2024, LintLevel::Deny)),
+};
+
+#[derive(Copy, Clone, Debug)]
+pub struct Lint {
+    pub name: &'static str,
+    pub desc: &'static str,
+    pub groups: &'static [LintGroup],
+    pub default_level: LintLevel,
+    pub edition_lint_opts: Option<(Edition, LintLevel)>,
+}
+
+impl Lint {
+    pub fn level(&self, lints: &TomlToolLints, edition: Edition) -> LintLevel {
+        let level = self
+            .groups
+            .iter()
+            .map(|g| g.name)
+            .chain(std::iter::once(self.name))
+            .filter_map(|n| lints.get(n).map(|l| (n, l)))
+            .max_by_key(|(n, l)| (l.priority(), std::cmp::Reverse(*n)));
+
+        match level {
+            Some((_, toml_lint)) => toml_lint.level().into(),
+            None => {
+                if let Some((lint_edition, lint_level)) = self.edition_lint_opts {
+                    if edition >= lint_edition {
+                        return lint_level;
+                    }
+                }
+                self.default_level
+            }
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum LintLevel {
+    Allow,
+    Warn,
+    Deny,
+    Forbid,
+}
+
+impl LintLevel {
+    pub fn to_diagnostic_level(self) -> Level {
+        match self {
+            LintLevel::Allow => Level::Note,
+            LintLevel::Warn => Level::Warning,
+            LintLevel::Deny => Level::Error,
+            LintLevel::Forbid => Level::Error,
+        }
+    }
+}
+
+impl From<TomlLintLevel> for LintLevel {
+    fn from(toml_lint_level: TomlLintLevel) -> LintLevel {
+        match toml_lint_level {
+            TomlLintLevel::Allow => LintLevel::Allow,
+            TomlLintLevel::Warn => LintLevel::Warn,
+            TomlLintLevel::Deny => LintLevel::Deny,
+            TomlLintLevel::Forbid => LintLevel::Forbid,
+        }
+    }
+}
+
+/// By default, cargo will treat any optional dependency as a [feature]. As of
+/// cargo 1.60, these can be disabled by declaring a feature that activates the
+/// optional dependency as `dep:<name>` (see [RFC #3143]).
+///
+/// In the 2024 edition, `cargo` will stop exposing optional dependencies as
+/// features implicitly, requiring users to add `foo = ["dep:foo"]` if they
+/// still want it exposed.
+///
+/// For more information, see [RFC #3491]
+///
+/// [feature]: https://doc.rust-lang.org/cargo/reference/features.html
+/// [RFC #3143]: https://rust-lang.github.io/rfcs/3143-cargo-weak-namespaced-features.html
+/// [RFC #3491]: https://rust-lang.github.io/rfcs/3491-remove-implicit-features.html
+const IMPLICIT_FEATURES: Lint = Lint {
+    name: "implicit-features",
+    desc: "warn about the use of unstable features",
+    groups: &[RUST_2024_COMPATIBILITY],
+    default_level: LintLevel::Allow,
+    edition_lint_opts: Some((Edition::Edition2024, LintLevel::Deny)),
+};
+
+pub fn check_implicit_features(
+    pkg: &Package,
+    path: &Path,
+    lints: &TomlToolLints,
+    error_count: &mut usize,
+    gctx: &GlobalContext,
+) -> CargoResult<()> {
+    let lint_level = IMPLICIT_FEATURES.level(lints, pkg.manifest().edition());
+    if lint_level == LintLevel::Allow {
+        return Ok(());
+    }
+
+    let manifest = pkg.manifest();
+    let user_defined_features = manifest.resolved_toml().features();
+    let features = user_defined_features.map_or(HashSet::new(), |f| {
+        f.keys().map(|k| InternedString::new(&k)).collect()
+    });
+    // Add implicit features for optional dependencies if they weren't
+    // explicitly listed anywhere.
+    let explicitly_listed = user_defined_features.map_or(HashSet::new(), |f| {
+        f.values()
+            .flatten()
+            .filter_map(|v| match FeatureValue::new(v.into()) {
+                Dep { dep_name } => Some(dep_name),
+                _ => None,
+            })
+            .collect()
+    });
+
+    for dep in manifest.dependencies() {
+        let dep_name_in_toml = dep.name_in_toml();
+        if !dep.is_optional()
+            || features.contains(&dep_name_in_toml)
+            || explicitly_listed.contains(&dep_name_in_toml)
+        {
+            continue;
+        }
+        if lint_level == LintLevel::Forbid || lint_level == LintLevel::Deny {
+            *error_count += 1;
+        }
+        let level = lint_level.to_diagnostic_level();
+        let manifest_path = rel_cwd_manifest_path(path, gctx);
+        let message = level.title("unused optional dependency").snippet(
+            Snippet::source(manifest.contents())
+                .origin(&manifest_path)
+                .annotation(
+                    level.span(
+                        get_span(
+                            manifest.document(),
+                            &["dependencies", &dep_name_in_toml],
+                            false,
+                        )
+                        .unwrap(),
+                    ),
+                )
+                .fold(true),
+        );
+        let renderer = Renderer::styled().term_width(
+            gctx.shell()
+                .err_width()
+                .diagnostic_terminal_width()
+                .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
+        );
+        writeln!(gctx.shell().err(), "{}", renderer.render(message))?;
+    }
+    Ok(())
+}

--- a/src/cargo/util/mod.rs
+++ b/src/cargo/util/mod.rs
@@ -51,6 +51,7 @@ pub mod into_url;
 mod into_url_with_base;
 mod io;
 pub mod job;
+pub mod lints;
 mod lockserver;
 pub mod machine_message;
 pub mod network;

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1230px" height="740px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1230px" height="758px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -37,67 +37,69 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z build-std-features     </tspan><tspan>  Configure features enabled for the standard library itself when building the standard library</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z check-cfg              </tspan><tspan>  Enable compile-time checking of `cfg` names/values/features</tspan>
+    <tspan x="10px" y="190px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z cargo-lints            </tspan><tspan>  Enable the `[lints.cargo]` table</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z codegen-backend        </tspan><tspan>  Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="208px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z check-cfg              </tspan><tspan>  Enable compile-time checking of `cfg` names/values/features</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z config-include         </tspan><tspan>  Enable the `include` key in config files</tspan>
+    <tspan x="10px" y="226px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z codegen-backend        </tspan><tspan>  Enable the `codegen-backend` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z direct-minimal-versions</tspan><tspan>  Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
+    <tspan x="10px" y="244px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z config-include         </tspan><tspan>  Enable the `include` key in config files</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z doctest-xcompile       </tspan><tspan>  Compile and run doctests for non-host target using runner config</tspan>
+    <tspan x="10px" y="262px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z direct-minimal-versions</tspan><tspan>  Resolve minimal dependency versions instead of maximum (direct dependencies only)</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z dual-proc-macros       </tspan><tspan>  Build proc-macros for both the host and the target</tspan>
+    <tspan x="10px" y="280px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z doctest-xcompile       </tspan><tspan>  Compile and run doctests for non-host target using runner config</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z gc                     </tspan><tspan>  Track cache usage and "garbage collect" unused files</tspan>
+    <tspan x="10px" y="298px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z dual-proc-macros       </tspan><tspan>  Build proc-macros for both the host and the target</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z git                    </tspan><tspan>  Enable support for shallow git fetch operations</tspan>
+    <tspan x="10px" y="316px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z gc                     </tspan><tspan>  Track cache usage and "garbage collect" unused files</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z gitoxide               </tspan><tspan>  Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
+    <tspan x="10px" y="334px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z git                    </tspan><tspan>  Enable support for shallow git fetch operations</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z host-config            </tspan><tspan>  Enable the `[host]` section in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="352px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z gitoxide               </tspan><tspan>  Use gitoxide for the given git interactions, or all of them if no argument is given</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z lints                  </tspan><tspan>  Pass `[lints]` to the linting tools</tspan>
+    <tspan x="10px" y="370px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z host-config            </tspan><tspan>  Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z minimal-versions       </tspan><tspan>  Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="388px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z lints                  </tspan><tspan>  Pass `[lints]` to the linting tools</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z msrv-policy            </tspan><tspan>  Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="406px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z minimal-versions       </tspan><tspan>  Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z mtime-on-use           </tspan><tspan>  Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="424px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z msrv-policy            </tspan><tspan>  Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z no-index-update        </tspan><tspan>  Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="442px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z mtime-on-use           </tspan><tspan>  Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z panic-abort-tests      </tspan><tspan>  Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="460px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z no-index-update        </tspan><tspan>  Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z precise-pre-release    </tspan><tspan>  Enable pre-release versions to be selected with `update --precise`</tspan>
+    <tspan x="10px" y="478px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z panic-abort-tests      </tspan><tspan>  Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z profile-rustflags      </tspan><tspan>  Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="496px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z precise-pre-release    </tspan><tspan>  Enable pre-release versions to be selected with `update --precise`</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z public-dependency      </tspan><tspan>  Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="514px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z profile-rustflags      </tspan><tspan>  Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z publish-timeout        </tspan><tspan>  Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="532px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z public-dependency      </tspan><tspan>  Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-map            </tspan><tspan>  Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="550px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z publish-timeout        </tspan><tspan>  Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-scrape-examples</tspan><tspan>  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="568px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-map            </tspan><tspan>  Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z script                 </tspan><tspan>  Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="586px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-scrape-examples</tspan><tspan>  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z target-applies-to-host </tspan><tspan>  Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="604px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z script                 </tspan><tspan>  Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z trim-paths             </tspan><tspan>  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="622px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z target-applies-to-host </tspan><tspan>  Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z unstable-options       </tspan><tspan>  Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="640px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z trim-paths             </tspan><tspan>  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="658px">
+    <tspan x="10px" y="658px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z unstable-options       </tspan><tspan>  Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>Run with `</tspan><tspan class="fg-cyan bold">cargo -Z</tspan><tspan> </tspan><tspan class="fg-cyan">[FLAG] [COMMAND]</tspan><tspan>`</tspan>
+    <tspan x="10px" y="676px">
 </tspan>
-    <tspan x="10px" y="694px">
+    <tspan x="10px" y="694px"><tspan>Run with `</tspan><tspan class="fg-cyan bold">cargo -Z</tspan><tspan> </tspan><tspan class="fg-cyan">[FLAG] [COMMAND]</tspan><tspan>`</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+    <tspan x="10px" y="712px">
 </tspan>
-    <tspan x="10px" y="730px">
+    <tspan x="10px" y="730px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
+</tspan>
+    <tspan x="10px" y="748px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints/implicit_features/edition_2021/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2021/mod.rs
@@ -1,0 +1,34 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+
+#[cargo_test]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("--quiet")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(str![""]);
+}

--- a/tests/testsuite/lints/implicit_features/edition_2021_warn/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2021_warn/mod.rs
@@ -1,0 +1,37 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+
+[lints.cargo]
+implicit-features = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("--quiet")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/implicit_features/edition_2021_warn/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/edition_2021_warn/stderr.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unused optional dependency</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:8:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">8 |</tspan><tspan> bar = { version = "0.1.0", optional = true }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-yellow bold"> ---</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/implicit_features/edition_2024/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2024/mod.rs
@@ -1,0 +1,39 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    Package::new("baz", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+cargo-features = ["edition2024"]
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+baz = { version = "0.1.0", optional = true }
+
+[features]
+baz = ["dep:baz"]
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .assert()
+        .code(101)
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/implicit_features/edition_2024/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/edition_2024/stderr.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">unused optional dependency</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> bar = { version = "0.1.0", optional = true }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-bright-red bold"> ^^^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/implicit_features/mod.rs
+++ b/tests/testsuite/lints/implicit_features/mod.rs
@@ -1,0 +1,4 @@
+mod edition_2021;
+mod edition_2021_warn;
+mod edition_2024;
+mod warn;

--- a/tests/testsuite/lints/implicit_features/warn/mod.rs
+++ b/tests/testsuite/lints/implicit_features/warn/mod.rs
@@ -1,0 +1,38 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+cargo-features = ["edition2024"]
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+
+[lints.cargo]
+implicit-features = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("--quiet")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/implicit_features/warn/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/warn/stderr.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unused optional dependency</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> bar = { version = "0.1.0", optional = true }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-yellow bold"> ---</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -1,0 +1,2 @@
+mod implicit_features;
+mod rust_2024_compatibility;

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021/mod.rs
@@ -1,0 +1,34 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+
+#[cargo_test]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("--quiet")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(str![""]);
+}

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/mod.rs
@@ -1,0 +1,37 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+
+[lints.cargo]
+rust-2024-compatibility = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("--quiet")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/stderr.term.svg
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/stderr.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unused optional dependency</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:8:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">8 |</tspan><tspan> bar = { version = "0.1.0", optional = true }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-yellow bold"> ---</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2024/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2024/mod.rs
@@ -1,0 +1,34 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+cargo-features = ["edition2024"]
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .assert()
+        .code(101)
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2024/stderr.term.svg
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2024/stderr.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-red { fill: #FF5555 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error</tspan><tspan>: </tspan><tspan class="bold">unused optional dependency</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> bar = { version = "0.1.0", optional = true }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-bright-red bold"> ^^^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/rust_2024_compatibility/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/mod.rs
@@ -1,0 +1,4 @@
+mod edition_2021;
+mod edition_2021_warn;
+mod edition_2024;
+mod warn;

--- a/tests/testsuite/lints/rust_2024_compatibility/warn/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/warn/mod.rs
@@ -1,0 +1,38 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::registry::Package;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn case() {
+    Package::new("bar", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+cargo-features = ["edition2024"]
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+bar = { version = "0.1.0", optional = true }
+
+[lints.cargo]
+rust-2024-compatibility = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("--quiet")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/rust_2024_compatibility/warn/stderr.term.svg
+++ b/tests/testsuite/lints/rust_2024_compatibility/warn/stderr.term.svg
@@ -1,0 +1,38 @@
+<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unused optional dependency</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> bar = { version = "0.1.0", optional = true }</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-yellow bold"> ---</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -107,6 +107,7 @@ mod inheritable_workspace_fields;
 mod install;
 mod install_upgrade;
 mod jobserver;
+mod lints;
 mod lints_table;
 mod list_availables;
 mod local_registry;


### PR DESCRIPTION
This PR adds a basic linting system, the first step towards [User control over cargo warnings](https://github.com/rust-lang/cargo/issues/12235). To demonstrate the system, a lint for #12826 is added. It supports controlling cargo lints via the `[lints.cargo]` table. Lints can be controlled either by a group or individually.

This is meant to lay down some fundamental infrastructure for the whole linting system and is not meant to be fully featured. Over time, features will be added that will help us reach a much more solid state.