### PR TITLE
Allows the default git/gitoxide configuration to be obtained from the ENV and config

### DIFF
--- a/src/cargo/util/context/de.rs
+++ b/src/cargo/util/context/de.rs
@@ -62,6 +62,12 @@ impl<'de, 'gctx> de::Deserializer<'de> for Deserializer<'gctx> {
             let (res, def) = res;
             return res.map_err(|e| e.with_key_context(&self.key, Some(def)));
         }
+
+        // The effect here is the same as in `deserialize_option`.
+        if self.gctx.has_key(&self.key, self.env_prefix_ok)? {
+            return visitor.visit_some(self);
+        }
+
         Err(ConfigError::missing(&self.key))
     }
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1923,3 +1923,51 @@ Caused by:
   missing field `bax`",
     );
 }
+
+#[cargo_test]
+fn git_features_env() {
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GIT", "true")
+        .build();
+    verify(gctx);
+
+    write_config_toml(
+        "\
+    [unstable.git]
+    ",
+    );
+    let gctx = GlobalContextBuilder::new().build();
+    verify(gctx);
+
+    fn verify(gctx: GlobalContext) {
+        assert_error(
+            gctx.get::<Option<cargo::core::CliUnstable>>("unstable")
+                .unwrap_err(),
+            "missing field `shallow_index`",
+        );
+    }
+}
+
+#[cargo_test]
+fn gitoxide_features_env() {
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GITOXIDE", "true")
+        .build();
+    verify(gctx);
+
+    write_config_toml(
+        "\
+    [unstable.gitoxide]
+    ",
+    );
+    let gctx = GlobalContextBuilder::new().build();
+    verify(gctx);
+
+    fn verify(gctx: GlobalContext) {
+        assert_error(
+            gctx.get::<Option<cargo::core::CliUnstable>>("unstable")
+                .unwrap_err(),
+            "missing field `fetch`",
+        );
+    }
+}

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,5 +1,6 @@
 //! Tests for config settings.
 
+use cargo::core::features::{GitFeatures, GitoxideFeatures};
 use cargo::core::{PackageIdSpec, Shell};
 use cargo::util::context::{
     self, Definition, GlobalContext, JobsConfig, SslVersionConfig, StringList,
@@ -1925,11 +1926,102 @@ Caused by:
 }
 
 #[cargo_test]
