### PR TITLE
fix(toml): Don't crash on parse errors that point to multi-byte character

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "fb686a972ccef8537b39eead3968b0e8616cb5040dbb9bba93007c8e07c9215f"
 dependencies = [
  "indexmap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ tempfile = "3.10.1"
 thiserror = "1.0.58"
 time = { version = "0.3", features = ["parsing", "formatting", "serde"] }
 toml = "0.8.12"
-toml_edit = { version = "0.22.9", features = ["serde"] }
+toml_edit = { version = "0.22.11", features = ["serde"] }
 tracing = "0.1.40" # be compatible with rustc_log: https://github.com/rust-lang/rust/blob/e51e98dde6a/compiler/rustc_log/Cargo.toml#L9
 tracing-chrome = "0.7.2"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }


### PR DESCRIPTION
This pulls in toml-rs/toml#713

Fixes #13772