### PR TITLE
feat(reslve): Respect '--ignore-rust-version'

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -771,7 +771,7 @@ impl<'gctx> Workspace<'gctx> {
             }
         }
 
-        debug!("find_members - {}", manifest_path.display());
+        debug!("find_path_deps - {}", manifest_path.display());
         self.members.push(manifest_path.clone());
 
         let candidates = {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -605,6 +605,10 @@ impl<'gctx> Workspace<'gctx> {
         self.members().filter_map(|pkg| pkg.rust_version()).min()
     }
 
+    pub fn resolve_honors_rust_version(&self) -> bool {
+        self.gctx().cli_unstable().msrv_policy
+    }
+
     pub fn custom_metadata(&self) -> Option<&toml::Value> {
         self.custom_metadata.as_ref()
     }

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -100,6 +100,7 @@ pub struct Workspace<'gctx> {
 
     /// The resolver behavior specified with the `resolver` field.
     resolve_behavior: ResolveBehavior,
+    honor_rust_version: Option<bool>,
 
     /// Workspace-level custom metadata
     custom_metadata: Option<toml::Value>,
@@ -229,6 +230,7 @@ impl<'gctx> Workspace<'gctx> {
             loaded_packages: RefCell::new(HashMap::new()),
             ignore_lock: false,
             resolve_behavior: ResolveBehavior::V1,
+            honor_rust_version: None,
             custom_metadata: None,
         }
     }
@@ -605,8 +607,12 @@ impl<'gctx> Workspace<'gctx> {
         self.members().filter_map(|pkg| pkg.rust_version()).min()
     }
 
+    pub fn set_honor_rust_version(&mut self, honor_rust_version: Option<bool>) {
+        self.honor_rust_version = honor_rust_version;
+    }
+
     pub fn resolve_honors_rust_version(&self) -> bool {
-        self.gctx().cli_unstable().msrv_policy
+        self.gctx().cli_unstable().msrv_policy && self.honor_rust_version.unwrap_or(true)
     }
 
     pub fn custom_metadata(&self) -> Option<&toml::Value> {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -323,7 +323,7 @@ pub fn resolve_with_previous<'gctx>(
     if ws.gctx().cli_unstable().minimal_versions {
         version_prefs.version_ordering(VersionOrdering::MinimumVersionsFirst)
     }
-    if ws.gctx().cli_unstable().msrv_policy {
+    if ws.resolve_honors_rust_version() {
         version_prefs.max_rust_version(ws.rust_version().cloned().map(RustVersion::into_partial));
     }
 

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -504,6 +504,7 @@ pub trait ArgMatchesExt {
     fn workspace<'a>(&self, gctx: &'a GlobalContext) -> CargoResult<Workspace<'a>> {
         let root = self.root_manifest(gctx)?;
         let mut ws = Workspace::new(&root, gctx)?;
+        ws.set_honor_rust_version(self.honor_rust_version());
         if gctx.cli_unstable().avoid_dev_deps {
             ws.set_require_optional_deps(false);
         }

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -347,15 +347,13 @@ fn dependency_rust_version_older_and_newer_than_package() {
     p.cargo("check --ignore-rust-version")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        // This should pick 1.6.0
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages
-[ADDING] bar v1.5.0 (latest: v1.6.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.5.0 (registry `dummy-registry`)
-[CHECKING] bar v1.5.0
+[DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
+[CHECKING] bar v1.6.0
 [CHECKING] [..]
 [FINISHED] [..]
 ",
@@ -483,15 +481,13 @@ fn workspace_with_mixed_rust_version() {
     p.cargo("check --ignore-rust-version")
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
-        // This should pick 1.6.0
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages
-[ADDING] bar v1.4.0 (latest: v1.6.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.4.0 (registry `dummy-registry`)
-[CHECKING] bar v1.4.0
+[DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
+[CHECKING] bar v1.6.0
 [CHECKING] [..]
 [FINISHED] [..]
 ",


### PR DESCRIPTION
### What does this PR try to resolve?

This is a part of #9930.

### How should we test and review this PR?

I had considered several ways of implementing this.  I first looked at passing this into `ops::resolve*`.
.This would get a bit annoying with the function signature, so I considered moving it to a builder..
Each of the entry points is slightly different with different ownership needs, making it hard to have a common abstraction.
In doing this, I noticed we currently pass some state around to the resolver via `Workspace`, so I mirrored that.

The nice thing about this location is it provides a good place to hook in config and `package.resolve` so they affect this.
 
### Additional information

