### PR TITLE
gate some libc usages under cfg(unix), drop os_info features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae99c7fa6dd38c7cafe1ec085e804f8f555a2f8659b0dbe03f1f9963a9b51092"
 dependencies = [
  "log",
- "serde",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-credential"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,7 +173,6 @@ indexmap.workspace = true
 itertools.workspace = true
 jobserver.workspace = true
 lazycell.workspace = true
-libc.workspace = true
 libgit2-sys.workspace = true
 memchr.workspace = true
 opener.workspace = true
@@ -207,6 +206,9 @@ supports-unicode = "3.0.0"
 
 [target.'cfg(target_has_atomic = "64")'.dependencies]
 tracing-chrome.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 cargo-credential-libsecret.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ miow = "0.6.0"
 opener = "0.7.0"
 openssl = "0.10.57"
 openssl-sys = "=0.9.92" # See rust-lang/cargo#13546 and openssl/openssl#23376 for pinning
-os_info = "3.8.2"
+os_info = { version = "3.8.2", default-features = false }
 pasetors = { version = "0.6.8", features = ["v3", "paserk", "std", "serde"] }
 pathdiff = "0.2"
 percent-encoding = "2.3"

--- a/crates/cargo-util/Cargo.toml
+++ b/crates/cargo-util/Cargo.toml
@@ -14,7 +14,6 @@ filetime.workspace = true
 hex.workspace = true
 ignore.workspace = true
 jobserver.workspace = true
-libc.workspace = true
 same-file.workspace = true
 sha2.workspace = true
 shell-escape.workspace = true
@@ -24,6 +23,9 @@ walkdir.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 miow.workspace = true

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -10,11 +10,13 @@ description = "A library to assist writing Cargo credential helpers."
 
 [dependencies]
 anyhow.workspace = true
-libc.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror.workspace = true
 time.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Console", "Win32_Foundation"] }

--- a/credential/cargo-credential/Cargo.toml
+++ b/credential/cargo-credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-credential"
-version = "0.4.4"
+version = "0.4.5"
 rust-version.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Places few `libc` usages under `cfg(unix)`. That didn't remove it from tree, but still looks cleaner.
Drop features from os_info crate, as serde support currently unused.