### PR TITLE
fix: create ephemeral workspace for git source

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -283,6 +283,10 @@ impl<'gctx> Workspace<'gctx> {
         ws.member_ids.insert(id);
         ws.default_members.push(ws.current_manifest.clone());
         ws.set_resolve_behavior();
+        // The find_root function is used here to traverse the directory tree and locate the root of the workspace.
+        // Despite being ephemeral, we still need to validate all the manifests in the workspace,
+        // which is what `find_root` helps us achieve here.
+        ws.find_root(ws.current_manifest.clone().as_path())?;
         Ok(ws)
     }
 

--- a/src/cargo/ops/cargo_install.rs
+++ b/src/cargo/ops/cargo_install.rs
@@ -816,7 +816,7 @@ fn make_ws_rustc_target<'gctx>(
     source_id: &SourceId,
     pkg: Package,
 ) -> CargoResult<(Workspace<'gctx>, Rustc, String)> {
-    let mut ws = if source_id.is_git() || source_id.is_path() {
+    let mut ws = if source_id.is_path() {
         Workspace::new(pkg.manifest_path(), gctx)?
     } else {
         Workspace::ephemeral(pkg, gctx, None, false)?

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2124,6 +2124,7 @@ fn git_install_the_same_bin_twice_with_different_rev() {
         "\
 [UPDATING] git repository [..]
 [INSTALLING] bin1 v0.1.0 [..]
+[COMPILING] bin1 v0.1.0 [..]
 [FINISHED] [..]
 [REPLACING] [..]home/.cargo/bin/bin1[..]
 [REPLACED] package `bin1 [..]


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/issues/13259

#### Root cause
The root cause of this problem is that cargo install creates a non-ephemeral workspace for git sources, that would try finding all member packages in that git repo, and add them as path dependencies.

However, when computing fingerprints to determine if a rebuild is needed, Cargo doesn't hash git revision into fingerprint directly. Instead, it checks if source file path has changed. For git source, it is an absolute path to ~/.cargo/git/checkouts/<pkg-hash>/<short-commit-sha>, so commit SHA is always there. For path dependency, it is relative to workspace root, so nothing change and Cargo doesn't rebuild even it is from a different git revision.

#### Sloution
If any time we create an ephemeral workspace, then we will update the git source every time and that would help us use the right code and rebuild the binary correctly.

There are some historical PRs related to this change:
1. 4 years ago, we tried to all use ephemeral workspace in https://github.com/rust-lang/cargo/pull/5350. But it caused https://github.com/rust-lang/cargo/issues/5662 so we revert that change in https://github.com/rust-lang/cargo/pull/5685.
2. https://github.com/rust-lang/cargo/pull/7768 In this PR, we try to search the root manifest by using `Workspace::new`, but it also caused the https://github.com/rust-lang/cargo/issues/13259.

So in my fix, I just rollback to use ephemera workspace but using `find_root` to achieve the same goal of searching the root manifest. You can find more in the test: `git_install_reads_workspace_manifest`

### How should we test and review this PR?

- [x] manually test https://github.com/rust-lang/cargo/pull/13689#issuecomment-2053473575
- [x] unit test

### Additional information

None
<!-- homu-ignore:end -->
