### PR TITLE
docs: clarify `--locked` ensures Cargo uses dependency versions in lockfile

### DIFF
--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -640,17 +640,17 @@ See '<cyan,bold>cargo help</> <cyan><<command>></>' for more information on a sp
                 .value_parser(clap::builder::ValueParser::path_buf()),
         )
         .arg(
-            flag("frozen", "Require Cargo.lock and cache to be up-to-date")
-                .help_heading(heading::MANIFEST_OPTIONS)
-                .global(true),
-        )
-        .arg(
             flag("locked", "Require Cargo.lock to be up-to-date")
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )
         .arg(
             flag("offline", "Run without accessing the network")
+                .help_heading(heading::MANIFEST_OPTIONS)
+                .global(true),
+        )
+        .arg(
+            flag("frozen", "Equivalent to specifying both --locked and --offline")
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )

--- a/src/bin/cargo/cli.rs
+++ b/src/bin/cargo/cli.rs
@@ -640,7 +640,7 @@ See '<cyan,bold>cargo help</> <cyan><<command>></>' for more information on a sp
                 .value_parser(clap::builder::ValueParser::path_buf()),
         )
         .arg(
-            flag("locked", "Require Cargo.lock to be up-to-date")
+            flag("locked", "Assert that `Cargo.lock` will remain unchanged")
                 .help_heading(heading::MANIFEST_OPTIONS)
                 .global(true),
         )

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -171,16 +171,14 @@ OPTIONS
        -p spec, --package spec
            Add dependencies to only the specified package.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -196,6 +194,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-add.txt
+++ b/src/doc/man/generated_txt/cargo-add.txt
@@ -172,13 +172,18 @@ OPTIONS
            Add dependencies to only the specified package.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -338,16 +338,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -363,6 +361,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -339,13 +339,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -273,13 +273,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-build.txt
+++ b/src/doc/man/generated_txt/cargo-build.txt
@@ -272,16 +272,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -297,6 +295,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -258,13 +258,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-check.txt
+++ b/src/doc/man/generated_txt/cargo-check.txt
@@ -257,16 +257,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -282,6 +280,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -92,13 +92,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-clean.txt
+++ b/src/doc/man/generated_txt/cargo-clean.txt
@@ -91,16 +91,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -116,6 +114,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -228,16 +228,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -253,6 +251,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-doc.txt
+++ b/src/doc/man/generated_txt/cargo-doc.txt
@@ -229,13 +229,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -72,13 +72,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-fetch.txt
+++ b/src/doc/man/generated_txt/cargo-fetch.txt
@@ -71,16 +71,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -95,6 +93,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -331,13 +331,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-fix.txt
+++ b/src/doc/man/generated_txt/cargo-fix.txt
@@ -330,16 +330,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -355,6 +353,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -46,16 +46,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -71,6 +69,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -47,13 +47,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -243,13 +243,18 @@ OPTIONS
 
    Manifest Options
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-install.txt
+++ b/src/doc/man/generated_txt/cargo-install.txt
@@ -242,16 +242,14 @@ OPTIONS
               machine-readable JSON information about timing information.
 
    Manifest Options
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -267,6 +265,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Miscellaneous Options
        -j N, --jobs N

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -405,13 +405,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -404,16 +404,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -429,6 +427,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -158,16 +158,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -183,6 +181,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Miscellaneous Options
        -j N, --jobs N

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -159,13 +159,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -85,13 +85,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-pkgid.txt
+++ b/src/doc/man/generated_txt/cargo-pkgid.txt
@@ -84,16 +84,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -109,6 +107,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -129,13 +129,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-publish.txt
+++ b/src/doc/man/generated_txt/cargo-publish.txt
@@ -128,16 +128,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -153,6 +151,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Miscellaneous Options
        -j N, --jobs N

--- a/src/doc/man/generated_txt/cargo-remove.txt
+++ b/src/doc/man/generated_txt/cargo-remove.txt
@@ -62,13 +62,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-remove.txt
+++ b/src/doc/man/generated_txt/cargo-remove.txt
@@ -61,16 +61,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -86,6 +84,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Package Selection
        -p spec…, --package spec…

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -176,16 +176,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -201,6 +199,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-run.txt
+++ b/src/doc/man/generated_txt/cargo-run.txt
@@ -177,13 +177,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -275,13 +275,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-rustc.txt
+++ b/src/doc/man/generated_txt/cargo-rustc.txt
@@ -274,16 +274,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -299,6 +297,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -244,16 +244,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -269,6 +267,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-rustdoc.txt
+++ b/src/doc/man/generated_txt/cargo-rustdoc.txt
@@ -245,13 +245,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -364,16 +364,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -389,6 +387,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-test.txt
+++ b/src/doc/man/generated_txt/cargo-test.txt
@@ -365,13 +365,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -211,16 +211,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -236,6 +234,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Feature Selection
        The feature flags allow you to control which features are enabled. When

--- a/src/doc/man/generated_txt/cargo-tree.txt
+++ b/src/doc/man/generated_txt/cargo-tree.txt
@@ -212,13 +212,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -82,13 +82,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -81,16 +81,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -106,6 +104,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -54,13 +54,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -53,16 +53,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -78,6 +76,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Display Options
        -v, --verbose

--- a/src/doc/man/generated_txt/cargo-verify-project.txt
+++ b/src/doc/man/generated_txt/cargo-verify-project.txt
@@ -49,16 +49,14 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
-       --frozen, --locked
-           Either of these flags requires that the Cargo.lock file be
-           up-to-date. If the lock file is missing, or it needs to be updated,
-           Cargo will exit with an error. The --frozen flag also prevents Cargo
-           from attempting to access the network to determine if it is
-           out-of-date.
+       --locked
+           Requires the Cargo.lock file be up-to-date. If the lock file is
+           missing, or it needs to be updated due to changes in the Cargo.toml
+           file, for example a new dependency is added, Cargo will exit with an
+           error.
 
