### PR TITLE
fix(add): Preserve comments when updating simple deps 

### DIFF
--- a/src/cargo/util/toml_mut/dependency.rs
+++ b/src/cargo/util/toml_mut/dependency.rs
@@ -474,9 +474,18 @@ impl Dependency {
         item: &mut toml_edit::Item,
     ) {
         if str_or_1_len_table(item) {
-            // Nothing to preserve
-            *item = self.to_toml(crate_root);
-            key.fmt();
+            // Little to preserve
+            let mut new_item = self.to_toml(crate_root);
+            match (&item, &mut new_item) {
+                (toml_edit::Item::Value(old), toml_edit::Item::Value(new)) => {
+                    *new.decor_mut() = old.decor().clone();
+                }
+                (toml_edit::Item::Table(old), toml_edit::Item::Table(new)) => {
+                    *new.decor_mut() = old.decor().clone();
+                }
+                (_, _) => {}
+            }
+            *item = new_item;
         } else if let Some(table) = item.as_table_like_mut() {
             match &self.source {
                 Some(Source::Registry(src)) => {

--- a/tests/testsuite/cargo_add/overwrite_default_features/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_default_features/in/Cargo.toml
@@ -6,5 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+# Before my-package1
+my-package1 = "99999.0.0"  # After my-package1
+# Before my-package2
+my-package2 = "0.4.1"  # After my-package2
+# End

--- a/tests/testsuite/cargo_add/overwrite_default_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_default_features/out/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+# Before my-package1
+my-package1 = "99999.0.0"  # After my-package1
+# Before my-package2
+my-package2 = "0.4.1"  # After my-package2
 # End

--- a/tests/testsuite/cargo_add/overwrite_default_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_default_features/out/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2015"
 [dependencies]
 my-package1 = "99999.0.0"
 my-package2 = "0.4.1"
+# End

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/in/Cargo.toml
@@ -6,5 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", default-features = true }
-my-package2 = { version = "0.4.1", default-features = true }
+# Before my-package1
+my-package1 = { version = "99999.0.0", default-features = true }  # After my-package1
+# Before my-package2
+my-package2 = { version = "0.4.1", default-features = true }  # After my-package2
+# End

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/out/Cargo.toml
@@ -6,5 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", default-features = false }
-my-package2 = { version = "0.4.1", default-features = false }
+# Before my-package1
+my-package1 = { version = "99999.0.0", default-features = false }  # After my-package1
+# Before my-package2
+my-package2 = { version = "0.4.1", default-features = false }  # After my-package2
+# End

--- a/tests/testsuite/cargo_add/overwrite_features/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_features/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "99999.0.0", features = ["eyes"] }
+# Before your-face
+your-face = { version = "99999.0.0", features = ["eyes"] }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_features/out/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "99999.0.0", features = ["eyes", "nose"] }
+# Before your-face
+your-face = { version = "99999.0.0", features = ["eyes", "nose"] }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_inline_features/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "99999.0.0", features = ["eyes"] }
+# Before your-face
+your-face = { version = "99999.0.0", features = ["eyes"] }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_inline_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/out/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2015"
 
 [dependencies]
 unrelateed-crate = "99999.0.0"
-your-face = { version = "99999.0.0", features = ["eyes", "nose", "mouth", "ears"] }
+# Before your-face
+your-face = { version = "99999.0.0", features = ["eyes", "nose", "mouth", "ears"] }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dev-dependencies]
-your-face = { version = "0.0.0", path = "dependency", default-features = false, features = ["nose", "mouth"], registry = "alternative" }
+# Before your-face
+your-face = { version = "0.0.0", path = "dependency", default-features = false, features = ["nose", "mouth"], registry = "alternative" }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/out/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dev-dependencies]
-your-face = { version = "0.0.0", path = "dependency", default-features = false, features = ["nose", "mouth"], registry = "alternative" }
+# Before your-face
+your-face = { version = "0.0.0", path = "dependency", default-features = false, features = ["nose", "mouth"], registry = "alternative" }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_name_noop/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }
+# Before your-face
+your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_name_noop/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/out/Cargo.toml
@@ -7,7 +7,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }
+# Before your-face
+your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }  # After your-face
 
 [features]
 your-face = ["dep:your-face"]
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/in/Cargo.toml
@@ -6,5 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = "99999.0.0"
-my-package2 = "0.4.1"
+# Before my-package1
+my-package1 = "99999.0.0"  # After my-package1
+# Before my-package2
+my-package2 = "0.4.1"  # After my-package2
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/out/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2015"
 [dependencies]
 my-package1 = { version = "99999.0.0", default-features = false }
 my-package2 = { version = "0.4.1", default-features = false }
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/out/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", default-features = false }
-my-package2 = { version = "0.4.1", default-features = false }
+# Before my-package1
+my-package1 = { version = "99999.0.0", default-features = false }  # After my-package1
+# Before my-package2
+my-package2 = { version = "0.4.1", default-features = false }  # After my-package2
 # End

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/in/Cargo.toml
@@ -6,5 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", default-features = false }
-my-package2 = { version = "0.4.1", default-features = false }
+# Before my-package1
+my-package1 = { version = "99999.0.0", default-features = false }  # After my-package1
+# Before my-package2
+my-package2 = { version = "0.4.1", default-features = false }  # After my-package2
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/out/Cargo.toml
@@ -6,5 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0" }
-my-package2 = { version = "0.4.1" }
+# Before my-package1
+my-package1 = { version = "99999.0.0" }  # After my-package1
+# Before my-package2
+my-package2 = { version = "0.4.1" }  # After my-package2
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = "0.1.0"
+# Before my-package
+my-package = "0.1.0"  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/out/Cargo.toml
@@ -6,5 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = "0.1.0"
+# Before my-package
+my-package = "0.1.0"  # After my-package
 # End

