### PR TITLE
feat(update): Include a Locking message

### DIFF
--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -358,8 +358,12 @@ fn print_lockfile_updates(
     resolve: &Resolve,
     registry: &mut PackageRegistry<'_>,
 ) -> CargoResult<()> {
+    let diff = PackageDiff::diff(&previous_resolve, &resolve);
+    let num_pkgs: usize = diff.iter().map(|d| d.added.len()).sum();
+    status_locking(ws, num_pkgs)?;
+
     let mut unchanged_behind = 0;
-    for diff in PackageDiff::diff(&previous_resolve, &resolve) {
+    for diff in diff {
         fn format_latest(version: semver::Version) -> String {
             let warn = style::WARN;
             format!(" {warn}(latest: v{version}){warn:#}")

--- a/src/cargo/ops/cargo_generate_lockfile.rs
+++ b/src/cargo/ops/cargo_generate_lockfile.rs
@@ -170,7 +170,13 @@ pub fn update_lockfile(ws: &Workspace<'_>, opts: &UpdateOptions<'_>) -> CargoRes
         true,
     )?;
 
-    print_lockfile_updates(ws, &previous_resolve, &resolve, &mut registry)?;
+    print_lockfile_updates(
+        ws,
+        &previous_resolve,
+        &resolve,
+        opts.precise.is_some(),
+        &mut registry,
+    )?;
     if opts.dry_run {
         opts.gctx
             .shell()
@@ -356,11 +362,14 @@ fn print_lockfile_updates(
     ws: &Workspace<'_>,
     previous_resolve: &Resolve,
     resolve: &Resolve,
+    precise: bool,
     registry: &mut PackageRegistry<'_>,
 ) -> CargoResult<()> {
     let diff = PackageDiff::diff(&previous_resolve, &resolve);
     let num_pkgs: usize = diff.iter().map(|d| d.added.len()).sum();
-    status_locking(ws, num_pkgs)?;
+    if !precise {
+        status_locking(ws, num_pkgs)?;
+    }
 
     let mut unchanged_behind = 0;
     for diff in diff {

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1590,6 +1590,7 @@ fn index_version_filtering() {
         .with_stderr(
             "\
 [UPDATING] [..]
+[LOCKING] 2 packages to latest compatible versions
 [ADDING] artifact v1.0.0
 [UPDATING] bar v1.0.0 -> v1.0.1",
         )

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -799,7 +799,6 @@ Caused by:
         .arg(&old_head.to_string())
         .with_stderr(
             "\
-[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.5.0 [..]",
         )
         .run();

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -616,7 +616,10 @@ fn recompilation() {
 
     p.cargo("update")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`",
+            "\
+[UPDATING] git repository `{}`
+[LOCKING] 0 packages to latest compatible versions
+",
             git_project.url()
         ))
         .run();
@@ -636,9 +639,11 @@ fn recompilation() {
     // Update the dependency and carry on!
     p.cargo("update")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`\n\
-             [UPDATING] bar v0.5.0 ([..]) -> #[..]\n\
-             ",
+            "\
+[UPDATING] git repository `{}`
+[LOCKING] 1 package to latest compatible version
+[UPDATING] bar v0.5.0 ([..]) -> #[..]
+",
             git_project.url()
         ))
         .run();
@@ -766,6 +771,7 @@ fn update_with_shared_deps() {
         .with_stderr(
             "\
 [UPDATING] git repository [..]
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.5.0 [..]
 ",
         )
@@ -791,16 +797,22 @@ Caused by:
     println!("bar precise update");
     p.cargo("update bar --precise")
         .arg(&old_head.to_string())
-        .with_stderr("[UPDATING] bar v0.5.0 [..]")
+        .with_stderr(
+            "\
+[LOCKING] 1 package to latest compatible version
+[UPDATING] bar v0.5.0 [..]",
+        )
         .run();
 
     // Updating recursively should, however, update the repo.
     println!("dep1 recursive update");
     p.cargo("update dep1 --recursive")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`\n\
-             [UPDATING] bar v0.5.0 ([..]) -> #[..]\n\
-             ",
+            "\
+[UPDATING] git repository `{}`
+[LOCKING] 1 package to latest compatible version
+[UPDATING] bar v0.5.0 ([..]) -> #[..]
+",
             git_project.url()
         ))
         .run();
@@ -822,7 +834,10 @@ Caused by:
     // We should be able to update transitive deps
     p.cargo("update bar")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`",
+            "\
+[UPDATING] git repository `{}`
+[LOCKING] 0 packages to latest compatible versions
+",
             git_project.url()
         ))
         .run();
@@ -1223,9 +1238,11 @@ fn two_deps_only_update_one() {
 
     p.cargo("update dep1")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`\n\
-             [UPDATING] dep1 v0.5.0 ([..]) -> #[..]\n\
-             ",
+            "\
+[UPDATING] git repository `{}`
+[LOCKING] 1 package to latest compatible version
+[UPDATING] dep1 v0.5.0 ([..]) -> #[..]
+",
             git1.url()
         ))
         .run();
@@ -1411,10 +1428,12 @@ fn dep_with_changed_submodule() {
     p.cargo("update")
         .with_stderr("")
         .with_stderr(&format!(
-            "[UPDATING] git repository `{}`\n\
-             [UPDATING] git submodule `file://[..]/dep3`\n\
-             [UPDATING] dep1 v0.5.0 ([..]) -> #[..]\n\
-             ",
+            "\
+[UPDATING] git repository `{}`
+[UPDATING] git submodule `file://[..]/dep3`
+[LOCKING] 1 package to latest compatible version
+[UPDATING] dep1 v0.5.0 ([..]) -> #[..]
+",
             git_project.url()
         ))
         .run();
@@ -1993,7 +2012,13 @@ fn update_one_dep_in_repo_with_many_deps() {
 
     p.cargo("generate-lockfile").run();
     p.cargo("update bar")
-        .with_stderr(&format!("[UPDATING] git repository `{}`", bar.url()))
+        .with_stderr(&format!(
+            "\
+[UPDATING] git repository `{}`
+[LOCKING] 0 packages to latest compatible versions
+",
+            bar.url()
+        ))
         .run();
 }
 

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -1481,6 +1481,7 @@ fn clean_max_git_age() {
         .with_stderr(
             "\
 [UPDATING] git repository [..]
+[LOCKING] 1 package to latest compatible version
 [UPDATING] git_a v1.0.0 [..]
 ",
         )
@@ -1562,6 +1563,7 @@ fn clean_max_src_crate_age() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v1.0.0 -> v1.0.1
 ",
         )

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -190,7 +190,11 @@ fn multiple_versions() {
         .publish();
 
     p.cargo("update")
-        .with_stderr("[UPDATING] bar v0.1.0 -> v0.2.0")
+        .with_stderr(
+            "\
+[LOCKING] 1 package to latest compatible version
+[UPDATING] bar v0.1.0 -> v0.2.0",
+        )
         .run();
 }
 

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -702,7 +702,6 @@ fn main(){
         .with_status(0)
         .with_stderr(
             "\
-[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] present_dep v1.2.9 -> v1.2.3
 ",
         )

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -702,6 +702,7 @@ fn main(){
         .with_status(0)
         .with_stderr(
             "\
+[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] present_dep v1.2.9 -> v1.2.3
 ",
         )
@@ -725,6 +726,7 @@ fn main(){
         .with_status(0)
         .with_stderr(
             "\
+[LOCKING] 1 package to latest compatible version
 [UPDATING] present_dep v1.2.3 -> v1.2.9
 ",
         )

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -2061,6 +2061,7 @@ fn update_unused_new_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.6 ([..]/bar)
 [REMOVING] bar v0.1.5
 ",
@@ -2073,6 +2074,7 @@ fn update_unused_new_version() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [ADDING] bar v0.1.6 ([..]/bar)
 [REMOVING] bar v0.1.5
 ",
@@ -2542,6 +2544,7 @@ fn can_update_with_alt_reg() {
             "\
 [UPDATING] `alternative` index
 [UPDATING] `dummy-registry` index
+[LOCKING] 0 packages to latest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )

--- a/tests/testsuite/precise_pre_release.rs
+++ b/tests/testsuite/precise_pre_release.rs
@@ -65,6 +65,7 @@ fn update_pre_release() {
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr(
             r#"[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] my-dependency v0.1.1 -> v0.1.2-pre.0
 "#,
         )
@@ -98,6 +99,7 @@ fn update_pre_release_differ() {
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr(
             r#"[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] my-dependency v0.1.2 -> v0.1.2-pre.0
 "#,
         )
@@ -107,6 +109,7 @@ fn update_pre_release_differ() {
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr(
             r#"[UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] my-dependency v0.1.2-pre.0 -> v0.1.2-pre.1
 "#,
         )

--- a/tests/testsuite/precise_pre_release.rs
+++ b/tests/testsuite/precise_pre_release.rs
@@ -65,7 +65,6 @@ fn update_pre_release() {
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr(
             r#"[UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] my-dependency v0.1.1 -> v0.1.2-pre.0
 "#,
         )
@@ -99,7 +98,6 @@ fn update_pre_release_differ() {
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr(
             r#"[UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] my-dependency v0.1.2 -> v0.1.2-pre.0
 "#,
         )
@@ -109,7 +107,6 @@ fn update_pre_release_differ() {
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
         .with_stderr(
             r#"[UPDATING] `dummy-registry` index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] my-dependency v0.1.2-pre.0 -> v0.1.2-pre.1
 "#,
         )

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -833,6 +833,7 @@ required by package `foo v0.0.1 ([..])`
         .with_stderr_contains(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] baz v0.0.1 -> v0.0.2
 ",
         )
@@ -995,6 +996,7 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.0.1 -> v0.0.2
 ",
         )
@@ -1018,6 +1020,7 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.0.2 -> v0.0.3
 ",
         )
@@ -1043,6 +1046,7 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] bar v0.0.3 -> v0.0.4
 [ADDING] spam v0.2.5
 ",
@@ -1055,6 +1059,7 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.0.4 -> v0.0.5
 [REMOVING] spam v0.2.5
 ",
@@ -1493,6 +1498,7 @@ fn update_transitive_dependency() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] b v0.1.0 -> v0.1.1
 ",
         )
@@ -1565,6 +1571,7 @@ fn update_backtracking_ok() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] hyper v0.6.5 -> v0.6.6
 [UPDATING] openssl v0.1.0 -> v0.1.1
 ",
@@ -1617,6 +1624,7 @@ fn update_multiple_packages() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] a v0.1.0 -> v0.1.1
 [UPDATING] b v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
@@ -1628,6 +1636,7 @@ fn update_multiple_packages() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] c v0.1.0 -> v0.1.1
 ",
         )
@@ -3767,6 +3776,7 @@ fn differ_only_by_metadata_with_lockfile() {
         .with_stderr(
             "\
 [UPDATING] [..] index
+[LOCKING] 1 package to latest compatible version
 [..] baz v0.0.1+c -> v0.0.1+b
 ",
         )

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -996,7 +996,6 @@ fn update_lockfile() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.0.1 -> v0.0.2
 ",
         )
@@ -3776,7 +3775,6 @@ fn differ_only_by_metadata_with_lockfile() {
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 1 package to latest compatible version
 [..] baz v0.0.1+c -> v0.0.1+b
 ",
         )

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -560,6 +560,7 @@ fn override_adds_some_deps() {
             "\
 [UPDATING] git repository `file://[..]`
 [UPDATING] `dummy-registry` index
+[LOCKING] 0 packages to latest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
@@ -568,6 +569,7 @@ fn override_adds_some_deps() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 0 packages to latest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
@@ -901,6 +903,7 @@ fn update() {
             "\
 [UPDATING] `[..]` index
 [UPDATING] git repository `[..]`
+[LOCKING] 0 packages to latest compatible versions
 ",
         )
         .run();

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -670,6 +670,7 @@ See https://github.com/rust-lang/cargo/issues/9930 for more information about th
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v1.5.0 -> v1.6.0
 ",
         )

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -405,7 +405,6 @@ fn update_precise() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
@@ -496,7 +495,6 @@ fn update_precise_build_metadata() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.0.1+first -> v0.0.1+second
 ",
         )
@@ -508,7 +506,6 @@ fn update_precise_build_metadata() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.0.1+second -> v0.0.1+first
 ",
         )
@@ -546,7 +543,6 @@ fn update_precise_do_not_force_update_deps() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.2.1 -> v0.2.2
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
@@ -702,7 +698,6 @@ fn update_precise_first_run() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
 ",
         )
