### PR TITLE
[doc]:Changed `cargo:paseto` to `cargo::paseto`.

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -108,7 +108,7 @@ For the latest nightly, see the [nightly version] of this page.
     * [`cargo config`](#cargo-config) --- Adds a new subcommand for viewing config files.
 * Registries
     * [publish-timeout](#publish-timeout) --- Controls the timeout between uploading the crate and being available in the index
-    * [asymmetric-token](#asymmetric-token) --- Adds support for authentication tokens using asymmetric cryptography (`cargo:paseto` provider).
+    * [asymmetric-token](#asymmetric-token) --- Adds support for authentication tokens using asymmetric cryptography (`cargo::paseto` provider).
 * Other
     * [gitoxide](#gitoxide) --- Use `gitoxide` instead of `git2` for a set of operations.
     * [script](#script) --- Enable support for single-file `.rs` packages.
@@ -978,7 +978,7 @@ timeout = 300  # in seconds
 * Tracking Issue: [10519](https://github.com/rust-lang/cargo/issues/10519)
 * RFC: [#3231](https://github.com/rust-lang/rfcs/pull/3231)
 
-The `-Z asymmetric-token` flag enables the `cargo:paseto` credential provider which allows Cargo to authenticate to registries without sending secrets over the network.
+The `-Z asymmetric-token` flag enables the `cargo::paseto` credential provider which allows Cargo to authenticate to registries without sending secrets over the network.
 
 In [`config.toml`](config.md) and `credentials.toml` files there is a field called `private-key`, which is a private key formatted in the secret [subset of `PASERK`](https://github.com/paseto-standard/paserk/blob/master/types/secret.md) and is used to sign asymmetric tokens
 


### PR DESCRIPTION
### What does this PR try to resolve?

I understand from [here](https://github.com/heisen-li/cargo/commit/bd230e810cbf307de33e974d1b59a3cf7389fe8c) that `cargo:` is currently deprecated, but there doesn't seem to be a change in the documentation.

This is a not-so-important issue, so feel free to close it if I've misunderstood.