### PR TITLE
Make sure to also wrap the initial `-vV` invocation

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -1907,7 +1907,10 @@ fn descriptive_pkg_name(name: &str, target: &Target, mode: &CompileMode) -> Stri
 }
 
 /// Applies environment variables from config `[env]` to [`ProcessBuilder`].
-fn apply_env_config(gctx: &crate::GlobalContext, cmd: &mut ProcessBuilder) -> CargoResult<()> {
+pub(crate) fn apply_env_config(
+    gctx: &crate::GlobalContext,
+    cmd: &mut ProcessBuilder,
+) -> CargoResult<()> {
     for (key, value) in gctx.env_config()?.iter() {
         // never override a value that has already been set by cargo
         if cmd.get_envs().contains_key(key) {

--- a/src/cargo/util/rustc.rs
+++ b/src/cargo/util/rustc.rs
@@ -9,6 +9,7 @@ use cargo_util::{paths, ProcessBuilder, ProcessError};
 use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
+use crate::core::compiler::apply_env_config;
 use crate::util::interning::InternedString;
 use crate::util::{CargoResult, GlobalContext, StableHasher};
 
@@ -57,7 +58,10 @@ impl Rustc {
             gctx,
         );
 
-        let mut cmd = ProcessBuilder::new(&path);
+        let mut cmd = ProcessBuilder::new(&path)
+            .wrapped(workspace_wrapper.as_ref())
+            .wrapped(wrapper.as_deref());
+        apply_env_config(gctx, &mut cmd)?;
         cmd.arg("-vV");
         let verbose_version = cache.cached_output(&cmd, 0)?.0;
 

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -5211,6 +5211,30 @@ fn rustc_wrapper() {
 }
 
 #[cargo_test]
+fn rustc_wrapper_queries() {
+    // Check that the invocations querying rustc for information are done with the wrapper.
+    let p = project().file("src/lib.rs", "").build();
+    let wrapper = tools::echo_wrapper();
+    p.cargo("build")
+        .env("CARGO_LOG", "cargo::util::rustc=debug")
+        .env("RUSTC_WRAPPER", &wrapper)
+        .with_stderr_contains("[..]running [..]rustc-echo-wrapper[EXE] rustc -vV[..]")
+        .with_stderr_contains(
+            "[..]running [..]rustc-echo-wrapper[EXE] rustc - --crate-name ___ --print[..]",
+        )
+        .run();
+    p.build_dir().rm_rf();
+    p.cargo("build")
+        .env("CARGO_LOG", "cargo::util::rustc=debug")
+        .env("RUSTC_WORKSPACE_WRAPPER", &wrapper)
+        .with_stderr_contains("[..]running [..]rustc-echo-wrapper[EXE] rustc -vV[..]")
+        .with_stderr_contains(
+            "[..]running [..]rustc-echo-wrapper[EXE] rustc - --crate-name ___ --print[..]",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn rustc_wrapper_relative() {
     Package::new("bar", "1.0.0").publish();
     let p = project()

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -192,10 +192,13 @@ fn env_applied_to_target_info_discovery_rustc() {
             "src/main.rs",
             r#"
             fn main() {
-                let mut args = std::env::args().skip(1);
+                let mut cmd = std::env::args().skip(1).collect::<Vec<_>>();
+                // This will be invoked twice (with `-vV` and with all the `--print`),
+                // make sure the environment variable exists each time.
                 let env_test = std::env::var("ENV_TEST").unwrap();
                 eprintln!("WRAPPER ENV_TEST:{env_test}");
-                let status = std::process::Command::new(&args.next().unwrap())
+                let (prog, args) = cmd.split_first().unwrap();
+                let status = std::process::Command::new(prog)
                     .args(args).status().unwrap();
                 std::process::exit(status.code().unwrap_or(1));
             }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/cargo/issues/10885 and therefore helps unblock https://github.com/rust-lang/miri/issues/3422.

This ensures that the version info actually matches the compiler that will later be doing the builds.