--- a/tests/testsuite/cargo_add/overwrite_no_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/out/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2015"
 
 [dependencies]
 my-package = "0.1.0"
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", optional = false }
+# Before my-package
+my-package = { version = "0.1.0", optional = false }  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/out/Cargo.toml
@@ -6,7 +6,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", optional = true }
+# Before my-package
+my-package = { version = "0.1.0", optional = true }  # After my-package
 
 [features]
 my-package = ["dep:my-package"]
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_public/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_public/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = "0.1.0"
+# Before my-package
+my-package = "0.1.0"  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_public/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_public/out/Cargo.toml
@@ -7,5 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = "0.1.0"
+# Before my-package
+my-package = "0.1.0"  # After my-package
 # End

--- a/tests/testsuite/cargo_add/overwrite_no_public/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_public/out/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2015"
 
 [dependencies]
 my-package = "0.1.0"
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_public_with_public/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_public_with_public/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", public = false }
+# Before my-package
+my-package = { version = "0.1.0", public = false }  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_no_public_with_public/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_no_public_with_public/out/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", public = true }
+# Before my-package
+my-package = { version = "0.1.0", public = true }  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = "0.1.0"
+# Before my-package
+my-package = "0.1.0"  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional/out/Cargo.toml
@@ -6,7 +6,8 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", optional = true }
+# Before my-package
+my-package = { version = "0.1.0", optional = true }  # After my-package
 
 [features]
 my-package = ["dep:my-package"]

--- a/tests/testsuite/cargo_add/overwrite_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional/out/Cargo.toml
@@ -10,3 +10,4 @@ my-package = { version = "0.1.0", optional = true }
 
 [features]
 my-package = ["dep:my-package"]
+# End

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/in/Cargo.toml
@@ -10,4 +10,6 @@ default = ["your-face"]
 other = ["your-face/nose"]
 
 [dependencies]
-your-face = { version = "99999.0.0", optional = true }
+# Before your-face
+your-face = { version = "99999.0.0", optional = true }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/out/Cargo.toml
@@ -10,4 +10,6 @@ default = []
 other = ["your-face/nose"]
 
 [dependencies]
-your-face = { version = "99999.0.0" }
+# Before your-face
+your-face = { version = "99999.0.0" }  # After your-face
+# End

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/in/Cargo.toml
@@ -6,7 +6,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", optional = true }
+# Before my-package1
+my-package1 = { version = "99999.0.0", optional = true }  # After my-package1
+# End
 
 [features]
 default = ["dep:my-package1"]

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/out/Cargo.toml
@@ -6,7 +6,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package1 = { version = "99999.0.0", optional = true }
+# Before my-package1
+my-package1 = { version = "99999.0.0", optional = true }  # After my-package1
+# End
 
 [features]
 default = ["dep:my-package1"]

--- a/tests/testsuite/cargo_add/overwrite_path_noop/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }
+# Before my-package1
+your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }  # After my-package1
+# End

--- a/tests/testsuite/cargo_add/overwrite_path_noop/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/out/Cargo.toml
@@ -7,7 +7,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }
+# Before my-package1
+your-face = { version = "0.0.0", path = "dependency", optional = true, default-features = false, features = ["nose", "mouth"], registry = "alternative" }  # After my-package1
 
 [features]
 your-face = ["dep:your-face"]