-           These may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build) or want to avoid
-           network access.
+           It may be used in environments where you want to assert that the
+           Cargo.lock file is up-to-date (such as a CI build).
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without
@@ -74,6 +72,9 @@ OPTIONS
 
            May also be specified with the net.offline config value
            <https://doc.rust-lang.org/cargo/reference/config.html>.
+
+       --frozen
+           Equivalent to specifying both --locked and --offline.
 
    Common Options
        +toolchain

--- a/src/doc/man/generated_txt/cargo-verify-project.txt
+++ b/src/doc/man/generated_txt/cargo-verify-project.txt
@@ -50,13 +50,18 @@ OPTIONS
            Cargo.toml file in the current directory or any parent directory.
 
        --locked
-           Requires the Cargo.lock file be up-to-date. If the lock file is
-           missing, or it needs to be updated due to changes in the Cargo.toml
-           file, for example a new dependency is added, Cargo will exit with an
-           error.
+           Asserts that the exact same dependencies and versions are used as
+           when the existing Cargo.lock file was originally generated. Cargo
+           will exit with an error when either of the following scenarios
+           arises:
 
-           It may be used in environments where you want to assert that the
-           Cargo.lock file is up-to-date (such as a CI build).
+           o  The lock file is missing.
+
+           o  Cargo attempted to change the lock file due to a different
+              dependency resolution.
+
+           It may be used in environments where deterministic builds are
+           desired, such as in CI pipelines.
 
        --offline
            Prevents Cargo from accessing the network for any reason. Without

