### PR TITLE
fix(generate-lockfile): hold lock before querying index

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -331,7 +331,7 @@ fn print_lockfile_sync(
     Ok(())
 }
 
-pub fn print_lockfile_updates(
+fn print_lockfile_updates(
     gctx: &GlobalContext,
     previous_resolve: &Resolve,
     resolve: &Resolve,

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -166,12 +166,17 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
     Ok(())
 }
 
+/// Prints lockfile change statuses.
+///
+/// This would acquire the package-cache lock, as it may update the index to
+/// show users latest available versions.
 pub fn print_lockfile_changes(
     gctx: &GlobalContext,
     previous_resolve: Option<&Resolve>,
     resolve: &Resolve,
     registry: &mut PackageRegistry<'_>,
 ) -> CargoResult<()> {
+    let _lock = gctx.acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
     if let Some(previous_resolve) = previous_resolve {
         print_lockfile_sync(gctx, previous_resolve, resolve, registry)
     } else {

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -9,7 +9,6 @@ pub use self::cargo_doc::{doc, DocOptions, OutputFormat};
 pub use self::cargo_fetch::{fetch, FetchOptions};
 pub use self::cargo_generate_lockfile::generate_lockfile;
 pub use self::cargo_generate_lockfile::print_lockfile_changes;
-pub use self::cargo_generate_lockfile::print_lockfile_updates;
 pub use self::cargo_generate_lockfile::update_lockfile;
 pub use self::cargo_generate_lockfile::UpdateOptions;
 pub use self::cargo_install::{install, install_list};

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -256,11 +256,6 @@ fn resolve_with_registry<'gctx>(
         false
     };
     if print {
-        // We only want one Cargo at a time resolving a crate graph since this can
-        // involve a lot of frobbing of the global caches.
-        let _lock = ws
-            .gctx()
-            .acquire_package_cache_lock(CacheLockMode::DownloadExclusive)?;
         ops::print_lockfile_changes(ws.gctx(), prev.as_ref(), &resolve, registry)?;
     }
     Ok(resolve)

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -237,3 +237,41 @@ fn duplicate_entries_in_lockfile() {
         )
         .run();
 }
+
+#[cargo_test]
+fn generate_lockfile_holds_lock_and_offline() {
+    Package::new("syn", "1.0.0").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+
+                [dependencies]
+                syn = "1.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("generate-lockfile")
+        .with_stderr(
+            "\
+[UPDATING] `[..]` index
+[LOCKING] 2 packages
+",
+        )
+        .run();
+
+    p.cargo("generate-lockfile --offline")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[..]thread 'main' panicked[..]
+[..]package cache lock is not currently held[..]
+",
+        )
+        .run();
+}

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -266,11 +266,9 @@ fn generate_lockfile_holds_lock_and_offline() {
         .run();
 
     p.cargo("generate-lockfile --offline")
-        .with_status(101)
         .with_stderr_contains(
             "\
-[..]thread 'main' panicked[..]
-[..]package cache lock is not currently held[..]
+[LOCKING] 2 packages
 ",
         )
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Fixes #13656

Always holds the lock before doing any index query.

### How should we test and review this PR?

The first commit verifies the panicking behavior.
The second fix that.

Lock acquisitions are consolidated into `print_lockfile_changes` but happy to move it to caller if preferred.

### Additional information

<!-- homu-ignore:end -->
