### PR TITLE
feat: Stablize `CARGO_RUSTC_CURRENT_DIR`

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -696,16 +696,14 @@ fn prepare_rustc(build_runner: &BuildRunner<'_, '_>, unit: &Unit) -> CargoResult
         let tmp = build_runner.files().layout(unit.kind).prepare_tmp()?;
         base.env("CARGO_TARGET_TMPDIR", tmp.display().to_string());
     }
-    if build_runner.bcx.gctx.nightly_features_allowed {
-        // This must come after `build_base_args` (which calls `add_path_args`) so that the `cwd`
-        // is set correctly.
-        base.env(
-            "CARGO_RUSTC_CURRENT_DIR",
-            base.get_cwd()
-                .map(|c| c.display().to_string())
-                .unwrap_or(String::new()),
-        );
-    }
+    // This must come after `build_base_args` (which calls `add_path_args`) so that the `cwd`
+    // is set correctly.
+    base.env(
+        "CARGO_RUSTC_CURRENT_DIR",
+        base.get_cwd()
+            .map(|c| c.display().to_string())
+            .unwrap_or(String::new()),
+    );
 
     Ok(base)
 }

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -267,7 +267,7 @@ corresponding environment variable is set to the empty string, `""`.
   where integration tests or benchmarks are free to put any data needed by
   the tests/benches. Cargo initially creates this directory but doesn't
   manage its content in any way, this is the responsibility of the test code.
-* `CARGO_RUSTC_CURRENT_DIR` --- This is a path that `rustc` is invoked from **(nightly only)**.
+* `CARGO_RUSTC_CURRENT_DIR` --- This is a path that `rustc` is invoked from
 
 [Cargo target]: cargo-targets.md
 [binaries]: cargo-targets.md#binaries

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1748,9 +1748,7 @@ fn crate_env_vars() {
     };
 
     println!("build");
-    p.cargo("build -v")
-        .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
-        .run();
+    p.cargo("build -v").run();
 
     println!("bin");
     p.process(&p.bin("foo-bar"))
@@ -1758,20 +1756,14 @@ fn crate_env_vars() {
         .run();
 
     println!("example");
-    p.cargo("run --example ex-env-vars -v")
-        .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
-        .run();
+    p.cargo("run --example ex-env-vars -v").run();
 
     println!("test");
-    p.cargo("test -v")
-        .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
-        .run();
+    p.cargo("test -v").run();
 
     if is_nightly() {
         println!("bench");
-        p.cargo("bench -v")
-            .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
-            .run();
+        p.cargo("bench -v").run();
     }
 }
 
@@ -1857,11 +1849,9 @@ fn cargo_rustc_current_dir_foreign_workspace_dep() {
 
     // Verify it works from a different workspace
     foo.cargo("test -p baz")
-        .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
         .with_stdout_contains("running 1 test\ntest baz_env ... ok")
         .run();
     foo.cargo("test -p baz_member")
-        .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
         .with_stdout_contains("running 1 test\ntest baz_member_env ... ok")
         .run();
 }
@@ -1906,31 +1896,8 @@ fn cargo_rustc_current_dir_non_local_dep() {
         .build();
 
     p.cargo("test -p bar")
-        .masquerade_as_nightly_cargo(&["CARGO_RUSTC_CURRENT_DIR"])
         .with_stdout_contains("running 1 test\ntest bar_env ... ok")
         .run();
-}
-
-#[cargo_test]
-fn cargo_rustc_current_dir_is_not_stable() {
-    if is_nightly() {
-        return;
-    }
-    let p = project()
-        .file(
-            "tests/env.rs",
-            r#"
-                use std::path::Path;
-
-                #[test]
-                fn env() {
-                    assert_eq!(option_env!("CARGO_RUSTC_CURRENT_DIR"), None);
-                }
-            "#,
-        )
-        .build();
-
-    p.cargo("test").run();
 }
 
 #[cargo_test]


### PR DESCRIPTION
This provides what cargo sets as the `current_dir` for the `rustc` process.
While `std::file!` is unspecified in what it is relative to, it is relatively safe, it is generally relative to `rustc`s `current_dir`.

This can be useful for snapshot testing.
For example, `snapbox` has been using this macro on nightly since assert-rs/trycmd#247, falling back to finding a parent of `CARGO_MANIFEST_DIR`, if present.
This has been in use in Cargo since rust-lang/cargo#13441.

This was added in #12996.
Relevant points discussed in that issue:
- This diverged from the original proposal from the Cargo team of having a `CARGO_WORKSPACE_DIR` that is the "workspace" of the package being built (ie registry packages would map to `CARGO_MANIFEST_DIR`). In looking at the `std::file!` use case, `CARGO_MANIFEST_DIR`, no matter how we defined it, would only sort of work because no sane definition of that maps to `rustc`'s `current_dir`.a This instead focuses on the mechanism currently being used.
- Using "current dir" in the name is meant to be consistent with `std::env::current_dir`.
- I can go either way on `CARGO_RUSTC` vs `RUSTC`.  Existing related variables:
  - `RUSTC`
  - `RUSTC_WRAPPER`
  - `RUSTC_WORKSPACE_WRAPPER`
  - `RUSTFLAGS` (no `C`)
  - `CARGO_CACHE_RUSTC_INFO`

Note that #3946 was overly broad and covered many use cases. One of those was for packages to look up information on their dependents.
Issue #13484 is being left open to track that.

Fixes #3946

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
