### PR TITLE
Fix doc collision for lib/bin with a dash in the inferred name.

### DIFF
--- a/src/cargo/ops/cargo_compile/unit_generator.rs
+++ b/src/cargo/ops/cargo_compile/unit_generator.rs
@@ -198,7 +198,9 @@ impl<'a> UnitGenerator<'a, '_> {
                     .filter(|t| {
                         t.documented()
                             && (!t.is_bin()
-                                || !targets.iter().any(|l| l.is_lib() && l.name() == t.name()))
+                                || !targets
+                                    .iter()
+                                    .any(|l| l.is_lib() && l.crate_name() == t.crate_name()))
                     })
                     .collect()
             }

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -488,30 +488,16 @@ fn doc_lib_bin_same_name_with_dash() {
         .file("src/main.rs", "fn main() {}")
         .build();
     p.cargo("doc")
-        .with_stderr_unordered(
+        .with_stderr(
             "\
-warning: output filename collision.
-The bin target `foo-bar` in package `foo-bar v1.0.0 ([ROOT]/foo)` has the same \
-output filename as the lib target `foo_bar` in package `foo-bar v1.0.0 ([ROOT]/foo)`.
-Colliding filename is: [ROOT]/foo/target/doc/foo_bar/index.html
-The output filenames should be unique.
-This is a known bug where multiple crates with the same name use
-the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
-If this looks unexpected, it may be a bug in Cargo. Please file a bug report at
-https://github.com/rust-lang/cargo/issues/ with as much information as you
-can provide.
-cargo [..]
-First unit: [..]
-Second unit: [..]
-[CHECKING] foo-bar v1.0.0 ([ROOT]/foo)
 [DOCUMENTING] foo-bar v1.0.0 ([ROOT]/foo)
 [FINISHED] [..]
-[GENERATED] [ROOT]/foo/target/doc/foo_bar/index.html and 1 other file
+[GENERATED] [ROOT]/foo/target/doc/foo_bar/index.html
 ",
         )
         .run();
     assert!(p.build_dir().join("doc/foo_bar/index.html").exists());
-    assert!(p.build_dir().join("doc/foo_bar/fn.main.html").exists());
+    assert!(!p.build_dir().join("doc/foo_bar/fn.main.html").exists());
 }
 
 #[cargo_test]


### PR DESCRIPTION
This fixes an issue where `cargo doc` would report a collision if the project has a `-` in the name, and both a lib and bin. As a consequence of the change in #12783, the target name for the library no longer has a `-`. The code that checks for the lib/bin doc collision was only checking if the target names were equal, which is no longer the case after #12783. The solution here is to use the `crate_name` and not the target name, which has the appropriate `_` translation done. This is the more correct method to use, even before #12783, because rustdoc uses crate names, not target names (and thus even documenting bins have their filenames converted to underscores).

Fixes #13628