### PR TITLE
fix(toml): Warn on unused workspace.dependencies keys on virtual workspaces

### DIFF
--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -28,6 +28,12 @@ pub enum EitherManifest {
 }
 
 impl EitherManifest {
+    pub fn warnings_mut(&mut self) -> &mut Warnings {
+        match self {
+            EitherManifest::Real(r) => r.warnings_mut(),
+            EitherManifest::Virtual(v) => v.warnings_mut(),
+        }
+    }
     pub(crate) fn workspace_config(&self) -> &WorkspaceConfig {
         match *self {
             EitherManifest::Real(ref r) => r.workspace_config(),

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -458,6 +458,8 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
     let toml_manifest =
         prepare_for_publish(orig_pkg.manifest().resolved_toml(), ws, orig_pkg.root())?;
     let source_id = orig_pkg.package_id().source_id();
+    let mut warnings = Default::default();
+    let mut errors = Default::default();
     let manifest = to_real_manifest(
         contents.to_owned(),
         document.clone(),
@@ -465,6 +467,8 @@ fn build_lock(ws: &Workspace<'_>, orig_pkg: &Package) -> CargoResult<String> {
         source_id,
         orig_pkg.manifest_path(),
         gctx,
+        &mut warnings,
+        &mut errors,
     )?;
     let new_pkg = Package::new(manifest, orig_pkg.manifest_path());
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -687,12 +687,7 @@ pub fn to_real_manifest(
 
     if let Some(links) = &package.links {
         if !targets.iter().any(|t| t.is_custom_build()) {
-            bail!(
-                "package `{}` specifies that it links to `{}` but does not \
-                     have a custom build script",
-                pkgid,
-                links
-            )
+            bail!("package specifies that it links to `{links}` but does not have a custom build script")
         }
     }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -519,17 +519,16 @@ pub fn to_real_manifest(
                  `[workspace]`, only one can be specified"
         ),
     };
-
-    let package_name = &package.name;
-    if package_name.contains(':') {
-        features.require(Feature::open_namespaces())?;
-    }
-
     let inherit_cell: LazyCell<InheritableFields> = LazyCell::new();
     let inherit = || {
         inherit_cell
             .try_borrow_with(|| load_inheritable_fields(gctx, manifest_file, &workspace_config))
     };
+
+    let package_name = &package.name;
+    if package_name.contains(':') {
+        features.require(Feature::open_namespaces())?;
+    }
 
     let version = package
         .version

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -926,7 +926,6 @@ pub fn to_real_manifest(
         .map(|mw| field_inherit_with(mw, "include", || inherit()?.include()))
         .transpose()?
         .unwrap_or_default();
-    let empty_features = BTreeMap::new();
 
     let summary = Summary::new(
         pkgid,
@@ -934,7 +933,7 @@ pub fn to_real_manifest(
         &original_toml
             .features
             .as_ref()
-            .unwrap_or(&empty_features)
+            .unwrap_or(&Default::default())
             .iter()
             .map(|(k, v)| {
                 (

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1228,33 +1228,6 @@ fn to_workspace_config(
     ws_root_config
 }
 
-fn load_inheritable_fields(
-    gctx: &GlobalContext,
-    resolved_path: &Path,
-    workspace_config: &WorkspaceConfig,
-) -> CargoResult<InheritableFields> {
-    match workspace_config {
-        WorkspaceConfig::Root(root) => Ok(root.inheritable().clone()),
-        WorkspaceConfig::Member {
-            root: Some(ref path_to_root),
-        } => {
-            let path = resolved_path
-                .parent()
-                .unwrap()
-                .join(path_to_root)
-                .join("Cargo.toml");
-            let root_path = paths::normalize_path(&path);
-            inheritable_from_path(gctx, root_path)
-        }
-        WorkspaceConfig::Member { root: None } => {
-            match find_workspace_root(&resolved_path, gctx)? {
-                Some(path_to_root) => inheritable_from_path(gctx, path_to_root),
-                None => Err(anyhow!("failed to find a workspace root")),
-            }
-        }
-    }
-}
-
 fn to_virtual_manifest(
     contents: String,
     document: toml_edit::ImDocument<String>,
@@ -1558,6 +1531,33 @@ fn unused_dep_keys(
     for unused in unused_keys {
         let key = format!("unused manifest key: {kind}.{dep_name}.{unused}");
         warnings.push(key);
+    }
+}
+
+fn load_inheritable_fields(
+    gctx: &GlobalContext,
+    resolved_path: &Path,
+    workspace_config: &WorkspaceConfig,
+) -> CargoResult<InheritableFields> {
+    match workspace_config {
+        WorkspaceConfig::Root(root) => Ok(root.inheritable().clone()),
+        WorkspaceConfig::Member {
+            root: Some(ref path_to_root),
+        } => {
+            let path = resolved_path
+                .parent()
+                .unwrap()
+                .join(path_to_root)
+                .join("Cargo.toml");
+            let root_path = paths::normalize_path(&path);
+            inheritable_from_path(gctx, root_path)
+        }
+        WorkspaceConfig::Member { root: None } => {
+            match find_workspace_root(&resolved_path, gctx)? {
+                Some(path_to_root) => inheritable_from_path(gctx, path_to_root),
+                None => Err(anyhow!("failed to find a workspace root")),
+            }
+        }
     }
 }
 

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1298,6 +1298,16 @@ fn to_virtual_manifest(
     let workspace_config = match original_toml.workspace {
         Some(ref toml_config) => {
             verify_lints(toml_config.lints.as_ref(), gctx, &mut warnings)?;
+            if let Some(ws_deps) = &toml_config.dependencies {
+                for (name, dep) in ws_deps {
+                    unused_dep_keys(
+                        name,
+                        "workspace.dependencies",
+                        dep.unused_keys(),
+                        &mut warnings,
+                    );
+                }
+            }
             let ws_root_config = to_workspace_config(toml_config, root);
             gctx.ws_roots
                 .borrow_mut()

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -993,8 +993,7 @@ fn links_no_build_cmd() {
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
 Caused by:
-  package `foo v0.5.0 ([CWD])` specifies that it links to `a` but does \
-not have a custom build script
+  package specifies that it links to `a` but does not have a custom build script
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This splits out refactors that build on #13589 in preparation for resolving #13456.

As part of those refactors, I noticed an inconsistency on when we warn for unused keys.  We have parallel code paths between `to_virtual_manifest` and `to_real_manifest` and only one got updated on a change.  This syncs them up.  Hopefully the end state this builds to will reduce duplication.

### How should we test and review this PR?



### Additional information

