### PR TITLE
feat(resolve): Fallback to 'rustc -V' for MSRV resolving

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -304,7 +304,8 @@ pub fn resolve_with_previous<'gctx>(
         version_prefs.version_ordering(VersionOrdering::MinimumVersionsFirst)
     }
     if ws.resolve_honors_rust_version() {
-        version_prefs.max_rust_version(ws.rust_version().cloned().map(RustVersion::into_partial));
+        let rust_version = ws.rust_version().cloned().map(RustVersion::into_partial);
+        version_prefs.max_rust_version(rust_version);
     }
 
     let avoid_patch_ids = if register_patches {

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -414,6 +414,7 @@ fn resolve_with_rustc() {
             "\
 [UPDATING] `dummy-registry` index
 [LOCKING] 2 packages
+[ADDING] bar v1.5.0 (latest: v1.6.0)
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of #9930 and adds a fallback if the rust-version isn't set

### How should we test and review this PR?

Tests are added in a separate commit so people can see how the behavior changed.

### Additional information
