### PR TITLE
clarify default behavior of `documentation` field

### DIFF
--- a/src/doc/src/reference/manifest.md
+++ b/src/doc/src/reference/manifest.md
@@ -205,9 +205,12 @@ description = "A short description of my package"
 ### The `documentation` field
 
 The `documentation` field specifies a URL to a website hosting the crate's
-documentation. If no URL is specified in the manifest file, [crates.io] will
+documentation.
+
+If no URL is specified in the manifest file, [crates.io] will
 automatically link your crate to the corresponding [docs.rs] page when the
 documentation has been built and is available (see [docs.rs queue]).
+However, this automatic link appears only on the crate page, not in search results.
 
 ```toml
 [package]


### PR DESCRIPTION
Cc https://github.com/rust-lang/cargo/issues/11777, https://github.com/rust-lang/crates.io/issues/1484