--- a/src/doc/man/includes/options-locked.md
+++ b/src/doc/man/includes/options-locked.md
@@ -1,10 +1,13 @@
 {{#option "`--locked`"}}
-Requires the `Cargo.lock` file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the `Cargo.toml` file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing `Cargo.lock` file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 
-It may be used in environments where you want to assert that the `Cargo.lock`
-file is up-to-date (such as a CI build).
+* The lock file is missing.
+* Cargo attempted to change the lock file due to a different dependency resolution.
+
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 {{/option}}
 
 {{#option "`--offline`"}}

--- a/src/doc/man/includes/options-locked.md
+++ b/src/doc/man/includes/options-locked.md
@@ -1,12 +1,10 @@
-{{#option "`--frozen`" "`--locked`"}}
-Either of these flags requires that the `Cargo.lock` file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The `--frozen` flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.
+{{#option "`--locked`"}}
+Requires the `Cargo.lock` file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the `Cargo.toml` file, for example
+a new dependency is added, Cargo will exit with an error.
 
-These may be used in environments where you want to assert that the
-`Cargo.lock` file is up-to-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the `Cargo.lock`
+file is up-to-date (such as a CI build).
 {{/option}}
 
 {{#option "`--offline`"}}
@@ -24,4 +22,8 @@ offline.
 {{/if}}
 
 May also be specified with the `net.offline` [config value](../reference/config.html).
+{{/option}}
+
+{{#option "`--frozen`"}}
+Equivalent to specifying both `--locked` and `--offline`.
 {{/option}}

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -192,11 +192,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-add---locked"><a class="option-anchor" href="#option-cargo-add---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-add---offline"><a class="option-anchor" href="#option-cargo-add---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-add.md
+++ b/src/doc/src/commands/cargo-add.md
@@ -191,15 +191,12 @@ terminal.</li>
 <dd class="option-desc">Add dependencies to only the specified package.</dd>
 
 
-<dt class="option-term" id="option-cargo-add---frozen"><a class="option-anchor" href="#option-cargo-add---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-add---locked"><a class="option-anchor" href="#option-cargo-add---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-add---offline"><a class="option-anchor" href="#option-cargo-add---offline"></a><code>--offline</code></dt>
@@ -213,6 +210,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-add---frozen"><a class="option-anchor" href="#option-cargo-add---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -377,15 +377,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-bench---frozen"><a class="option-anchor" href="#option-cargo-bench---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-bench---locked"><a class="option-anchor" href="#option-cargo-bench---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---offline"><a class="option-anchor" href="#option-cargo-bench---offline"></a><code>--offline</code></dt>
@@ -399,6 +396,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-bench---frozen"><a class="option-anchor" href="#option-cargo-bench---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -378,11 +378,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-bench---locked"><a class="option-anchor" href="#option-cargo-bench---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-bench---offline"><a class="option-anchor" href="#option-cargo-bench---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -309,11 +309,15 @@ See <a href="https://github.com/rust-lang/cargo/issues/5579">https://github.com/
 
 
 <dt class="option-term" id="option-cargo-build---locked"><a class="option-anchor" href="#option-cargo-build---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-build---offline"><a class="option-anchor" href="#option-cargo-build---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-build.md
+++ b/src/doc/src/commands/cargo-build.md
@@ -308,15 +308,12 @@ See <a href="https://github.com/rust-lang/cargo/issues/5579">https://github.com/
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-build---frozen"><a class="option-anchor" href="#option-cargo-build---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-build---locked"><a class="option-anchor" href="#option-cargo-build---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-build---offline"><a class="option-anchor" href="#option-cargo-build---offline"></a><code>--offline</code></dt>
@@ -330,6 +327,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-build---frozen"><a class="option-anchor" href="#option-cargo-build---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -291,11 +291,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-check---locked"><a class="option-anchor" href="#option-cargo-check---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-check---offline"><a class="option-anchor" href="#option-cargo-check---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-check.md
+++ b/src/doc/src/commands/cargo-check.md
@@ -290,15 +290,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-check---frozen"><a class="option-anchor" href="#option-cargo-check---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-check---locked"><a class="option-anchor" href="#option-cargo-check---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-check---offline"><a class="option-anchor" href="#option-cargo-check---offline"></a><code>--offline</code></dt>
@@ -312,6 +309,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-check---frozen"><a class="option-anchor" href="#option-cargo-check---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -111,11 +111,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-clean---locked"><a class="option-anchor" href="#option-cargo-clean---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-clean---offline"><a class="option-anchor" href="#option-cargo-clean---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-clean.md
+++ b/src/doc/src/commands/cargo-clean.md
@@ -110,15 +110,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-clean---frozen"><a class="option-anchor" href="#option-cargo-clean---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-clean---locked"><a class="option-anchor" href="#option-cargo-clean---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-clean---offline"><a class="option-anchor" href="#option-cargo-clean---offline"></a><code>--offline</code></dt>
@@ -132,6 +129,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-clean---frozen"><a class="option-anchor" href="#option-cargo-clean---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -265,15 +265,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-doc---frozen"><a class="option-anchor" href="#option-cargo-doc---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-doc---locked"><a class="option-anchor" href="#option-cargo-doc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-doc---offline"><a class="option-anchor" href="#option-cargo-doc---offline"></a><code>--offline</code></dt>
@@ -287,6 +284,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-doc---frozen"><a class="option-anchor" href="#option-cargo-doc---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-doc.md
+++ b/src/doc/src/commands/cargo-doc.md
@@ -266,11 +266,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-doc---locked"><a class="option-anchor" href="#option-cargo-doc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-doc---offline"><a class="option-anchor" href="#option-cargo-doc---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -79,15 +79,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-fetch---frozen"><a class="option-anchor" href="#option-cargo-fetch---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-fetch---locked"><a class="option-anchor" href="#option-cargo-fetch---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-fetch---offline"><a class="option-anchor" href="#option-cargo-fetch---offline"></a><code>--offline</code></dt>
@@ -99,6 +96,10 @@ proceed without the network if possible.</p>
 mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-fetch---frozen"><a class="option-anchor" href="#option-cargo-fetch---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-fetch.md
+++ b/src/doc/src/commands/cargo-fetch.md
@@ -80,11 +80,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-fetch---locked"><a class="option-anchor" href="#option-cargo-fetch---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-fetch---offline"><a class="option-anchor" href="#option-cargo-fetch---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -371,11 +371,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-fix---locked"><a class="option-anchor" href="#option-cargo-fix---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---offline"><a class="option-anchor" href="#option-cargo-fix---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-fix.md
+++ b/src/doc/src/commands/cargo-fix.md
@@ -370,15 +370,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-fix---frozen"><a class="option-anchor" href="#option-cargo-fix---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-fix---locked"><a class="option-anchor" href="#option-cargo-fix---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-fix---offline"><a class="option-anchor" href="#option-cargo-fix---offline"></a><code>--offline</code></dt>
@@ -392,6 +389,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-fix---frozen"><a class="option-anchor" href="#option-cargo-fix---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -59,11 +59,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-generate-lockfile---locked"><a class="option-anchor" href="#option-cargo-generate-lockfile---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-generate-lockfile---offline"><a class="option-anchor" href="#option-cargo-generate-lockfile---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -58,15 +58,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-generate-lockfile---frozen"><a class="option-anchor" href="#option-cargo-generate-lockfile---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-generate-lockfile---locked"><a class="option-anchor" href="#option-cargo-generate-lockfile---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-generate-lockfile---offline"><a class="option-anchor" href="#option-cargo-generate-lockfile---offline"></a><code>--offline</code></dt>
@@ -80,6 +77,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-generate-lockfile---frozen"><a class="option-anchor" href="#option-cargo-generate-lockfile---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -267,11 +267,15 @@ information about timing information.</li>
 
 <dl>
 <dt class="option-term" id="option-cargo-install---locked"><a class="option-anchor" href="#option-cargo-install---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-install---offline"><a class="option-anchor" href="#option-cargo-install---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-install.md
+++ b/src/doc/src/commands/cargo-install.md
@@ -266,15 +266,12 @@ information about timing information.</li>
 ### Manifest Options
 
 <dl>
-<dt class="option-term" id="option-cargo-install---frozen"><a class="option-anchor" href="#option-cargo-install---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-install---locked"><a class="option-anchor" href="#option-cargo-install---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-install---offline"><a class="option-anchor" href="#option-cargo-install---offline"></a><code>--offline</code></dt>
@@ -288,6 +285,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-install---frozen"><a class="option-anchor" href="#option-cargo-install---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -429,11 +429,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-metadata---locked"><a class="option-anchor" href="#option-cargo-metadata---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-metadata---offline"><a class="option-anchor" href="#option-cargo-metadata---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -428,15 +428,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-metadata---frozen"><a class="option-anchor" href="#option-cargo-metadata---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-metadata---locked"><a class="option-anchor" href="#option-cargo-metadata---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-metadata---offline"><a class="option-anchor" href="#option-cargo-metadata---offline"></a><code>--offline</code></dt>
@@ -450,6 +447,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-metadata---frozen"><a class="option-anchor" href="#option-cargo-metadata---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -182,15 +182,12 @@ be specified multiple times, which enables all specified features.</dd>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-package---frozen"><a class="option-anchor" href="#option-cargo-package---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-package---locked"><a class="option-anchor" href="#option-cargo-package---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-package---offline"><a class="option-anchor" href="#option-cargo-package---offline"></a><code>--offline</code></dt>
@@ -204,6 +201,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-package---frozen"><a class="option-anchor" href="#option-cargo-package---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -183,11 +183,15 @@ be specified multiple times, which enables all specified features.</dd>
 
 
 <dt class="option-term" id="option-cargo-package---locked"><a class="option-anchor" href="#option-cargo-package---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-package---offline"><a class="option-anchor" href="#option-cargo-package---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -90,15 +90,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-pkgid---frozen"><a class="option-anchor" href="#option-cargo-pkgid---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-pkgid---locked"><a class="option-anchor" href="#option-cargo-pkgid---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-pkgid---offline"><a class="option-anchor" href="#option-cargo-pkgid---offline"></a><code>--offline</code></dt>
@@ -112,6 +109,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-pkgid---frozen"><a class="option-anchor" href="#option-cargo-pkgid---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-pkgid.md
+++ b/src/doc/src/commands/cargo-pkgid.md
@@ -91,11 +91,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-pkgid---locked"><a class="option-anchor" href="#option-cargo-pkgid---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-pkgid---offline"><a class="option-anchor" href="#option-cargo-pkgid---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -152,11 +152,15 @@ be specified multiple times, which enables all specified features.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---locked"><a class="option-anchor" href="#option-cargo-publish---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---offline"><a class="option-anchor" href="#option-cargo-publish---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-publish.md
+++ b/src/doc/src/commands/cargo-publish.md
@@ -151,15 +151,12 @@ be specified multiple times, which enables all specified features.</dd>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-publish---frozen"><a class="option-anchor" href="#option-cargo-publish---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-publish---locked"><a class="option-anchor" href="#option-cargo-publish---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-publish---offline"><a class="option-anchor" href="#option-cargo-publish---offline"></a><code>--offline</code></dt>
@@ -173,6 +170,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-publish---frozen"><a class="option-anchor" href="#option-cargo-publish---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -82,11 +82,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-remove---locked"><a class="option-anchor" href="#option-cargo-remove---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-remove---offline"><a class="option-anchor" href="#option-cargo-remove---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-remove.md
+++ b/src/doc/src/commands/cargo-remove.md
@@ -81,15 +81,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-remove---frozen"><a class="option-anchor" href="#option-cargo-remove---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-remove---locked"><a class="option-anchor" href="#option-cargo-remove---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-remove---offline"><a class="option-anchor" href="#option-cargo-remove---offline"></a><code>--offline</code></dt>
@@ -103,6 +100,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-remove---frozen"><a class="option-anchor" href="#option-cargo-remove---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -211,11 +211,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-run---locked"><a class="option-anchor" href="#option-cargo-run---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-run---offline"><a class="option-anchor" href="#option-cargo-run---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-run.md
+++ b/src/doc/src/commands/cargo-run.md
@@ -210,15 +210,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-run---frozen"><a class="option-anchor" href="#option-cargo-run---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-run---locked"><a class="option-anchor" href="#option-cargo-run---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-run---offline"><a class="option-anchor" href="#option-cargo-run---offline"></a><code>--offline</code></dt>
@@ -232,6 +229,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-run---frozen"><a class="option-anchor" href="#option-cargo-run---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -305,11 +305,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-rustc---locked"><a class="option-anchor" href="#option-cargo-rustc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---offline"><a class="option-anchor" href="#option-cargo-rustc---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-rustc.md
+++ b/src/doc/src/commands/cargo-rustc.md
@@ -304,15 +304,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-rustc---frozen"><a class="option-anchor" href="#option-cargo-rustc---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-rustc---locked"><a class="option-anchor" href="#option-cargo-rustc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-rustc---offline"><a class="option-anchor" href="#option-cargo-rustc---offline"></a><code>--offline</code></dt>
@@ -326,6 +323,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-rustc---frozen"><a class="option-anchor" href="#option-cargo-rustc---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -285,15 +285,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-rustdoc---frozen"><a class="option-anchor" href="#option-cargo-rustdoc---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-rustdoc---locked"><a class="option-anchor" href="#option-cargo-rustdoc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---offline"><a class="option-anchor" href="#option-cargo-rustdoc---offline"></a><code>--offline</code></dt>
@@ -307,6 +304,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-rustdoc---frozen"><a class="option-anchor" href="#option-cargo-rustdoc---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 </dl>
 

--- a/src/doc/src/commands/cargo-rustdoc.md
+++ b/src/doc/src/commands/cargo-rustdoc.md
@@ -286,11 +286,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-rustdoc---locked"><a class="option-anchor" href="#option-cargo-rustdoc---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-rustdoc---offline"><a class="option-anchor" href="#option-cargo-rustdoc---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -406,15 +406,12 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-test---frozen"><a class="option-anchor" href="#option-cargo-test---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-test---locked"><a class="option-anchor" href="#option-cargo-test---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-test---offline"><a class="option-anchor" href="#option-cargo-test---offline"></a><code>--offline</code></dt>
@@ -428,6 +425,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-test---frozen"><a class="option-anchor" href="#option-cargo-test---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-test.md
+++ b/src/doc/src/commands/cargo-test.md
@@ -407,11 +407,15 @@ coming from rustc are still emitted. Cannot be used with <code>human</code> or <
 
 
 <dt class="option-term" id="option-cargo-test---locked"><a class="option-anchor" href="#option-cargo-test---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-test---offline"><a class="option-anchor" href="#option-cargo-test---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -223,11 +223,15 @@ single quotes or double quotes around each pattern.</dd>
 
 
 <dt class="option-term" id="option-cargo-tree---locked"><a class="option-anchor" href="#option-cargo-tree---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-tree---offline"><a class="option-anchor" href="#option-cargo-tree---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-tree.md
+++ b/src/doc/src/commands/cargo-tree.md
@@ -222,15 +222,12 @@ single quotes or double quotes around each pattern.</dd>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-tree---frozen"><a class="option-anchor" href="#option-cargo-tree---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-tree---locked"><a class="option-anchor" href="#option-cargo-tree---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-tree---offline"><a class="option-anchor" href="#option-cargo-tree---offline"></a><code>--offline</code></dt>
@@ -244,6 +241,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-tree---frozen"><a class="option-anchor" href="#option-cargo-tree---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -100,11 +100,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-update---locked"><a class="option-anchor" href="#option-cargo-update---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-update---offline"><a class="option-anchor" href="#option-cargo-update---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -99,15 +99,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-update---frozen"><a class="option-anchor" href="#option-cargo-update---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-update---locked"><a class="option-anchor" href="#option-cargo-update---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-update---offline"><a class="option-anchor" href="#option-cargo-update---offline"></a><code>--offline</code></dt>
@@ -121,6 +118,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-update---frozen"><a class="option-anchor" href="#option-cargo-update---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -69,11 +69,15 @@ only a subset of the packages have changed.</dd>
 
 
 <dt class="option-term" id="option-cargo-vendor---locked"><a class="option-anchor" href="#option-cargo-vendor---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-vendor---offline"><a class="option-anchor" href="#option-cargo-vendor---offline"></a><code>--offline</code></dt>

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -68,15 +68,12 @@ only a subset of the packages have changed.</dd>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-vendor---frozen"><a class="option-anchor" href="#option-cargo-vendor---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-vendor---locked"><a class="option-anchor" href="#option-cargo-vendor---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-vendor---offline"><a class="option-anchor" href="#option-cargo-vendor---offline"></a><code>--offline</code></dt>
@@ -90,6 +87,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-vendor---frozen"><a class="option-anchor" href="#option-cargo-vendor---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -63,15 +63,12 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
-<dt class="option-term" id="option-cargo-verify-project---frozen"><a class="option-anchor" href="#option-cargo-verify-project---frozen"></a><code>--frozen</code></dt>
 <dt class="option-term" id="option-cargo-verify-project---locked"><a class="option-anchor" href="#option-cargo-verify-project---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Either of these flags requires that the <code>Cargo.lock</code> file be
-up-to-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The <code>--frozen</code> flag also prevents Cargo from
-attempting to access the network to determine if it is out-of-date.</p>
-<p>These may be used in environments where you want to assert that the
-<code>Cargo.lock</code> file is up-to-date (such as a CI build) or want to avoid network
-access.</dd>
+<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
+or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
+a new dependency is added, Cargo will exit with an error.</p>
+<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
+file is up-to-date (such as a CI build).</dd>
 
 
 <dt class="option-term" id="option-cargo-verify-project---offline"><a class="option-anchor" href="#option-cargo-verify-project---offline"></a><code>--offline</code></dt>
@@ -85,6 +82,10 @@ if there might be a newer version as indicated in the local copy of the index.
 See the <a href="cargo-fetch.html">cargo-fetch(1)</a> command to download dependencies before going
 offline.</p>
 <p>May also be specified with the <code>net.offline</code> <a href="../reference/config.html">config value</a>.</dd>
+
+
+<dt class="option-term" id="option-cargo-verify-project---frozen"><a class="option-anchor" href="#option-cargo-verify-project---frozen"></a><code>--frozen</code></dt>
+<dd class="option-desc">Equivalent to specifying both <code>--locked</code> and <code>--offline</code>.</dd>
 
 
 </dl>

--- a/src/doc/src/commands/cargo-verify-project.md
+++ b/src/doc/src/commands/cargo-verify-project.md
@@ -64,11 +64,15 @@ terminal.</li>
 
 
 <dt class="option-term" id="option-cargo-verify-project---locked"><a class="option-anchor" href="#option-cargo-verify-project---locked"></a><code>--locked</code></dt>
-<dd class="option-desc">Requires the <code>Cargo.lock</code> file be up-to-date. If the lock file is missing,
-or it needs to be updated due to changes in the <code>Cargo.toml</code> file, for example
-a new dependency is added, Cargo will exit with an error.</p>
-<p>It may be used in environments where you want to assert that the <code>Cargo.lock</code>
-file is up-to-date (such as a CI build).</dd>
+<dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
+existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:</p>
+<ul>
+<li>The lock file is missing.</li>
+<li>Cargo attempted to change the lock file due to a different dependency resolution.</li>
+</ul>
+<p>It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.</dd>
 
 
 <dt class="option-term" id="option-cargo-verify-project---offline"><a class="option-anchor" href="#option-cargo-verify-project---offline"></a><code>--offline</code></dt>

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -223,12 +223,20 @@ Add dependencies to only the specified package.
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-add.1
+++ b/src/etc/man/cargo-add.1
@@ -221,17 +221,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 Add dependencies to only the specified package.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -248,6 +245,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -417,17 +417,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -444,6 +441,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -419,12 +419,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -337,12 +337,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-build.1
+++ b/src/etc/man/cargo-build.1
@@ -335,17 +335,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -362,6 +359,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -316,17 +316,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -343,6 +340,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-check.1
+++ b/src/etc/man/cargo-check.1
@@ -318,12 +318,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -117,12 +117,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-clean.1
+++ b/src/etc/man/cargo-clean.1
@@ -115,17 +115,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -142,6 +139,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -283,17 +283,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -310,6 +307,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-doc.1
+++ b/src/etc/man/cargo-doc.1
@@ -285,12 +285,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -85,12 +85,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-fetch.1
+++ b/src/etc/man/cargo-fetch.1
@@ -83,17 +83,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -108,6 +105,11 @@ mode. Cargo will restrict itself to crates that are downloaded locally, even
 if there might be a newer version as indicated in the local copy of the index.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -411,17 +411,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -438,6 +435,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-fix.1
+++ b/src/etc/man/cargo-fix.1
@@ -413,12 +413,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -64,12 +64,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -62,17 +62,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -89,6 +86,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -304,12 +304,20 @@ information about timing information.
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-install.1
+++ b/src/etc/man/cargo-install.1
@@ -302,17 +302,14 @@ information about timing information.
 .RE
 .SS "Manifest Options"
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -329,6 +326,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Miscellaneous Options"
 .sp

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -438,12 +438,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -436,17 +436,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -463,6 +460,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -198,17 +198,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -225,6 +222,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Miscellaneous Options"
 .sp

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -200,12 +200,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -121,17 +121,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -148,6 +145,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-pkgid.1
+++ b/src/etc/man/cargo-pkgid.1
@@ -123,12 +123,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -156,12 +156,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-publish.1
+++ b/src/etc/man/cargo-publish.1
@@ -154,17 +154,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -181,6 +178,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Miscellaneous Options"
 .sp

--- a/src/etc/man/cargo-remove.1
+++ b/src/etc/man/cargo-remove.1
@@ -83,12 +83,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-remove.1
+++ b/src/etc/man/cargo-remove.1
@@ -81,17 +81,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -108,6 +105,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Package Selection"
 .sp

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -222,12 +222,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-run.1
+++ b/src/etc/man/cargo-run.1
@@ -220,17 +220,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -247,6 +244,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -334,17 +334,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -361,6 +358,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-rustc.1
+++ b/src/etc/man/cargo-rustc.1
@@ -336,12 +336,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -302,17 +302,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -329,6 +326,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-rustdoc.1
+++ b/src/etc/man/cargo-rustdoc.1
@@ -304,12 +304,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -446,12 +446,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-test.1
+++ b/src/etc/man/cargo-test.1
@@ -444,17 +444,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -471,6 +468,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -268,12 +268,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-tree.1
+++ b/src/etc/man/cargo-tree.1
@@ -266,17 +266,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -293,6 +290,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Feature Selection"
 The feature flags allow you to control which features are enabled. When no

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -107,12 +107,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -105,17 +105,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -132,6 +129,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -62,17 +62,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -89,6 +86,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Display Options"
 .sp

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -64,12 +64,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -72,17 +72,14 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
-\fB\-\-frozen\fR, 
 \fB\-\-locked\fR
 .RS 4
-Either of these flags requires that the \fBCargo.lock\fR file be
-up\-to\-date. If the lock file is missing, or it needs to be updated, Cargo will
-exit with an error. The \fB\-\-frozen\fR flag also prevents Cargo from
-attempting to access the network to determine if it is out\-of\-date.
+Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
+or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
+a new dependency is added, Cargo will exit with an error.
 .sp
-These may be used in environments where you want to assert that the
-\fBCargo.lock\fR file is up\-to\-date (such as a CI build) or want to avoid network
-access.
+It may be used in environments where you want to assert that the \fBCargo.lock\fR
+file is up\-to\-date (such as a CI build).
 .RE
 .sp
 \fB\-\-offline\fR
@@ -99,6 +96,11 @@ See the \fBcargo\-fetch\fR(1) command to download dependencies before going
 offline.
 .sp
 May also be specified with the \fBnet.offline\fR \fIconfig value\fR <https://doc.rust\-lang.org/cargo/reference/config.html>\&.
+.RE
+.sp
+\fB\-\-frozen\fR
+.RS 4
+Equivalent to specifying both \fB\-\-locked\fR and \fB\-\-offline\fR\&.
 .RE
 .SS "Common Options"
 .sp

--- a/src/etc/man/cargo-verify-project.1
+++ b/src/etc/man/cargo-verify-project.1
@@ -74,12 +74,20 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 .sp
 \fB\-\-locked\fR
 .RS 4
-Requires the \fBCargo.lock\fR file be up\-to\-date. If the lock file is missing,
-or it needs to be updated due to changes in the \fBCargo.toml\fR file, for example
-a new dependency is added, Cargo will exit with an error.
+Asserts that the exact same dependencies and versions are used as when the
+existing \fBCargo.lock\fR file was originally generated. Cargo will exit with an
+error when either of the following scenarios arises:
 .sp
-It may be used in environments where you want to assert that the \fBCargo.lock\fR
-file is up\-to\-date (such as a CI build).
+.RS 4
+\h'-04'\(bu\h'+02'The lock file is missing.
+.RE
+.sp
+.RS 4
+\h'-04'\(bu\h'+02'Cargo attempted to change the lock file due to a different dependency resolution.
+.RE
+.sp
+It may be used in environments where deterministic builds are desired,
+such as in CI pipelines.
 .RE
 .sp
 \fB\-\-offline\fR

--- a/tests/testsuite/cargo/help/stdout.term.svg
+++ b/tests/testsuite/cargo/help/stdout.term.svg
@@ -45,7 +45,7 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-C</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>            Change to DIRECTORY before doing anything (nightly-only)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>              Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>              Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>             Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo/help/stdout.term.svg
+++ b/tests/testsuite/cargo/help/stdout.term.svg
@@ -45,11 +45,11 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-cyan bold">-C</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DIRECTORY&gt;</tspan><tspan>            Change to DIRECTORY before doing anything (nightly-only)</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>              Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>              Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>              Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>             Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>             Run without accessing the network</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>              Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--config</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;KEY=VALUE&gt;</tspan><tspan>  Override a configuration value</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/help/stdout.term.svg
+++ b/tests/testsuite/cargo_add/help/stdout.term.svg
@@ -179,21 +179,21 @@
 </tspan>
     <tspan x="10px" y="1450px">
 </tspan>
-    <tspan x="10px" y="1468px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan>
+    <tspan x="10px" y="1468px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan>
 </tspan>
-    <tspan x="10px" y="1486px"><tspan>          Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="1486px"><tspan>          Require Cargo.lock to be up-to-date</tspan>
 </tspan>
     <tspan x="10px" y="1504px">
 </tspan>
-    <tspan x="10px" y="1522px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan>
+    <tspan x="10px" y="1522px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan>
 </tspan>
-    <tspan x="10px" y="1540px"><tspan>          Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1540px"><tspan>          Run without accessing the network</tspan>
 </tspan>
     <tspan x="10px" y="1558px">
 </tspan>
-    <tspan x="10px" y="1576px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan>
+    <tspan x="10px" y="1576px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan>
 </tspan>
-    <tspan x="10px" y="1594px"><tspan>          Run without accessing the network</tspan>
+    <tspan x="10px" y="1594px"><tspan>          Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1612px">
 </tspan>

--- a/tests/testsuite/cargo_add/help/stdout.term.svg
+++ b/tests/testsuite/cargo_add/help/stdout.term.svg
@@ -181,7 +181,7 @@
 </tspan>
     <tspan x="10px" y="1468px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan>
 </tspan>
-    <tspan x="10px" y="1486px"><tspan>          Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1486px"><tspan>          Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1504px">
 </tspan>

--- a/tests/testsuite/cargo_bench/help/stdout.term.svg
+++ b/tests/testsuite/cargo_bench/help/stdout.term.svg
@@ -127,11 +127,11 @@
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1054px">
 </tspan>

--- a/tests/testsuite/cargo_bench/help/stdout.term.svg
+++ b/tests/testsuite/cargo_bench/help/stdout.term.svg
@@ -127,7 +127,7 @@
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_build/help/stdout.term.svg
+++ b/tests/testsuite/cargo_build/help/stdout.term.svg
@@ -125,11 +125,11 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1036px">
 </tspan>

--- a/tests/testsuite/cargo_build/help/stdout.term.svg
+++ b/tests/testsuite/cargo_build/help/stdout.term.svg
@@ -125,7 +125,7 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_check/help/stdout.term.svg
+++ b/tests/testsuite/cargo_check/help/stdout.term.svg
@@ -121,11 +121,11 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>

--- a/tests/testsuite/cargo_check/help/stdout.term.svg
+++ b/tests/testsuite/cargo_check/help/stdout.term.svg
@@ -121,7 +121,7 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_clean/help/stdout.term.svg
+++ b/tests/testsuite/cargo_clean/help/stdout.term.svg
@@ -69,7 +69,7 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_clean/help/stdout.term.svg
+++ b/tests/testsuite/cargo_clean/help/stdout.term.svg
@@ -69,11 +69,11 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/testsuite/cargo_config/help/stdout.term.svg
+++ b/tests/testsuite/cargo_config/help/stdout.term.svg
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_config/help/stdout.term.svg
+++ b/tests/testsuite/cargo_config/help/stdout.term.svg
@@ -51,11 +51,11 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_doc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_doc/help/stdout.term.svg
@@ -115,11 +115,11 @@
 </tspan>
     <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="928px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>

--- a/tests/testsuite/cargo_doc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_doc/help/stdout.term.svg
@@ -115,7 +115,7 @@
 </tspan>
     <tspan x="10px" y="874px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="892px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="910px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_fetch/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fetch/help/stdout.term.svg
@@ -53,11 +53,11 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_fetch/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fetch/help/stdout.term.svg
@@ -53,7 +53,7 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -129,7 +129,7 @@
 </tspan>
     <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_fix/help/stdout.term.svg
+++ b/tests/testsuite/cargo_fix/help/stdout.term.svg
@@ -129,11 +129,11 @@
 </tspan>
     <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1072px">
 </tspan>

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
@@ -47,7 +47,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
@@ -47,11 +47,11 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>

--- a/tests/testsuite/cargo_help/help/stdout.term.svg
+++ b/tests/testsuite/cargo_help/help/stdout.term.svg
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_help/help/stdout.term.svg
+++ b/tests/testsuite/cargo_help/help/stdout.term.svg
@@ -51,11 +51,11 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_init/help/stdout.term.svg
+++ b/tests/testsuite/cargo_init/help/stdout.term.svg
@@ -69,11 +69,11 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/testsuite/cargo_init/help/stdout.term.svg
+++ b/tests/testsuite/cargo_init/help/stdout.term.svg
@@ -69,7 +69,7 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -121,7 +121,7 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_install/help/stdout.term.svg
+++ b/tests/testsuite/cargo_install/help/stdout.term.svg
@@ -121,11 +121,11 @@
 </tspan>
     <tspan x="10px" y="928px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1000px">
 </tspan>

--- a/tests/testsuite/cargo_locate_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_locate_project/help/stdout.term.svg
@@ -53,11 +53,11 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/testsuite/cargo_locate_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_locate_project/help/stdout.term.svg
@@ -53,7 +53,7 @@
 </tspan>
     <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_login/help/stdout.term.svg
+++ b/tests/testsuite/cargo_login/help/stdout.term.svg
@@ -55,11 +55,11 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>

--- a/tests/testsuite/cargo_login/help/stdout.term.svg
+++ b/tests/testsuite/cargo_login/help/stdout.term.svg
@@ -55,7 +55,7 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_logout/help/stdout.term.svg
+++ b/tests/testsuite/cargo_logout/help/stdout.term.svg
@@ -47,11 +47,11 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>

--- a/tests/testsuite/cargo_logout/help/stdout.term.svg
+++ b/tests/testsuite/cargo_logout/help/stdout.term.svg
@@ -47,7 +47,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_metadata/help/stdout.term.svg
+++ b/tests/testsuite/cargo_metadata/help/stdout.term.svg
@@ -69,7 +69,7 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_metadata/help/stdout.term.svg
+++ b/tests/testsuite/cargo_metadata/help/stdout.term.svg
@@ -69,11 +69,11 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/testsuite/cargo_new/help/stdout.term.svg
+++ b/tests/testsuite/cargo_new/help/stdout.term.svg
@@ -69,11 +69,11 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/testsuite/cargo_new/help/stdout.term.svg
+++ b/tests/testsuite/cargo_new/help/stdout.term.svg
@@ -69,7 +69,7 @@
 </tspan>
     <tspan x="10px" y="460px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_owner/help/stdout.term.svg
+++ b/tests/testsuite/cargo_owner/help/stdout.term.svg
@@ -63,7 +63,7 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_owner/help/stdout.term.svg
+++ b/tests/testsuite/cargo_owner/help/stdout.term.svg
@@ -63,11 +63,11 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -87,7 +87,7 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_package/help/stdout.term.svg
+++ b/tests/testsuite/cargo_package/help/stdout.term.svg
@@ -87,11 +87,11 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="694px">
 </tspan>

--- a/tests/testsuite/cargo_pkgid/help/stdout.term.svg
+++ b/tests/testsuite/cargo_pkgid/help/stdout.term.svg
@@ -59,7 +59,7 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_pkgid/help/stdout.term.svg
+++ b/tests/testsuite/cargo_pkgid/help/stdout.term.svg
@@ -59,11 +59,11 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>

--- a/tests/testsuite/cargo_publish/help/stdout.term.svg
+++ b/tests/testsuite/cargo_publish/help/stdout.term.svg
@@ -87,7 +87,7 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_publish/help/stdout.term.svg
+++ b/tests/testsuite/cargo_publish/help/stdout.term.svg
@@ -87,11 +87,11 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="676px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="694px">
 </tspan>

--- a/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
+++ b/tests/testsuite/cargo_read_manifest/help/stdout.term.svg
@@ -51,11 +51,11 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_remove/help/stdout.term.svg
+++ b/tests/testsuite/cargo_remove/help/stdout.term.svg
@@ -71,11 +71,11 @@
 </tspan>
     <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>

--- a/tests/testsuite/cargo_remove/help/stdout.term.svg
+++ b/tests/testsuite/cargo_remove/help/stdout.term.svg
@@ -71,7 +71,7 @@
 </tspan>
     <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_report/help/stdout.term.svg
+++ b/tests/testsuite/cargo_report/help/stdout.term.svg
@@ -51,7 +51,7 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_report/help/stdout.term.svg
+++ b/tests/testsuite/cargo_report/help/stdout.term.svg
@@ -51,11 +51,11 @@
 </tspan>
     <tspan x="10px" y="298px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_run/help/stdout.term.svg
+++ b/tests/testsuite/cargo_run/help/stdout.term.svg
@@ -103,7 +103,7 @@
 </tspan>
     <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_run/help/stdout.term.svg
+++ b/tests/testsuite/cargo_run/help/stdout.term.svg
@@ -103,11 +103,11 @@
 </tspan>
     <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="784px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="802px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="820px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="838px">
 </tspan>

--- a/tests/testsuite/cargo_rustc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustc/help/stdout.term.svg
@@ -125,11 +125,11 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1018px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1036px">
 </tspan>

--- a/tests/testsuite/cargo_rustc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustc/help/stdout.term.svg
@@ -125,7 +125,7 @@
 </tspan>
     <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -123,7 +123,7 @@
 </tspan>
     <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
+++ b/tests/testsuite/cargo_rustdoc/help/stdout.term.svg
@@ -123,11 +123,11 @@
 </tspan>
     <tspan x="10px" y="946px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="964px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="982px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1000px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1018px">
 </tspan>

--- a/tests/testsuite/cargo_search/help/stdout.term.svg
+++ b/tests/testsuite/cargo_search/help/stdout.term.svg
@@ -57,11 +57,11 @@
 </tspan>
     <tspan x="10px" y="352px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="424px">
 </tspan>

--- a/tests/testsuite/cargo_search/help/stdout.term.svg
+++ b/tests/testsuite/cargo_search/help/stdout.term.svg
@@ -57,7 +57,7 @@
 </tspan>
     <tspan x="10px" y="352px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_test/help/stdout.term.svg
+++ b/tests/testsuite/cargo_test/help/stdout.term.svg
@@ -133,11 +133,11 @@
 </tspan>
     <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="1090px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="1108px">
 </tspan>

--- a/tests/testsuite/cargo_test/help/stdout.term.svg
+++ b/tests/testsuite/cargo_test/help/stdout.term.svg
@@ -133,7 +133,7 @@
 </tspan>
     <tspan x="10px" y="1036px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="1054px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="1072px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_tree/help/stdout.term.svg
+++ b/tests/testsuite/cargo_tree/help/stdout.term.svg
@@ -97,7 +97,7 @@
 </tspan>
     <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_tree/help/stdout.term.svg
+++ b/tests/testsuite/cargo_tree/help/stdout.term.svg
@@ -97,11 +97,11 @@
 </tspan>
     <tspan x="10px" y="712px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="730px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="748px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="766px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="784px">
 </tspan>

--- a/tests/testsuite/cargo_uninstall/help/stdout.term.svg
+++ b/tests/testsuite/cargo_uninstall/help/stdout.term.svg
@@ -65,11 +65,11 @@
 </tspan>
     <tspan x="10px" y="424px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="496px">
 </tspan>

--- a/tests/testsuite/cargo_uninstall/help/stdout.term.svg
+++ b/tests/testsuite/cargo_uninstall/help/stdout.term.svg
@@ -65,7 +65,7 @@
 </tspan>
     <tspan x="10px" y="424px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -61,7 +61,7 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -61,11 +61,11 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>

--- a/tests/testsuite/cargo_vendor/help/stdout.term.svg
+++ b/tests/testsuite/cargo_vendor/help/stdout.term.svg
@@ -63,11 +63,11 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>

--- a/tests/testsuite/cargo_vendor/help/stdout.term.svg
+++ b/tests/testsuite/cargo_vendor/help/stdout.term.svg
@@ -63,7 +63,7 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_verify_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_verify_project/help/stdout.term.svg
@@ -47,7 +47,7 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_verify_project/help/stdout.term.svg
+++ b/tests/testsuite/cargo_verify_project/help/stdout.term.svg
@@ -47,11 +47,11 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="334px">
 </tspan>

--- a/tests/testsuite/cargo_version/help/stdout.term.svg
+++ b/tests/testsuite/cargo_version/help/stdout.term.svg
@@ -45,7 +45,7 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_version/help/stdout.term.svg
+++ b/tests/testsuite/cargo_version/help/stdout.term.svg
@@ -45,11 +45,11 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="316px">
 </tspan>

--- a/tests/testsuite/cargo_yank/help/stdout.term.svg
+++ b/tests/testsuite/cargo_yank/help/stdout.term.svg
@@ -61,7 +61,7 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>

--- a/tests/testsuite/cargo_yank/help/stdout.term.svg
+++ b/tests/testsuite/cargo_yank/help/stdout.term.svg
@@ -61,11 +61,11 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan class="fg-green bold">Manifest Options:</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Require Cargo.lock and cache to be up-to-date</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>   Require Cargo.lock to be up-to-date</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>  Run without accessing the network</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>   Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
     <tspan x="10px" y="460px">
 </tspan>


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?


Fixes #11143

This is an attempt to remove the `up-to-date` mentioned in `--locked`.
Up-to-date is quite confusing, especially when MSRV resolution is out,
dependency version may lag behind more often.

`--frozen` is now documented as an equivalent of `--locked` + `--offline`.

### How should we test and review this PR?

```
cargo run -- help build 
# and read the man page

cargo build --help
# and check the help text
```



### Additional information

<!-- homu-ignore:end -->
