### PR TITLE
deprecate: Discard the existence of `[project]` and change `WARNING` to `ERROR`

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -32,7 +32,6 @@ pub struct TomlManifest {
     // when adding new fields, be sure to check whether `requires_package` should disallow them
     pub cargo_features: Option<Vec<String>>,
     pub package: Option<Box<TomlPackage>>,
-    pub project: Option<Box<TomlPackage>>,
     pub profile: Option<TomlProfiles>,
     pub lib: Option<TomlLibTarget>,
     pub bin: Option<Vec<TomlBinTarget>>,
@@ -87,7 +86,7 @@ impl TomlManifest {
     }
 
     pub fn package(&self) -> Option<&Box<TomlPackage>> {
-        self.package.as_ref().or(self.project.as_ref())
+        self.package.as_ref()
     }
 
     pub fn dev_dependencies(&self) -> Option<&BTreeMap<PackageName, InheritableDependency>> {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -935,40 +935,10 @@ fn to_real_manifest(
     };
 
     let package_name = match &original_toml.package {
-        Some(package) => {
-            package.clone().name
-        }
-        None => {
-            bail!("no `package` section found");
-        }
+        Some(package) => package.clone().name,
+        None => bail!("no `package` section found"),
     };
 
-    // let original_package = match (&original_toml.package, &original_toml.project) {
-    //     (Some(_), Some(project)) => {
-    //         bail!(format!(
-    //             "manifest at `{}` contains both `project` and `package`",
-    //             package_root.display()
-    //         ));
-    //         // warnings.push(format!(
-    //         //     "manifest at `{}` contains both `project` and `package`, \
-    //         //         this could become a hard error in the future",
-    //         //     package_root.display()
-    //         // ));
-    //         project.clone()
-    //     }
-    //     (Some(package), None) => package.clone(),
-    //     (None, Some(project)) => {
-    //         warnings.push(format!(
-    //             "manifest at `{}` contains `[project]` instead of `[package]`, \
-    //                             this could become a hard error in the future",
-    //             package_root.display()
-    //         ));
-    //         project.clone()
-    //     }
-    //     (None, None) => bail!("no `package` section found"),
-    // };
-
-    // let package_name = &original_package.name;
     if package_name.contains(':') {
         features.require(Feature::open_namespaces())?;
     }

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1462,7 +1462,7 @@ fn sparse_lockfile() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "a"
                 version = "0.5.0"
                 authors = []

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -980,37 +980,6 @@ fn rustc_workspace_wrapper_excludes_published_deps() {
 }
 
 #[cargo_test]
-fn warn_manifest_package_and_project() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-
-                [project]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-            "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    p.cargo("check")
-        .with_stderr(
-            "\
-[WARNING] manifest at `[CWD]` contains both `project` and `package`, this could become a hard error in the future
-[CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
-        .run();
-}
-
-#[cargo_test]
 fn git_manifest_package_and_project() {
     let p = project();
     let git_project = git::new("bar", |p| {
@@ -1066,39 +1035,13 @@ fn git_manifest_package_and_project() {
 }
 
 #[cargo_test]
-fn warn_manifest_with_project() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [project]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-            "#,
-        )
-        .file("src/main.rs", "fn main() {}")
-        .build();
-
-    p.cargo("check")
-        .with_stderr(
-            "\
-[WARNING] manifest at `[CWD]` contains `[project]` instead of `[package]`, this could become a hard error in the future
-[CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
-        .run();
-}
-
-#[cargo_test]
 fn git_manifest_with_project() {
     let p = project();
     let git_project = git::new("bar", |p| {
         p.file(
             "Cargo.toml",
             r#"
-            [project]
+            [package]
             name = "bar"
             version = "0.0.1"
             edition = "2015"

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -103,7 +103,7 @@ fn simple_add_with_asymmetric() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []
@@ -170,7 +170,7 @@ fn simple_remove_with_asymmetric() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -2864,7 +2864,7 @@ You may press ctrl-c [..]
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "bar"
                 version = "0.0.1"
                 edition = "2015"

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -62,7 +62,7 @@ fn explicit_version_with_asymmetric() {
         .file(
             "Cargo.toml",
             r#"
-                [project]
+                [package]
                 name = "foo"
                 version = "0.0.1"
                 authors = []


### PR DESCRIPTION
### What does this PR try to resolve?

a part of  #13629

Maybe start this now? It's always good to get rid of something：)

