### PR TITLE
docs: update `checkout` GitHub action version

### DIFF
--- a/src/doc/src/guide/continuous-integration.md
+++ b/src/doc/src/guide/continuous-integration.md
@@ -29,7 +29,7 @@ jobs:
           - beta
           - nightly
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
       - run: cargo update --verbose
       - run: cargo build --verbose


### PR DESCRIPTION
### What does this PR try to resolve?

This PR updates the GitHub CI examples in The Cargo Book to use the latest version of the `actions/checkout` GitHub action, since using `actions/checkout@v3` (currently used in the examples) produces warnings about deprecated Node.js 16 (see also [GitHub Actions: Transitioning from Node 16 to Node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) blog post).

Also, v4 is already used in the "Verifying `rust-version`" example:

https://github.com/rust-lang/cargo/blob/a9f86addbc3eef731468c3b07addc74a5bc1d8ae/src/doc/src/guide/continuous-integration.md?plain=1#L174


