### PR TITLE
fix 13773 - 'cargo build' fails when list_files() with gix is triggered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "gix-dir"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6943a1f213ad7a060a0548ece229be53f3c2151534b126446ce3533eaf5f14c"
+checksum = "3d6fcd56ffa1133f35525af890226ad0d3b2e607b4490360c94b1869e278eba3"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "gix-index"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3383122cf18655ef4c097c0b935bba5eb56983947959aaf3b0ceb1949d4dd371"
+checksum = "881ab3b1fa57f497601a5add8289e72a7ae09471fc0b9bbe483b628ae8e418a1"
 dependencies = [
  "bitflags 2.5.0",
  "bstr",
@@ -1592,9 +1592,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d479789f3abd10f68a709454ce04cd68b54092ee882c8622ae3aa1bb9bf8496c"
+checksum = "ea9f934a111e0efdf93ae06e3648427e60e783099fbebd6a53a7a2ffb10a1e65"
 dependencies = [
  "bitflags 2.5.0",
  "bstr",
@@ -1833,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359a87dfef695b5f91abb9a424c947edca82768f34acfc269659f66174a510b4"
+checksum = "f06ca5dd164678914fc9280ba9d1ffeb66499ccc16ab1278c513828beee88401"
 dependencies = [
  "bstr",
  "gix-attributes",

--- a/crates/cargo-test-support/src/git.rs
+++ b/crates/cargo-test-support/src/git.rs
@@ -38,7 +38,7 @@ use some of the helper functions in this file to interact with the repository.
 
 */
 
-use crate::{path2url, project, Project, ProjectBuilder};
+use crate::{path2url, project, Project, ProjectBuilder, SymlinkBuilder};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Once;
@@ -74,6 +74,13 @@ impl RepoBuilder {
         let mut me = self.nocommit_file(path, contents);
         me.files.push(PathBuf::from(path));
         me
+    }
+
+    /// Create a symlink to a directory
+    pub fn nocommit_symlink_dir<T: AsRef<Path>>(self, dst: T, src: T) -> Self {
+        let workdir = self.repo.workdir().unwrap();
+        SymlinkBuilder::new_dir(workdir.join(dst), workdir.join(src)).mk();
+        self
     }
 
     /// Add a file that will be left in the working directory, but not added


### PR DESCRIPTION
Fixes #13773.

### Tasks

* [x] reproduce issue with new test-case
* [x] update [fixed `gix-dir`](https://github.com/rust-lang/cargo/pull/13777) in Cargo.lock to turn test green

