### PR TITLE
fix(credential): trim newlines in tokens from stdin

### DIFF
--- a/src/cargo/ops/registry/login.rs
+++ b/src/cargo/ops/registry/login.rs
@@ -39,7 +39,7 @@ pub fn registry_login(
     let mut token_from_stdin = None;
     let token = token_from_cmdline.or_else(|| {
         if !std::io::stdin().is_terminal() {
-            let token = std::io::read_to_string(std::io::stdin()).unwrap_or_default();
+            let token = cargo_credential::read_line().unwrap_or_default();
             if !token.is_empty() {
                 token_from_stdin = Some(token);
             }

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -695,3 +695,22 @@ fn alias_builtin_warning() {
         )
         .run();
 }
+
+#[cargo_test]
+fn login_token_from_stdin() {
+    // Test reading a token from stdin, ensuring newlines are trimmed.
+    let registry = registry::RegistryBuilder::new()
+        .no_configure_token()
+        .credential_provider(&[&build_provider("test-cred", r#"{"Ok": {"kind": "login"}}"#)])
+        .build();
+
+    cargo_process("login")
+        .replace_crates_io(registry.index_url())
+        .with_stdin("abcdefg\n")
+        .with_stderr(
+            r#"[UPDATING] [..]
+{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg\n","login-url":"[..]"}
+"#,
+        )
+        .run();
+}

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -709,7 +709,7 @@ fn login_token_from_stdin() {
         .with_stdin("abcdefg\n")
         .with_stderr(
             r#"[UPDATING] [..]
-{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg\n","login-url":"[..]"}
+{"v":1,"registry":{"index-url":"https://github.com/rust-lang/crates.io-index","name":"crates-io"},"kind":"login","token":"abcdefg","login-url":"[..]"}
 "#,
         )
         .run();

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -113,6 +113,7 @@ fn empty_login_token() {
         .with_stderr(
             "\
 [UPDATING] crates.io index
+please paste the token found on [..] below
 [ERROR] credential provider `cargo:token` failed action `login`
 
 Caused by:


### PR DESCRIPTION
### What does this PR try to resolve?

`cargo login` when using a credential provider other than `cargo:token` does not automatically trim whitespace from tokens.

This can lead to extra whitespace being included in the pasted token value (usually a trailing newline) that makes the token invalid.

### How should we test and review this PR?

First commit adds a test showing the problematic behavior. Second commit fixes it.
