### PR TITLE
docs(profiles): change `strip = "none"` to `strip = "debuginfo"` in r…

### DIFF
--- a/src/doc/src/reference/profiles.md
+++ b/src/doc/src/reference/profiles.md
@@ -293,7 +293,7 @@ The default settings for the `release` profile are:
 opt-level = 3
 debug = false
 split-debuginfo = '...'  # Platform-specific.
-strip = "none"
+strip = "debuginfo"
 debug-assertions = false
 overflow-checks = false
 lto = false


### PR DESCRIPTION


### What does this PR try to resolve?

Update docs to reflect https://github.com/rust-lang/cargo/pull/13257

