### PR TITLE
fix(msrv): Put MSRV-aware resolver behind a config 

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -2644,6 +2644,19 @@ impl BuildTargetConfig {
     }
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct CargoResolverConfig {
+    pub something_like_precedence: Option<CargoResolverPrecedence>,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CargoResolverPrecedence {
+    SomethingLikeMaximum,
+    SomethingLikeRustVersion,
+}
+
 #[derive(Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
 pub struct TermConfig {

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -336,15 +336,26 @@ This was stabilized in 1.79 in [#13608](https://github.com/rust-lang/cargo/pull/
 
 ### MSRV-aware resolver
 
-By default, `-Zmsrv-policy` enables an MSRV-aware resolver.
+`-Zmsrv-policy` allows access to an MSRV-aware resolver which can be enabled with:
+- `resolver.something-like-precedence` config field
+
 The resolver will prefer dependencies with a `package.rust-version` that is the same or older than your project's MSRV.
 Your project's MSRV is determined by taking the lowest `package.rust-version` set among your workspace members.
 If there is none set, your toolchain version will be used with the intent to pick up the version from rustup's `rust-toolchain.toml`, if present.
 
-MSRV-incompatible dependencies can still be selected by:
+#### `resolver.something-like-precedence`
+* Type: string
+* Default: "something-like-maximum"
+* Environment: `CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE`
+
+Select which policy should be used when resolving dependencies.  Values include
+- `something-like-maximum`: prefer highest compatible versions of a package
+- `something-like-rust-version`: prefer versions of packages compatible with your project's Rust version
+
+Can be overridden with
+- `--ignore-rust-version` CLI option
 - Setting the dependency's version requirement too high
 - Specifying the version to `cargo update` with `--precise`
-- Passing `--ignore-rust-version`
 
 ## precise-pre-release
 

--- a/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_ignore/mod.rs
@@ -25,6 +25,10 @@ fn case() {
         .arg("--ignore-rust-version")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .code(0)

--- a/tests/testsuite/cargo_add/rust_version_incompatible/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_incompatible/mod.rs
@@ -27,6 +27,10 @@ fn case() {
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .failure()

--- a/tests/testsuite/cargo_add/rust_version_latest/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_latest/mod.rs
@@ -24,6 +24,10 @@ fn case() {
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/rust_version_older/mod.rs
+++ b/tests/testsuite/cargo_add/rust_version_older/mod.rs
@@ -24,6 +24,10 @@ fn case() {
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/rustc_ignore/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_ignore/mod.rs
@@ -28,6 +28,10 @@ fn case() {
         .arg("--ignore-rust-version")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .code(0)

--- a/tests/testsuite/cargo_add/rustc_incompatible/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_incompatible/mod.rs
@@ -21,6 +21,10 @@ fn case() {
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .failure()

--- a/tests/testsuite/cargo_add/rustc_latest/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_latest/mod.rs
@@ -27,6 +27,10 @@ fn case() {
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/rustc_older/mod.rs
+++ b/tests/testsuite/cargo_add/rustc_older/mod.rs
@@ -27,6 +27,10 @@ fn case() {
         .arg("add")
         .arg_line("rust-version-user")
         .current_dir(cwd)
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .assert()
         .success()

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -576,6 +576,7 @@ fn resolve_unstable_config_on_stable() {
         )
         .with_stderr(
             "\
+[WARNING] ignoring `resolver` config table without `-Zmsrv-policy`
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 ",
@@ -595,6 +596,7 @@ foo v0.0.1 ([CWD])
         .env("CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE", "non-existent")
         .with_stderr(
             "\
+[WARNING] ignoring `resolver` config table without `-Zmsrv-policy`
 [UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 ",

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -213,6 +213,10 @@ fn resolve_with_rust_version() {
         .build();
 
     p.cargo("generate-lockfile --ignore-rust-version")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -233,6 +237,10 @@ foo v0.0.1 ([CWD])
         .run();
 
     p.cargo("generate-lockfile")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -289,6 +297,10 @@ fn resolve_with_rustc() {
         .build();
 
     p.cargo("generate-lockfile --ignore-rust-version")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -309,6 +321,10 @@ foo v0.0.1 ([CWD])
         .run();
 
     p.cargo("generate-lockfile")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -363,6 +379,10 @@ fn resolve_with_backtracking() {
         .build();
 
     p.cargo("generate-lockfile --ignore-rust-version")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -384,6 +404,10 @@ foo v0.0.1 ([CWD])
 
     // Ideally we'd pick `has-rust-version` 1.6.0 which requires backtracking
     p.cargo("generate-lockfile")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -462,6 +486,10 @@ fn resolve_with_multiple_rust_versions() {
         .build();
 
     p.cargo("generate-lockfile --ignore-rust-version")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -482,6 +510,10 @@ higher v0.0.1 ([CWD])
         .run();
 
     p.cargo("generate-lockfile")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -572,6 +604,10 @@ fn update_msrv_resolve() {
         .build();
 
     p.cargo("update")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -593,6 +629,10 @@ See https://github.com/rust-lang/cargo/issues/9930 for more information about th
         )
         .run();
     p.cargo("update --ignore-rust-version")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -634,6 +674,10 @@ fn update_precise_overrides_msrv_resolver() {
         .build();
 
     p.cargo("update")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -645,6 +689,10 @@ fn update_precise_overrides_msrv_resolver() {
         )
         .run();
     p.cargo("update --precise 1.6.0 bar")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -691,6 +739,10 @@ fn check_msrv_resolve() {
         .build();
 
     p.cargo("check --ignore-rust-version")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(
@@ -719,6 +771,10 @@ foo v0.0.1 ([CWD])
 
     std::fs::remove_file(p.root().join("Cargo.lock")).unwrap();
     p.cargo("check")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-rust-version",
+        )
         .arg("-Zmsrv-policy")
         .masquerade_as_nightly_cargo(&["msrv-policy"])
         .with_stderr(


### PR DESCRIPTION
### What does this PR try to resolve?
This is a part of #13540 which is a party of #9930.

The config is `resolver.something-like-precedence` with values:
- `something-like-maximum` (default)
- `something-like-rust-version`

This is punting on the actual config schema so we can implement
`package.resolver` and `edition = "2024"` support as we want the
MSRV-aware resolver available without `cargo_features`.

### How should we test and review this PR?

One of the included test cases shows a bug with `cargo install`.  Resolving that will be tracked in #9930

### Additional information