@@ -857,7 +852,6 @@ fn update_precise_first_run() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
-[LOCKING] 0 packages to latest compatible versions
 ",
         )
         .run();
@@ -1024,7 +1018,6 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0+extra-stuff.0 -> v0.1.1+extra-stuff.1
 ",
         )
@@ -1047,7 +1040,6 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
         .with_stderr(
             "\
 [UPDATING] [..] index
-[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.1+extra-stuff.1 -> v0.1.3
 ",
         )
@@ -1379,7 +1371,6 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{}",
             &tag_commit_id[..8],
         ))
@@ -1393,7 +1384,6 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{short_id}",
         ))
         .run();
@@ -1408,7 +1398,6 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{}",
             &tag_commit_id[..8],
         ))
@@ -1427,7 +1416,6 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
-[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{}",
             &head_id[..8],
         ))
@@ -1487,7 +1475,6 @@ Caused by:
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
 [NOTE] if possible, try a compatible non-yanked version
-[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0 -> v0.1.1
 ",
         )
@@ -1531,7 +1518,6 @@ fn precise_yanked_multiple_presence() {
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
 [NOTE] if possible, try a compatible non-yanked version
-[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0 -> v0.1.1
 ",
         )

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -114,6 +114,7 @@ fn transitive_minor_update() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 0 packages to latest compatible versions
 [NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 ",
         )
@@ -167,6 +168,7 @@ fn conservative() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
@@ -403,6 +405,7 @@ fn update_precise() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
@@ -493,6 +496,7 @@ fn update_precise_build_metadata() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.0.1+first -> v0.0.1+second
 ",
         )
