### PR TITLE
test(schemas): Ensure tests cover the correct case

### DIFF
--- a/crates/cargo-util-schemas/src/core/package_id_spec.rs
+++ b/crates/cargo-util-schemas/src/core/package_id_spec.rs
@@ -641,12 +641,12 @@ mod tests {
             ErrorKind::UnexpectedQueryString(_)
         );
         err!(
-            "registry+https://github.com/rust-lang/cargo#0.52.0?branch=dev",
-            ErrorKind::PartialVersion(_)
+            "registry+https://github.com/rust-lang/cargo?branch=dev#0.52.0",
+            ErrorKind::UnexpectedQueryString(_)
         );
         err!(
-            "sparse+https://github.com/rust-lang/cargo#0.52.0?branch=dev",
-            ErrorKind::PartialVersion(_)
+            "sparse+https://github.com/rust-lang/cargo?branch=dev#0.52.0",
+            ErrorKind::UnexpectedQueryString(_)
         );
         err!("@1.2.3", ErrorKind::NameValidation(_));
         err!("registry+https://github.com", ErrorKind::NameValidation(_));

--- a/crates/cargo-util-schemas/src/core/package_id_spec.rs
+++ b/crates/cargo-util-schemas/src/core/package_id_spec.rs
@@ -318,6 +318,7 @@ enum ErrorKind {
 
 #[cfg(test)]
 mod tests {
+    use super::ErrorKind;
     use super::PackageIdSpec;
     use crate::core::{GitReference, SourceKind};
     use url::Url;
@@ -602,31 +603,53 @@ mod tests {
 
     #[test]
     fn bad_parsing() {
-        assert!(PackageIdSpec::parse("baz:").is_err());
-        assert!(PackageIdSpec::parse("baz:*").is_err());
-        assert!(PackageIdSpec::parse("baz@").is_err());
-        assert!(PackageIdSpec::parse("baz@*").is_err());
-        assert!(PackageIdSpec::parse("baz@^1.0").is_err());
-        assert!(PackageIdSpec::parse("https://baz:1.0").is_err());
-        assert!(PackageIdSpec::parse("https://#baz:1.0").is_err());
-        assert!(
-            PackageIdSpec::parse("foobar+https://github.com/rust-lang/crates.io-index").is_err()
+        macro_rules! err {
+            ($spec:expr, $expected:pat) => {
+                let err = PackageIdSpec::parse($spec).unwrap_err();
+                let kind = err.0;
+                assert!(
+                    matches!(kind, $expected),
+                    "`{}` parse error mismatch, got {kind:?}",
+                    $spec
+                );
+            };
+        }
+
+        err!("baz:", ErrorKind::PartialVersion(_));
+        err!("baz:*", ErrorKind::PartialVersion(_));
+        err!("baz@", ErrorKind::PartialVersion(_));
+        err!("baz@*", ErrorKind::PartialVersion(_));
+        err!("baz@^1.0", ErrorKind::PartialVersion(_));
+        err!("https://baz:1.0", ErrorKind::PartialVersion(_));
+        err!("https://#baz:1.0", ErrorKind::PartialVersion(_));
+        err!(
+            "foobar+https://github.com/rust-lang/crates.io-index",
+            ErrorKind::UnsupportedProtocol(_)
         );
-        assert!(PackageIdSpec::parse("path+https://github.com/rust-lang/crates.io-index").is_err());
+        err!(
+            "path+https://github.com/rust-lang/crates.io-index",
+            ErrorKind::UnsupportedPathPlusScheme(_)
+        );
 
         // Only `git+` can use `?`
-        assert!(PackageIdSpec::parse("file:///path/to/my/project/foo?branch=dev").is_err());
-        assert!(PackageIdSpec::parse("path+file:///path/to/my/project/foo?branch=dev").is_err());
-        assert!(PackageIdSpec::parse(
-            "registry+https://github.com/rust-lang/cargo#0.52.0?branch=dev"
-        )
-        .is_err());
-        assert!(PackageIdSpec::parse(
-            "sparse+https://github.com/rust-lang/cargo#0.52.0?branch=dev"
-        )
-        .is_err());
-        assert!(PackageIdSpec::parse("@1.2.3").is_err());
-        assert!(PackageIdSpec::parse("registry+https://github.com").is_err());
-        assert!(PackageIdSpec::parse("https://crates.io/1foo#1.2.3").is_err())
+        err!(
+            "file:///path/to/my/project/foo?branch=dev",
+            ErrorKind::UnexpectedQueryString(_)
+        );
+        err!(
+            "path+file:///path/to/my/project/foo?branch=dev",
+            ErrorKind::UnexpectedQueryString(_)
+        );
+        err!(
+            "registry+https://github.com/rust-lang/cargo#0.52.0?branch=dev",
+            ErrorKind::PartialVersion(_)
+        );
+        err!(
+            "sparse+https://github.com/rust-lang/cargo#0.52.0?branch=dev",
+            ErrorKind::PartialVersion(_)
+        );
+        err!("@1.2.3", ErrorKind::NameValidation(_));
+        err!("registry+https://github.com", ErrorKind::NameValidation(_));
+        err!("https://crates.io/1foo#1.2.3", ErrorKind::NameValidation(_));
     }
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?
<!-- homu-ignore:end -->

Test against `ErrorKind` to cover more thoroughly.

See https://github.com/rust-lang/cargo/pull/13761/commits/eacdfd2917ee851d861c19072a1c32772aee2652, as these tests never cover what they want to exercise.

<!-- homu-ignore:start -->
### How should we test and review this PR?

Should have no behavior change.

### Additional information
<!-- homu-ignore:end -->

Also, I am preparing an experiment of unidiff patch, which will introduce one more error kind.
