### PR TITLE
feat(resolve): Tell the user the style of resovle done 

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -212,9 +212,7 @@ fn print_lockfile_generation(
         // just ourself, nothing worth reporting
         return Ok(());
     }
-    ws.gctx()
-        .shell()
-        .status("Locking", format!("{num_pkgs} packages"))?;
+    status_locking(ws, num_pkgs)?;
 
     for diff in diff {
         fn format_latest(version: semver::Version) -> String {
@@ -271,10 +269,7 @@ fn print_lockfile_sync(
     if num_pkgs == 0 {
         return Ok(());
     }
-    let plural = if num_pkgs == 1 { "" } else { "s" };
-    ws.gctx()
-        .shell()
-        .status("Locking", format!("{num_pkgs} package{plural}"))?;
+    status_locking(ws, num_pkgs)?;
 
     for diff in diff {
         fn format_latest(version: semver::Version) -> String {
@@ -485,6 +480,14 @@ fn print_lockfile_updates(
         }
     }
 
+    Ok(())
+}
+
+fn status_locking(ws: &Workspace<'_>, num_pkgs: usize) -> CargoResult<()> {
+    let plural = if num_pkgs == 1 { "" } else { "s" };
+    ws.gctx()
+        .shell()
+        .status("Locking", format!("{num_pkgs} package{plural}"))?;
     Ok(())
 }
 

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -255,7 +255,7 @@ fn resolve_with_registry<'gctx>(
         false
     };
     if print {
-        ops::print_lockfile_changes(ws.gctx(), prev.as_ref(), &resolve, registry)?;
+        ops::print_lockfile_changes(ws, prev.as_ref(), &resolve, registry)?;
     }
     Ok(resolve)
 }

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -33,7 +33,7 @@ fn depend_on_alt_registry() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
@@ -88,7 +88,7 @@ fn depend_on_alt_registry_depends_on_same_registry_no_index() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
@@ -132,7 +132,7 @@ fn depend_on_alt_registry_depends_on_same_registry() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
 [DOWNLOADED] [..] v0.0.1 (registry `alternative`)
@@ -177,7 +177,7 @@ fn depend_on_alt_registry_depends_on_crates_io() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
@@ -217,7 +217,7 @@ fn registry_and_path_dep_works() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
@@ -421,7 +421,7 @@ fn alt_registry_and_crates_io_deps() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] crates_io_dep v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] alt_reg_dep v0.1.0 (registry `alternative`)
@@ -698,7 +698,7 @@ fn patch_alt_reg() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -791,7 +791,7 @@ fn no_api() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [CHECKING] bar v0.0.1 (registry `alternative`)
@@ -1354,7 +1354,7 @@ fn registries_index_relative_url() {
         .with_stderr(
             "\
 [UPDATING] `relative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `relative`)
 [CHECKING] bar v0.0.1 (registry `relative`)

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -213,7 +213,7 @@ fn disallow_artifact_and_no_artifact_dep_to_same_package_within_the_same_dep_cat
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
         .with_stderr("\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] foo v0.0.0 ([CWD]) ignoring invalid dependency `bar_stable` which is missing a lib target
 [ERROR] the crate `foo v0.0.0 ([CWD])` depends on crate `bar v0.5.0 ([CWD]/bar)` multiple times with different names",
         )
@@ -323,7 +323,7 @@ fn features_are_unified_among_lib_and_bin_dep_of_same_target() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] d2 v0.0.1 ([CWD]/d2)
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [COMPILING] foo v0.0.1 ([CWD])
@@ -775,7 +775,7 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar-baz v0.5.0 ([CWD]/bar)
 [COMPILING] foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -877,7 +877,7 @@ fn lib_with_selected_dashed_bin_artifact_and_lib_true() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar-baz v0.5.0 ([CWD]/bar)
 [COMPILING] foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -998,7 +998,7 @@ fn disallow_using_example_binaries_as_artifacts() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] dependency `bar` in package `foo` requires a `bin:one-example` artifact to be present.",
         )
         .run();
@@ -1169,7 +1169,7 @@ fn build_script_deps_adopt_do_not_allow_multiple_targets_under_different_name_an
         .with_status(101)
         .with_stderr(format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 error: the crate `foo v0.0.0 ([CWD])` depends on crate `bar v0.5.0 ([CWD]/bar)` multiple times with different names",
         ))
         .run();
@@ -1274,7 +1274,7 @@ fn no_cross_doctests_works_with_artifacts() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1757,7 +1757,7 @@ fn allow_artifact_and_non_artifact_dependency_to_same_crate_if_these_are_not_the
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar [..]
 [COMPILING] foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1794,7 +1794,7 @@ fn prevent_no_lib_warning_with_artifact_dependencies() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-            [LOCKING] 2 packages\n\
