### PR TITLE
feat(cli): Add --ignore-rust-version to update/generate-lockfile

### DIFF
--- a/src/bin/cargo/commands/generate_lockfile.rs
+++ b/src/bin/cargo/commands/generate_lockfile.rs
@@ -7,12 +7,23 @@ pub fn cli() -> Command {
         .about("Generate the lockfile for a package")
         .arg_silent_suggestion()
         .arg_manifest_path()
+        .arg_ignore_rust_version_with_help(
+            "Ignore `rust-version` specification in packages (unstable)",
+        )
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help generate-lockfile</>` for more detailed information.\n"
         ))
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
+    if args.honor_rust_version().is_some() {
+        gctx.cli_unstable().fail_if_stable_opt_custom_z(
+            "--ignore-rust-version",
+            9930,
+            "msrv-policy",
+            gctx.cli_unstable().msrv_policy,
+        )?;
+    }
     let ws = args.workspace(gctx)?;
     ops::generate_lockfile(&ws)?;
     Ok(())

--- a/src/bin/cargo/commands/update.rs
+++ b/src/bin/cargo/commands/update.rs
@@ -42,12 +42,23 @@ pub fn cli() -> Command {
                 .help_heading(heading::PACKAGE_SELECTION),
         )
         .arg_manifest_path()
+        .arg_ignore_rust_version_with_help(
+            "Ignore `rust-version` specification in packages (unstable)",
+        )
         .after_help(color_print::cstr!(
             "Run `<cyan,bold>cargo help update</>` for more detailed information.\n"
         ))
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
+    if args.honor_rust_version().is_some() {
+        gctx.cli_unstable().fail_if_stable_opt_custom_z(
+            "--ignore-rust-version",
+            9930,
+            "msrv-policy",
+            gctx.cli_unstable().msrv_policy,
+        )?;
+    }
     let ws = args.workspace(gctx)?;
 
     if args.is_present_with_zero_values("package") {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -352,13 +352,11 @@ pub trait CommandExt: Sized {
     }
 
     fn arg_ignore_rust_version(self) -> Self {
-        self._arg(
-            flag(
-                "ignore-rust-version",
-                "Ignore `rust-version` specification in packages",
-            )
-            .help_heading(heading::MANIFEST_OPTIONS),
-        )
+        self.arg_ignore_rust_version_with_help("Ignore `rust-version` specification in packages")
+    }
+
+    fn arg_ignore_rust_version_with_help(self, help: &'static str) -> Self {
+        self._arg(flag("ignore-rust-version", help).help_heading(heading::MANIFEST_OPTIONS))
     }
 
     fn arg_future_incompat_report(self) -> Self {

--- a/src/doc/man/cargo-generate-lockfile.md
+++ b/src/doc/man/cargo-generate-lockfile.md
@@ -30,6 +30,8 @@ lockfile and has more options for controlling update behavior.
 {{#options}}
 {{> options-manifest-path }}
 
+{{> options-ignore-rust-version }}
+
 {{> options-locked }}
 {{/options}}
 

--- a/src/doc/man/cargo-update.md
+++ b/src/doc/man/cargo-update.md
@@ -75,6 +75,8 @@ Displays what would be updated, but doesn't actually write the lockfile.
 
 {{> options-manifest-path }}
 
+{{> options-ignore-rust-version }}
+
 {{> options-locked }}
 
 {{/options}}

--- a/src/doc/man/generated_txt/cargo-generate-lockfile.txt
+++ b/src/doc/man/generated_txt/cargo-generate-lockfile.txt
@@ -46,6 +46,9 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
+       --ignore-rust-version
+           Ignore rust-version specification in packages.
+
        --locked
            Asserts that the exact same dependencies and versions are used as
            when the existing Cargo.lock file was originally generated. Cargo

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -85,6 +85,9 @@ OPTIONS
            Path to the Cargo.toml file. By default, Cargo searches for the
            Cargo.toml file in the current directory or any parent directory.
 
+       --ignore-rust-version
+           Ignore rust-version specification in packages.
+
        --locked
            Asserts that the exact same dependencies and versions are used as
            when the existing Cargo.lock file was originally generated. Cargo

--- a/src/doc/src/commands/cargo-generate-lockfile.md
+++ b/src/doc/src/commands/cargo-generate-lockfile.md
@@ -58,6 +58,10 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
+<dt class="option-term" id="option-cargo-generate-lockfile---ignore-rust-version"><a class="option-anchor" href="#option-cargo-generate-lockfile---ignore-rust-version"></a><code>--ignore-rust-version</code></dt>
+<dd class="option-desc">Ignore <code>rust-version</code> specification in packages.</dd>
+
+
 <dt class="option-term" id="option-cargo-generate-lockfile---locked"><a class="option-anchor" href="#option-cargo-generate-lockfile---locked"></a><code>--locked</code></dt>
 <dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
 existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -100,6 +100,10 @@ terminal.</li>
 <code>Cargo.toml</code> file in the current directory or any parent directory.</dd>
 
 
+<dt class="option-term" id="option-cargo-update---ignore-rust-version"><a class="option-anchor" href="#option-cargo-update---ignore-rust-version"></a><code>--ignore-rust-version</code></dt>
+<dd class="option-desc">Ignore <code>rust-version</code> specification in packages.</dd>
+
+
 <dt class="option-term" id="option-cargo-update---locked"><a class="option-anchor" href="#option-cargo-update---locked"></a><code>--locked</code></dt>
 <dd class="option-desc">Asserts that the exact same dependencies and versions are used as when the
 existing <code>Cargo.lock</code> file was originally generated. Cargo will exit with an

--- a/src/etc/man/cargo-generate-lockfile.1
+++ b/src/etc/man/cargo-generate-lockfile.1
@@ -62,6 +62,11 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
+\fB\-\-ignore\-rust\-version\fR
+.RS 4
+Ignore \fBrust\-version\fR specification in packages.
+.RE
+.sp
 \fB\-\-locked\fR
 .RS 4
 Asserts that the exact same dependencies and versions are used as when the

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -107,6 +107,11 @@ Path to the \fBCargo.toml\fR file. By default, Cargo searches for the
 \fBCargo.toml\fR file in the current directory or any parent directory.
 .RE
 .sp
+\fB\-\-ignore\-rust\-version\fR
+.RS 4
+Ignore \fBrust\-version\fR specification in packages.
+.RE
+.sp
 \fB\-\-locked\fR
 .RS 4
 Asserts that the exact same dependencies and versions are used as when the

--- a/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
+++ b/tests/testsuite/cargo_generate_lockfile/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="380px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="398px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -47,17 +47,19 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="334px">
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help generate-lockfile</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="352px">
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help generate-lockfile</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
   </text>
 

--- a/tests/testsuite/cargo_update/help/stdout.term.svg
+++ b/tests/testsuite/cargo_update/help/stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="506px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="524px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { background: #000000 }
@@ -61,17 +61,19 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-cyan bold">--manifest-path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to Cargo.toml</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-cyan bold">--ignore-rust-version</tspan><tspan>   Ignore `rust-version` specification in packages (unstable)</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-cyan bold">--locked</tspan><tspan>                Assert that `Cargo.lock` will remain unchanged</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-cyan bold">--offline</tspan><tspan>               Run without accessing the network</tspan>
 </tspan>
-    <tspan x="10px" y="460px">
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-cyan bold">--frozen</tspan><tspan>                Equivalent to specifying both --locked and --offline</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help update</tspan><tspan class="bold">` for more detailed information.</tspan>
+    <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px">
+    <tspan x="10px" y="496px"><tspan>Run `</tspan><tspan class="fg-cyan bold">cargo help update</tspan><tspan class="bold">` for more detailed information.</tspan>
+</tspan>
+    <tspan x="10px" y="514px">
 </tspan>
   </text>
 

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -533,16 +533,22 @@ fn generate_lockfile_msrv_resolve() {
         .build();
 
     p.cargo("generate-lockfile --ignore-rust-version")
-        .arg("-Zmsrv-policy")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_status(1)
+        .with_status(101)
         .with_stderr(
             "\
-error: unexpected argument '--ignore-rust-version' found
-
-Usage: cargo generate-lockfile [OPTIONS]
-
-For more information, try '--help'.
+[ERROR] the `--ignore-rust-version` flag is unstable, and only available on the nightly channel of Cargo, but this is the `stable` channel
+See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
+See https://github.com/rust-lang/cargo/issues/9930 for more information about the `--ignore-rust-version` flag.
+",
+        )
+        .run();
+    p.cargo("generate-lockfile --ignore-rust-version")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[LOCKING] 2 packages
 ",
         )
         .run();
@@ -599,18 +605,22 @@ fn update_msrv_resolve() {
         )
         .run();
     p.cargo("update --ignore-rust-version")
-        .arg("-Zmsrv-policy")
-        .masquerade_as_nightly_cargo(&["msrv-policy"])
-        .with_status(1)
+        .with_status(101)
         .with_stderr(
             "\
-error: unexpected argument '--ignore-rust-version' found
-
-  tip: to pass '--ignore-rust-version' as a value, use '-- --ignore-rust-version'
-
-Usage: cargo update [OPTIONS] [SPEC]...
-
-For more information, try '--help'.
+[ERROR] the `--ignore-rust-version` flag is unstable, and only available on the nightly channel of Cargo, but this is the `stable` channel
+See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
+See https://github.com/rust-lang/cargo/issues/9930 for more information about the `--ignore-rust-version` flag.
+",
+        )
+        .run();
+    p.cargo("update --ignore-rust-version")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[UPDATING] bar v1.5.0 -> v1.6.0
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #9930 and extends `--ignore-rust-version` to `cargo update` and `cargo generate-lockfile`

### How should we test and review this PR?

First commit sets up tests

### Additional information

