### PR TITLE
fix(toml): Error on `[project]` in Edition 2024

### DIFF
--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -1,5 +1,6 @@
 use crate::command_prelude::*;
 
+use cargo::core::Workspace;
 use cargo::ops;
 
 pub fn cli() -> Command {
@@ -69,7 +70,8 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
 
     // Unlike other commands default `cargo fix` to all targets to fix as much
     // code as we can.
-    let ws = args.workspace(gctx)?;
+    let root_manifest = args.root_manifest(gctx)?;
+    let ws = Workspace::new(&root_manifest, gctx)?;
     let mut opts = args.compile_options(gctx, mode, Some(&ws), ProfileChecking::LegacyTestOnly)?;
 
     if !opts.filter.is_specific() {

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -60,7 +60,6 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    let ws = args.workspace(gctx)?;
     // This is a legacy behavior that causes `cargo fix` to pass `--test`.
     let test = matches!(
         args.get_one::<String>("profile").map(String::as_str),
@@ -70,6 +69,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
 
     // Unlike other commands default `cargo fix` to all targets to fix as much
     // code as we can.
+    let ws = args.workspace(gctx)?;
     let mut opts = args.compile_options(gctx, mode, Some(&ws), ProfileChecking::LegacyTestOnly)?;
 
     if !opts.filter.is_specific() {

--- a/src/bin/cargo/commands/fix.rs
+++ b/src/bin/cargo/commands/fix.rs
@@ -71,7 +71,8 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     // Unlike other commands default `cargo fix` to all targets to fix as much
     // code as we can.
     let root_manifest = args.root_manifest(gctx)?;
-    let ws = Workspace::new(&root_manifest, gctx)?;
+    let mut ws = Workspace::new(&root_manifest, gctx)?;
+    ws.set_honor_rust_version(args.honor_rust_version());
     let mut opts = args.compile_options(gctx, mode, Some(&ws), ProfileChecking::LegacyTestOnly)?;
 
     if !opts.filter.is_specific() {
@@ -80,7 +81,9 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     }
 
     ops::fix(
+        gctx,
         &ws,
+        &root_manifest,
         &mut ops::FixOptions {
             edition: args.flag("edition"),
             idioms: args.flag("edition-idioms"),

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -611,6 +611,10 @@ impl<'gctx> Workspace<'gctx> {
         self.honor_rust_version = honor_rust_version;
     }
 
+    pub fn honor_rust_version(&self) -> Option<bool> {
+        self.honor_rust_version
+    }
+
     pub fn resolve_honors_rust_version(&self) -> bool {
         self.gctx().cli_unstable().msrv_policy && self.honor_rust_version.unwrap_or(true)
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1028,7 +1028,13 @@ fn to_real_manifest(
     }
 
     if original_toml.project.is_some() {
-        warnings.push(format!("`[project]` is deprecated in favor of `[package]`"));
+        if Edition::Edition2024 <= edition {
+            anyhow::bail!(
+                "`[project]` is not supported as of the 2024 Edition, please use `[package]`"
+            );
+        } else {
+            warnings.push(format!("`[project]` is deprecated in favor of `[package]`"));
+        }
     }
 
     if resolved_package.metabuild.is_some() {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1027,22 +1027,8 @@ fn to_real_manifest(
         )));
     }
 
-    match (&original_toml.package, &original_toml.project) {
-        (Some(_), Some(_)) => {
-            warnings.push(format!(
-                "manifest at `{}` contains both `project` and `package`, \
-                    this could become a hard error in the future",
-                package_root.display()
-            ));
-        }
-        (None, Some(_)) => {
-            warnings.push(format!(
-                "manifest at `{}` contains `[project]` instead of `[package]`, \
-                                this could become a hard error in the future",
-                package_root.display()
-            ));
-        }
-        (Some(_), None) | (None, None) => {}
+    if original_toml.project.is_some() {
+        warnings.push(format!("`[project]` is deprecated in favor of `[package]`"));
     }
 
     if resolved_package.metabuild.is_some() {

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -980,6 +980,32 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
 }
 
 #[cargo_test]
+fn warn_manifest_with_project() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2015"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_stderr(
+            "\
+[WARNING] `[project]` is deprecated in favor of `[package]`
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn warn_manifest_package_and_project() {
     let p = project()
         .file(
@@ -1058,32 +1084,6 @@ fn git_manifest_package_and_project() {
 [UPDATING] git repository `[..]`
 [LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([..])
-[CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
-        .run();
-}
-
-#[cargo_test]
-fn warn_manifest_with_project() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [project]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-            "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    p.cargo("check")
-        .with_stderr(
-            "\
-[WARNING] `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1002,7 +1002,7 @@ fn warn_manifest_package_and_project() {
     p.cargo("check")
         .with_stderr(
             "\
-[WARNING] manifest at `[CWD]` contains both `project` and `package`, this could become a hard error in the future
+[WARNING] `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1083,7 +1083,7 @@ fn warn_manifest_with_project() {
     p.cargo("check")
         .with_stderr(
             "\
-[WARNING] manifest at `[CWD]` contains `[project]` instead of `[package]`, this could become a hard error in the future
+[WARNING] `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1005,6 +1005,37 @@ fn warn_manifest_with_project() {
         .run();
 }
 
+#[cargo_test(nightly, reason = "edition2024")]
+fn error_manifest_with_project_on_2024() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["edition2024"]
+
+                [project]
+                name = "foo"
+                version = "0.0.1"
+                edition = "2024"
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_status(101)
+        .with_stderr(
+            "\
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  `[project]` is not supported as of the 2024 Edition, please use `[package]`
+",
+        )
+        .run();
+}
+
 #[cargo_test]
 fn warn_manifest_package_and_project() {
     let p = project()

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1975,7 +1975,7 @@ edition = "2021"
         .with_stderr(
             "\
 [MIGRATING] Cargo.toml from 2021 edition to 2024
-[WARNING] `[project]` is deprecated in favor of `[package]`
+[FIXED] Cargo.toml (1 fix)
 [CHECKING] foo v0.0.0 ([CWD])
 [MIGRATING] src/lib.rs from 2021 edition to 2024
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
@@ -1988,7 +1988,7 @@ edition = "2021"
 cargo-features = ["edition2024"]
 
 # Before project
-[ project ] # After project header
+[ package ] # After project header
 # After project header line
 name = "foo"
 edition = "2021"
@@ -2028,7 +2028,7 @@ edition = "2021"
         .with_stderr(
             "\
 [MIGRATING] Cargo.toml from 2021 edition to 2024
-[WARNING] `[project]` is deprecated in favor of `[package]`
+[FIXED] Cargo.toml (1 fix)
 [CHECKING] foo v0.0.0 ([CWD])
 [MIGRATING] src/lib.rs from 2021 edition to 2024
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
@@ -2043,13 +2043,6 @@ cargo-features = ["edition2024"]
 # Before package
 [ package ] # After package header
 # After package header line
-name = "foo"
-edition = "2021"
-# After package table
-
-# Before project
-[ project ] # After project header
-# After project header line
 name = "foo"
 edition = "2021"
 # After project table

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -172,6 +172,7 @@ fn prepare_for_2018() {
         .build();
 
     let stderr = "\
+[MIGRATING] Cargo.toml from 2015 edition to 2018
 [CHECKING] foo v0.0.1 ([..])
 [MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (2 fixes)
@@ -211,6 +212,7 @@ fn local_paths() {
     p.cargo("fix --edition --allow-no-vcs")
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2015 edition to 2018
 [CHECKING] foo v0.0.1 ([..])
 [MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (1 fix)
@@ -298,6 +300,7 @@ fn specify_rustflags() {
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2015 edition to 2018
 [CHECKING] foo v0.0.1 ([..])
 [MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (1 fix)
@@ -770,6 +773,7 @@ https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-proje
         .masquerade_as_nightly_cargo(&["always_nightly"])
         .with_stderr(&format!(
             "\
+[MIGRATING] Cargo.toml from {latest_stable} edition to {next}
 [CHECKING] foo [..]
 [MIGRATING] src/lib.rs from {latest_stable} edition to {next}
 [FINISHED] [..]
@@ -804,11 +808,11 @@ fn prepare_for_latest_stable() {
     p.cargo("fix --edition --allow-no-vcs")
         .with_stderr(&format!(
             "\
+[MIGRATING] Cargo.toml from {previous} edition to {latest_stable}
 [CHECKING] foo [..]
-[MIGRATING] src/lib.rs from {} edition to {}
+[MIGRATING] src/lib.rs from {previous} edition to {latest_stable}
 [FINISHED] [..]
 ",
-            previous, latest_stable
         ))
         .run();
 }
@@ -911,6 +915,7 @@ fn fix_overlapping() {
     p.cargo("fix --allow-no-vcs --edition --lib")
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2015 edition to 2018
 [CHECKING] foo [..]
 [MIGRATING] src/lib.rs from 2015 edition to 2018
 [FIXED] src/lib.rs (2 fixes)
@@ -1202,6 +1207,7 @@ fn only_warn_for_relevant_crates() {
     p.cargo("fix --allow-no-vcs --edition")
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2015 edition to 2018
 [LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
@@ -1398,6 +1404,7 @@ fn edition_v2_resolver_report() {
 
     p.cargo("fix --edition --allow-no-vcs")
         .with_stderr_unordered("\
+[MIGRATING] Cargo.toml from 2018 edition to 2021
 [UPDATING] [..]
 [LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -1477,6 +1484,7 @@ fn fix_edition_2021() {
     p.cargo("fix --edition --allow-no-vcs")
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2018 edition to 2021
 [CHECKING] foo v0.1.0 [..]
 [MIGRATING] src/lib.rs from 2018 edition to 2021
 [FIXED] src/lib.rs (1 fix)
@@ -1966,6 +1974,7 @@ edition = "2021"
         .masquerade_as_nightly_cargo(&["edition2024"])
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2021 edition to 2024
 [WARNING] `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.0 ([CWD])
 [MIGRATING] src/lib.rs from 2021 edition to 2024
@@ -2018,6 +2027,7 @@ edition = "2021"
         .masquerade_as_nightly_cargo(&["edition2024"])
         .with_stderr(
             "\
+[MIGRATING] Cargo.toml from 2021 edition to 2024
 [WARNING] `[project]` is deprecated in favor of `[package]`
 [CHECKING] foo v0.0.0 ([CWD])
 [MIGRATING] src/lib.rs from 2021 edition to 2024


### PR DESCRIPTION
### What does this PR try to resolve?

`[package]` was added in 86b2a2a432a73b3747cca3593850293a5fc3951a in the pre-1.0 days but `[project]` was never removed nor did we warn on its use until recently in #11135.  So likely we can't remove it completely but we can remove it in Edition 2024+.

This includes `cargo fix` support which is hard coded directly into the `cargo fix` command.

This is part of
- #13629
- rust-lang/rust#123754

While we haven't signed off on everything in #13629, I figured this (and a couple other changes) are not very controversial.

### How should we test and review this PR?

Per commit.  Tests are added to show the behavior changes, including in `cargo fix`.

### Additional information