-fn git_features_env() {
+fn git_features() {
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GIT", "shallow-index")
+        .build();
+    assert!(do_check(
+        gctx,
+        Some(GitFeatures {
+            shallow_index: true,
+            ..GitFeatures::default()
+        }),
+    ));
+
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GIT", "shallow-index,abc")
+        .build();
+    assert_error(
+        gctx.get::<Option<cargo::core::CliUnstable>>("unstable")
+            .unwrap_err(),
+        "\
+error in environment variable `CARGO_UNSTABLE_GIT`: could not load config key `unstable.git`
+
+Caused by:
+[..]unstable 'git' only takes [..] as valid inputs",
+    );
+
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GIT", "shallow-deps")
+        .build();
+    assert!(do_check(
+        gctx,
+        Some(GitFeatures {
+            shallow_index: false,
+            shallow_deps: true,
+        }),
+    ));
+
     let gctx = GlobalContextBuilder::new()
         .env("CARGO_UNSTABLE_GIT", "true")
         .build();
-    verify(gctx);
+    assert!(do_check(gctx, Some(GitFeatures::all())));
+
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GIT_SHALLOW_INDEX", "true")
+        .build();
+    assert!(do_check(
+        gctx,
+        Some(GitFeatures {
+            shallow_index: true,
+            ..Default::default()
+        }),
+    ));
+
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GIT_SHALLOW_INDEX", "true")
+        .env("CARGO_UNSTABLE_GIT_SHALLOW_DEPS", "true")
+        .build();
+    assert!(do_check(
+        gctx,
+        Some(GitFeatures {
+            shallow_index: true,
+            shallow_deps: true,
+            ..Default::default()
+        }),
+    ));
+
+    write_config_toml(
+        "\
+[unstable]
+git = 'shallow-index'
+",
+    );
+    let gctx = GlobalContextBuilder::new().build();
+    assert!(do_check(
+        gctx,
+        Some(GitFeatures {
+            shallow_index: true,
+            shallow_deps: false,
+        }),
+    ));
+
+    write_config_toml(
+        "\
+    [unstable.git]
+    shallow_deps = false
+    shallow_index = true
+    ",
+    );
+    let gctx = GlobalContextBuilder::new().build();
+    assert!(do_check(
+        gctx,
+        Some(GitFeatures {
+            shallow_index: true,
+            shallow_deps: false,
+            ..Default::default()
+        }),
+    ));
 
     write_config_toml(
         "\
@@ -1937,23 +2029,92 @@ fn git_features_env() {
     ",
     );
     let gctx = GlobalContextBuilder::new().build();
-    verify(gctx);
+    assert!(do_check(gctx, Some(Default::default())));
 
-    fn verify(gctx: GlobalContext) {
-        assert_error(
-            gctx.get::<Option<cargo::core::CliUnstable>>("unstable")
-                .unwrap_err(),
-            "missing field `shallow_index`",
-        );
+    fn do_check(gctx: GlobalContext, expect: Option<GitFeatures>) -> bool {
+        let unstable_flags = gctx
+            .get::<Option<cargo::core::CliUnstable>>("unstable")
+            .unwrap()
+            .unwrap();
+        unstable_flags.git == expect
     }
 }
 
 #[cargo_test]
-fn gitoxide_features_env() {
+fn gitoxide_features() {
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GITOXIDE", "fetch")
+        .build();
+    assert!(do_check(
+        gctx,
+        Some(GitoxideFeatures {
+            fetch: true,
+            ..GitoxideFeatures::default()
+        }),
+    ));
+
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GITOXIDE", "fetch,abc")
+        .build();
+
+    assert_error(
+    gctx.get::<Option<cargo::core::CliUnstable>>("unstable")
+        .unwrap_err(),
+    "\
+error in environment variable `CARGO_UNSTABLE_GITOXIDE`: could not load config key `unstable.gitoxide`
+
+Caused by:
+[..]unstable 'gitoxide' only takes [..] as valid inputs, for shallow fetches see `-Zgit=shallow-index,shallow-deps`",
+);
+
     let gctx = GlobalContextBuilder::new()
         .env("CARGO_UNSTABLE_GITOXIDE", "true")
         .build();
-    verify(gctx);
+    assert!(do_check(gctx, Some(GitoxideFeatures::all())));
+
+    let gctx = GlobalContextBuilder::new()
+        .env("CARGO_UNSTABLE_GITOXIDE_FETCH", "true")
+        .build();
+    assert!(do_check(
+        gctx,
+        Some(GitoxideFeatures {
+            fetch: true,
+            ..Default::default()
+        }),
+    ));
+
+    write_config_toml(
+        "\
+[unstable]
+gitoxide = \"fetch\"
+",
+    );
+    let gctx = GlobalContextBuilder::new().build();
+    assert!(do_check(
+        gctx,
+        Some(GitoxideFeatures {
+            fetch: true,
+            ..GitoxideFeatures::default()
+        }),
+    ));
+
+    write_config_toml(
+        "\
+    [unstable.gitoxide]
+    fetch = true
+    checkout = false
+    internal_use_git2 = false
+    ",
+    );
+    let gctx = GlobalContextBuilder::new().build();
+    assert!(do_check(
+        gctx,
+        Some(GitoxideFeatures {
+            fetch: true,
+            checkout: false,
+            internal_use_git2: false,
+        }),
+    ));
 
     write_config_toml(
         "\
@@ -1961,13 +2122,13 @@ fn gitoxide_features_env() {
     ",
     );
     let gctx = GlobalContextBuilder::new().build();
-    verify(gctx);
+    assert!(do_check(gctx, Some(Default::default())));
 
-    fn verify(gctx: GlobalContext) {
-        assert_error(
-            gctx.get::<Option<cargo::core::CliUnstable>>("unstable")
-                .unwrap_err(),
-            "missing field `fetch`",
-        );
+    fn do_check(gctx: GlobalContext, expect: Option<GitoxideFeatures>) -> bool {
+        let unstable_flags = gctx
+            .get::<Option<cargo::core::CliUnstable>>("unstable")
+            .unwrap()
+            .unwrap();
+        unstable_flags.gitoxide == expect
     }
 }


### PR DESCRIPTION
### What does this PR try to resolve?
The default git/gitoxide feautures config can be obtained througt `-Zgit` and `-Zgitoxide`.  
However, it cannot be obtained from environment variables or configurations.
It's not very ergonomic.

### How should we test and review this PR?
The previous commit explained the staus quo, the next commit addressed the problem.


### Additional information
Inspired by https://github.com/rust-lang/cargo/issues/11813#issuecomment-1817517629
See also https://github.com/rust-lang/cargo/issues/13285#issuecomment-2016875459



### Change of usage

1. Mirror Zgit/Zgitoxide when they parsed as string

Specify the feature you like
```
CARGO_UNSABLE_GIT='shallow-deps' cargo fetch
cargo fetch --config "unstable.git='shallow-deps'"
cargo fetch -Zgit="shallow-deps"
```

2. Specify partial fields when parsed as table

```
CARGO_UNSTABLE_GITOXIDE_FETCH=true cargo fetch

```

The rest fields will use Rust default value. That said, checkout and internal_use_git2 will be false.


Besides, you can pass true to the whole feature to specify the pre-defined features.

```
CARGO_UNSTABLE_GITOXIDE=true cargo fetch

```


