### PR TITLE
feat(resolver): Add default Edition2024 to resolver v3

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -300,7 +300,9 @@ impl Edition {
     }
 
     pub(crate) fn default_resolve_behavior(&self) -> ResolveBehavior {
-        if *self >= Edition::Edition2021 {
+        if *self >= Edition::Edition2024 {
+            ResolveBehavior::V3
+        } else if *self >= Edition::Edition2021 {
             ResolveBehavior::V2
         } else {
             ResolveBehavior::V1

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -310,9 +310,6 @@ impl<'gctx> Workspace<'gctx> {
             ResolveBehavior::V1 | ResolveBehavior::V2 => {}
             ResolveBehavior::V3 => {
                 if self.resolve_behavior == ResolveBehavior::V3 {
-                    if !self.gctx().cli_unstable().msrv_policy {
-                        anyhow::bail!("`resolver=\"3\"` requires `-Zmsrv-policy`");
-                    }
                     self.resolve_honors_rust_version = true;
                 }
             }

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -339,6 +339,7 @@ This was stabilized in 1.79 in [#13608](https://github.com/rust-lang/cargo/pull/
 `-Zmsrv-policy` allows access to an MSRV-aware resolver which can be enabled with:
 - `resolver.something-like-precedence` config field
 - `workspace.resolver = "3"` / `package.resolver = "3"`
+- `package.edition = "2024"` (only in workspace root)
 
 The resolver will prefer dependencies with a `package.rust-version` that is the same or older than your project's MSRV.
 Your project's MSRV is determined by taking the lowest `package.rust-version` set among your workspace members.

--- a/tests/testsuite/lints/implicit_features/edition_2024/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/edition_2024/stderr.term.svg
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest compatible versions</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">     Locking</tspan><tspan> 2 packages to latest Rust [..] compatible versions</tspan>
 </tspan>
     <tspan x="10px" y="64px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.1.0 ([ROOT]/foo)</tspan>
 </tspan>

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -614,6 +614,117 @@ foo v0.0.1 ([CWD])
 }
 
 #[cargo_test(nightly, reason = "edition2024 in rustc is unstable")]
+fn resolve_edition2024() {
+    Package::new("only-newer", "1.6.0")
+        .rust_version("1.65.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("newer-and-older", "1.5.0")
+        .rust_version("1.55.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+    Package::new("newer-and-older", "1.6.0")
+        .rust_version("1.65.0")
+        .file("src/lib.rs", "fn other_stuff() {}")
+        .publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["edition2024"]
+
+            [package]
+            name = "foo"
+            version = "0.0.1"
+            edition = "2024"
+            authors = []
+            rust-version = "1.60.0"
+
+            [dependencies]
+            only-newer = "1.0.0"
+            newer-and-older = "1.0.0"
+        "#,
+        )
+        .file("src/main.rs", "fn main(){}")
+        .build();
+
+    // Edition2024 should resolve for MSRV
+    p.cargo("generate-lockfile")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest Rust 1.60.0 compatible versions
+[ADDING] newer-and-older v1.5.0 (latest: v1.6.0)
+",
+        )
+        .run();
+    p.cargo("tree")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
+        .with_stdout(
+            "\
+foo v0.0.1 ([CWD])
+├── newer-and-older v1.5.0
+└── only-newer v1.6.0
+",
+        )
+        .run();
+
+    // `--ignore-rust-version` has precedence over Edition2024
+    p.cargo("generate-lockfile --ignore-rust-version")
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest compatible versions
+",
+        )
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        .run();
+    p.cargo("tree")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
+        .with_stdout(
+            "\
+foo v0.0.1 ([CWD])
+├── newer-and-older v1.6.0
+└── only-newer v1.6.0
+",
+        )
+        .run();
+
+    // config has precedence over Edition2024
+    p.cargo("generate-lockfile")
+        .env(
+            "CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE",
+            "something-like-maximum",
+        )
+        .with_stderr(
+            "\
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest compatible versions
+",
+        )
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["msrv-policy"])
+        .run();
+    p.cargo("tree")
+        .arg("-Zmsrv-policy")
+        .masquerade_as_nightly_cargo(&["edition2024", "msrv-policy"])
+        .with_stdout(
+            "\
+foo v0.0.1 ([CWD])
+├── newer-and-older v1.6.0
+└── only-newer v1.6.0
+",
+        )
+        .run();
+}
+
+#[cargo_test(nightly, reason = "edition2024 in rustc is unstable")]
 fn resolve_v3() {
     Package::new("only-newer", "1.6.0")
         .rust_version("1.65.0")


### PR DESCRIPTION
### What does this PR try to resolve?

With #13776 done, we can now make MSRV-aware resolver the default for the new edition as part of #9930

### How should we test and review this PR?



### Additional information


