### PR TITLE
refactor(toml): Split out an explicit step to resolve `Cargo.toml`

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -245,6 +245,10 @@ impl TomlPackage {
     pub fn resolved_license(&self) -> Result<Option<&String>, UnresolvedError> {
         self.license.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_license_file(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.license_file.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -219,6 +219,10 @@ impl TomlPackage {
         self.include.as_ref().map(|v| v.resolved()).transpose()
     }
 
+    pub fn resolved_publish(&self) -> Result<Option<&VecStringOrBool>, UnresolvedError> {
+        self.publish.as_ref().map(|v| v.resolved()).transpose()
+    }
+
     pub fn resolved_description(&self) -> Result<Option<&String>, UnresolvedError> {
         self.description.as_ref().map(|v| v.resolved()).transpose()
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -106,6 +106,12 @@ impl TomlManifest {
         self.features.as_ref()
     }
 
+    pub fn resolved_badges(
+        &self,
+    ) -> Result<Option<&BTreeMap<String, BTreeMap<String, String>>>, UnresolvedError> {
+        self.badges.as_ref().map(|l| l.resolved()).transpose()
+    }
+
     pub fn resolved_lints(&self) -> Result<Option<&TomlLints>, UnresolvedError> {
         self.lints.as_ref().map(|l| l.resolved()).transpose()
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -211,6 +211,14 @@ impl TomlPackage {
         self.authors.as_ref().map(|v| v.resolved()).transpose()
     }
 
+    pub fn resolved_exclude(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.exclude.as_ref().map(|v| v.resolved()).transpose()
+    }
+
+    pub fn resolved_include(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.include.as_ref().map(|v| v.resolved()).transpose()
+    }
+
     pub fn resolved_description(&self) -> Result<Option<&String>, UnresolvedError> {
         self.description.as_ref().map(|v| v.resolved()).transpose()
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -249,6 +249,10 @@ impl TomlPackage {
     pub fn resolved_license_file(&self) -> Result<Option<&String>, UnresolvedError> {
         self.license_file.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_repository(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.repository.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -589,6 +589,13 @@ impl InheritableDependency {
             InheritableDependency::Inherit(w) => w._unused_keys.keys().cloned().collect(),
         }
     }
+
+    pub fn resolved(&self) -> Result<&TomlDependency, UnresolvedError> {
+        match self {
+            InheritableDependency::Value(d) => Ok(d),
+            InheritableDependency::Inherit(_) => Err(UnresolvedError),
+        }
+    }
 }
 
 impl<'de> de::Deserialize<'de> for InheritableDependency {

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -214,6 +214,13 @@ impl TomlPackage {
     pub fn resolved_homepage(&self) -> Result<Option<&String>, UnresolvedError> {
         self.homepage.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_documentation(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.documentation
+            .as_ref()
+            .map(|v| v.resolved())
+            .transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -233,6 +233,10 @@ impl TomlPackage {
             })
             .transpose()
     }
+
+    pub fn resolved_keywords(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.keywords.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -241,6 +241,10 @@ impl TomlPackage {
     pub fn resolved_categories(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
         self.categories.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_license(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.license.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -221,6 +221,18 @@ impl TomlPackage {
             .map(|v| v.resolved())
             .transpose()
     }
+
+    pub fn resolved_readme(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.readme
+            .as_ref()
+            .map(|v| {
+                v.resolved().and_then(|sb| match sb {
+                    StringOrBool::Bool(_) => Err(UnresolvedError),
+                    StringOrBool::String(value) => Ok(value),
+                })
+            })
+            .transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -207,6 +207,10 @@ impl TomlPackage {
         self.version.as_ref().map(|v| v.resolved()).transpose()
     }
 
+    pub fn resolved_authors(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.authors.as_ref().map(|v| v.resolved()).transpose()
+    }
+
     pub fn resolved_description(&self) -> Result<Option<&String>, UnresolvedError> {
         self.description.as_ref().map(|v| v.resolved()).transpose()
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -195,6 +195,10 @@ pub struct TomlPackage {
 }
 
 impl TomlPackage {
+    pub fn resolved_edition(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.edition.as_ref().map(|v| v.resolved()).transpose()
+    }
+
     pub fn resolved_rust_version(&self) -> Result<Option<&RustVersion>, UnresolvedError> {
         self.rust_version.as_ref().map(|v| v.resolved()).transpose()
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -210,6 +210,10 @@ impl TomlPackage {
     pub fn resolved_description(&self) -> Result<Option<&String>, UnresolvedError> {
         self.description.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_homepage(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.homepage.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -237,6 +237,10 @@ impl TomlPackage {
     pub fn resolved_keywords(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
         self.keywords.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_categories(&self) -> Result<Option<&Vec<String>>, UnresolvedError> {
+        self.categories.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -206,6 +206,10 @@ impl TomlPackage {
     pub fn resolved_version(&self) -> Result<Option<&semver::Version>, UnresolvedError> {
         self.version.as_ref().map(|v| v.resolved()).transpose()
     }
+
+    pub fn resolved_description(&self) -> Result<Option<&String>, UnresolvedError> {
+        self.description.as_ref().map(|v| v.resolved()).transpose()
+    }
 }
 
 /// An enum that allows for inheriting keys from a workspace in a Cargo.toml.

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -195,6 +195,10 @@ pub struct TomlPackage {
 }
 
 impl TomlPackage {
+    pub fn resolved_rust_version(&self) -> Result<Option<&RustVersion>, UnresolvedError> {
+        self.rust_version.as_ref().map(|v| v.resolved()).transpose()
+    }
+
     pub fn resolved_version(&self) -> Result<Option<&semver::Version>, UnresolvedError> {
         self.version.as_ref().map(|v| v.resolved()).transpose()
     }

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -105,6 +105,10 @@ impl TomlManifest {
     pub fn features(&self) -> Option<&BTreeMap<FeatureName, Vec<String>>> {
         self.features.as_ref()
     }
+
+    pub fn resolved_lints(&self) -> Result<Option<&TomlLints>, UnresolvedError> {
+        self.lints.as_ref().map(|l| l.resolved()).transpose()
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -1376,6 +1380,16 @@ pub struct InheritableLints {
     pub workspace: bool,
     #[serde(flatten)]
     pub lints: TomlLints,
+}
+
+impl InheritableLints {
+    pub fn resolved(&self) -> Result<&TomlLints, UnresolvedError> {
+        if self.workspace {
+            Err(UnresolvedError)
+        } else {
+            Ok(&self.lints)
+        }
+    }
 }
 
 fn is_false(b: &bool) -> bool {

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -151,7 +151,7 @@ pub type AllowFeatures = BTreeSet<String>;
 /// - Update [`CLI_VALUES`] to include the new edition.
 /// - Set [`LATEST_UNSTABLE`] to Some with the new edition.
 /// - Add an unstable feature to the [`features!`] macro invocation below for the new edition.
-/// - Gate on that new feature in [`toml::to_real_manifest`].
+/// - Gate on that new feature in [`toml`].
 /// - Update the shell completion files.
 /// - Update any failing tests (hopefully there are very few).
 /// - Update unstable.md to add a new section for this new edition (see [this example]).
@@ -178,7 +178,7 @@ pub type AllowFeatures = BTreeSet<String>;
 /// [`LATEST_STABLE`]: Edition::LATEST_STABLE
 /// [this example]: https://github.com/rust-lang/cargo/blob/3ebb5f15a940810f250b68821149387af583a79e/src/doc/src/reference/unstable.md?plain=1#L1238-L1264
 /// [`is_stable`]: Edition::is_stable
-/// [`toml::to_real_manifest`]: crate::util::toml::to_real_manifest
+/// [`toml`]: crate::util::toml
 /// [`features!`]: macro.features.html
 #[derive(
     Default, Clone, Copy, Debug, Hash, PartialOrd, Ord, Eq, PartialEq, Serialize, Deserialize,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -449,7 +449,6 @@ impl<'gctx> Workspace<'gctx> {
                             // NOTE: Since we use ConfigRelativePath, this root isn't used as
                             // any relative paths are resolved before they'd be joined with root.
                             Path::new("unused-relative-path"),
-                            self.unstable_features(),
                             /* kind */ None,
                         )
                     })

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -562,6 +562,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "version", || inherit()?.version()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.description = package
+        .description
+        .clone()
+        .map(|value| field_inherit_with(value, "description", || inherit()?.description()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -862,10 +868,9 @@ pub fn to_real_manifest(
 
     let metadata = ManifestMetadata {
         description: package
-            .description
-            .clone()
-            .map(|mw| field_inherit_with(mw, "description", || inherit()?.description()))
-            .transpose()?,
+            .resolved_description()
+            .expect("previously resolved")
+            .cloned(),
         homepage: package
             .homepage
             .clone()
@@ -927,10 +932,6 @@ pub fn to_real_manifest(
         links: package.links.clone(),
         rust_version: rust_version.clone(),
     };
-    package.description = metadata
-        .description
-        .clone()
-        .map(|description| manifest::InheritableField::Value(description));
     package.homepage = metadata
         .homepage
         .clone()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -596,6 +596,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "keywords", || inherit()?.keywords()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.categories = package
+        .categories
+        .clone()
+        .map(|value| field_inherit_with(value, "categories", || inherit()?.categories()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -938,10 +944,9 @@ pub fn to_real_manifest(
             .cloned()
             .unwrap_or_default(),
         categories: package
-            .categories
-            .clone()
-            .map(|mw| field_inherit_with(mw, "categories", || inherit()?.categories()))
-            .transpose()?
+            .resolved_categories()
+            .expect("previously resolved")
+            .cloned()
             .unwrap_or_default(),
         badges: original_toml
             .badges
@@ -968,10 +973,6 @@ pub fn to_real_manifest(
         .repository
         .clone()
         .map(|repository| manifest::InheritableField::Value(repository));
-    package.categories = package
-        .categories
-        .as_ref()
-        .map(|_| manifest::InheritableField::Value(metadata.categories.clone()));
     package.exclude = package
         .exclude
         .as_ref()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -608,6 +608,16 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "license", || inherit()?.license()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.license_file = package
+        .license_file
+        .clone()
+        .map(|value| {
+            field_inherit_with(value, "license-file", || {
+                inherit()?.license_file(package_root)
+            })
+        })
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -934,10 +944,9 @@ pub fn to_real_manifest(
             .expect("previously resolved")
             .cloned(),
         license_file: package
-            .license_file
-            .clone()
-            .map(|mw| field_inherit_with(mw, "license", || inherit()?.license_file(package_root)))
-            .transpose()?,
+            .resolved_license_file()
+            .expect("previously resolved")
+            .cloned(),
         repository: package
             .repository
             .clone()
@@ -966,10 +975,6 @@ pub fn to_real_manifest(
         .authors
         .as_ref()
         .map(|_| manifest::InheritableField::Value(metadata.authors.clone()));
-    package.license_file = metadata
-        .license_file
-        .clone()
-        .map(|license_file| manifest::InheritableField::Value(license_file));
     package.repository = metadata
         .repository
         .clone()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -562,6 +562,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "version", || inherit()?.version()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.authors = package
+        .authors
+        .clone()
+        .map(|value| field_inherit_with(value, "authors", || inherit()?.authors()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
     package.description = package
         .description
         .clone()
@@ -940,10 +946,9 @@ pub fn to_real_manifest(
             .expect("previously resolved")
             .cloned(),
         authors: package
-            .authors
-            .clone()
-            .map(|mw| field_inherit_with(mw, "authors", || inherit()?.authors()))
-            .transpose()?
+            .resolved_authors()
+            .expect("previously resolved")
+            .cloned()
             .unwrap_or_default(),
         license: package
             .resolved_license()
@@ -976,10 +981,6 @@ pub fn to_real_manifest(
         links: package.links.clone(),
         rust_version: rust_version.clone(),
     };
-    package.authors = package
-        .authors
-        .as_ref()
-        .map(|_| manifest::InheritableField::Value(metadata.authors.clone()));
     package.exclude = package
         .exclude
         .as_ref()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -602,6 +602,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "categories", || inherit()?.categories()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.license = package
+        .license
+        .clone()
+        .map(|value| field_inherit_with(value, "license", || inherit()?.license()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -924,10 +930,9 @@ pub fn to_real_manifest(
             .transpose()?
             .unwrap_or_default(),
         license: package
-            .license
-            .clone()
-            .map(|mw| field_inherit_with(mw, "license", || inherit()?.license()))
-            .transpose()?,
+            .resolved_license()
+            .expect("previously resolved")
+            .cloned(),
         license_file: package
             .license_file
             .clone()
@@ -961,10 +966,6 @@ pub fn to_real_manifest(
         .authors
         .as_ref()
         .map(|_| manifest::InheritableField::Value(metadata.authors.clone()));
-    package.license = metadata
-        .license
-        .clone()
-        .map(|license| manifest::InheritableField::Value(license));
     package.license_file = metadata
         .license_file
         .clone()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -544,13 +544,12 @@ pub fn to_real_manifest(
         features.require(Feature::open_namespaces())?;
     }
 
-    let version = package
+    package.version = package
         .version
         .clone()
-        .map(|version| field_inherit_with(version, "version", || inherit()?.version()))
-        .transpose()?;
-
-    package.version = version.clone().map(manifest::InheritableField::Value);
+        .map(|value| field_inherit_with(value, "version", || inherit()?.version()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = if let Some(rust_version) = &package.rust_version {
         let rust_version = field_inherit_with(rust_version.clone(), "rust_version", || {
@@ -990,6 +989,7 @@ pub fn to_real_manifest(
         .clone()
         .map(|p| manifest::InheritableField::Value(p));
 
+    let version = package.resolved_version().expect("previously resolved");
     let publish = match publish {
         Some(manifest::VecStringOrBool::VecString(ref vecstring)) => Some(vecstring.clone()),
         Some(manifest::VecStringOrBool::Bool(false)) => Some(vec![]),
@@ -1004,7 +1004,7 @@ pub fn to_real_manifest(
     let pkgid = PackageId::new(
         package.name.as_str().into(),
         version
-            .clone()
+            .cloned()
             .unwrap_or_else(|| semver::Version::new(0, 0, 0)),
         source_id,
     );

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -568,6 +568,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "description", || inherit()?.description()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.homepage = package
+        .homepage
+        .clone()
+        .map(|value| field_inherit_with(value, "homepage", || inherit()?.homepage()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -872,10 +878,9 @@ pub fn to_real_manifest(
             .expect("previously resolved")
             .cloned(),
         homepage: package
-            .homepage
-            .clone()
-            .map(|mw| field_inherit_with(mw, "homepage", || inherit()?.homepage()))
-            .transpose()?,
+            .resolved_homepage()
+            .expect("previously resolved")
+            .cloned(),
         documentation: package
             .documentation
             .clone()
@@ -932,10 +937,6 @@ pub fn to_real_manifest(
         links: package.links.clone(),
         rust_version: rust_version.clone(),
     };
-    package.homepage = metadata
-        .homepage
-        .clone()
-        .map(|homepage| manifest::InheritableField::Value(homepage));
     package.documentation = metadata
         .documentation
         .clone()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1032,6 +1032,11 @@ pub fn to_real_manifest(
         }
     }
 
+    let resolved_badges = original_toml
+        .badges
+        .clone()
+        .map(|mw| field_inherit_with(mw, "badges", || inherit()?.badges()))
+        .transpose()?;
     let metadata = ManifestMetadata {
         description: resolved_package
             .resolved_description()
@@ -1076,12 +1081,7 @@ pub fn to_real_manifest(
             .expect("previously resolved")
             .cloned()
             .unwrap_or_default(),
-        badges: original_toml
-            .badges
-            .clone()
-            .map(|mw| field_inherit_with(mw, "badges", || inherit()?.badges()))
-            .transpose()?
-            .unwrap_or_default(),
+        badges: resolved_badges.clone().unwrap_or_default(),
         links: resolved_package.links.clone(),
         rust_version: rust_version.clone(),
     };
@@ -1200,10 +1200,7 @@ pub fn to_real_manifest(
         replace: original_toml.replace.clone(),
         patch: original_toml.patch.clone(),
         workspace: original_toml.workspace.clone(),
-        badges: original_toml
-            .badges
-            .as_ref()
-            .map(|_| manifest::InheritableField::Value(metadata.badges.clone())),
+        badges: resolved_badges.map(manifest::InheritableField::Value),
         lints: resolved_lints.map(|lints| manifest::InheritableLints {
             workspace: false,
             lints,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -580,6 +580,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "include", || inherit()?.include()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.publish = package
+        .publish
+        .clone()
+        .map(|value| field_inherit_with(value, "publish", || inherit()?.publish()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
     package.description = package
         .description
         .clone()
@@ -986,17 +992,8 @@ pub fn to_real_manifest(
         validate_profiles(profiles, cli_unstable, &features, warnings)?;
     }
 
-    let publish = package
-        .publish
-        .clone()
-        .map(|publish| field_inherit_with(publish, "publish", || inherit()?.publish()).unwrap());
-
-    package.publish = publish
-        .clone()
-        .map(|p| manifest::InheritableField::Value(p));
-
     let version = package.resolved_version().expect("previously resolved");
-    let publish = match publish {
+    let publish = match package.resolved_publish().expect("previously resolved") {
         Some(manifest::VecStringOrBool::VecString(ref vecstring)) => Some(vecstring.clone()),
         Some(manifest::VecStringOrBool::Bool(false)) => Some(vec![]),
         Some(manifest::VecStringOrBool::Bool(true)) => None,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -618,6 +618,12 @@ pub fn to_real_manifest(
         })
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.repository = package
+        .repository
+        .clone()
+        .map(|value| field_inherit_with(value, "repository", || inherit()?.repository()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -948,10 +954,9 @@ pub fn to_real_manifest(
             .expect("previously resolved")
             .cloned(),
         repository: package
-            .repository
-            .clone()
-            .map(|mw| field_inherit_with(mw, "repository", || inherit()?.repository()))
-            .transpose()?,
+            .resolved_repository()
+            .expect("previously resolved")
+            .cloned(),
         keywords: package
             .resolved_keywords()
             .expect("previously resolved")
@@ -975,10 +980,6 @@ pub fn to_real_manifest(
         .authors
         .as_ref()
         .map(|_| manifest::InheritableField::Value(metadata.authors.clone()));
-    package.repository = metadata
-        .repository
-        .clone()
-        .map(|repository| manifest::InheritableField::Value(repository));
     package.exclude = package
         .exclude
         .as_ref()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -590,6 +590,12 @@ pub fn to_real_manifest(
             .as_ref(),
     )
     .map(|s| manifest::InheritableField::Value(StringOrBool::String(s)));
+    package.keywords = package
+        .keywords
+        .clone()
+        .map(|value| field_inherit_with(value, "keywords", || inherit()?.keywords()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -927,10 +933,9 @@ pub fn to_real_manifest(
             .map(|mw| field_inherit_with(mw, "repository", || inherit()?.repository()))
             .transpose()?,
         keywords: package
-            .keywords
-            .clone()
-            .map(|mw| field_inherit_with(mw, "keywords", || inherit()?.keywords()))
-            .transpose()?
+            .resolved_keywords()
+            .expect("previously resolved")
+            .cloned()
             .unwrap_or_default(),
         categories: package
             .categories
@@ -963,10 +968,6 @@ pub fn to_real_manifest(
         .repository
         .clone()
         .map(|repository| manifest::InheritableField::Value(repository));
-    package.keywords = package
-        .keywords
-        .as_ref()
-        .map(|_| manifest::InheritableField::Value(metadata.keywords.clone()));
     package.categories = package
         .categories
         .as_ref()

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -925,7 +925,7 @@ pub fn to_real_manifest(
 
     let resolve_behavior = match (
         resolved_package.resolver.as_ref(),
-        original_toml
+        resolved_toml
             .workspace
             .as_ref()
             .and_then(|ws| ws.resolver.as_ref()),
@@ -942,7 +942,7 @@ pub fn to_real_manifest(
     // If we have a lib with no path, use the inferred lib or else the package name.
     let targets = targets(
         &features,
-        &original_toml,
+        &resolved_toml,
         package_name,
         package_root,
         edition,
@@ -1107,8 +1107,8 @@ pub fn to_real_manifest(
         )?;
     }
 
-    let replace = replace(&original_toml, &mut manifest_ctx)?;
-    let patch = patch(&original_toml, &mut manifest_ctx)?;
+    let replace = replace(&resolved_toml, &mut manifest_ctx)?;
+    let patch = patch(&resolved_toml, &mut manifest_ctx)?;
 
     {
         let mut names_sources = BTreeMap::new();
@@ -1179,7 +1179,7 @@ pub fn to_real_manifest(
         rust_version: rust_version.clone(),
     };
 
-    if let Some(profiles) = &original_toml.profile {
+    if let Some(profiles) = &resolved_toml.profile {
         let cli_unstable = gctx.cli_unstable();
         validate_profiles(profiles, cli_unstable, &features, warnings)?;
     }
@@ -1211,7 +1211,7 @@ pub fn to_real_manifest(
     let summary = Summary::new(
         pkgid,
         deps,
-        &original_toml
+        &resolved_toml
             .features
             .as_ref()
             .unwrap_or(&Default::default())

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -568,6 +568,18 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "authors", || inherit()?.authors()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.exclude = package
+        .exclude
+        .clone()
+        .map(|value| field_inherit_with(value, "exclude", || inherit()?.exclude()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
+    package.include = package
+        .include
+        .clone()
+        .map(|value| field_inherit_with(value, "include", || inherit()?.include()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
     package.description = package
         .description
         .clone()
@@ -915,19 +927,6 @@ pub fn to_real_manifest(
         }
     }
 
-    let exclude = package
-        .exclude
-        .clone()
-        .map(|mw| field_inherit_with(mw, "exclude", || inherit()?.exclude()))
-        .transpose()?
-        .unwrap_or_default();
-    let include = package
-        .include
-        .clone()
-        .map(|mw| field_inherit_with(mw, "include", || inherit()?.include()))
-        .transpose()?
-        .unwrap_or_default();
-
     let metadata = ManifestMetadata {
         description: package
             .resolved_description()
@@ -981,14 +980,6 @@ pub fn to_real_manifest(
         links: package.links.clone(),
         rust_version: rust_version.clone(),
     };
-    package.exclude = package
-        .exclude
-        .as_ref()
-        .map(|_| manifest::InheritableField::Value(exclude.clone()));
-    package.include = package
-        .include
-        .as_ref()
-        .map(|_| manifest::InheritableField::Value(include.clone()));
 
     if let Some(profiles) = &original_toml.profile {
         let cli_unstable = gctx.cli_unstable();
@@ -1073,6 +1064,16 @@ pub fn to_real_manifest(
         .map(|t| CompileTarget::new(&*t))
         .transpose()?
         .map(CompileKind::Target);
+    let include = package
+        .resolved_include()
+        .expect("previously resolved")
+        .cloned()
+        .unwrap_or_default();
+    let exclude = package
+        .resolved_exclude()
+        .expect("previously resolved")
+        .cloned()
+        .unwrap_or_default();
     let custom_metadata = package.metadata.clone();
     let resolved_toml = manifest::TomlManifest {
         cargo_features: original_toml.cargo_features.clone(),

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -645,6 +645,10 @@ fn resolve_toml(
             .map(|mw| field_inherit_with(mw, "badges", || inherit()?.badges()))
             .transpose()?;
         resolved_toml.badges = resolved_badges.map(manifest::InheritableField::Value);
+    } else {
+        for field in original_toml.requires_package() {
+            bail!("this virtual manifest specifies a `{field}` section, which is not allowed");
+        }
     }
 
     Ok(resolved_toml)
@@ -1512,10 +1516,6 @@ fn to_virtual_manifest(
     _errors: &mut Vec<String>,
 ) -> CargoResult<VirtualManifest> {
     let root = manifest_file.parent().unwrap();
-
-    for field in original_toml.requires_package() {
-        bail!("this virtual manifest specifies a `{field}` section, which is not allowed");
-    }
 
     let mut deps = Vec::new();
     let (replace, patch) = {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -574,6 +574,12 @@ pub fn to_real_manifest(
         .map(|value| field_inherit_with(value, "homepage", || inherit()?.homepage()))
         .transpose()?
         .map(manifest::InheritableField::Value);
+    package.documentation = package
+        .documentation
+        .clone()
+        .map(|value| field_inherit_with(value, "documentation", || inherit()?.documentation()))
+        .transpose()?
+        .map(manifest::InheritableField::Value);
 
     let rust_version = package
         .resolved_rust_version()
@@ -882,10 +888,9 @@ pub fn to_real_manifest(
             .expect("previously resolved")
             .cloned(),
         documentation: package
-            .documentation
-            .clone()
-            .map(|mw| field_inherit_with(mw, "documentation", || inherit()?.documentation()))
-            .transpose()?,
+            .resolved_documentation()
+            .expect("previously resolved")
+            .cloned(),
         readme: readme_for_package(
             package_root,
             package
@@ -937,10 +942,6 @@ pub fn to_real_manifest(
         links: package.links.clone(),
         rust_version: rust_version.clone(),
     };
-    package.documentation = metadata
-        .documentation
-        .clone()
-        .map(|documentation| manifest::InheritableField::Value(documentation));
     package.readme = metadata
         .readme
         .clone()


### PR DESCRIPTION
### What does this PR try to resolve?

This builds on #13664 and #13666.   Currently, once we have deserialized `Cargo.toml`, we pass it to a large machinery (`to_real_manifest`, `to_virtual_manifest`) so that
- `Cargo.toml` is resolved
- `Summary` is created
- `Manifest` is created

This splits out the resolving of `Cargo.toml` which is mostly workspace inheritance today.

While splitting logic conjoined like this can be a bit messy in the short term, the hope is that overall this makes the logic easier to follow (more condensed, focused sections to view; more explicit inputs/outputs).

In particular, I hope that this will make it clearer and easier to shift more logic into the resolving step, specifically the inferring of build targets for #13456.

### How should we test and review this PR?

This is broken up into very small steps in the hope that it makes it easier to analyze a step.

### Additional information
