### PR TITLE
test: Add asserts to catch BorrowMutError's

### DIFF
--- a/src/cargo/core/registry.rs
+++ b/src/cargo/core/registry.rs
@@ -739,6 +739,11 @@ impl<'gctx> Registry for PackageRegistry<'gctx> {
     }
 
     fn block_until_ready(&mut self) -> CargoResult<()> {
+        if cfg!(debug_assertions) {
+            // Force borrow to catch invalid borrows, regardless of which source is used and how it
+            // happens to behave this time
+            self.gctx.shell().verbosity();
+        }
         for (source_id, source) in self.sources.sources_mut() {
             source
                 .block_until_ready()

--- a/src/cargo/util/flock.rs
+++ b/src/cargo/util/flock.rs
@@ -392,6 +392,10 @@ fn acquire(
     lock_try: &dyn Fn() -> io::Result<()>,
     lock_block: &dyn Fn() -> io::Result<()>,
 ) -> CargoResult<()> {
+    if cfg!(debug_assertions) {
+        // Force borrow to catch invalid borrows outside of contention situations
+        gctx.shell().verbosity();
+    }
     if try_acquire(path, lock_try)? {
         return Ok(());
     }


### PR DESCRIPTION
### What does this PR try to resolve?

This intentionally borrows from `RefCell`s before conditional code to try to prevent regressions like #13646 without exhaustively covering every case that could hit these `BorrowMutError`s with complicated tests.

### How should we test and review this PR?

I tested this by ensuring the registry code path panicked before rebasing on top of #13647.
Once I rebased, the panic went away.

### Additional information

Split off from #13649 to try to avoid appveyor