### PR TITLE
refactor: Make lint names snake_case

### DIFF
--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -67,7 +67,7 @@ pub struct LintGroup {
 }
 
 const RUST_2024_COMPATIBILITY: LintGroup = LintGroup {
-    name: "rust-2024-compatibility",
+    name: "rust_2024_compatibility",
     default_level: LintLevel::Allow,
     desc: "warn about compatibility with Rust 2024",
     edition_lint_opts: Some((Edition::Edition2024, LintLevel::Deny)),
@@ -150,7 +150,7 @@ impl From<TomlLintLevel> for LintLevel {
 /// [RFC #3143]: https://rust-lang.github.io/rfcs/3143-cargo-weak-namespaced-features.html
 /// [RFC #3491]: https://rust-lang.github.io/rfcs/3491-remove-implicit-features.html
 const IMPLICIT_FEATURES: Lint = Lint {
-    name: "implicit-features",
+    name: "implicit_features",
     desc: "warn about the use of unstable features",
     groups: &[RUST_2024_COMPATIBILITY],
     default_level: LintLevel::Allow,

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -846,3 +846,45 @@ fn cargo_lints_success() {
         )
         .run();
 }
+
+#[cargo_test]
+fn cargo_lints_underscore_supported() {
+    Package::new("bar", "0.1.0").publish();
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2021"
+                authors = []
+
+                [lints.cargo]
+                "implicit_features" = "warn"
+
+                [dependencies]
+                bar = { version = "0.1.0", optional = true }
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    foo.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["-Zcargo-lints"])
+        .with_stderr(
+            "\
+warning: unused optional dependency
+  --> Cargo.toml:12:17
+   |
+12 |                 bar = { version = \"0.1.0\", optional = true }
+   |                 ---
+   |
+[UPDATING] `dummy-registry` index
+[LOCKING] [..]
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
When working on #13621, I somehow missed that lint names should be `snake_case` according to the [`rustc-dev-guide`](https://rustc-dev-guide.rust-lang.org/diagnostics.html#lint-naming) as well as [`RFC #344`](https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints). 

This PR renames: 
- `implicit-features` => `implicit_featires`
- `rust-2024-compatibility` => `rust_2024_compatibility`. 

<hr>

Note: We should probably have some tooling to enforce this, but I was unsure if it belonged to this PR or another one. One solution would be to use a macro to create the `const LINT_NAME: Lint = {...}`, where `LINT_NAME` would be the `ident` as well as the `name: &'static str` and then have a method on `Lint` to make it lowercase as needed. This is what `rustc` does, and it could work well here. It would ensure snake case as `const` names need to be [`SCREAMING_SNAKE_CASE`](https://rust-lang.github.io/rfcs/0430-finalizing-naming-conventions.html#general-naming-conventions), or a warning is shown.