### PR TITLE
Don't depend on `?` affecting type inference in weird ways

### DIFF
--- a/crates/cargo-util/src/paths.rs
+++ b/crates/cargo-util/src/paths.rs
@@ -510,8 +510,7 @@ fn _remove_file(p: &Path) -> Result<()> {
         }
     }
 
-    Err(err).with_context(|| format!("failed to remove file `{}`", p.display()))?;
-    Ok(())
+    Err(err).with_context(|| format!("failed to remove file `{}`", p.display()))
 }
 
 fn set_not_readonly(p: &Path) -> io::Result<bool> {


### PR DESCRIPTION
This is likely to stop working in the future versions of Rust, see https://github.com/rust-lang/rust/pull/122412#issuecomment-2037813927.