### PR TITLE
feat(install): Including Locking message 

### DIFF
--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -147,6 +147,7 @@ pub fn resolve_ws_with_opts<'gctx>(
             specs,
             add_patches,
         )?;
+        ops::print_lockfile_changes(ws, None, &resolved_with_overrides, &mut registry)?;
         (resolve, resolved_with_overrides)
     } else if ws.require_optional_deps() {
         // First, resolve the root_package's *listed* dependencies, as well as
@@ -205,6 +206,8 @@ pub fn resolve_ws_with_opts<'gctx>(
             specs,
             add_patches,
         )?;
+        // Skipping `print_lockfile_changes` as there are cases where this prints irrelevant
+        // information
         (resolve, resolved_with_overrides)
     };
 

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -252,6 +252,10 @@ fn resolve_with_registry<'gctx>(
     let print = if !ws.is_ephemeral() && ws.require_optional_deps() {
         ops::write_pkg_lockfile(ws, &mut resolve)?
     } else {
+        // This mostly represents
+        // - `cargo install --locked` and the only change is the package is no longer local but
+        //   from the registry which is noise
+        // - publish of libraries
         false
     };
     if print {

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -134,15 +134,26 @@ pub fn resolve_ws_with_opts<'gctx>(
     force_all_targets: ForceAllTargets,
 ) -> CargoResult<WorkspaceResolve<'gctx>> {
     let mut registry = PackageRegistry::new(ws.gctx())?;
-    let mut add_patches = true;
-    let resolve = if ws.ignore_lock() {
-        None
+    let (resolve, resolved_with_overrides) = if ws.ignore_lock() {
+        let add_patches = true;
+        let resolve = None;
+        let resolved_with_overrides = resolve_with_previous(
+            &mut registry,
+            ws,
+            cli_features,
+            has_dev_units,
+            resolve.as_ref(),
+            None,
+            specs,
+            add_patches,
+        )?;
+        (resolve, resolved_with_overrides)
     } else if ws.require_optional_deps() {
         // First, resolve the root_package's *listed* dependencies, as well as
         // downloading and updating all remotes and such.
         let resolve = resolve_with_registry(ws, &mut registry)?;
         // No need to add patches again, `resolve_with_registry` has done it.
-        add_patches = false;
+        let add_patches = false;
 
         // Second, resolve with precisely what we're doing. Filter out
         // transitive dependencies if necessary, specify features, handle
@@ -170,21 +181,32 @@ pub fn resolve_ws_with_opts<'gctx>(
             }
         }
 
-        Some(resolve)
+        let resolved_with_overrides = resolve_with_previous(
+            &mut registry,
+            ws,
+            cli_features,
+            has_dev_units,
+            Some(&resolve),
+            None,
+            specs,
+            add_patches,
+        )?;
+        (Some(resolve), resolved_with_overrides)
     } else {
-        ops::load_pkg_lockfile(ws)?
+        let add_patches = true;
+        let resolve = ops::load_pkg_lockfile(ws)?;
+        let resolved_with_overrides = resolve_with_previous(
+            &mut registry,
+            ws,
+            cli_features,
+            has_dev_units,
+            resolve.as_ref(),
+            None,
+            specs,
+            add_patches,
+        )?;
+        (resolve, resolved_with_overrides)
     };
-
-    let resolved_with_overrides = resolve_with_previous(
-        &mut registry,
-        ws,
-        cli_features,
-        has_dev_units,
-        resolve.as_ref(),
-        None,
-        specs,
-        add_patches,
-    )?;
 
     let pkg_set = get_resolved_packages(&resolved_with_overrides, registry)?;
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -148,6 +148,7 @@ fn simple_install() {
         .with_stderr(
             "\
 [INSTALLING] bar v0.1.0
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [..]s
@@ -243,6 +244,7 @@ fn install_without_feature_dep() {
         .with_stderr(
             "\
 [INSTALLING] bar v0.1.0
+[LOCKING] 2 packages to latest compatible versions
 [COMPILING] foo v0.0.1
 [COMPILING] bar v0.1.0
 [FINISHED] `release` profile [optimized] target(s) in [..]s

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -2410,6 +2410,8 @@ fn self_referential() {
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.2 (registry [..])
 [INSTALLING] foo v0.0.2
+[LOCKING] 2 packages to latest compatible versions
+[ADDING] foo v0.0.1 (latest: v0.0.2)
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [COMPILING] foo v0.0.1
@@ -2455,6 +2457,7 @@ fn ambiguous_registry_vs_local_package() {
             "\
 [INSTALLING] foo v0.1.0 ([..])
 [UPDATING] `[..]` index
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] foo v0.0.1 (registry [..])
 [COMPILING] foo v0.0.1

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -415,6 +415,7 @@ dependencies = [
             "\
 [UPDATING] `[..]` index
 [INSTALLING] foo v0.1.0
+[LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.1.1 (registry `[..]`)
 [COMPILING] bar v0.1.1

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1129,6 +1129,7 @@ Consider enabling them by passing, e.g., `--features=\"bar/a\"`
         .with_stderr(
             "\
 [INSTALLING] foo v0.0.1 ([..])
+[LOCKING] 2 packages to latest compatible versions
 [FINISHED] `release` profile [optimized] target(s) in [..]
 [WARNING] none of the package's binaries are available for install using the selected features
   bin \"foo\" requires the features: `bar/a`


### PR DESCRIPTION
### What does this PR try to resolve?

This extends #13561 to include `cargo install`, like #13759 did for `cargo update`.

As we switch to MSRV-aware resolver, this will help users work out why
MSRV-aware resolving isn't helping them.

This will also make it more obvious if we breaking things when
developing the MSRV-aware resolver.

### How should we test and review this PR?

### Additional information

This still leaves `cargo publish` and a couple other misc situations that I'm intentionally avoiding because
- They hit some weird cases that can confuse the user (e.g. causing `cargo install --locked` to show that 1 package is being added) and we can't distinguish these cases too well from where this is happening
- The value is lower