### PR TITLE
CI: Update macos images to macos-13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,11 +134,11 @@ jobs:
           rust: nightly
           other: i686-unknown-linux-gnu
         - name: macOS x86_64 stable
-          os: macos-latest
+          os: macos-13
           rust: stable
           other: x86_64-apple-ios
         - name: macOS x86_64 nightly
-          os: macos-latest
+          os: macos-13
           rust: nightly
           other: x86_64-apple-ios
         - name: macOS aarch64 stable


### PR DESCRIPTION
This changes the CI workflows to use `macos-13` instead of `macos-latest`. `latest` is currently `macos-12`, but GitHub is [migrating](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) latest to `macos-14` starting immediately. 14 switches to aarch64 which we do not want, yet.

rust-lang/rust already migrated to macos-13 a little while ago in https://github.com/rust-lang/rust/pull/113544. This might have some performance improvements here, as the macos-12 images inconsistently have SIP enabled, but macos-13 seems to reliably have it disabled.

We do not yet know when GitHub will be retiring their x86_64 runners. Their current roadmap, posted at https://github.com/actions/runner-images/issues/9255, shows macos-13 supported through at least the end of the year. However, I suspect next year might spell the end for it. At that time, the Rust project might need to consider downgrading x86_64-apple-darwin to tier 2 or figure out some other option.
