### PR TITLE
[beta-1.78] Do not strip debuginfo by default for MSVC

### DIFF
--- a/src/cargo/ops/cargo_compile/mod.rs
+++ b/src/cargo/ops/cargo_compile/mod.rs
@@ -35,6 +35,7 @@
 //! [`drain_the_queue`]: crate::core::compiler::job_queue
 //! ["Cargo Target"]: https://doc.rust-lang.org/nightly/cargo/reference/cargo-targets.html
 
+use cargo_platform::Cfg;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -442,6 +443,7 @@ pub fn create_bcx<'a, 'gctx>(
             &units,
             &scrape_units,
             host_kind_requested.then_some(explicit_host_kind),
+            &target_data,
         );
     }
 
@@ -573,6 +575,7 @@ fn rebuild_unit_graph_shared(
     roots: &[Unit],
     scrape_units: &[Unit],
     to_host: Option<CompileKind>,
+    target_data: &RustcTargetData<'_>,
 ) -> (Vec<Unit>, Vec<Unit>, UnitGraph) {
     let mut result = UnitGraph::new();
     // Map of the old unit to the new unit, used to avoid recursing into units
@@ -589,6 +592,7 @@ fn rebuild_unit_graph_shared(
                 root,
                 false,
                 to_host,
+                target_data,
             )
         })
         .collect();
@@ -615,6 +619,7 @@ fn traverse_and_share(
     unit: &Unit,
     unit_is_for_host: bool,
     to_host: Option<CompileKind>,
+    target_data: &RustcTargetData<'_>,
 ) -> Unit {
     if let Some(new_unit) = memo.get(unit) {
         // Already computed, no need to recompute.
@@ -632,6 +637,7 @@ fn traverse_and_share(
                 &dep.unit,
                 dep.unit_for.is_for_host(),
                 to_host,
+                target_data,
             );
             new_dep_unit.hash(&mut dep_hash);
             UnitDep {
@@ -655,8 +661,13 @@ fn traverse_and_share(
         _ => unit.kind,
     };
 
+    let cfg = target_data.cfg(unit.kind);
+    let is_target_windows_msvc = cfg.contains(&Cfg::Name("windows".to_string()))
+        && cfg.contains(&Cfg::KeyPair("target_env".to_string(), "msvc".to_string()));
     let mut profile = unit.profile.clone();
-    if profile.strip.is_deferred() {
+    // For MSVC, rustc currently treats -Cstrip=debuginfo same as -Cstrip=symbols, which causes
+    // this optimization to also remove symbols and thus break backtraces.
+    if profile.strip.is_deferred() && !is_target_windows_msvc {
         // If strip was not manually set, and all dependencies of this unit together
         // with this unit have debuginfo turned off, we enable debuginfo stripping.
         // This will remove pre-existing debug symbols coming from the standard library.

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -630,7 +630,9 @@ fn strip_accepts_false_to_disable_strip() {
         .run();
 }
 
+// Temporarily disabled on Windows due to https://github.com/rust-lang/rust/issues/122857
 #[cargo_test]
+#[cfg(not(windows))]
 fn strip_debuginfo_in_release() {
     let p = project()
         .file(
@@ -650,7 +652,32 @@ fn strip_debuginfo_in_release() {
         .run();
 }
 
+// Using -Cstrip=debuginfo in release mode by default is temporarily disabled on Windows due to
+// https://github.com/rust-lang/rust/issues/122857
 #[cargo_test]
+#[cfg(all(target_os = "windows", target_env = "msvc"))]
+fn do_not_strip_debuginfo_in_release_on_windows() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("build --release -v")
+        .with_stderr_does_not_contain("[..]strip=debuginfo[..]")
+        .run();
+}
+
+// Temporarily disabled on Windows due to https://github.com/rust-lang/rust/issues/122857
+#[cargo_test]
+#[cfg(not(windows))]
 fn strip_debuginfo_without_debug() {
     let p = project()
         .file(

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -740,7 +740,9 @@ fn one_bin_multiple_examples() {
         .run();
 }
 
+// Temporarily disabled on Windows due to https://github.com/rust-lang/rust/issues/122857
 #[cargo_test]
+#[cfg(not(windows))]
 fn example_with_release_flag() {
     let p = project()
         .file(


### PR DESCRIPTION
Beta backports:

- https://github.com/rust-lang/cargo/pull/13630

In order to make CI pass, the following PRs are also cherry-picked:

- 