### PR TITLE
Update book: Rust 1.77 changed the default behaviour on debug symbol stripping

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -113,11 +113,12 @@ strip either symbols or debuginfo from a binary. This can be enabled like so:
 # ...
 
 [profile.release]
-strip = "debuginfo"
+strip = "symbols"
 ```
 
 Possible string values of `strip` are `"none"`, `"debuginfo"`, and `"symbols"`.
-The default is `"none"`.
+For debug profiles the default is `"none"`, and for profiles with `debug = false` 
+the default is `"debuginfo"`.
 
 You can also configure this option with the boolean values `true` or `false`.
 `strip = true` is equivalent to `strip = "symbols"`. `strip = false` is
@@ -293,7 +294,7 @@ The default settings for the `release` profile are:
 opt-level = 3
 debug = false
 split-debuginfo = '...'  # Platform-specific.
-strip = "none"
+strip = "debuginfo" 
 debug-assertions = false
 overflow-checks = false
 lto = false


### PR DESCRIPTION
[Rust 1.77](https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#enable-strip-in-release-profiles-by-default) changed the default behaviour on debug symbols stripping. That change seems not to be yet updated to the book, which this PR fixes.
