### PR TITLE
docs: remove untrue TODO for `native_dirs`

### DIFF
--- a/src/cargo/core/compiler/compilation.rs
+++ b/src/cargo/core/compiler/compilation.rs
@@ -140,7 +140,6 @@ impl<'gctx> Compilation<'gctx> {
         }
 
         Ok(Compilation {
-            // TODO: deprecated; remove.
             native_dirs: BTreeSet::new(),
             root_output: HashMap::new(),
             deps_output: HashMap::new(),


### PR DESCRIPTION
`native_dirs` is still in use.