### PR TITLE
fix(cargo-fix): dont fix into standard library

### DIFF
--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2200,53 +2200,6 @@ fn fix_in_rust_src() {
         .env("RUSTC", &rustc_bin)
         .with_status(101)
         .with_stderr(r#"[CHECKING] foo v0.0.0 ([..])
-[WARNING] failed to automatically apply fixes suggested by rustc to crate `foo`
-
-after fixes were automatically applied the compiler reported errors within these files:
-
-  * [..]/lib/rustlib/src/rust/library/core/src/macros/mod.rs
-  * lib.rs
-
-This likely indicates a bug in either rustc or cargo itself,
-and we would appreciate a bug report! You're likely to see
-a number of compiler warnings after this message which cargo
-attempted to fix but failed. If you could open an issue at
-https://github.com/rust-lang/rust/issues
-quoting the full output of this command we'd be very appreciative!
-Note that you may be able to make some more progress in the near-term
-fixing code with the `--broken-code` flag
-
-The following errors were reported:
-error[E0308]: mismatched types
- --> lib.rs:5:9
-  |
-2 | /     if true {
-3 | |         writeln!(w, "`;?` here ->")?;
-4 | |     } else {
-5 | |         writeln!(w, "but not here")
-  | |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<(), Error>`
-6 | |     }
-  | |_____- expected this to be `()`
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), std::fmt::Error>`
-  = note: this error originates in the macro `writeln` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider using a semicolon here
-  |
-6 |     };
-  |      +
-help: you might have meant to return this value
-  |
-5 |         return writeln!(w, "but not here");
-  |         ++++++                            +
-help: use the `?` operator to extract the `Result<(), std::fmt::Error>` value, propagating a `Result::Err` value to the caller
- --> [..]/lib/rustlib/src/rust/library/core/src/macros/mod.rs:670:58
-  |
-67|         $dst.write_fmt($crate::format_args_nl!($($arg)*))?
-  |                                                          +
-
-Original diagnostics will follow.
-
 error[E0308]: mismatched types
  --> lib.rs:5:9
   |


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Protect standard library source from being fixed by `cargo fix`.

This is a bug in rustc, which it shouldn't have given any fix suggestion to the standard library.
However, I believe Cargo should have a layer of protection regardless it's a bug in rustc or not.

See <https://github.com/rust-lang/cargo/issues/9857#issuecomment-2043477022>

### How should we test and review this PR?

This first commit shows the problematic behavior. The second fixes it.

The alternative idea has been brought up: only paths under workspace root are fixable.
However, it might encounter some corner cases:

* `#[path]` attribute pointing outside a workspace.
* Path dependencies that are not inside the same workspace.

I took this conservative approach that Cargo just stop writing into whatever pointing to sysroot.

<!-- homu-ignore:start -->

r? ehuss


<!-- homu-ignore:end -->
