### PR TITLE
refactor(toml): Decouple target discovery from Target creation

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -32,7 +32,7 @@ use crate::util::{self, context::ConfigRelativePath, GlobalContext, IntoUrl, Opt
 mod embedded;
 mod targets;
 
-use self::targets::targets;
+use self::targets::to_targets;
 
 /// See also `bin/cargo/commands/run.rs`s `is_manifest_command`
 pub fn is_embedded(path: &Path) -> bool {
@@ -1065,7 +1065,7 @@ fn to_real_manifest(
     // If we have no lib at all, use the inferred lib, if available.
     // If we have a lib with a path, we're done.
     // If we have a lib with no path, use the inferred lib or else the package name.
-    let targets = targets(
+    let targets = to_targets(
         &features,
         &resolved_toml,
         package_name,

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -476,7 +476,7 @@ fn resolve_package_toml<'a>(
             .map(|value| field_inherit_with(value, "documentation", || inherit()?.documentation()))
             .transpose()?
             .map(manifest::InheritableField::Value),
-        readme: readme_for_package(
+        readme: resolve_package_readme(
             package_root,
             original_package
                 .readme
@@ -530,7 +530,7 @@ fn resolve_package_toml<'a>(
 }
 
 /// Returns the name of the README file for a [`manifest::TomlPackage`].
-fn readme_for_package(
+fn resolve_package_readme(
     package_root: &Path,
     readme: Option<&manifest::StringOrBool>,
 ) -> Option<String> {
@@ -764,7 +764,7 @@ impl InheritableFields {
 
     /// Gets the field `workspace.package.readme`.
     fn readme(&self, package_root: &Path) -> CargoResult<manifest::StringOrBool> {
-        let Some(readme) = readme_for_package(
+        let Some(readme) = resolve_package_readme(
             self._ws_root.as_path(),
             self.package.as_ref().and_then(|p| p.readme.as_ref()),
         ) else {

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -159,18 +159,14 @@ fn to_lib_target(
         })
     });
     let Some(mut lib) = lib else { return Ok(None) };
-    let name = lib
-        .name
+    lib.name
         .get_or_insert_with(|| package_name.replace("-", "_"));
-    if name.contains('-') {
-        anyhow::bail!("library target names cannot contain hyphens: {}", name)
-    }
 
     let lib = &lib;
     validate_proc_macro(lib, "library", warnings);
     validate_crate_types(lib, "library", warnings);
 
-    validate_target_name(lib, "library", "lib", warnings)?;
+    validate_lib_name(lib, warnings)?;
 
     let path = match (lib.path.as_ref(), inferred) {
         (Some(path), _) => package_root.join(&path.0),
@@ -767,6 +763,16 @@ fn inferred_to_toml_targets(inferred: &[(String, PathBuf)]) -> Vec<TomlTarget> {
             ..TomlTarget::new()
         })
         .collect()
+}
+
+fn validate_lib_name(target: &TomlTarget, warnings: &mut Vec<String>) -> CargoResult<()> {
+    validate_target_name(target, "library", "lib", warnings)?;
+    let name = name_or_panic(target);
+    if name.contains('-') {
+        anyhow::bail!("library target names cannot contain hyphens: {}", name)
+    }
+
+    Ok(())
 }
 
 fn validate_target_name(

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -409,7 +409,7 @@ fn resolve_examples(
 ) -> CargoResult<Vec<TomlExampleTarget>> {
     let inferred = infer_from_directory(&package_root.join(DEFAULT_EXAMPLE_DIR_NAME));
 
-    let targets = clean_targets(
+    let targets = resolve_targets(
         "example",
         "example",
         toml_examples,
@@ -477,7 +477,7 @@ fn resolve_tests(
 ) -> CargoResult<Vec<TomlTestTarget>> {
     let inferred = infer_from_directory(&package_root.join(DEFAULT_TEST_DIR_NAME));
 
-    let targets = clean_targets(
+    let targets = resolve_targets(
         "test",
         "test",
         toml_tests,
@@ -552,7 +552,7 @@ fn resolve_benches(
 
     let inferred = infer_from_directory(&package_root.join("benches"));
 
-    let targets = clean_targets_with_legacy_path(
+    let targets = resolve_targets_with_legacy_path(
         "benchmark",
         "bench",
         toml_benches,
@@ -605,7 +605,7 @@ fn to_bench_targets(
     Ok(result)
 }
 
-fn clean_targets(
+fn resolve_targets(
     target_kind_human: &str,
     target_kind: &str,
     toml_targets: Option<&Vec<TomlTarget>>,
@@ -617,7 +617,7 @@ fn clean_targets(
     errors: &mut Vec<String>,
     autodiscover_flag_name: &str,
 ) -> CargoResult<Vec<TomlTarget>> {
-    clean_targets_with_legacy_path(
+    resolve_targets_with_legacy_path(
         target_kind_human,
         target_kind,
         toml_targets,
@@ -632,7 +632,7 @@ fn clean_targets(
     )
 }
 
-fn clean_targets_with_legacy_path(
+fn resolve_targets_with_legacy_path(
     target_kind_human: &str,
     target_kind: &str,
     toml_targets: Option<&Vec<TomlTarget>>,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -30,7 +30,6 @@ use crate::util::toml::warn_on_deprecated;
 const DEFAULT_TEST_DIR_NAME: &'static str = "tests";
 const DEFAULT_BENCH_DIR_NAME: &'static str = "benches";
 const DEFAULT_EXAMPLE_DIR_NAME: &'static str = "examples";
-const DEFAULT_BIN_DIR_NAME: &'static str = "bin";
 
 #[tracing::instrument(skip_all)]
 pub(super) fn to_targets(
@@ -392,10 +391,7 @@ fn legacy_bin_path(package_root: &Path, name: &str, has_lib: bool) -> Option<Pat
         return Some(path);
     }
 
-    let path = package_root
-        .join("src")
-        .join(DEFAULT_BIN_DIR_NAME)
-        .join("main.rs");
+    let path = package_root.join("src").join("bin").join("main.rs");
     if path.exists() {
         return Some(path);
     }
@@ -658,9 +654,7 @@ fn inferred_bins(package_root: &Path, package_name: &str) -> Vec<(String, PathBu
     if main.exists() {
         result.push((package_name.to_string(), main));
     }
-    result.extend(infer_from_directory(
-        &package_root.join("src").join(DEFAULT_BIN_DIR_NAME),
-    ));
+    result.extend(infer_from_directory(&package_root.join("src").join("bin")));
 
     result
 }
@@ -938,7 +932,7 @@ fn target_path_not_found_error_message(
             ("example", false) => target_path.push(DEFAULT_EXAMPLE_DIR_NAME),
             ("bin", false) => {
                 target_path.push("src");
-                target_path.push(DEFAULT_BIN_DIR_NAME);
+                target_path.push("bin");
             }
             _ => unreachable!("invalid target kind: {}", kind),
         }

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -422,6 +422,8 @@ fn to_example_targets(
         "autoexamples",
     )?;
 
+    validate_unique_names(&targets, "example")?;
+
     let mut result = Vec::new();
     for toml in targets {
         let path = toml.path.clone().expect("previously resolved").0;
@@ -467,6 +469,8 @@ fn to_test_targets(
         errors,
         "autotests",
     )?;
+
+    validate_unique_names(&targets, "test")?;
 
     let mut result = Vec::new();
     for toml in targets {
@@ -524,8 +528,9 @@ fn to_bench_targets(
             "autobenches",
         )?
     };
-
     warnings.append(&mut legacy_warnings);
+
+    validate_unique_names(&targets, "bench")?;
 
     let mut result = Vec::new();
     for toml in targets {
@@ -599,7 +604,6 @@ fn clean_targets_with_legacy_path(
         validate_target_name(target, target_kind_human, target_kind, warnings)?;
     }
 
-    validate_unique_names(&toml_targets, target_kind)?;
     let mut result = Vec::new();
     for mut target in toml_targets {
         let path = target_path(

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -48,10 +48,17 @@ pub(super) fn to_targets(
 
     let has_lib;
 
-    if let Some(target) = to_lib_target(
+    let lib = resolve_lib(
         resolved_toml.lib.as_ref(),
         package_root,
         package_name,
+        edition,
+        warnings,
+    )?;
+    if let Some(target) = to_lib_target(
+        resolved_toml.lib.as_ref(),
+        lib.as_ref(),
+        package_root,
         edition,
         warnings,
     )? {
@@ -191,14 +198,12 @@ fn resolve_lib(
 
 fn to_lib_target(
     original_lib: Option<&TomlLibTarget>,
+    resolved_lib: Option<&TomlLibTarget>,
     package_root: &Path,
-    package_name: &str,
     edition: Edition,
     warnings: &mut Vec<String>,
 ) -> CargoResult<Option<Target>> {
-    let lib = resolve_lib(original_lib, package_root, package_name, edition, warnings)?;
-
-    let Some(lib) = &lib else {
+    let Some(lib) = resolved_lib else {
         return Ok(None);
     };
     validate_proc_macro(lib, "library", warnings);

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -33,7 +33,7 @@ const DEFAULT_EXAMPLE_DIR_NAME: &'static str = "examples";
 const DEFAULT_BIN_DIR_NAME: &'static str = "bin";
 
 #[tracing::instrument(skip_all)]
-pub(super) fn targets(
+pub(super) fn to_targets(
     features: &Features,
     resolved_toml: &TomlManifest,
     package_name: &str,
@@ -48,7 +48,7 @@ pub(super) fn targets(
 
     let has_lib;
 
-    if let Some(target) = clean_lib(
+    if let Some(target) = to_lib_target(
         resolved_toml.lib.as_ref(),
         package_root,
         package_name,
@@ -66,7 +66,7 @@ pub(super) fn targets(
         .as_ref()
         .ok_or_else(|| anyhow::format_err!("manifest has no `package` (or `project`)"))?;
 
-    targets.extend(clean_bins(
+    targets.extend(to_bin_targets(
         features,
         resolved_toml.bin.as_ref(),
         package_root,
@@ -78,7 +78,7 @@ pub(super) fn targets(
         has_lib,
     )?);
 
-    targets.extend(clean_examples(
+    targets.extend(to_example_targets(
         resolved_toml.example.as_ref(),
         package_root,
         edition,
@@ -87,7 +87,7 @@ pub(super) fn targets(
         errors,
     )?);
 
-    targets.extend(clean_tests(
+    targets.extend(to_test_targets(
         resolved_toml.test.as_ref(),
         package_root,
         edition,
@@ -96,7 +96,7 @@ pub(super) fn targets(
         errors,
     )?);
 
-    targets.extend(clean_benches(
+    targets.extend(to_bench_targets(
         resolved_toml.bench.as_ref(),
         package_root,
         edition,
@@ -144,7 +144,7 @@ pub(super) fn targets(
     Ok(targets)
 }
 
-fn clean_lib(
+fn to_lib_target(
     resolved_lib: Option<&TomlLibTarget>,
     package_root: &Path,
     package_name: &str,
@@ -267,7 +267,7 @@ fn clean_lib(
     Ok(Some(target))
 }
 
-fn clean_bins(
+fn to_bin_targets(
     features: &Features,
     toml_bins: Option<&Vec<TomlBinTarget>>,
     package_root: &Path,
@@ -390,7 +390,7 @@ fn clean_bins(
     }
 }
 
-fn clean_examples(
+fn to_example_targets(
     toml_examples: Option<&Vec<TomlExampleTarget>>,
     package_root: &Path,
     edition: Edition,
@@ -435,7 +435,7 @@ fn clean_examples(
     Ok(result)
 }
 
-fn clean_tests(
+fn to_test_targets(
     toml_tests: Option<&Vec<TomlTestTarget>>,
     package_root: &Path,
     edition: Edition,
@@ -472,7 +472,7 @@ fn clean_tests(
     Ok(result)
 }
 
-fn clean_benches(
+fn to_bench_targets(
     toml_benches: Option<&Vec<TomlBenchTarget>>,
     package_root: &Path,
     edition: Edition,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -406,7 +406,7 @@ fn resolve_examples(
     warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
 ) -> CargoResult<Vec<TomlExampleTarget>> {
-    let inferred = infer_from_directory(&package_root.join(DEFAULT_EXAMPLE_DIR_NAME));
+    let inferred = infer_from_directory(&package_root, Path::new(DEFAULT_EXAMPLE_DIR_NAME));
 
     let targets = resolve_targets(
         "example",
@@ -462,7 +462,7 @@ fn resolve_tests(
     warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
 ) -> CargoResult<Vec<TomlTestTarget>> {
-    let inferred = infer_from_directory(&package_root.join(DEFAULT_TEST_DIR_NAME));
+    let inferred = infer_from_directory(&package_root, Path::new(DEFAULT_TEST_DIR_NAME));
 
     let targets = resolve_targets(
         "test",
@@ -521,7 +521,7 @@ fn resolve_benches(
         Some(legacy_path)
     };
 
-    let inferred = infer_from_directory(&package_root.join(DEFAULT_BENCH_DIR_NAME));
+    let inferred = infer_from_directory(&package_root, Path::new(DEFAULT_BENCH_DIR_NAME));
 
     let targets = resolve_targets_with_legacy_path(
         "benchmark",
@@ -654,12 +654,14 @@ fn inferred_bins(package_root: &Path, package_name: &str) -> Vec<(String, PathBu
     if main.exists() {
         result.push((package_name.to_string(), main));
     }
-    result.extend(infer_from_directory(&package_root.join("src").join("bin")));
+    let default_bin_dir_name = Path::new("src").join("bin");
+    result.extend(infer_from_directory(&package_root, &default_bin_dir_name));
 
     result
 }
 
-fn infer_from_directory(directory: &Path) -> Vec<(String, PathBuf)> {
+fn infer_from_directory(package_root: &Path, relpath: &Path) -> Vec<(String, PathBuf)> {
+    let directory = package_root.join(relpath);
     let entries = match fs::read_dir(directory) {
         Err(_) => return Vec::new(),
         Ok(dir) => dir,

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -525,7 +525,7 @@ fn resolve_benches(
         Some(legacy_path)
     };
 
-    let inferred = infer_from_directory(&package_root.join("benches"));
+    let inferred = infer_from_directory(&package_root.join(DEFAULT_BENCH_DIR_NAME));
 
     let targets = resolve_targets_with_legacy_path(
         "benchmark",

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -84,32 +84,35 @@ pub(super) fn to_targets(
     )?;
     targets.extend(to_bin_targets(features, &bins, edition, errors)?);
 
-    targets.extend(to_example_targets(
+    let toml_examples = resolve_examples(
         resolved_toml.example.as_ref(),
         package_root,
         edition,
         package.autoexamples,
         warnings,
         errors,
-    )?);
+    )?;
+    targets.extend(to_example_targets(&toml_examples, edition, warnings)?);
 
-    targets.extend(to_test_targets(
+    let toml_tests = resolve_tests(
         resolved_toml.test.as_ref(),
         package_root,
         edition,
         package.autotests,
         warnings,
         errors,
-    )?);
+    )?;
+    targets.extend(to_test_targets(&toml_tests, edition)?);
 
-    targets.extend(to_bench_targets(
+    let toml_benches = resolve_benches(
         resolved_toml.bench.as_ref(),
         package_root,
         edition,
         package.autobenches,
         warnings,
         errors,
-    )?);
+    )?;
+    targets.extend(to_bench_targets(&toml_benches, edition)?);
 
     // processing the custom build script
     if let Some(custom_build) = maybe_custom_build(custom_build, package_root) {
@@ -426,22 +429,10 @@ fn resolve_examples(
 }
 
 fn to_example_targets(
-    toml_examples: Option<&Vec<TomlExampleTarget>>,
-    package_root: &Path,
+    targets: &[TomlExampleTarget],
     edition: Edition,
-    autodiscover: Option<bool>,
     warnings: &mut Vec<String>,
-    errors: &mut Vec<String>,
 ) -> CargoResult<Vec<Target>> {
-    let targets = resolve_examples(
-        toml_examples,
-        package_root,
-        edition,
-        autodiscover,
-        warnings,
-        errors,
-    )?;
-
     validate_unique_names(&targets, "example")?;
 
     let mut result = Vec::new();
@@ -493,23 +484,7 @@ fn resolve_tests(
     Ok(targets)
 }
 
-fn to_test_targets(
-    toml_tests: Option<&Vec<TomlTestTarget>>,
-    package_root: &Path,
-    edition: Edition,
-    autodiscover: Option<bool>,
-    warnings: &mut Vec<String>,
-    errors: &mut Vec<String>,
-) -> CargoResult<Vec<Target>> {
-    let targets = resolve_tests(
-        toml_tests,
-        package_root,
-        edition,
-        autodiscover,
-        warnings,
-        errors,
-    )?;
-
+fn to_test_targets(targets: &[TomlTestTarget], edition: Edition) -> CargoResult<Vec<Target>> {
     validate_unique_names(&targets, "test")?;
 
     let mut result = Vec::new();
@@ -570,23 +545,7 @@ fn resolve_benches(
     Ok(targets)
 }
 
-fn to_bench_targets(
-    toml_benches: Option<&Vec<TomlBenchTarget>>,
-    package_root: &Path,
-    edition: Edition,
-    autodiscover: Option<bool>,
-    warnings: &mut Vec<String>,
-    errors: &mut Vec<String>,
-) -> CargoResult<Vec<Target>> {
-    let targets = resolve_benches(
-        toml_benches,
-        package_root,
-        edition,
-        autodiscover,
-        warnings,
-        errors,
-    )?;
-
+fn to_bench_targets(targets: &[TomlBenchTarget], edition: Edition) -> CargoResult<Vec<Target>> {
     validate_unique_names(&targets, "bench")?;
 
     let mut result = Vec::new();

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -686,18 +686,18 @@ fn infer_any(entry: &DirEntry) -> Option<(String, PathBuf)> {
 
 fn infer_file(entry: &DirEntry) -> Option<(String, PathBuf)> {
     let path = entry.path();
-    path.file_stem()
-        .and_then(|p| p.to_str())
-        .map(|p| (p.to_owned(), path.clone()))
+    let stem = path.file_stem()?.to_str()?.to_owned();
+    Some((stem, path))
 }
 
 fn infer_subdirectory(entry: &DirEntry) -> Option<(String, PathBuf)> {
     let path = entry.path();
     let main = path.join("main.rs");
-    let name = path.file_name().and_then(|n| n.to_str());
-    match (name, main.exists()) {
-        (Some(name), true) => Some((name.to_owned(), main)),
-        _ => None,
+    let name = path.file_name()?.to_str()?.to_owned();
+    if main.exists() {
+        Some((name, main))
+    } else {
+        None
     }
 }
 

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -372,29 +372,29 @@ fn to_bin_targets(
         configure(bin, &mut target)?;
         result.push(target);
     }
-    return Ok(result);
+    Ok(result)
+}
 
-    fn legacy_bin_path(package_root: &Path, name: &str, has_lib: bool) -> Option<PathBuf> {
-        if !has_lib {
-            let path = package_root.join("src").join(format!("{}.rs", name));
-            if path.exists() {
-                return Some(path);
-            }
-        }
-        let path = package_root.join("src").join("main.rs");
+fn legacy_bin_path(package_root: &Path, name: &str, has_lib: bool) -> Option<PathBuf> {
+    if !has_lib {
+        let path = package_root.join("src").join(format!("{}.rs", name));
         if path.exists() {
             return Some(path);
         }
-
-        let path = package_root
-            .join("src")
-            .join(DEFAULT_BIN_DIR_NAME)
-            .join("main.rs");
-        if path.exists() {
-            return Some(path);
-        }
-        None
     }
+    let path = package_root.join("src").join("main.rs");
+    if path.exists() {
+        return Some(path);
+    }
+
+    let path = package_root
+        .join("src")
+        .join(DEFAULT_BIN_DIR_NAME)
+        .join("main.rs");
+    if path.exists() {
+        return Some(path);
+    }
+    None
 }
 
 fn to_example_targets(

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -3479,24 +3479,25 @@ fn build_script_outside_pkg_root() {
         )
         .file("src/main.rs", "fn main() {}")
         .build();
-    let mut expect_msg = String::from("\
+    // custom_build.rs does not exist
+    p.cargo("package -l")
+        .with_status(101)
+        .with_stderr("\
 warning: manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
 error: the source file of build script doesn't appear to exist.
 This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.
 Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and point to a path inside the root of the package.
-");
-    // custom_build.rs does not exist
-    p.cargo("package -l")
-        .with_status(101)
-        .with_stderr(&expect_msg)
+")
         .run();
 
     // custom_build.rs outside the package root
     let custom_build_root = paths::root().join("t_custom_build");
     _ = fs::create_dir(&custom_build_root).unwrap();
     _ = fs::write(&custom_build_root.join("custom_build.rs"), "fn main() {}");
-    expect_msg = format!(
+    p.cargo("package -l")
+        .with_status(101)
+        .with_stderr(&format!(
         "\
 warning: manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
@@ -3504,10 +3505,7 @@ error: the source file of build script doesn't appear to be a path inside of the
 It is at `{}/t_custom_build/custom_build.rs`, whereas the root the package is `[CWD]`.
 This may cause issue during packaging, as modules resolution and resources included via macros are often relative to the path of source files.
 Please update the `build` setting in the manifest at `[CWD]/Cargo.toml` and point to a path inside the root of the package.
-", paths::root().display());
-    p.cargo("package -l")
-        .with_status(101)
-        .with_stderr(&expect_msg)
+", paths::root().display()))
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

This builds on #13693 so that the resolving of targets is easier to pull out into `resolve_toml` in prep for fixing #13456

### How should we test and review this PR?

### Additional information