+# End

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face={version="99999.0.0",features=["eyes"]}  # Hello world
+# Before my-package1
+your-face={version="99999.0.0",features=["eyes"]}  # After my-package1
+# End

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/out/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-your-face={ version = "99999.0.0", features = ["eyes", "nose"] }  # Hello world
+# Before my-package1
+your-face={ version = "99999.0.0", features = ["eyes", "nose"] }  # After my-package1
+# End

--- a/tests/testsuite/cargo_add/overwrite_public/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_public/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = "0.1.0"
+# Before my-package
+my-package = "0.1.0"  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_public/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_public/out/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2015"
 
 [dependencies]
 my-package = { version = "0.1.0", public = true }
+# End

--- a/tests/testsuite/cargo_add/overwrite_public/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_public/out/Cargo.toml
@@ -7,5 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", public = true }
+# Before my-package
+my-package = { version = "0.1.0", public = true }  # After my-package
 # End

--- a/tests/testsuite/cargo_add/overwrite_public_with_no_public/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_public_with_no_public/in/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0", public = true }
+# Before my-package
+my-package = { version = "0.1.0", public = true }  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_public_with_no_public/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_public_with_no_public/out/Cargo.toml
@@ -7,4 +7,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-my-package = { version = "0.1.0" }
+# Before my-package
+my-package = { version = "0.1.0" }  # After my-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-a1 = { package = "versioned-package", version = "0.1.1", optional = true }
+# Before a1
+a1 = { package = "versioned-package", version = "0.1.1", optional = true }  # After a1
+# End

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/out/Cargo.toml
@@ -6,5 +6,7 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-a1 = { package = "versioned-package", version = "0.1.1", optional = true }
+# Before a1
+a1 = { package = "versioned-package", version = "0.1.1", optional = true }  # After a1
 versioned-package = "99999.0.0"
+# End

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-a1 = { package = "versioned-package", version = "0.1.1", optional = true }
+# Before a1
+a1 = { package = "versioned-package", version = "0.1.1", optional = true }  # After a1
+# End

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/out/Cargo.toml
@@ -6,5 +6,7 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-a1 = { package = "versioned-package", version = "0.1.1", optional = true }
+# Before a1
+a1 = { package = "versioned-package", version = "0.1.1", optional = true }  # After a1
 a2 = { version = "99999.0.0", package = "versioned-package" }
+# End

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-a1 = { package = "versioned-package", version = "0.1.1", optional = true }
+# Before a1
+a1 = { package = "versioned-package", version = "0.1.1", optional = true }  # After a1
+# End

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/out/Cargo.toml
@@ -6,7 +6,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-a1 = { package = "versioned-package", version = "0.1.1", optional = true }
+# Before a1
+a1 = { package = "versioned-package", version = "0.1.1", optional = true }  # After a1
 
 [features]
 a1 = ["dep:a1"]
+# End

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-versioned-package = { version = "0.1.1", optional = true }
+# Before versioned-package
+versioned-package = { version = "0.1.1", optional = true }  # After versioned-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/out/Cargo.toml
@@ -6,7 +6,9 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-versioned-package = { version = "0.3.0", optional = true, git = "[ROOTURL]/versioned-package" }
+# Before versioned-package
+versioned-package = { version = "0.3.0", optional = true, git = "[ROOTURL]/versioned-package" }  # After versioned-package
 
 [features]
 versioned-package = ["dep:versioned-package"]
+# End

--- a/tests/testsuite/cargo_add/overwrite_with_rename/in/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/in/Cargo.toml
@@ -6,4 +6,6 @@ version = "0.0.0"
 edition = "2015"
 
 [dependencies]
-versioned-package = { version = "0.1.1", optional = true }
+# Before versioned-package
+versioned-package = { version = "0.1.1", optional = true }  # After versioned-package
+# End

--- a/tests/testsuite/cargo_add/overwrite_with_rename/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/out/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2015"
 
 [dependencies]
 renamed = { version = "99999.0.0", package = "versioned-package" }
-versioned-package = { version = "0.1.1", optional = true }
+# Before versioned-package
+versioned-package = { version = "0.1.1", optional = true }  # After versioned-package
+# End


### PR DESCRIPTION


### What does this PR try to resolve?

Fixes https://github.com/rust-lang/cargo/issues/13645

### How should we test and review this PR?

A case the tests showed but isn't covered here is when a `[features]`
table is created, the dependencies-end comment gets attached to that,
e.g. see cargo_add/overwrite_optional


### Additional information

