### PR TITLE
chore: downgrade to openssl v1.1.1 (again)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,6 +78,8 @@
       matchUpdateTypes: [
         'patch',
       ],
+      // See rust-lang/cargo#13546 and openssl/openssl#23376 for the exclusion
+      excludePackageNames: ['openssl', 'openssl-src', 'openssl-sys'],
       automerge: false,
       groupName: 'compatible',
     },
@@ -89,6 +91,8 @@
       matchUpdateTypes: [
         'minor',
       ],
+      // See rust-lang/cargo#13546 and openssl/openssl#23376 for the exclusion
+      excludePackageNames: ['openssl', 'openssl-src', 'openssl-sys'],
       automerge: false,
       groupName: 'compatible',
     },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -2432,18 +2432,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.3+3.2.1"
+version = "111.28.1+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ memchr = "2.7.2"
 miow = "0.6.0"
 opener = "0.7.0"
 openssl = "0.10.57"
+openssl-sys = "=0.9.92" # See rust-lang/cargo#13546 and openssl/openssl#23376 for pinning
 os_info = "3.8.2"
 pasetors = { version = "0.6.8", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"


### PR DESCRIPTION
Accidentally updated by <https://github.com/rust-lang/cargo/pull/13674>

See https://github.com/rust-lang/cargo/issues/13546#issuecomment-2047366361 

<!-- homu-ignore:start -->
I am not sure if we should pin this. Somebody might want to build Cargo with openssl v3.
<!-- homu-ignore:end -->