@@ -504,6 +508,7 @@ fn update_precise_build_metadata() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.0.1+second -> v0.0.1+first
 ",
         )
@@ -541,6 +546,7 @@ fn update_precise_do_not_force_update_deps() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.2.1 -> v0.2.2
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
@@ -579,6 +585,7 @@ fn update_recursive() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] log v0.1.0 -> v0.1.1
 [UPDATING] serde v0.2.1 -> v0.2.2
 ",
@@ -617,6 +624,7 @@ fn update_aggressive_alias_for_recursive() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] log v0.1.0 -> v0.1.1
 [UPDATING] serde v0.2.1 -> v0.2.2
 ",
@@ -694,6 +702,7 @@ fn update_precise_first_run() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [DOWNGRADING] serde v0.2.1 -> v0.2.0
 ",
         )
@@ -848,6 +857,7 @@ fn update_precise_first_run() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 0 packages to latest compatible versions
 ",
         )
         .run();
@@ -926,6 +936,7 @@ fn dry_run_update() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] serde v0.1.0 -> v0.1.1
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
@@ -1013,6 +1024,7 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
         .with_stderr(
             "\
 [UPDATING] [..] index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0+extra-stuff.0 -> v0.1.1+extra-stuff.1
 ",
         )
@@ -1035,6 +1047,7 @@ required by package `foo v0.1.0 ([ROOT]/foo)`
         .with_stderr(
             "\
 [UPDATING] [..] index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.1+extra-stuff.1 -> v0.1.3
 ",
         )
