### PR TITLE
Switch to using gitoxide by default for listing files

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -909,8 +909,6 @@ fn parse_git(it: impl Iterator<Item = impl AsRef<str>>) -> CargoResult<Option<Gi
 pub struct GitoxideFeatures {
     /// All fetches are done with `gitoxide`, which includes git dependencies as well as the crates index.
     pub fetch: bool,
-    /// Listing of files suitable for packaging with Git support.
-    pub list_files: bool,
     /// Checkout git dependencies using `gitoxide` (submodules are still handled by git2 ATM, and filters
     /// like linefeed conversions are unsupported).
     pub checkout: bool,
@@ -924,7 +922,6 @@ impl GitoxideFeatures {
     fn all() -> Self {
         GitoxideFeatures {
             fetch: true,
-            list_files: true,
             checkout: true,
             internal_use_git2: false,
         }
@@ -935,7 +932,6 @@ impl GitoxideFeatures {
     fn safe() -> Self {
         GitoxideFeatures {
             fetch: true,
-            list_files: true,
             checkout: true,
             internal_use_git2: false,
         }
@@ -948,7 +944,6 @@ fn parse_gitoxide(
     let mut out = GitoxideFeatures::default();
     let GitoxideFeatures {
         fetch,
-        list_files,
         checkout,
         internal_use_git2,
     } = &mut out;
@@ -957,10 +952,9 @@ fn parse_gitoxide(
         match e.as_ref() {
             "fetch" => *fetch = true,
             "checkout" => *checkout = true,
-            "list-files" => *list_files = true,
             "internal-use-git2" => *internal_use_git2 = true,
             _ => {
-                bail!("unstable 'gitoxide' only takes `fetch`, `list-files` and 'checkout' as valid input, for shallow fetches see `-Zgit=shallow-index,shallow-deps`")
+                bail!("unstable 'gitoxide' only takes `fetch` and 'checkout' as valid input, for shallow fetches see `-Zgit=shallow-index,shallow-deps`")
             }
         }
     }

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -533,8 +533,9 @@ fn check_repo_state(
         if let Some(workdir) = repo.workdir() {
             debug!("found a git repo at {:?}", workdir);
             let path = p.manifest_path();
-            let path = path.strip_prefix(workdir).unwrap_or(path);
-            if let Ok(status) = repo.status_file(path) {
+            let path =
+                paths::strip_prefix_canonical(path, workdir).unwrap_or_else(|_| path.to_path_buf());
+            if let Ok(status) = repo.status_file(&path) {
                 if (status & git2::Status::IGNORED).is_empty() {
                     debug!(
                         "found (git) Cargo.toml at {:?} in workdir {:?}",

--- a/src/cargo/sources/path.rs
+++ b/src/cargo/sources/path.rs
@@ -143,13 +143,14 @@ impl<'gctx> PathSource<'gctx> {
         let git_repo = if no_include_option {
             if self
                 .gctx
-                .cli_unstable()
-                .gitoxide
-                .map_or(false, |features| features.list_files)
+                .get_env("__CARGO_GITOXIDE_DISABLE_LIST_FILES")
+                .ok()
+                .as_deref()
+                == Some("1")
             {
-                self.discover_gix_repo(root)?.map(Git2OrGixRepository::Gix)
-            } else {
                 self.discover_git_repo(root)?.map(Git2OrGixRepository::Git2)
+            } else {
+                self.discover_gix_repo(root)?.map(Git2OrGixRepository::Gix)
             }
         } else {
             None

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3538,7 +3538,7 @@ fn symlink_manifest_path() {
 warning: manifest has no description, license, license-file, documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 [PACKAGING] foo v1.0.0 ([..]foo-symlink)
-[PACKAGED] 5 files[..]
+[PACKAGED] 6 files[..]
 ",
         )
         .run()


### PR DESCRIPTION
### What does this PR try to resolve?

Uses gitoxide by for listing the contents of a git repository by default. Fixes #10150

It's possible out-opt of this change with the environment variable `__CARGO_GITOXIDE_DISABLE_LIST_FILES=1`. This opt-out mechanism is temporary and will be removed before the next release.

### How should we test and review this PR?

The newly added test fails with the `git2` implementation.