+            [LOCKING] 2 packages to latest compatible versions\n\
             [COMPILING] bar v0.5.0 ([CWD]/bar)\n\
             [CHECKING] foo v0.0.0 ([CWD])\n\
             [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -1895,7 +1895,7 @@ fn check_missing_crate_type_in_package_fails() {
             .with_status(101)
             .with_stderr(
                 "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] dependency `bar` in package `foo` requires a `[..]` artifact to be present.",
             )
             .run();
@@ -2042,7 +2042,7 @@ fn env_vars_and_build_products_for_various_build_targets() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar [..]
 [COMPILING] foo [..]
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
@@ -2219,7 +2219,7 @@ fn doc_lib_true() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
@@ -2302,7 +2302,7 @@ fn rustdoc_works_on_libs_with_artifacts_and_lib_false() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -2510,7 +2510,7 @@ fn calc_bin_artifact_fingerprint() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -2592,7 +2592,7 @@ fn with_target_and_optional() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d1 v0.0.1 [..]
 [RUNNING] `rustc --crate-name d1 [..]--crate-type bin[..]
 [CHECKING] foo v0.0.1 [..]
@@ -2642,7 +2642,7 @@ fn with_assumed_host_target_and_optional_build_dep() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1 ([CWD])
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [RUNNING] `rustc --crate-name build_script_build --edition=2021 [..]--crate-type bin[..]
@@ -2770,7 +2770,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 5 packages
+[LOCKING] 5 packages to latest compatible versions
 [COMPILING] c v0.1.0 ([CWD]/c)
 [COMPILING] b v0.1.0 ([CWD]/b)
 [COMPILING] a v0.1.0 ([CWD]/a)
@@ -2874,7 +2874,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_lib() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] b v0.1.0 ([CWD]/b)
 [COMPILING] a v0.1.0 ([CWD]/a)
 [COMPILING] bar v0.1.0 ([CWD]/bar)
@@ -3001,7 +3001,7 @@ fn decouple_same_target_transitive_dep_from_artifact_dep_and_proc_macro() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr_unordered(
             "\
-[LOCKING] 6 packages
+[LOCKING] 6 packages to latest compatible versions
 [COMPILING] d v0.1.0 ([CWD]/d)
 [COMPILING] a v0.1.0 ([CWD]/a)
 [COMPILING] b v0.1.0 ([CWD]/b)
@@ -3067,7 +3067,7 @@ fn same_target_artifact_dep_sharing() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] a v0.1.0 ([CWD]/a)
 [COMPILING] bar v0.1.0 ([CWD]/bar)
 [COMPILING] foo v0.1.0 ([CWD])

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -438,7 +438,7 @@ fn bench_with_deep_lib_dep() {
     p.cargo("bench")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([CWD])
 [FINISHED] `bench` profile [optimized] target(s) in [..]
@@ -904,7 +904,7 @@ fn bench_dylib() {
     p.cargo("bench -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [RUNNING] [..] -C opt-level=3 [..]
 [COMPILING] foo v0.0.1 ([CWD])

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1454,7 +1454,7 @@ fn cargo_default_env_metadata_env_var() {
     p.cargo("build -v")
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type dylib \
         --emit=[..]link \
@@ -2477,7 +2477,7 @@ fn verbose_release_build_deps() {
     p.cargo("build -v --release")
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.0 ([CWD]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]\
         --crate-type dylib --crate-type rlib \
@@ -4171,7 +4171,7 @@ fn invalid_spec() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] package ID specification `notAValidDep` did not match any packages",
         )
         .run();
@@ -4605,7 +4605,7 @@ fn build_all_workspace() {
     p.cargo("build --workspace")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -4640,7 +4640,7 @@ fn build_all_exclude() {
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -4711,7 +4711,7 @@ fn build_all_exclude_not_found() {
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] excluded package(s) `baz` not found in workspace [..]
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
@@ -4747,7 +4747,7 @@ fn build_all_exclude_glob() {
         .with_stderr_does_not_contain("[COMPILING] baz v0.1.0 [..]")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] foo v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -4781,7 +4781,7 @@ fn build_all_exclude_glob_not_found() {
         .with_stderr(
             "\
 [WARNING] excluded package pattern(s) `*z` not found in workspace [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] [..] v0.1.0 ([..])
 [COMPILING] [..] v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -4832,7 +4832,7 @@ fn build_all_workspace_implicit_examples() {
 
     p.cargo("build --workspace --examples")
         .with_stderr(
-            "[LOCKING] 2 packages\n\
+            "[LOCKING] 2 packages to latest compatible versions\n\
              [..] Compiling bar v0.1.0 ([..])\n\
              [..] Compiling foo v0.1.0 ([..])\n\
              [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -4868,7 +4868,7 @@ fn build_all_virtual_manifest() {
     p.cargo("build --workspace")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -4897,7 +4897,7 @@ fn build_virtual_manifest_all_implied() {
     p.cargo("build")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -4926,7 +4926,7 @@ fn build_virtual_manifest_one_project() {
         .with_stderr_does_not_contain("[..]baz[..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -4954,7 +4954,7 @@ fn build_virtual_manifest_glob() {
         .with_stderr_does_not_contain("[..]bar[..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -5030,7 +5030,7 @@ fn build_all_virtual_manifest_implicit_examples() {
     p.cargo("build --workspace --examples")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] baz v0.1.0 ([..])
 [COMPILING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -5077,7 +5077,7 @@ fn build_all_member_dependency_same_name() {
     p.cargo("build --workspace")
         .with_stderr(
             "[UPDATING] `[..]` index\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [DOWNLOADING] crates ...\n\
              [DOWNLOADED] a v0.1.0 ([..])\n\
              [COMPILING] a v0.1.0\n\
@@ -6131,7 +6131,7 @@ fn target_filters_workspace() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] no example target named `ex`
 
 <tab>Did you mean `ex1`?",
@@ -6179,7 +6179,7 @@ fn target_filters_workspace_not_found() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] no library targets found in packages: a, b",
         )
         .run();
@@ -6239,7 +6239,7 @@ fn signal_display() {
     foo.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] pm [..]
 [COMPILING] foo [..]
 [ERROR] could not compile `foo` [..]
@@ -6298,7 +6298,7 @@ fn pipelining_works() {
         .with_stdout("")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] [..]
 [COMPILING] [..]
 [FINISHED] [..]
@@ -6415,7 +6415,7 @@ fn forward_rustc_output() {
         .with_stdout("a\nb\n{}")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] [..]
 [COMPILING] [..]
 c

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -889,7 +889,7 @@ fn custom_build_script_rustc_flags() {
     p.cargo("build --verbose")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]
 [RUNNING] `[..]build-script-build`
@@ -951,7 +951,7 @@ fn custom_build_script_rustc_flags_no_space() {
     p.cargo("build --verbose")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo [..]
 [RUNNING] `rustc --crate-name build_script_build --edition=2015 foo/build.rs [..]
 [RUNNING] `[..]build-script-build`
@@ -1091,7 +1091,7 @@ fn links_duplicates_old_registry() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
 [ERROR] multiple packages link to native library `a`, \
@@ -1705,7 +1705,7 @@ fn build_deps_simple() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] a v0.5.0 ([CWD]/a)
 [RUNNING] `rustc --crate-name a [..]`
 [COMPILING] foo v0.5.0 ([CWD])
@@ -1818,7 +1818,7 @@ fn build_cmd_with_a_build_cmd() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] b v0.5.0 ([CWD]/b)
 [RUNNING] `rustc --crate-name b [..]`
 [COMPILING] a v0.5.0 ([CWD]/a)
@@ -2994,7 +2994,7 @@ fn flags_go_into_tests() {
     p.cargo("test -v --test=foo")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] a v0.5.0 ([..]
 [RUNNING] `rustc [..] a/build.rs [..]`
 [RUNNING] `[..]/build-script-build`
@@ -3094,7 +3094,7 @@ fn diamond_passes_args_only_once() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] c v0.5.0 ([..]
 [RUNNING] `rustc [..]`
 [RUNNING] `[..]`
@@ -3974,7 +3974,7 @@ fn warnings_hidden_for_upstream() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
@@ -4036,7 +4036,7 @@ fn warnings_printed_on_vv() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
 [COMPILING] bar v0.1.0
@@ -4775,7 +4775,7 @@ fn optional_build_dep_and_required_normal_dep() {
         .with_stdout("0")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([..])
 [COMPILING] foo v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -261,7 +261,7 @@ fn link_arg_transitive_not_allowed() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/cargo_add/add_basic/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_basic/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_multiple/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_no_vendored_package_with_alter_registry/stderr.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> serde_test</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/testsuite/cargo_add/add_normalized_name_external/stderr.term.svg
+++ b/tests/testsuite/cargo_add/add_normalized_name_external/stderr.term.svg
@@ -56,7 +56,7 @@
 </tspan>
     <tspan x="10px" y="334px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unstable</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="352px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="370px">
 </tspan>

--- a/tests/testsuite/cargo_add/build/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-build-package2 v99999.0.0 to build-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/build_prefer_existing_version/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/change_rename_target/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `some-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/cyclic_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> feature-two</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_features/stderr.term.svg
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/detect_workspace_inherit_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/detect_workspace_inherit_public/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-dev-package2 v99999.0.0 to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/dev_prefer_existing_version/stderr.term.svg
@@ -27,7 +27,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> two</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_activated_over_limit/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan>             100 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_deactivated_over_limit/stderr.term.svg
@@ -86,7 +86,7 @@
 </tspan>
     <tspan x="10px" y="622px"><tspan>             170 deactivated features</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="640px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="658px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_empty/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_empty/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_multiple_occurrences/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_preserve/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
+++ b/tests/testsuite/cargo_add/features_spaced_values/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_branch/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_branch/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_dev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_inferred_name/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_names/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_multiple_packages_features/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_rev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_rev/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/git_tag/stderr.term.svg
+++ b/tests/testsuite/cargo_add/git_tag/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/git-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
+++ b/tests/testsuite/cargo_add/infer_prerelease/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> prerelease_only v0.2.0-alpha.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path/stderr.term.svg
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
+++ b/tests/testsuite/cargo_add/list_features_path_no_default/stderr.term.svg
@@ -35,7 +35,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/lockfile_updated/stderr.term.svg
+++ b/tests/testsuite/cargo_add/lockfile_updated/stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 1 package to latest compatible version</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v99999.0.0+my-package</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/manifest_path_package/stderr.term.svg
+++ b/tests/testsuite/cargo_add/manifest_path_package/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/merge_activated_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/merge_activated_features/stderr.term.svg
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/testsuite/cargo_add/namever/stderr.term.svg
+++ b/tests/testsuite/cargo_add/namever/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.2.3+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_default_features_with_no_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_features/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_git_with_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_features_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_features_noop/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> test</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_noop/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (workspace) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inherit_optional_noop/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `foo`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_inline_features/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_dev_noop/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_name_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_default_features_with_default_features/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v0.4.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package2 v0.4.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_optional_with_optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_no_public_with_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `my-package`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_no_optional/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_optional_with_optional/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to optional dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_noop/stderr.term.svg
@@ -28,7 +28,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `your-face`</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_path_with_version/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency v20.0.0+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_preserves_inline_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> mouth</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_public_with_no_public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_no_rename/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_rename_with_rename_noop/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `a1`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_git/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">    Updating</tspan><tspan> git repository `[ROOTURL]/versioned-package`</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_version_with_path/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> feature `cargo-list-test-fixture-dependency`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_with_rename/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> versioned-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> versioned-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> foo (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/overwrite_workspace_dep_features/stderr.term.svg
+++ b/tests/testsuite/cargo_add/overwrite_workspace_dep_features/stderr.term.svg
@@ -39,7 +39,7 @@
 </tspan>
     <tspan x="10px" y="190px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> unrelated</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/testsuite/cargo_add/path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_dev/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/path_inferred_name/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_dep_std_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_sorted/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_table/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_features_unsorted/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="154px"><tspan>             </tspan><tspan class="fg-green bold">+</tspan><tspan> e</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_sorted/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
+++ b/tests/testsuite/cargo_add/preserve_unsorted/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> toml v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 4 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-package v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/public/stderr.term.svg
+++ b/tests/testsuite/cargo_add/public/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v0.1.0 to public dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/registry/stderr.term.svg
+++ b/tests/testsuite/cargo_add/registry/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/rename/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rename/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/require_weak/stderr.term.svg
+++ b/tests/testsuite/cargo_add/require_weak/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="136px"><tspan>             </tspan><tspan class="fg-red bold">-</tspan><tspan> nose</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_ignore/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_latest/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust 1.72 compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rust_version_older/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust 1.70 compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.0 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_ignore/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.2.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_latest/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust [..] compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
+++ b/tests/testsuite/cargo_add/rustc_older/stderr.term.svg
@@ -26,7 +26,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> rust-version-user v0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust [..] compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> rust-version-user v0.1.1 </tspan><tspan class="fg-yellow bold">(latest: v0.2.1)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
+++ b/tests/testsuite/cargo_add/sorted_table_with_dotted_item/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> unrelateed-crate v99999.0.0 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 5 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 5 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-cyan bold">      Adding</tspan><tspan> my-build-package1 v0.1.1+my-package </tspan><tspan class="fg-yellow bold">(latest: v99999.0.0+my-package)</tspan>
 </tspan>

--- a/tests/testsuite/cargo_add/target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `i686-unknown-linux-gnu`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target_cfg/stderr.term.svg
@@ -24,7 +24,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `cfg(unix)`</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/testsuite/cargo_add/vers/stderr.term.svg
+++ b/tests/testsuite/cargo_add/vers/stderr.term.svg
@@ -22,7 +22,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package &gt;=0.1.1 to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_name/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_name/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_path/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_path/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_add/workspace_path_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_add/workspace_path_dev/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">      Adding</tspan><tspan> cargo-list-test-fixture-dependency (local) to dev-dependencies</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -106,7 +106,7 @@ fn feature_required_dependency() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] bar v1.0.0 [..]
 error: failed to download replaced source registry `crates-io`
@@ -500,7 +500,7 @@ fn nightly_feature_requires_nightly_in_dep() {
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a [..]
 [CHECKING] b [..]
 [FINISHED] [..]

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -56,7 +56,7 @@ fn dont_include() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.0.1 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -96,7 +96,7 @@ fn works_through_the_registry() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [DOWNLOADED] [..]
@@ -146,7 +146,7 @@ fn ignore_version_from_other_platform() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -383,7 +383,7 @@ fn check_all_exclude() {
         .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -411,7 +411,7 @@ fn check_all_exclude_glob() {
         .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -461,7 +461,7 @@ fn check_virtual_manifest_one_project() {
         .with_stderr_does_not_contain("[CHECKING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -489,7 +489,7 @@ fn check_virtual_manifest_glob() {
         .with_stderr_does_not_contain("[CHECKING] bar v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] baz v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1056,7 +1056,7 @@ fn git_manifest_package_and_project() {
         .with_stderr(
             "\
 [UPDATING] git repository `[..]`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1132,7 +1132,7 @@ fn git_manifest_with_project() {
         .with_stderr(
             "\
 [UPDATING] git repository `[..]`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1456,7 +1456,7 @@ fn check_unused_manifest_keys() {
 [WARNING] unused manifest key: target.cfg(windows).dependencies.foo.wxz
 [WARNING] unused manifest key: target.x86_64-pc-windows-gnu.dev-dependencies.foo.wxz
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -197,7 +197,7 @@ fn collision_doc_multiple_versions() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [ADDING] bar v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v2.0.0 [..]
@@ -372,7 +372,7 @@ fn collision_doc_profile_split() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 [..]
 [COMPILING] common v1.0.0
@@ -429,7 +429,7 @@ fn collision_doc_sources() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 [..]
 [WARNING] output filename collision.
@@ -485,7 +485,7 @@ fn collision_doc_target() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [ADDING] bar v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] orphaned v1.0.0 [..]
@@ -553,7 +553,7 @@ fn collision_with_root() {
     p.cargo("doc -j=1")
         .with_stderr_unordered("\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo-macro v1.0.0 [..]
 warning: output filename collision.

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -613,7 +613,7 @@ fn basic_provider() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 CARGO=Some([..])
 CARGO_REGISTRY_NAME_OPT=Some(\"alternative\")
 CARGO_REGISTRY_INDEX_URL=Some([..])

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -984,7 +984,7 @@ fn build_script_with_platform_specific_dependencies() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] d2 v0.0.0 ([..])
 [RUNNING] `rustc [..] d2/src/lib.rs [..]`
 [COMPILING] d1 v0.0.0 ([..])
@@ -1233,7 +1233,7 @@ fn cross_test_dylib() {
         .arg(&target)
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/direct_minimal_versions.rs
+++ b/tests/testsuite/direct_minimal_versions.rs
@@ -28,6 +28,13 @@ fn simple() {
 
     p.cargo("generate-lockfile -Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[LOCKING] 2 packages
+[ADDING] dep v1.0.0 (latest: v1.1.0)
+",
+        )
         .run();
 
     let lock = p.read_lockfile();
@@ -111,6 +118,13 @@ fn yanked() {
 
     p.cargo("generate-lockfile -Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[LOCKING] 2 packages
+[ADDING] dep v1.1.0 (latest: v1.2.0)
+",
+        )
         .run();
 
     let lock = p.read_lockfile();
@@ -159,6 +173,13 @@ fn indirect() {
 
     p.cargo("generate-lockfile -Zdirect-minimal-versions")
         .masquerade_as_nightly_cargo(&["direct-minimal-versions"])
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[LOCKING] 3 packages
+[ADDING] direct v1.0.0 (latest: v1.1.0)
+",
+        )
         .run();
 
     let lock = p.read_lockfile();

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -107,7 +107,7 @@ fn simple() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([CWD])
 [FINISHED] [..]
@@ -331,7 +331,7 @@ fn multiple() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.1.0 ([CWD])
@@ -371,7 +371,7 @@ fn crates_io_then_directory() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 ([..])
 [CHECKING] bar v0.1.0
@@ -483,7 +483,7 @@ fn bad_file_checksum() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 error: the listed checksum of `[..]lib.rs` has changed:
 expected: [..]
 actual:   [..]
@@ -746,7 +746,7 @@ fn workspace_different_locations() {
         .cwd("bar")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -111,7 +111,7 @@ fn doc_deps() {
     p.cargo("doc")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [..] bar v0.0.1 ([CWD]/bar)
 [..] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
@@ -168,7 +168,7 @@ fn doc_no_deps() {
     p.cargo("doc --no-deps")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([CWD]/bar)
 [DOCUMENTING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -250,7 +250,7 @@ fn doc_multiple_targets_same_name_lib() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 error: document output filename collision
 The lib `foo_lib` in package `foo v0.1.0 ([ROOT]/foo/foo)` has the same name as \
 the lib `foo_lib` in package `bar v0.1.0 ([ROOT]/foo/bar)`.
@@ -301,7 +301,7 @@ fn doc_multiple_targets_same_name() {
     p.cargo("doc --workspace")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 warning: output filename collision.
 The bin target `foo_lib` in package `foo v0.1.0 ([ROOT]/foo/foo)` \
 has the same output filename as the lib target `foo_lib` in package \
@@ -355,7 +355,7 @@ fn doc_multiple_targets_same_name_bin() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 error: document output filename collision
 The bin `foo-cli` in package `foo v0.1.0 ([ROOT]/foo/foo)` has the same name as \
 the bin `foo-cli` in package `bar v0.1.0 ([ROOT]/foo/bar)`.
@@ -740,7 +740,7 @@ fn doc_dash_p() {
     p.cargo("doc -p a")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [..] b v0.0.1 ([CWD]/b)
 [..] b v0.0.1 ([CWD]/b)
 [DOCUMENTING] a v0.0.1 ([CWD]/a)
@@ -771,7 +771,7 @@ fn doc_all_exclude() {
         .with_stderr_does_not_contain("[DOCUMENTING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
@@ -800,7 +800,7 @@ fn doc_all_exclude_glob() {
         .with_stderr_does_not_contain("[DOCUMENTING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
@@ -1083,7 +1083,7 @@ fn features() {
     p.cargo("doc --features foo")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 [..]
 [DOCUMENTING] bar v0.0.1 [..]
 [DOCUMENTING] foo v0.0.1 [..]
@@ -1320,7 +1320,7 @@ fn doc_virtual_manifest_one_project() {
         .with_stderr_does_not_contain("[DOCUMENTING] baz v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/bar/index.html
@@ -1349,7 +1349,7 @@ fn doc_virtual_manifest_glob() {
         .with_stderr_does_not_contain("[DOCUMENTING] bar v0.1.0 [..]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] baz v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 [GENERATED] [CWD]/target/doc/baz/index.html
@@ -1389,7 +1389,7 @@ fn doc_all_member_dependency_same_name() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 warning: output filename collision.
@@ -1769,7 +1769,7 @@ fn doc_cap_lints() {
     p.cargo("doc")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] git repository `[..]`
 [DOCUMENTING] a v0.5.0 ([..])
 [CHECKING] a v0.5.0 ([..])
@@ -2102,7 +2102,7 @@ fn bin_private_items_deps() {
     p.cargo("doc")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.0.1 ([..])
 [CHECKING] bar v0.0.1 ([..])
 [DOCUMENTING] foo v0.0.1 ([CWD])
@@ -2673,7 +2673,7 @@ fn doc_lib_false() {
     p.cargo("doc")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.1.0 [..]
 [DOCUMENTING] foo v0.1.0 [..]
@@ -2724,7 +2724,7 @@ fn doc_lib_false_dep() {
     p.cargo("doc")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 [..]
 [DOCUMENTING] foo v0.1.0 [..]
 [FINISHED] [..]

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -115,7 +115,7 @@ impl Foo {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.0.1 ([CWD]/crates/a)
 [CHECKING] foo v0.0.1 ([CWD])
 [SCRAPING] foo v0.0.1 ([CWD])
@@ -603,7 +603,7 @@ fn no_scrape_with_dev_deps() {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 warning: Rustdoc did not scrape the following examples because they require dev-dependencies: ex
     If you want Rustdoc to scrape these examples, then add `doc-scrape-examples = true`
     to the [[example]] target configuration of at least one example.
@@ -671,7 +671,7 @@ fn use_dev_deps_if_explicitly_enabled() {
         .masquerade_as_nightly_cargo(&["rustdoc-scrape-examples"])
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.0.1 ([CWD])
 [CHECKING] a v0.0.1 ([CWD]/a)
 [SCRAPING] foo v0.0.1 ([CWD])

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -100,7 +100,7 @@ fn same_name() {
         .arg("{p} [{f}]")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .with_stdout(
@@ -362,7 +362,7 @@ fn invalid9() {
     p.cargo("check --features bar")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 error: Package `foo v0.0.1 ([..])` does not have feature `bar`. It has a required dependency with that name, but only optional dependencies can be used as features.
 ",
         ).with_status(101).run();
@@ -527,7 +527,7 @@ fn no_feature_doesnt_build() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -588,7 +588,7 @@ fn default_feature_pulled_in() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -715,7 +715,7 @@ fn groups_on_groups_on_groups() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
@@ -766,7 +766,7 @@ fn many_cli_features() {
         .arg("bar baz")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
@@ -853,7 +853,7 @@ fn union_features() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] d2 v0.0.1 ([CWD]/d2)
 [CHECKING] d1 v0.0.1 ([CWD]/d1)
 [CHECKING] foo v0.0.1 ([CWD])
@@ -902,7 +902,7 @@ fn many_features_no_rebuilds() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.1.0 ([CWD]/a)
 [CHECKING] b v0.1.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1185,7 +1185,7 @@ fn optional_and_dev_dep() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] test v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1463,7 +1463,7 @@ fn many_cli_features_comma_delimited() {
     p.cargo("check --features bar,baz")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] foo v0.0.1 ([CWD])
@@ -1530,7 +1530,7 @@ fn many_cli_features_comma_and_space_delimited() {
         .arg("bar,baz bam bap")
         .with_stderr(
             "\
-[LOCKING] 5 packages
+[LOCKING] 5 packages to latest compatible versions
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
 [CHECKING] ba[..] v0.0.1 ([CWD]/ba[..])
@@ -1702,7 +1702,7 @@ fn warn_if_default_features() {
         .with_stderr(
             r#"
 [WARNING] `default-features = [".."]` was found in [features]. Did you mean to use `default = [".."]`?
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
             "#.trim(),
@@ -2041,7 +2041,7 @@ fn registry_summary_order_doesnt_matter() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [DOWNLOADED] [..]

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -836,7 +836,7 @@ fn required_features_host_dep() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] target `x` in package `foo` requires the features: `bdep/f1`
 Consider enabling them by passing, e.g., `--features=\"bdep/f1\"`
 ",
@@ -950,7 +950,7 @@ fn required_features_inactive_dep() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [FINISHED] [..]",
         )
         .run();
@@ -1188,7 +1188,7 @@ fn has_dev_dep_for_test() {
     p.cargo("check -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.1.0 [..]
 [RUNNING] `rustc --crate-name foo [..]
 [FINISHED] [..]
@@ -1605,7 +1605,7 @@ fn resolver_enables_new_features() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common [..]
 [COMPILING] common v1.0.0
@@ -1840,7 +1840,7 @@ fn shared_dep_same_but_dependencies() {
         // unordered because bin1 and bin2 build at the same time
         .with_stderr_unordered(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] subdep [..]
 [COMPILING] dep [..]
 [COMPILING] bin2 [..]
@@ -1991,7 +1991,7 @@ fn doc_optional() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] spin v1.0.0 [..]
 [DOWNLOADED] bar v1.0.0 [..]
@@ -2106,7 +2106,7 @@ fn minimal_download() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 15 packages
+[LOCKING] 15 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] normal_pm v1.0.0 [..]
 [DOWNLOADED] normal v1.0.0 [..]
@@ -2344,7 +2344,7 @@ fn pm_with_int_shared() {
     p.cargo("build --workspace --all-targets --all-features -v")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] shared [..]
 [RUNNING] `rustc --crate-name shared [..]--crate-type lib [..]
 [RUNNING] `rustc --crate-name shared [..]--crate-type lib [..]
@@ -2546,7 +2546,7 @@ fn all_features_merges_with_features() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [COMPILING] dep v0.1.0
@@ -2632,7 +2632,7 @@ fn dep_with_optional_host_deps_activated() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] serde_build v0.1.0 ([CWD]/serde_build)
 [COMPILING] serde_derive v0.1.0 ([CWD]/serde_derive)
 [COMPILING] serde v0.1.0 ([CWD]/serde)

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -32,7 +32,7 @@ fn dependency_with_crate_syntax() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [DOWNLOADED] [..]
@@ -175,7 +175,7 @@ fn namespaced_implicit_feature() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.0.1 [..]
 [FINISHED] [..]
 ",
@@ -325,7 +325,7 @@ fn namespaced_same_name() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1 [..]
 [FINISHED] [..]
 [RUNNING] [..]
@@ -387,7 +387,7 @@ fn no_implicit_feature() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] foo v0.1.0 [..]
 [FINISHED] [..]
 [RUNNING] `target/debug/foo[EXE]`
@@ -568,7 +568,7 @@ fn crate_required_features() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] invalid feature `dep:bar` in required-features of target `foo`: \
 `dep:` prefixed feature values are not allowed in required-features
 ",
@@ -691,7 +691,7 @@ fn crate_feature_with_explicit() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 [..]
 [CHECKING] bar v1.0.0
@@ -1297,7 +1297,7 @@ foo v0.1.0 ([ROOT]/foo) features=",
         )
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -98,7 +98,7 @@ fn fix_path_deps() {
         .with_stdout("")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [FIXED] bar/src/lib.rs (1 fix)
 [CHECKING] foo v0.1.0 ([..])
@@ -260,7 +260,7 @@ fn upgrade_extern_crate() {
         .build();
 
     let stderr = "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
 [FIXED] src/lib.rs (1 fix)
@@ -1097,7 +1097,7 @@ fn doesnt_rebuild_dependencies() {
         .with_stdout("")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1202,7 +1202,7 @@ fn only_warn_for_relevant_crates() {
     p.cargo("fix --allow-no-vcs --edition")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.1.0 ([..])
 [CHECKING] foo v0.1.0 ([..])
 [MIGRATING] src/lib.rs from 2015 edition to 2018
@@ -1399,7 +1399,7 @@ fn edition_v2_resolver_report() {
     p.cargo("fix --edition --allow-no-vcs")
         .with_stderr_unordered("\
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] common v1.0.0 [..]
 [DOWNLOADED] bar v1.0.0 [..]
@@ -1520,7 +1520,7 @@ fn fix_shared_cross_workspace() {
         .env("__CARGO_FIX_YOLO", "1")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.1.0 [..]
 [CHECKING] bar v0.1.0 [..]
 [FIXED] [..]foo/src/shared.rs (2 fixes)

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -138,7 +138,7 @@ fn rebuild_sub_package_then_while_package() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] b [..]
 [COMPILING] a [..]
 [COMPILING] foo [..]
@@ -383,7 +383,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .with_stdout("ftest off")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [..]Compiling dep_crate v0.0.1 ([..])
 [..]Compiling a v0.0.1 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -410,7 +410,7 @@ fn changing_bin_paths_common_target_features_caches_targets() {
         .with_stdout("ftest on")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [..]Compiling dep_crate v0.0.1 ([..])
 [..]Compiling b v0.0.1 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -756,7 +756,7 @@ fn same_build_dir_cached_packages() {
         .cwd("a1")
         .with_stderr(&format!(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] d v0.0.1 ({dir}/d)
 [COMPILING] c v0.0.1 ({dir}/c)
 [COMPILING] b v0.0.1 ({dir}/b)
@@ -770,7 +770,7 @@ fn same_build_dir_cached_packages() {
         .cwd("a2")
         .with_stderr(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] a2 v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1317,7 +1317,7 @@ fn update_dependency_mtime_does_not_rebuild() {
         .env("RUSTFLAGS", "-C linker=cc")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -1463,7 +1463,7 @@ fn reuse_panic_build_dep_test() {
     p.cargo("test --lib --no-run -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar [..]
 [COMPILING] foo [..]
@@ -1524,7 +1524,7 @@ fn reuse_panic_pm() {
     p.cargo("build -v")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C debuginfo=2 [..]
@@ -1695,7 +1695,7 @@ fn rebuild_on_mid_build_file_modification() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] proc_macro_dep v0.1.0 ([..]/proc_macro_dep)
 [COMPILING] root v0.1.0 ([..]/root)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -90,7 +90,7 @@ fn no_index_update() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -100,7 +100,7 @@ fn no_index_update() {
         .with_stdout("")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -260,7 +260,7 @@ fn generate_lockfile_holds_lock_and_offline() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -268,7 +268,7 @@ fn generate_lockfile_holds_lock_and_offline() {
     p.cargo("generate-lockfile --offline")
         .with_stderr_contains(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -62,7 +62,7 @@ fn cargo_compile_simple_git_dep() {
         .cargo("build")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [COMPILING] dep1 v0.5.0 ({}#[..])\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -134,7 +134,7 @@ fn cargo_compile_git_dep_branch() {
         .cargo("build")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [COMPILING] dep1 v0.5.0 ({}?branch=branchy#[..])\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -211,7 +211,7 @@ fn cargo_compile_git_dep_tag() {
         .cargo("build")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [COMPILING] dep1 v0.5.0 ({}?tag=v0.1.0#[..])\n\
              [COMPILING] foo v0.5.0 ([CWD])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -282,7 +282,7 @@ fn cargo_compile_git_dep_pull_request() {
         .cargo("build")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [COMPILING] dep1 v0.5.0 ({}?rev=refs/pull/330/head#[..])\n\
              [COMPILING] foo v0.0.0 ([CWD])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -596,7 +596,7 @@ fn recompilation() {
     p.cargo("check")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [CHECKING] bar v0.5.0 ({}#[..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) \
@@ -741,7 +741,7 @@ fn update_with_shared_deps() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{git}`
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [CHECKING] bar v0.5.0 ({git}#[..])
 [CHECKING] [..] v0.5.0 ([..])
 [CHECKING] [..] v0.5.0 ([..])
@@ -872,7 +872,7 @@ fn dep_with_submodule() {
             "\
 [UPDATING] git repository [..]
 [UPDATING] git submodule `file://[..]/dep2`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep1 [..]
 [CHECKING] foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -941,7 +941,7 @@ fn dep_with_relative_submodule() {
             "\
 [UPDATING] git repository [..]
 [UPDATING] git submodule `file://[..]/deployment`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] deployment [..]
 [CHECKING] base [..]
 [CHECKING] foo [..]
@@ -1079,7 +1079,7 @@ fn dep_with_skipped_submodule() {
             "\
 [UPDATING] git repository `file://[..]/bar`
 [SKIPPING] git submodule `file://[..]/qux` [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar [..]
 [CHECKING] foo [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -1207,7 +1207,7 @@ fn two_deps_only_update_one() {
         .with_stderr(
             "[UPDATING] git repository `[..]`\n\
              [UPDATING] git repository `[..]`\n\
-             [LOCKING] 3 packages\n\
+             [LOCKING] 3 packages to latest compatible versions\n\
              [CHECKING] [..] v0.5.0 ([..])\n\
              [CHECKING] [..] v0.5.0 ([..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
@@ -1367,7 +1367,7 @@ fn dep_with_changed_submodule() {
         .with_stderr(
             "[UPDATING] git repository `[..]`\n\
              [UPDATING] git submodule `file://[..]/dep2`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [COMPILING] dep1 v0.5.0 ([..])\n\
              [COMPILING] foo v0.5.0 ([..])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in \
@@ -1484,7 +1484,7 @@ fn dev_deps_with_testing() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{bar}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1592,7 +1592,7 @@ fn git_name_not_always_needed() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{bar}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1636,7 +1636,7 @@ fn git_repo_changing_no_rebuild() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{bar}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] [..]
 [CHECKING] [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1675,7 +1675,7 @@ fn git_repo_changing_no_rebuild() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{bar}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] [..]
 [CHECKING] [..]
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1791,7 +1791,7 @@ fn fetch_downloads() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
             url = bar.url()
         ))
@@ -1839,7 +1839,7 @@ fn fetch_downloads_with_git2_first_then_with_gitoxide_and_vice_versa() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 2 packages",
+[LOCKING] 2 packages to latest compatible versions",
             url = bar.url()
         ))
         .run();
@@ -1878,7 +1878,7 @@ fn warnings_in_git_dep() {
     p.cargo("check")
         .with_stderr(&format!(
             "[UPDATING] git repository `{}`\n\
-             [LOCKING] 2 packages\n\
+             [LOCKING] 2 packages to latest compatible versions\n\
              [CHECKING] bar v0.5.0 ({}#[..])\n\
              [CHECKING] foo v0.5.0 ([CWD])\n\
              [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -2069,7 +2069,7 @@ fn switch_deps_does_not_update_transitive() {
             "\
 [UPDATING] git repository `{}`
 [UPDATING] git repository `{}`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] transitive [..]
 [CHECKING] dep [..]
 [CHECKING] foo [..]
@@ -2102,7 +2102,7 @@ fn switch_deps_does_not_update_transitive() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] dep v0.5.0 ([..])
 [CHECKING] dep [..]
 [CHECKING] foo [..]
@@ -2223,7 +2223,7 @@ fn switch_sources() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]a1`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] a v0.5.0 ([..]a1#[..]
 [CHECKING] b v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
@@ -2252,7 +2252,7 @@ fn switch_sources() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]a2`
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] a v0.5.1 ([..])
 [CHECKING] a v0.5.1 ([..]a2#[..]
 [CHECKING] b v0.5.0 ([..])
@@ -2387,7 +2387,7 @@ fn lints_are_suppressed() {
         .with_stderr(
             "\
 [UPDATING] git repository `[..]`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.5.0 ([..])
 [CHECKING] foo v0.0.1 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -2432,7 +2432,7 @@ fn denied_lints_are_allowed() {
         .with_stderr(
             "\
 [UPDATING] git repository `[..]`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a v0.5.0 ([..])
 [CHECKING] foo v0.0.1 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -3125,7 +3125,7 @@ fn default_not_master() {
         .with_stderr(
             "\
 [UPDATING] git repository `[..]`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep1 v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -3189,7 +3189,7 @@ dependencies = [
         .cargo("check")
         .with_stderr(
             "\
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] dep1 v0.5.0 ([..])
 [FINISHED] [..]
 ",
@@ -3785,7 +3785,7 @@ fn different_user_relative_submodules() {
 [UPDATING] git repository `{}`
 [UPDATING] git submodule `{}`
 [UPDATING] git submodule `{}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] dep1 v0.5.0 ({}#[..])
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -130,7 +130,7 @@ fn self_signed_with_cacert() {
         .with_stderr(
             "\
 [UPDATING] git repository `https://127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -158,7 +158,7 @@ fn github_works() {
         .with_stderr(
             "\
 [UPDATING] git repository `https://github.com/rust-lang/bitflags.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -294,7 +294,7 @@ fn inherit_own_dependencies() {
         .with_stderr_unordered(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 ([..])
 [DOWNLOADED] dep-build v0.8.2 ([..])
@@ -446,7 +446,7 @@ fn inherit_own_detailed_dependencies() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 ([..])
 [CHECKING] dep v0.1.2
@@ -616,7 +616,7 @@ fn inherited_dependencies_union_features() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
@@ -846,7 +846,7 @@ fn inherit_dependencies() {
         .with_stderr_unordered(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 ([..])
 [DOWNLOADED] dep-build v0.8.2 ([..])
@@ -1001,7 +1001,7 @@ fn inherit_target_dependencies() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.2 ([..])
 [CHECKING] dep v0.1.2
@@ -1049,7 +1049,7 @@ fn inherit_dependency_override_optional() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.2.0 ([CWD]/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -1093,7 +1093,7 @@ fn inherit_dependency_features() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
@@ -1166,7 +1166,7 @@ fn inherit_detailed_dependencies() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`\n\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] detailed v0.5.0 ({}?branch=branchy#[..])\n\
 [CHECKING] bar v0.2.0 ([CWD]/bar)\n\
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]\n",
@@ -1209,7 +1209,7 @@ fn inherit_path_dependencies() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep v0.9.0 ([CWD]/dep)
 [CHECKING] bar v0.2.0 ([CWD]/bar)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1482,7 +1482,7 @@ fn warn_inherit_def_feat_true_member_def_feat_false() {
 [WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \
 true for `workspace.dependencies.dep`, this could become a hard error in the future
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
@@ -1532,7 +1532,7 @@ fn warn_inherit_simple_member_def_feat_false() {
 [WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \
 not specified for `workspace.dependencies.dep`, this could become a hard error in the future
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
@@ -1580,7 +1580,7 @@ fn inherit_def_feat_false_member_def_feat_true() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] fancy_dep v0.2.4 ([..])
 [DOWNLOADED] dep v0.1.0 ([..])
@@ -1673,7 +1673,7 @@ fn warn_inherit_unused_manifest_key_dep() {
 [WARNING] [CWD]/Cargo.toml: unused manifest key: workspace.dependencies.dep.wxz
 [WARNING] [CWD]/Cargo.toml: unused manifest key: dependencies.dep.wxz
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 ([..])
 [CHECKING] [..]

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -43,7 +43,7 @@ fn dependency_warning_ignored() {
     foo.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] [..]
 [CHECKING] [..]
 [FINISHED] [..]

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -52,7 +52,7 @@ fn simple() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [UNPACKING] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])
@@ -175,7 +175,7 @@ fn multiple_versions() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [UNPACKING] bar v0.1.0 ([..])
 [CHECKING] bar v0.1.0
 [CHECKING] foo v0.0.1 ([CWD])
@@ -237,7 +237,7 @@ fn multiple_names() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [UNPACKING] [..]
 [UNPACKING] [..]
 [CHECKING] [..]
@@ -293,7 +293,7 @@ fn interdependent() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [UNPACKING] [..]
 [UNPACKING] [..]
 [CHECKING] bar v0.0.1
@@ -364,7 +364,7 @@ fn path_dep_rewritten() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [UNPACKING] [..]
 [UNPACKING] [..]
 [CHECKING] bar v0.0.1
@@ -532,7 +532,7 @@ fn crates_io_registry_url_is_optional() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [UNPACKING] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
 [COMPILING] foo v0.0.1 ([CWD])

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -1055,7 +1055,7 @@ dependencies = [
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] dep1 v0.5.0 ({url}?{ref_kind}={git_ref}#[..])
 [ADDING] foo v0.0.1 ([CWD])
 [CHECKING] dep1 v0.5.0 ({url}?{ref_kind}={git_ref}#[..])
@@ -1151,7 +1151,7 @@ dependencies = [
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] dep1 v0.5.0 ({url}?{ref_kind}={git_ref}#[..])
 [ADDING] foo v0.0.1 ([CWD])
 [CHECKING] dep1 v0.5.0 ({url}?{ref_kind}={git_ref}#[..])

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -258,7 +258,7 @@ fn off_in_manifest_works() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
 [COMPILING] bar v0.0.1
@@ -677,7 +677,7 @@ fn test_profile() {
         // unordered because the two `foo` builds start in parallel
         .with_stderr_unordered("\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
 [COMPILING] bar v0.0.1
@@ -816,7 +816,7 @@ fn fresh_swapping_commands() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 [..]
 [COMPILING] bar v1.0.0

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1915,7 +1915,7 @@ fn cargo_metadata_with_invalid_artifact_deps() {
         .with_stderr(
             "\
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] dependency `artifact` in package `foo` requires a `bin:notfound` artifact to be present.",
         )
         .run();
@@ -1946,7 +1946,7 @@ fn cargo_metadata_with_invalid_duplicate_renamed_deps() {
         .with_stderr(
             "\
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] the crate `foo v0.5.0 ([..])` depends on crate `bar v0.5.0 ([..])` multiple times with different names",
         )
         .run();
@@ -3398,7 +3398,7 @@ fn filter_platform() {
             "\
 [UPDATING] [..]
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
-[LOCKING] 5 packages
+[LOCKING] 5 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] normal-dep v0.0.1 [..]
 [DOWNLOADED] host-dep v0.0.1 [..]

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -33,7 +33,7 @@ fn minimal_version_cli() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to earliest compatible versions
 [ADDING] dep v1.0.0 (latest: v1.1.0)
 ",
         )

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -30,6 +30,13 @@ fn minimal_version_cli() {
 
     p.cargo("generate-lockfile -Zminimal-versions")
         .masquerade_as_nightly_cargo(&["minimal-versions"])
+        .with_stderr(
+            "\
+[UPDATING] [..]
+[LOCKING] 2 packages
+[ADDING] dep v1.0.0 (latest: v1.1.0)
+",
+        )
         .run();
 
     let lock = p.read_lockfile();

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -144,7 +144,7 @@ fn cargo_compile_with_downloaded_dependency_with_offline() {
     p2.cargo("check --offline")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] present_dep v1.2.3
 [CHECKING] bar v0.1.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -254,7 +254,7 @@ fn main(){
     p2.cargo("run --offline")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] present_dep v1.2.3
 [COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -503,7 +503,7 @@ fn compile_offline_with_cached_git_dep(shallow: bool) {
     let mut cargo = p.cargo("build --offline");
     cargo.with_stderr(format!(
         "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] dep1 v0.5.0 ({}#[..])
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]",
@@ -687,7 +687,7 @@ fn main(){
     p2.cargo("build --offline")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] present_dep v1.2.9
 [COMPILING] foo v0.1.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -59,7 +59,7 @@ fn virtual_no_default_features() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] a v0.1.0 [..]
 [CHECKING] b v0.1.0 [..]
 [FINISHED] [..]
@@ -153,7 +153,7 @@ fn virtual_features() {
     p.cargo("check --features f1")
         .with_stderr_unordered(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] a [..]
 [CHECKING] b [..]
 [FINISHED] [..]
@@ -225,7 +225,7 @@ fn virtual_with_specific() {
 [CHECKING] a [..]
 [CHECKING] b [..]
 [FINISHED] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -500,7 +500,7 @@ fn non_member() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
 [CHECKING] dep [..]

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -54,7 +54,7 @@ fn replace() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 ([..])
 [CHECKING] bar v0.1.0 ([CWD]/bar)
@@ -102,7 +102,7 @@ fn from_config() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -145,7 +145,7 @@ fn from_config_relative() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -191,7 +191,7 @@ fn from_config_precedence() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 ([..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -233,7 +233,7 @@ fn nonexistent() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -282,7 +282,7 @@ fn patch_git() {
         .with_stderr(
             "\
 [UPDATING] git repository `file://[..]`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -332,7 +332,7 @@ fn patch_to_git() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -377,7 +377,7 @@ Check that [..]
 with the [..]
 what is [..]
 version. [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
@@ -456,7 +456,7 @@ Check that [..]
 with the [..]
 what is [..]
 version. [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.3.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
@@ -498,7 +498,7 @@ fn prefer_patch_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -558,7 +558,7 @@ Check that [..]
 with the [..]
 what is [..]
 version. [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
@@ -634,7 +634,7 @@ Check that [..]
 with the [..]
 what is [..]
 version. [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
@@ -685,7 +685,7 @@ fn add_patch() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
@@ -716,7 +716,7 @@ fn add_patch() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
@@ -754,7 +754,7 @@ fn add_patch_from_config() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
@@ -776,7 +776,7 @@ fn add_patch_from_config() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
@@ -814,7 +814,7 @@ fn add_ignored_patch() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 [..]
 [CHECKING] bar v0.1.0
@@ -909,7 +909,7 @@ fn add_patch_with_features() {
 [WARNING] patch for `bar` uses the features mechanism. \
 default-features and features will not take effect because the patch dependency does not support this mechanism
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -959,7 +959,7 @@ fn add_patch_with_setting_default_features() {
 [WARNING] patch for `bar` uses the features mechanism. \
 default-features and features will not take effect because the patch dependency does not support this mechanism
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([CWD]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1016,7 +1016,7 @@ fn no_warn_ws_patch() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] a [..]
 [FINISHED] [..]",
         )
@@ -1053,7 +1053,7 @@ fn new_minor() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 [..]
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1106,7 +1106,7 @@ fn transitive_new_minor() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v0.1.1 [..]
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.0.1 ([CWD])
@@ -1146,7 +1146,7 @@ fn new_major() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.2.0 [..]
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1177,7 +1177,7 @@ fn new_major() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.2.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.2.0 [..]
@@ -1233,7 +1233,7 @@ fn transitive_new_major() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v0.2.0 [..]
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.0.1 ([CWD])
@@ -1293,7 +1293,7 @@ fn shared_by_transitive() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v0.1.2 [..]
 [CHECKING] bar v0.1.0 [..]
 [CHECKING] foo v0.1.0 ([CWD])
@@ -1637,7 +1637,7 @@ fn patch_older() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v1.0.1 [..]
 [CHECKING] bar v0.5.0 [..]
 [CHECKING] foo v0.1.0 [..]
@@ -2041,7 +2041,7 @@ fn update_unused_new_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.6 ([ROOT]/bar)
 [CHECKING] bar v0.1.6 ([..]/bar)
 [CHECKING] foo v0.0.1 ([..]/foo)
@@ -2241,7 +2241,7 @@ fn patch_walks_backwards() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2256,7 +2256,7 @@ fn patch_walks_backwards() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] bar v0.1.1 ([CWD]/bar) -> v0.1.0
 [CHECKING] bar v0.1.0 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
@@ -2297,7 +2297,7 @@ fn patch_walks_backwards_restricted() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.1 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
 [FINISHED] [..]
@@ -2370,7 +2370,7 @@ fn patched_dep_new_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 [..]
 [CHECKING] baz v0.1.0
@@ -2405,7 +2405,7 @@ fn patched_dep_new_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [UPDATING] baz v0.1.0 -> v0.1.1
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry `dummy-registry`)
@@ -2453,7 +2453,7 @@ fn patch_update_doesnt_update_other_sources() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] `alternative` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `alternative`)
 [CHECKING] bar v0.1.0 (registry `alternative`)
@@ -2479,7 +2479,7 @@ fn patch_update_doesnt_update_other_sources() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0 ([CWD]/bar) -> v0.1.1
 [CHECKING] bar v0.1.1 ([..]/foo/bar)
 [CHECKING] foo v0.1.0 ([..]/foo)
@@ -2521,7 +2521,7 @@ fn can_update_with_alt_reg() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `alternative`)
 [CHECKING] bar v0.1.1 (registry `alternative`)
@@ -2569,7 +2569,7 @@ fn can_update_with_alt_reg() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.1 (registry `alternative`) -> v0.1.2
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.2 (registry `alternative`)
@@ -2659,7 +2659,7 @@ dependencies = [
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v1.0.0 (file://[..])
 ",
         )

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -73,7 +73,7 @@ fn cargo_compile_with_nested_deps_shorthand() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] baz v0.5.0 ([CWD]/bar/baz)
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.5.0 ([CWD])
@@ -195,7 +195,7 @@ fn cargo_compile_with_root_dev_deps_with_testing() {
     p.cargo("test")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] [..] v0.5.0 ([..])
 [COMPILING] [..] v0.5.0 ([..])
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
@@ -257,7 +257,7 @@ fn cargo_compile_with_transitive_dev_deps() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -295,7 +295,7 @@ fn no_rebuild_dependency() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.5.0 ([CWD]/bar)
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -365,7 +365,7 @@ fn deep_dependencies_trigger_rebuild() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v0.5.0 ([CWD]/baz)
 [CHECKING] bar v0.5.0 ([CWD]/bar)
 [CHECKING] foo v0.5.0 ([CWD])
@@ -455,7 +455,7 @@ fn no_rebuild_two_deps() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] baz v0.5.0 ([CWD]/baz)
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.5.0 ([CWD])
@@ -495,7 +495,7 @@ fn nested_deps_recompile() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.5.0 ([CWD]/src/bar)
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -745,7 +745,7 @@ fn path_dep_build_cmd() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -806,7 +806,7 @@ fn dev_deps_no_rebuild_lib() {
         .env("FOO", "bar")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -862,7 +862,7 @@ fn custom_target_no_rebuild() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] a v0.5.0 ([..])
 [CHECKING] foo v0.5.0 ([..])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -924,7 +924,7 @@ fn override_and_depend() {
         .cwd("b")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [WARNING] skipping duplicate package `a2` found at `[..]`
 [CHECKING] a2 v0.5.0 ([..])
 [CHECKING] a1 v0.5.0 ([..])

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -58,7 +58,7 @@ fn broken_path_override_warns() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] bar v0.1.0 (latest: v0.2.0)
 warning: path override for crate `a` has altered the original list of
 dependencies; the dependency on `bar` was either added or
@@ -179,7 +179,7 @@ fn paths_ok_with_optional() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..]bar2)
 [CHECKING] foo v0.0.1 ([..])
 [FINISHED] [..]

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -520,7 +520,7 @@ fn proc_macro_built_once() {
     p.cargo("build --verbose")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] the-macro [..]
 [RUNNING] `rustc --crate-name the_macro [..]`
 [COMPILING] b [..]

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -231,7 +231,7 @@ fn profile_config_override_spec_multiple() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] multiple package overrides in profile `dev` match package `bar v0.5.0 ([..])`
 found package specs: bar, bar@0.5.0",
         )
@@ -318,7 +318,7 @@ fn profile_config_override_precedence() {
     p.cargo("build -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=2[..]-C codegen-units=2 [..]
 [COMPILING] foo [..]
@@ -513,7 +513,7 @@ fn test_with_dev_profile() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
 [COMPILING] somedep v1.0.0

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -335,7 +335,7 @@ fn overrides_with_custom() {
     p.cargo("build -v")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] xxx [..]
 [COMPILING] yyy [..]
 [COMPILING] foo [..]

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -33,7 +33,7 @@ fn profile_override_basic() {
     p.cargo("check -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar [..]
 [RUNNING] `rustc --crate-name bar [..] -C opt-level=3 [..]`
 [CHECKING] foo [..]
@@ -220,7 +220,7 @@ fn profile_override_hierarchy() {
     // m1: 1 (as [profile.dev])
 
     p.cargo("build -v").with_stderr_unordered("\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [COMPILING] m3 [..]
 [COMPILING] dep [..]
 [RUNNING] `rustc --crate-name m3 --edition=2015 m3/src/lib.rs [..] --crate-type lib --emit=[..]link[..]-C codegen-units=4 [..]
@@ -485,7 +485,7 @@ fn no_warning_ws() {
     p.cargo("check -p b")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] b [..]
 [FINISHED] [..]
 ",

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -88,7 +88,7 @@ fn profile_selection_build() {
     //   are built with debuginfo=0.
     p.cargo("build -vv")
         .with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
@@ -123,7 +123,7 @@ fn profile_selection_build_release() {
 
     // `build --release`
     p.cargo("build --release -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
@@ -184,7 +184,7 @@ fn profile_selection_build_all_targets() {
     //   example  dev        build
     p.cargo("build --all-targets -vv")
         .with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=1 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C panic=abort[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -254,7 +254,7 @@ fn profile_selection_build_all_targets_release() {
     //   bin      release        build
     //   example  release        build
     p.cargo("build --all-targets --release -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..]-C codegen-units=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
@@ -312,7 +312,7 @@ fn profile_selection_test() {
     //   bin      test           build
     //
     p.cargo("test -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=3 -C debuginfo=2 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
@@ -380,7 +380,7 @@ fn profile_selection_test_release() {
     //   bin      release        build
     //
     p.cargo("test --release -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=2 [..]
@@ -447,7 +447,7 @@ fn profile_selection_bench() {
     //   bin      bench          build
     //
     p.cargo("bench -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3[..]-C codegen-units=4 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link -C opt-level=3 -C panic=abort[..]-C codegen-units=4 [..]
@@ -513,7 +513,7 @@ fn profile_selection_check_all_targets() {
     //   bin      dev-panic      check-test (checking bin as a unittest)
     //
     p.cargo("check --all-targets -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=1 -C debuginfo=2 [..]
@@ -559,7 +559,7 @@ fn profile_selection_check_all_targets_release() {
     // `profile_selection_check_all_targets` that uses `release` instead of
     // `dev` for all targets.
     p.cargo("check --all-targets --release -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=6 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata -C opt-level=3[..]-C codegen-units=2 [..]
@@ -619,7 +619,7 @@ fn profile_selection_check_all_targets_test() {
     //   bin      test-panic  check-test
     //
     p.cargo("check --all-targets --profile=test -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]metadata[..]-C codegen-units=3 -C debuginfo=2 [..]
@@ -665,7 +665,7 @@ fn profile_selection_doc() {
     //
     //   `*` = wants panic, but it is cleared when args are built.
     p.cargo("doc -vv").with_stderr_unordered("\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] bar [..]
 [DOCUMENTING] bar [..]
 [RUNNING] `[..] rustc --crate-name bar --edition=2015 bar/src/lib.rs [..]--crate-type lib --emit=[..]link[..]-C codegen-units=5 [..]

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -239,7 +239,7 @@ fn registry_dependency() {
         .with_stderr(&format!(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1
@@ -297,7 +297,7 @@ fn git_dependency() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ({url}[..])
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
@@ -345,7 +345,7 @@ fn path_dependency() {
         .with_stdout("cocktail-bar/src/lib.rs")
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([..]/cocktail-bar)
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \
@@ -396,7 +396,7 @@ fn path_dependency_outside_workspace() {
         .with_stdout("bar-0.0.1/src/lib.rs")
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([..]/bar)
 [RUNNING] `rustc [..]\
     -Zremap-path-scope=object \

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -211,7 +211,7 @@ fn top_level_overrides_deps() {
     p.cargo("build -v --release")
         .with_stderr(&format!(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.0 ([CWD]/foo)
 [RUNNING] `rustc --crate-name foo --edition=2015 foo/src/lib.rs [..]\
         --crate-type dylib --crate-type rlib \
@@ -285,7 +285,7 @@ fn profile_in_non_root_manifest_triggers_a_warning() {
 [WARNING] profiles for the non root package will be ignored, specify profiles at the workspace root:
 package:   [..]
 workspace: [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc [..]`
 [FINISHED] `dev` profile [unoptimized] target(s) in [..]",

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -78,7 +78,7 @@ fn exported_pub_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 ([..])
 [CHECKING] pub_dep v0.1.0
@@ -144,7 +144,7 @@ fn requires_feature() {
             "\
 [WARNING] ignoring `public` on dependency pub_dep, pass `-Zpublic-dependency` to enable support for it
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_dep v0.1.0 ([..])
 [CHECKING] pub_dep v0.1.0
@@ -233,7 +233,7 @@ fn pub_dev_dependency_without_feature() {
             "\
 [WARNING] 'public' specifier can only be used on regular dependencies, not dev-dependencies
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
         )
@@ -334,7 +334,7 @@ fn allow_priv_in_tests() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
@@ -380,7 +380,7 @@ fn allow_priv_in_benchs() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
@@ -427,7 +427,7 @@ fn allow_priv_in_bins() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
@@ -474,7 +474,7 @@ fn allow_priv_in_examples() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [CHECKING] priv_dep v0.1.0
@@ -522,7 +522,7 @@ fn allow_priv_in_custom_build() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] priv_dep v0.1.0 ([..])
 [COMPILING] priv_dep v0.1.0
@@ -577,7 +577,7 @@ fn publish_package_with_public_dependency() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] pub_bar v0.1.0 ([..])
 [DOWNLOADED] bar v0.1.0 ([..])

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -268,7 +268,7 @@ fn outdated_lock_version_change_does_not_warn() {
     p.cargo("package --no-verify")
         .with_stderr(
             "\
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [UPDATING] foo v0.1.0 ([CWD]) -> v0.2.0
 [PACKAGING] foo v0.2.0 ([..])
 [PACKAGED] [..] files, [..] ([..] compressed)

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -60,7 +60,7 @@ fn simple() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -122,7 +122,7 @@ fn deps() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
@@ -373,7 +373,7 @@ fn bad_cksum() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum [..]
 [ERROR] failed to download replaced source registry `crates-io`
@@ -433,7 +433,7 @@ required by package `foo v0.0.1 ([..])`
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] notyet v0.0.1 (registry `dummy-registry`)
 [CHECKING] notyet v0.0.1
@@ -551,7 +551,7 @@ fn lockfile_locks() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -603,7 +603,7 @@ fn lockfile_locks_transitively() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
@@ -663,7 +663,7 @@ fn yanks_are_not_used() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
@@ -896,7 +896,7 @@ fn yanks_in_lockfiles_are_ok_with_new_dep() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [ADDING] baz v0.0.1
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `dummy-registry`)
@@ -1098,7 +1098,7 @@ fn dev_dependency_not_used() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1195,7 +1195,7 @@ fn updating_a_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -1233,7 +1233,7 @@ fn updating_a_dep() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.0.1 -> v0.1.0
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
@@ -1310,7 +1310,7 @@ fn git_and_registry_dep() {
             "\
 [UPDATING] [..]
 [UPDATING] [..]
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.0.1 (registry `dummy-registry`)
 [CHECKING] a v0.0.1
@@ -1445,7 +1445,7 @@ fn fetch_downloads() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] a v0.1.0 (registry [..])
 ",
@@ -1873,7 +1873,7 @@ fn only_download_relevant() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.0 ([..])
 [CHECKING] baz v0.1.0
@@ -2174,7 +2174,7 @@ fn bump_version_dont_update_registry() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 1 package
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.5.0 ([CWD]) -> v0.6.0
 [CHECKING] bar v0.6.0 ([..])
 [FINISHED] [..]
@@ -2311,7 +2311,7 @@ fn bad_and_or_malicious_packages_rejected() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 error: failed to download [..]
@@ -2807,7 +2807,7 @@ fn reach_max_unpack_size() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [ERROR] failed to download replaced source registry `crates-io`
@@ -2882,7 +2882,7 @@ internal server error
 warning: spurious network error (2 tries remaining): failed to get successful HTTP response from `[..]` (127.0.0.1), got 500
 body:
 internal server error
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `dummy-registry`)
 [CHECKING] bar v0.0.1
@@ -2968,7 +2968,7 @@ fn sparse_retry_multiple() {
     write!(
         &mut expected,
         "\
-[LOCKING] 94 packages
+[LOCKING] 94 packages to latest compatible versions
 "
     )
     .unwrap();
@@ -3020,7 +3020,7 @@ fn dl_retry_single() {
     p.cargo("fetch")
         .with_stderr("\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 warning: spurious network error (3 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 500
@@ -3115,7 +3115,11 @@ fn dl_retry_multiple() {
         )
         .unwrap();
     }
-    write!(&mut expected, "[LOCKING] 94 packages\n").unwrap();
+    write!(
+        &mut expected,
+        "[LOCKING] 94 packages to latest compatible versions\n"
+    )
+    .unwrap();
     let _server = builder.build();
     for (_, name) in &pkgs {
         Package::new(name, "1.0.0").publish();
@@ -3158,7 +3162,7 @@ fn deleted_entry() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `dummy-registry`)
 ",
@@ -3197,7 +3201,7 @@ foo v0.1.0 ([ROOT]/foo)
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0 (registry `dummy-registry`)
 ",
@@ -3268,7 +3272,7 @@ fn corrupted_ok_overwritten() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 ",
@@ -3535,7 +3539,7 @@ fn debug_header_message_dl() {
 
     p.cargo("fetch").with_status(101).with_stderr("\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 warning: spurious network error (3 tries remaining): \
     failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/1.0.0/download` (127.0.0.1), got 503
@@ -3592,7 +3596,7 @@ fn set_mask_during_unpacking() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 ",
@@ -3643,7 +3647,7 @@ fn unpack_again_when_cargo_ok_is_unrecognized() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 ",
@@ -3718,7 +3722,7 @@ fn differ_only_by_metadata() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..] v0.0.1+b (registry `dummy-registry`)
 [CHECKING] baz v0.0.1+b
@@ -3813,7 +3817,7 @@ fn builtin_source_replacement() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bad-cksum [..]
 [ERROR] failed to verify the checksum of `bad-cksum v0.0.1`

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -39,7 +39,7 @@ fn make_project() -> Project {
 
 static SUCCESS_OUTPUT: &'static str = "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `alternative`)
 [COMPILING] bar v0.0.1 (registry `alternative`)
@@ -60,7 +60,7 @@ fn requires_credential_provider() {
         .with_status(101)
         .with_stderr(
             r#"[UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 error: failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
@@ -272,7 +272,7 @@ fn missing_token_git() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
@@ -331,7 +331,7 @@ fn incorrect_token_git() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [ERROR] failed to download from `http://[..]/dl/bar/0.0.1/download`
 
@@ -424,7 +424,7 @@ fn duplicate_index() {
         .with_stderr(
             "\
 [UPDATING] `alternative` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -192,7 +192,7 @@ fn rename_twice() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.1.0 (registry [..])
 error: the crate `test v0.1.0 ([CWD])` depends on crate `foo v0.1.0` multiple times with different names

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -45,7 +45,7 @@ fn override_simple() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -94,7 +94,7 @@ fn override_with_features() {
             "\
 [UPDATING] [..] index
 [UPDATING] git repository `[..]`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [WARNING] replacement for `bar` uses the features mechanism. default-features and features \
 will not take effect because the replacement dependency does not support this mechanism
 [CHECKING] bar v0.1.0 (file://[..])
@@ -145,7 +145,7 @@ fn override_with_setting_default_features() {
             "\
 [UPDATING] [..] index
 [UPDATING] git repository `[..]`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [WARNING] replacement for `bar` uses the features mechanism. default-features and features \
 will not take effect because the replacement dependency does not support this mechanism
 [CHECKING] bar v0.1.0 (file://[..])
@@ -305,7 +305,7 @@ fn transitive() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.2.0 (registry [..])
 [CHECKING] bar v0.1.0 (file://[..])
@@ -359,7 +359,7 @@ fn persists_across_rebuilds() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `file://[..]`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] bar v0.1.0 (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -407,7 +407,7 @@ fn replace_registry_with_path() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([ROOT][..]/bar)
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -475,7 +475,7 @@ fn use_a_spec_to_select() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
-[LOCKING] 5 packages
+[LOCKING] 5 packages to latest compatible versions
 [ADDING] baz v0.1.1 (latest: v0.2.0)
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
@@ -540,7 +540,7 @@ fn override_adds_some_deps() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.1.1 (registry [..])
 [CHECKING] baz v0.1.1
@@ -1171,7 +1171,7 @@ fn no_warnings_when_replace_is_used_in_another_workspace_member() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [CHECKING] first_crate v0.1.0 ([..])
 [FINISHED] [..]",
@@ -1435,7 +1435,7 @@ fn override_respects_spec_metadata() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] package replacement is not used: https://github.com/rust-lang/crates.io-index#bar@0.1.0+notTheBuild
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.0+a (registry `dummy-registry`)
@@ -1495,7 +1495,7 @@ fn override_spec_metadata_is_optional() {
             "\
 [UPDATING] `dummy-registry` index
 [UPDATING] git repository `[..]`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] bar v0.1.0+a (file://[..])
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1051,7 +1051,7 @@ fn dep_feature_in_cmd_line() {
     p.cargo("build")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [FINISHED] `dev` profile [..]",
         )
         .run();
@@ -1376,7 +1376,7 @@ fn renamed_required_features() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [ERROR] target `x` in package `foo` requires the features: `a1/f1`
 Consider enabling them by passing, e.g., `--features=\"a1/f1\"`
 ",

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -792,7 +792,7 @@ fn example_with_release_flag() {
     p.cargo("run -v --release --example a")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.5.0 ([CWD]/bar)
 [RUNNING] `rustc --crate-name bar --edition=2015 bar/src/bar.rs [..]--crate-type lib \
         --emit=[..]link \
@@ -925,7 +925,7 @@ fn run_with_bin_dep() {
     p.cargo("run")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [WARNING] foo v0.0.1 ([CWD]) ignoring invalid dependency `bar` which is missing a lib target
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
@@ -986,7 +986,7 @@ fn run_with_bin_deps() {
     p.cargo("run")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [WARNING] foo v0.0.1 ([CWD]) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo v0.0.1 ([CWD]) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo v0.0.1 ([CWD])
@@ -1081,7 +1081,7 @@ available binaries: bar1, bar2, foo1, foo2",
     p.cargo("run --bin foo1")
         .with_stderr(
             "\
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [WARNING] foo1 v0.0.1 ([CWD]/foo1) ignoring invalid dependency `bar1` which is missing a lib target
 [WARNING] foo2 v0.0.1 ([CWD]/foo2) ignoring invalid dependency `bar2` which is missing a lib target
 [COMPILING] foo1 v0.0.1 ([CWD]/foo1)

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -217,7 +217,7 @@ fn dependency_rust_version_newer_than_rustc() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `[..]`)
 [ERROR] rustc [..] is not supported by the following package:
@@ -265,7 +265,7 @@ fn dependency_tree_rust_version_newer_than_rustc() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] baz v0.0.1 (registry `[..]`)
 [DOWNLOADED] bar v0.0.1 (registry `[..]`)
@@ -350,7 +350,7 @@ fn dependency_rust_version_older_and_newer_than_package() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
 [CHECKING] bar v1.6.0
@@ -403,7 +403,7 @@ fn resolve_with_rustc() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -413,7 +413,7 @@ fn resolve_with_rustc() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest Rust [..] compatible versions
 [ADDING] bar v1.5.0 (latest: v1.6.0)
 ",
         )
@@ -457,7 +457,7 @@ fn dependency_rust_version_backtracking() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] no-rust-version v2.2.0 (registry `dummy-registry`)
 [DOWNLOADED] has-rust-version v1.6.0 (registry `dummy-registry`)
@@ -534,7 +534,7 @@ fn workspace_with_mixed_rust_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.6.0 (registry `dummy-registry`)
 [CHECKING] bar v1.6.0
@@ -598,7 +598,7 @@ See https://github.com/rust-lang/cargo/issues/9930 for more information about th
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -608,7 +608,7 @@ See https://github.com/rust-lang/cargo/issues/9930 for more information about th
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] bar v1.5.0 (latest: v1.6.0)
 ",
         )
@@ -649,7 +649,7 @@ fn update_msrv_resolve() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
 [ADDING] bar v1.5.0 (latest: v1.6.0)
 ",
         )

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -244,7 +244,7 @@ fn build_with_crate_type_for_foo_with_deps() {
     p.cargo("rustc -v --crate-type cdylib")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] a v0.1.0 ([CWD]/a)
 [RUNNING] `rustc --crate-name a --edition=2015 a/src/lib.rs [..]--crate-type lib [..]
 [COMPILING] foo v0.0.1 ([CWD])
@@ -424,7 +424,7 @@ fn build_foo_with_bar_dependency() {
     foo.cargo("rustc -v -- -C debug-assertions")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `[..] -C debuginfo=2 [..]`
 [COMPILING] foo v0.0.1 ([CWD])
@@ -462,7 +462,7 @@ fn build_only_bar_dependency() {
     foo.cargo("rustc -v -p bar -- -C debug-assertions")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.1.0 ([..])
 [RUNNING] `rustc --crate-name bar [..]--crate-type lib [..] -C debug-assertions [..]`
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -163,7 +163,7 @@ fn rustdoc_foo_with_bar_dependency() {
     foo.cargo("rustdoc -v -- --cfg=foo")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.0.1 ([..])
 [RUNNING] `rustc [..]bar/src/lib.rs [..]`
 [DOCUMENTING] foo v0.0.1 ([CWD])
@@ -208,7 +208,7 @@ fn rustdoc_only_bar_dependency() {
     foo.cargo("rustdoc -v -p bar -- --cfg=foo")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOCUMENTING] bar v0.0.1 ([..])
 [RUNNING] `rustdoc [..]--crate-name bar [..]bar/src/lib.rs [..]\
         -o [CWD]/target/doc \

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -736,7 +736,7 @@ fn main() {
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
 [UPDATING] `dummy-registry` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] script v1.0.0 (registry `dummy-registry`)
 [COMPILING] script v1.0.0
@@ -775,7 +775,7 @@ fn main() {
         .with_stderr(
             "\
 [WARNING] `package.edition` is unspecified, defaulting to `2021`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([ROOT]/foo/bar)
 [COMPILING] script v0.0.0 ([ROOT]/foo)
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -287,7 +287,7 @@ fn source_replacement_with_registry_url() {
         .with_stderr(
             "\
 [UPDATING] `using-registry-url` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `using-registry-url`)
 [CHECKING] bar v0.0.1

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -206,7 +206,7 @@ fn known_host_works() {
         .with_stderr(
             "\
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -283,7 +283,7 @@ fn known_host_without_port() {
         .with_stderr(
             "\
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -320,7 +320,7 @@ fn hostname_case_insensitive() {
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `ssh://testuser@{hostname}:{port}/repos/bar.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 "
         ))
         .run();
@@ -398,7 +398,7 @@ Caused by:
         .with_stderr(
             "\
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();
@@ -611,7 +611,7 @@ fn ssh_key_in_config() {
         .with_stderr(
             "\
 [UPDATING] git repository `ssh://testuser@127.0.0.1:[..]/repos/bar.git`
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 ",
         )
         .run();

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -91,7 +91,7 @@ fn cargo_test_release() {
     p.cargo("test -v --release")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [RUNNING] [..] -C opt-level=3 [..]
 [COMPILING] foo v0.1.0 ([CWD])
@@ -598,7 +598,7 @@ fn test_with_deep_lib_dep() {
     p.cargo("test")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([..])
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1376,7 +1376,7 @@ fn test_dylib() {
     p.cargo("test")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] bar v0.0.1 ([CWD]/bar)
 [COMPILING] foo v0.0.1 ([CWD])
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
@@ -1924,7 +1924,7 @@ fn selective_testing() {
     p.cargo("test -p d1")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/d1-[..][EXE])
@@ -2136,7 +2136,7 @@ fn selective_testing_with_docs() {
     p.cargo("test -p d1")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] d1 v0.0.1 ([CWD]/d1)
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
 [RUNNING] [..] (target/debug/deps/d1[..][EXE])
@@ -2232,7 +2232,7 @@ fn example_with_dev_dep() {
     p.cargo("test -v")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [..]
 [..]
 [..]
@@ -2521,7 +2521,7 @@ fn cyclic_dev_dep_doc_test() {
     p.cargo("test")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1 ([..])
 [COMPILING] bar v0.0.1 ([..])
 [FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
@@ -2781,7 +2781,7 @@ fn selective_test_optional_dep() {
     p.cargo("test -v --no-run --features a -p a")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] a v0.0.1 ([..])
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
 [RUNNING] `rustc [..] a/src/lib.rs [..]`
@@ -3920,7 +3920,7 @@ fn test_hint_workspace_virtual() {
     p.cargo("test")
         .with_stderr_unordered(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [COMPILING] c v0.1.0 [..]
 [COMPILING] a v0.1.0 [..]
 [COMPILING] b v0.1.0 [..]
@@ -4375,7 +4375,7 @@ fn test_dep_with_dev() {
         .with_status(101)
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] package `bar` cannot be tested because it requires dev-dependencies \
 and is not a member of the workspace",
         )

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -30,7 +30,7 @@ fn timings_works() {
         .with_stderr_unordered(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v0.1.0 [..]
 [COMPILING] dep v0.1.0

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1109,7 +1109,7 @@ rustdns.workspace = true
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 ",
             git_project.url(),
         ))
@@ -1200,7 +1200,7 @@ rustdns.workspace = true
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 ",
             git_project.url(),
         ))
@@ -1291,7 +1291,7 @@ rustdns.workspace = true
         .with_stderr(&format!(
             "\
 [UPDATING] git repository `{}`
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 ",
             git_project.url(),
         ))
@@ -1352,7 +1352,7 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 2 packages"
+[LOCKING] 2 packages to latest compatible versions"
         ))
         .run();
 

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -773,7 +773,7 @@ fn git_duplicate() {
             "\
 [UPDATING] [..]
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] [..]
 [DOWNLOADED] [..]
 error: failed to sync
@@ -1087,7 +1087,7 @@ fn no_remote_dependency_no_vendor() {
     p.cargo("vendor")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 There is no dependency to vendor in this project.",
         )
         .run();

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -66,7 +66,7 @@ fn no_warning_on_success() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 ([..])
 [COMPILING] bar v0.0.1

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -51,7 +51,7 @@ fn simple() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 [..]
 [CHECKING] foo v0.1.0 [..]
@@ -107,7 +107,7 @@ fn deferred() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep v1.0.0 [..]
 [DOWNLOADED] bar_activator v1.0.0 [..]
@@ -187,7 +187,7 @@ fn optional_cli_syntax() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 [..]
 [CHECKING] foo v0.1.0 [..]
@@ -262,7 +262,7 @@ fn required_features() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [ERROR] invalid feature `bar?/feat` in required-features of target `foo`: \
 optional dependency with `?` is not allowed in required-features
 ",
@@ -358,7 +358,7 @@ fn weak_with_host_decouple() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] [..]
 [DOWNLOADED] [..]
@@ -405,7 +405,7 @@ fn weak_namespaced() {
         .with_stderr(
             "\
 [UPDATING] [..]
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 [..]
 [CHECKING] foo v0.1.0 [..]

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -112,7 +112,7 @@ fn non_virtual_default_members_build_other_member() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [CHECKING] baz v0.1.0 ([..])
 [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -154,7 +154,7 @@ fn non_virtual_default_members_build_root_project() {
     p.cargo("check")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] foo v0.1.0 ([..])
 [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -701,7 +701,7 @@ fn share_dependencies() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [ADDING] dep1 v0.1.3 (latest: v0.1.8)
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 ([..])
@@ -752,7 +752,7 @@ fn fetch_fetches_all() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] dep1 v0.1.3 ([..])
 ",
@@ -803,7 +803,7 @@ fn lock_works_for_everyone() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 4 packages",
+[LOCKING] 4 packages to latest compatible versions",
         )
         .run();
 
@@ -985,7 +985,7 @@ fn virtual_default_members_build_other_member() {
     p.cargo("check --manifest-path bar/Cargo.toml")
         .with_stderr(
             "\
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest compatible versions
 [CHECKING] bar v0.1.0 ([..])
 [..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
 ",
@@ -2065,7 +2065,7 @@ fn dep_used_with_separate_features() {
     p.cargo("build --workspace")
         .with_stderr(
             "\
-[LOCKING] 3 packages
+[LOCKING] 3 packages to latest compatible versions
 [..]Compiling feat_lib v0.1.0 ([..])
 [..]Compiling caller1 v0.1.0 ([..])
 [..]Compiling caller2 v0.1.0 ([..])


### PR DESCRIPTION
### What does this PR try to resolve?

This is to help with https://github.com/rust-lang/cargo/issues/9930

Example changes:
```diff
-[LOCKING] 4 packages
+[LOCKING] 4 packages to latest compatible version
-[LOCKING] 2 packages
+[LOCKING] 2 packages to latest Rust 1.60.0 compatible versions
-[LOCKING] 2 packages
+[LOCKING] 2 packages to earliest compatible versions
```

Benefits
- The package count is of "added" packages and this makes that more
  logically clear
- This gives users transparency into what is happening, especially with
  - what rust-version is use
  - the transition to this feature in the new edition
  - whether the planned config was applied or not (as I don't want it to
    require an MSRV bump)
- Will make it easier in tests to show what changed
- Provides more motiviation to show this message in `cargo update` and
  `cargo install` (that will be explored in a follow up PR)

This does come at the cost of more verbose output but hopefully not too
verbose.  This is why I left off other factors, like avoid-dev-deps.

### How should we test and review this PR?



### Additional information

