### PR TITLE
Document variance in strip

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -117,7 +117,9 @@ strip = "debuginfo"
 ```
 
 Possible string values of `strip` are `"none"`, `"debuginfo"`, and `"symbols"`.
-The default is `"none"`.
+The default is `"none"` by default, and `"debuginfo"` in release profile.
+Be aware that stripping `"symbols"` may make backtraces incomprehensible,
+depending on the platform.
 
 You can also configure this option with the boolean values `true` or `false`.
 `strip = true` is equivalent to `strip = "symbols"`. `strip = false` is
@@ -293,7 +295,7 @@ The default settings for the `release` profile are:
 opt-level = 3
 debug = false
 split-debuginfo = '...'  # Platform-specific.
-strip = "none"
+strip = "debuginfo"
 debug-assertions = false
 overflow-checks = false
 lto = false


### PR DESCRIPTION
Two variances in strip will remain, even after MSVC shenanigans settle:
- Its default based on profile.
- That it can sometimes make backtraces nonsensical.

In my experience, people will complain to me if backtraces are fucked up, but sometimes it was their own decision to make the backtrace really bad. Inform them of this. Hopefully this also encourages people to report if their backtraces regress in some platform-dependent way without enabling `strip = "symbols"`, which we would want to know about.