### PR TITLE
Add `unknown-lints` lint

### DIFF
--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -155,31 +155,14 @@ pub fn unknown_lints(
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
-    let edition = match maybe_pkg {
-        MaybePackage::Package(pkg) => pkg.manifest().edition(),
-        MaybePackage::Virtual(_) => Edition::default(),
-    };
-
-    let lint_level = UNKNOWN_LINTS.level(resolved_lints, edition);
+    let lint_level = UNKNOWN_LINTS.level(resolved_lints, maybe_pkg.edition());
     if lint_level == LintLevel::Allow {
         return Ok(());
     }
 
-    let original_toml = match maybe_pkg {
-        MaybePackage::Package(pkg) => pkg.manifest().original_toml(),
-        MaybePackage::Virtual(vm) => vm.original_toml(),
-    };
-
-    let contents = match maybe_pkg {
-        MaybePackage::Package(pkg) => pkg.manifest().contents(),
-        MaybePackage::Virtual(vm) => vm.contents(),
-    };
-
-    let document = match maybe_pkg {
-        MaybePackage::Package(pkg) => pkg.manifest().document(),
-        MaybePackage::Virtual(vm) => vm.document(),
-    };
-
+    let original_toml = maybe_pkg.original_toml();
+    let contents = maybe_pkg.contents();
+    let document = maybe_pkg.document();
     let renderer = Renderer::styled().term_width(
         gctx.shell()
             .err_width()

--- a/tests/testsuite/lints/implicit_features/edition_2021/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2021/mod.rs
@@ -1,7 +1,7 @@
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
-use cargo_test_support::str;
+use cargo_test_support::{file, str};
 
 #[cargo_test]
 fn case() {
@@ -23,12 +23,10 @@ bar = { version = "0.1.0", optional = true }
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
         .current_dir(p.root())
         .arg("check")
-        .arg("--quiet")
         .assert()
         .success()
         .stdout_matches(str![""])
-        .stderr_matches(str![""]);
+        .stderr_matches(file!["stderr.term.svg"]);
 }

--- a/tests/testsuite/lints/implicit_features/edition_2021/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/edition_2021/stderr.term.svg
@@ -1,0 +1,33 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Finished</tspan><tspan>[..]</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/implicit_features/edition_2021_warn/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2021_warn/mod.rs
@@ -26,10 +26,10 @@ implicit-features = "warn"
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .current_dir(p.root())
         .arg("check")
-        .arg("--quiet")
+        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_matches(str![""])

--- a/tests/testsuite/lints/implicit_features/edition_2021_warn/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/edition_2021_warn/stderr.term.svg
@@ -1,8 +1,9 @@
-<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
+    .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -31,7 +32,15 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-green bold">    Finished</tspan><tspan>[..]</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints/implicit_features/edition_2024/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2024/mod.rs
@@ -29,7 +29,7 @@ baz = ["dep:baz"]
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .masquerade_as_nightly_cargo(&["edition2024"])
         .current_dir(p.root())
         .arg("check")
         .assert()

--- a/tests/testsuite/lints/implicit_features/warn/mod.rs
+++ b/tests/testsuite/lints/implicit_features/warn/mod.rs
@@ -27,10 +27,10 @@ implicit-features = "warn"
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .current_dir(p.root())
         .arg("check")
-        .arg("--quiet")
+        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_matches(str![""])

--- a/tests/testsuite/lints/implicit_features/warn/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/warn/stderr.term.svg
@@ -1,8 +1,9 @@
-<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
+    .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -31,7 +32,15 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-green bold">    Finished</tspan><tspan>[..]</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -1,2 +1,3 @@
 mod implicit_features;
 mod rust_2024_compatibility;
+mod unknown_lints;

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021/mod.rs
@@ -1,7 +1,7 @@
 use cargo_test_support::prelude::*;
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
-use cargo_test_support::str;
+use cargo_test_support::{file, str};
 
 #[cargo_test]
 fn case() {
@@ -23,12 +23,10 @@ bar = { version = "0.1.0", optional = true }
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
         .current_dir(p.root())
         .arg("check")
-        .arg("--quiet")
         .assert()
         .success()
         .stdout_matches(str![""])
-        .stderr_matches(str![""]);
+        .stderr_matches(file!["stderr.term.svg"]);
 }

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021/stderr.term.svg
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021/stderr.term.svg
@@ -1,0 +1,33 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">    Finished</tspan><tspan>[..]</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/mod.rs
@@ -26,10 +26,10 @@ rust-2024-compatibility = "warn"
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
         .current_dir(p.root())
         .arg("check")
-        .arg("--quiet")
+        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_matches(str![""])

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/stderr.term.svg
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2021_warn/stderr.term.svg
@@ -1,8 +1,9 @@
-<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
+    .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -31,7 +32,15 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-green bold">    Finished</tspan><tspan>[..]</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints/rust_2024_compatibility/edition_2024/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/edition_2024/mod.rs
@@ -24,9 +24,10 @@ bar = { version = "0.1.0", optional = true }
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .masquerade_as_nightly_cargo(&["edition2024"])
         .current_dir(p.root())
         .arg("check")
+        .arg("-Zcargo-lints")
         .assert()
         .code(101)
         .stdout_matches(str![""])

--- a/tests/testsuite/lints/rust_2024_compatibility/warn/mod.rs
+++ b/tests/testsuite/lints/rust_2024_compatibility/warn/mod.rs
@@ -27,10 +27,10 @@ rust-2024-compatibility = "warn"
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["always_nightly"])
+        .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .current_dir(p.root())
         .arg("check")
-        .arg("--quiet")
+        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_matches(str![""])

--- a/tests/testsuite/lints/rust_2024_compatibility/warn/stderr.term.svg
+++ b/tests/testsuite/lints/rust_2024_compatibility/warn/stderr.term.svg
@@ -1,8 +1,9 @@
-<svg width="740px" height="146px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
     .fg-bright-blue { fill: #5555FF }
+    .fg-green { fill: #00AA00 }
     .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
@@ -31,7 +32,15 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px">
+    <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-green bold">    Finished</tspan><tspan>[..]</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
 </tspan>
   </text>
 

--- a/tests/testsuite/lints/unknown_lints/default/mod.rs
+++ b/tests/testsuite/lints/unknown_lints/default/mod.rs
@@ -1,0 +1,35 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::project;
+use cargo_test_support::{file, str};
+
+#[cargo_test]
+fn case() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace.lints.cargo]
+this-lint-does-not-exist-ws = "warn"
+
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2021"
+
+[lints.cargo]
+this-lint-does-not-exist = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("-Zcargo-lints")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/unknown_lints/default/stderr.term.svg
+++ b/tests/testsuite/lints/unknown_lints/default/stderr.term.svg
@@ -1,0 +1,55 @@
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-green { fill: #00AA00 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unknown lint: `this-lint-does-not-exist-ws`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:3:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">3 |</tspan><tspan> this-lint-does-not-exist-ws = "warn"</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-yellow bold"> ---------------------------</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unknown lint: `this-lint-does-not-exist`</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:11:1</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-blue bold">11 |</tspan><tspan> this-lint-does-not-exist = "warn"</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-blue bold">   |</tspan><tspan class="fg-yellow bold"> ------------------------</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-blue bold">   |</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-green bold">    Finished</tspan><tspan> [..]</tspan>
+</tspan>
+    <tspan x="10px" y="280px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/unknown_lints/mod.rs
+++ b/tests/testsuite/lints/unknown_lints/mod.rs
@@ -1,0 +1,1 @@
+mod default;

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -763,7 +763,6 @@ fn cargo_lints_nightly_required() {
                 authors = []
 
                 [lints.cargo]
-                "unused-features" = "deny"
             "#,
         )
         .file("src/lib.rs", "")
@@ -797,7 +796,6 @@ fn cargo_lints_no_z_flag() {
                 authors = []
 
                 [lints.cargo]
-                "unused-features" = "deny"
             "#,
         )
         .file("src/lib.rs", "")
@@ -830,7 +828,6 @@ fn cargo_lints_success() {
                 authors = []
 
                 [lints.cargo]
-                "unused-features" = "deny"
             "#,
         )
         .file("src/lib.rs", "")


### PR DESCRIPTION
This PR adds a lint for `unknown-lints` similar [`rustc::unknown-lints`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unknown-lints). This will help users know when they are passing something to `cargo` that `cargo` doesn't understand.