@@ -1126,6 +1139,7 @@ rustdns.workspace = true
     p.cargo("update -p rootcrate")
         .with_stderr(&format!(
             "\
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] rootcrate v2.29.8 ([CWD]/rootcrate) -> v2.29.81
 [UPDATING] subcrate v2.29.8 ([CWD]/subcrate) -> v2.29.81",
         ))
@@ -1217,6 +1231,7 @@ rustdns.workspace = true
     p.cargo("update -p crate2")
         .with_stderr(&format!(
             "\
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] crate1 v2.29.8 ([CWD]/crate1) -> v2.29.81
 [UPDATING] crate2 v2.29.8 ([CWD]/crate2) -> v2.29.81",
         ))
@@ -1308,6 +1323,7 @@ rustdns.workspace = true
     p.cargo("update --workspace")
         .with_stderr(
             "\
+[LOCKING] 2 packages to latest compatible versions
 [UPDATING] crate1 v2.29.8 ([CWD]/crate1) -> v2.29.81
 [UPDATING] crate2 v2.29.8 ([CWD]/crate2) -> v2.29.81",
         )
@@ -1363,6 +1379,7 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
+[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{}",
             &tag_commit_id[..8],
         ))
@@ -1376,6 +1393,7 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
+[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{short_id}",
         ))
         .run();
