### PR TITLE
fix: Warn on -Zlints

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -762,7 +762,6 @@ unstable_cli_options!(
     git: Option<GitFeatures> = ("Enable support for shallow git fetch operations"),
     gitoxide: Option<GitoxideFeatures> = ("Use gitoxide for the given git interactions, or all of them if no argument is given"),
     host_config: bool = ("Enable the `[host]` section in the .cargo/config.toml file"),
-    lints: bool = ("Pass `[lints]` to the linting tools"),
     minimal_versions: bool = ("Resolve minimal dependency versions instead of maximum"),
     msrv_policy: bool = ("Enable rust-version aware policy within cargo"),
     mtime_on_use: bool = ("Configure Cargo to update the mtime of used files"),
@@ -852,6 +851,8 @@ const STABILIZED_CREDENTIAL_PROCESS: &str =
 
 const STABILIZED_REGISTRY_AUTH: &str =
     "Authenticated registries are available if a credential provider is configured.";
+
+const STABILIZED_LINTS: &str = "The `[lints]` table is now always available.";
 
 fn deserialize_build_std<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
 where
@@ -1105,6 +1106,7 @@ impl CliUnstable {
             "terminal-width" => stabilized_warn(k, "1.68", STABILIZED_TERMINAL_WIDTH),
             "doctest-in-workspace" => stabilized_warn(k, "1.72", STABILIZED_DOCTEST_IN_WORKSPACE),
             "credential-process" => stabilized_warn(k, "1.74", STABILIZED_CREDENTIAL_PROCESS),
+            "lints" => stabilized_warn(k, "1.74", STABILIZED_LINTS),
             "registry-auth" => stabilized_warn(k, "1.74", STABILIZED_REGISTRY_AUTH),
 
             // Unstable features
@@ -1141,7 +1143,6 @@ impl CliUnstable {
                 )?
             }
             "host-config" => self.host_config = parse_empty(k, v)?,
-            "lints" => self.lints = parse_empty(k, v)?,
             "next-lockfile-bump" => self.next_lockfile_bump = parse_empty(k, v)?,
             "minimal-versions" => self.minimal_versions = parse_empty(k, v)?,
             "msrv-policy" => self.msrv_policy = parse_empty(k, v)?,

--- a/tests/testsuite/cargo/z_help/stdout.term.svg
+++ b/tests/testsuite/cargo/z_help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="1230px" height="758px" xmlns="http://www.w3.org/2000/svg">
+<svg width="1230px" height="740px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -59,47 +59,45 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z host-config            </tspan><tspan>  Enable the `[host]` section in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z lints                  </tspan><tspan>  Pass `[lints]` to the linting tools</tspan>
+    <tspan x="10px" y="388px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z minimal-versions       </tspan><tspan>  Resolve minimal dependency versions instead of maximum</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z minimal-versions       </tspan><tspan>  Resolve minimal dependency versions instead of maximum</tspan>
+    <tspan x="10px" y="406px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z msrv-policy            </tspan><tspan>  Enable rust-version aware policy within cargo</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z msrv-policy            </tspan><tspan>  Enable rust-version aware policy within cargo</tspan>
+    <tspan x="10px" y="424px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z mtime-on-use           </tspan><tspan>  Configure Cargo to update the mtime of used files</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z mtime-on-use           </tspan><tspan>  Configure Cargo to update the mtime of used files</tspan>
+    <tspan x="10px" y="442px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z no-index-update        </tspan><tspan>  Do not update the registry index even if the cache is outdated</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z no-index-update        </tspan><tspan>  Do not update the registry index even if the cache is outdated</tspan>
+    <tspan x="10px" y="460px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z panic-abort-tests      </tspan><tspan>  Enable support to run tests with -Cpanic=abort</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z panic-abort-tests      </tspan><tspan>  Enable support to run tests with -Cpanic=abort</tspan>
+    <tspan x="10px" y="478px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z precise-pre-release    </tspan><tspan>  Enable pre-release versions to be selected with `update --precise`</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z precise-pre-release    </tspan><tspan>  Enable pre-release versions to be selected with `update --precise`</tspan>
+    <tspan x="10px" y="496px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z profile-rustflags      </tspan><tspan>  Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z profile-rustflags      </tspan><tspan>  Enable the `rustflags` option in profiles in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="514px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z public-dependency      </tspan><tspan>  Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z public-dependency      </tspan><tspan>  Respect a dependency's `public` field in Cargo.toml to control public/private dependencies</tspan>
+    <tspan x="10px" y="532px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z publish-timeout        </tspan><tspan>  Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z publish-timeout        </tspan><tspan>  Enable the `publish.timeout` key in .cargo/config.toml file</tspan>
+    <tspan x="10px" y="550px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-map            </tspan><tspan>  Allow passing external documentation mappings to rustdoc</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-map            </tspan><tspan>  Allow passing external documentation mappings to rustdoc</tspan>
+    <tspan x="10px" y="568px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-scrape-examples</tspan><tspan>  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z rustdoc-scrape-examples</tspan><tspan>  Allows Rustdoc to scrape code examples from reverse-dependencies</tspan>
+    <tspan x="10px" y="586px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z script                 </tspan><tspan>  Enable support for single-file, `.rs` packages</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z script                 </tspan><tspan>  Enable support for single-file, `.rs` packages</tspan>
+    <tspan x="10px" y="604px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z target-applies-to-host </tspan><tspan>  Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z target-applies-to-host </tspan><tspan>  Enable the `target-applies-to-host` key in the .cargo/config.toml file</tspan>
+    <tspan x="10px" y="622px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z trim-paths             </tspan><tspan>  Enable the `trim-paths` option in profiles</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z trim-paths             </tspan><tspan>  Enable the `trim-paths` option in profiles</tspan>
+    <tspan x="10px" y="640px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z unstable-options       </tspan><tspan>  Allow the usage of unstable options</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    </tspan><tspan class="fg-cyan bold">-Z unstable-options       </tspan><tspan>  Allow the usage of unstable options</tspan>
+    <tspan x="10px" y="658px">
 </tspan>
-    <tspan x="10px" y="676px">
+    <tspan x="10px" y="676px"><tspan>Run with `</tspan><tspan class="fg-cyan bold">cargo -Z</tspan><tspan> </tspan><tspan class="fg-cyan">[FLAG] [COMMAND]</tspan><tspan>`</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>Run with `</tspan><tspan class="fg-cyan bold">cargo -Z</tspan><tspan> </tspan><tspan class="fg-cyan">[FLAG] [COMMAND]</tspan><tspan>`</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
-    <tspan x="10px" y="712px">
+    <tspan x="10px" y="712px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html for more information about these flags.</tspan>
-</tspan>
-    <tspan x="10px" y="748px">
+    <tspan x="10px" y="730px">
 </tspan>
   </text>
 


### PR DESCRIPTION
When the `[lints]` table was stabilized in #12648, it appears that making `-Zlints` into a warning when specified was missed, this PR fixes that.