### PR TITLE
Reword sentence describing workspace toml for clarity

### DIFF
--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -15,7 +15,7 @@ The key points of workspaces are:
   sections in `Cargo.toml` are only recognized in the *root* manifest, and
   ignored in member crates' manifests.
 
-In the `Cargo.toml`, the `[workspace]` table supports the following sections:
+The root `Cargo.toml` of a workspace supports the following sections:
 
 * [`[workspace]`](#the-workspace-section) --- Defines a workspace.
   * [`resolver`](resolver.md#resolver-versions) --- Sets the dependency resolver to use.


### PR DESCRIPTION
Judging by the commit history, the original sentence was written before the `[patch]` and `[profile]` sections were added and since those sections do not go underneath the workspace table the original sentence needed to be updated.