@@ -1390,6 +1408,7 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
+[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{}",
             &tag_commit_id[..8],
         ))
@@ -1408,6 +1427,7 @@ fn update_precise_git_revisions() {
         .with_stderr(format!(
             "\
 [UPDATING] git repository `{url}`
+[LOCKING] 1 package to latest compatible version
 [UPDATING] git v0.5.0 ([..]) -> #{}",
             &head_id[..8],
         ))
@@ -1467,6 +1487,7 @@ Caused by:
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
 [NOTE] if possible, try a compatible non-yanked version
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0 -> v0.1.1
 ",
         )
@@ -1510,6 +1531,7 @@ fn precise_yanked_multiple_presence() {
 [UPDATING] `dummy-registry` index
 [WARNING] selected package `bar@0.1.1` was yanked by the author
 [NOTE] if possible, try a compatible non-yanked version
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0 -> v0.1.1
 ",
         )
@@ -1553,6 +1575,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 [NOTE] pass `--verbose` to see 2 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
@@ -1564,6 +1587,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] breaking v0.1.0 -> v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
@@ -1579,6 +1603,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 0 packages to latest compatible versions
 [NOTE] pass `--verbose` to see 3 unchanged dependencies behind latest
 [WARNING] not updating lockfile due to dry run
 ",
@@ -1589,6 +1614,7 @@ fn report_behind() {
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
+[LOCKING] 0 packages to latest compatible versions
 [UNCHANGED] breaking v0.1.1 (latest: v0.2.0)
 [UNCHANGED] pre v1.0.0-alpha.0 (latest: v1.0.0-alpha.1)
 [UNCHANGED] two-ver v0.1.0 (latest: v0.2.0)
@@ -1629,6 +1655,7 @@ fn update_with_missing_feature() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 0 packages to latest compatible versions
 [NOTE] pass `--verbose` to see 1 unchanged dependencies behind latest
 ",
         )
@@ -1640,6 +1667,7 @@ fn update_with_missing_feature() {
         .with_stderr(
             "\
 [UPDATING] `[..]` index
+[LOCKING] 1 package to latest compatible version
 [UPDATING] bar v0.1.0 -> v0.1.2
 ",
         )


### PR DESCRIPTION
### What does this PR try to resolve?

This extends #13561 to `cargo update`.  I previously left it out because the locking message was redundant.  However the `Locking` message has been extended in #13754 to include the resolving policy which can be a useful point of interest (e.g. "why does `cargo update` do nothing? Oh, `-Zminimal-versions` is enabled").

I still left out the message for `--precise` because the user is overriding all of that.

I'd still like to extend all of this to `cargo install` (and maybe all resolves) but that is taking more investigation.

### How should we test and review this PR?

### Additional information

