### PR TITLE
docs(ref): Index differences between virtual / real manifests

### DIFF
--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -120,10 +120,8 @@ is not inside a subdirectory of the workspace root.
 In a workspace, package-related Cargo commands like [`cargo build`] can use
 the `-p` / `--package` or `--workspace` command-line flags to determine which
 packages to operate on. If neither of those flags are specified, Cargo will
-use the package in the current working directory. If the current directory is
-a [virtual workspace](#virtual-workspace), it will apply to all members (as if
-`--workspace` were specified on the command-line).  See also
-[`default-members`](#the-default-members-field).
+use the package in the current working directory. However, if the current directory is
+a workspace root, the [`default-members`](#the-default-members-field) will be used.
 
 ## The `default-members` field
 
@@ -136,6 +134,10 @@ used:
 members = ["path/to/member1", "path/to/member2", "path/to/member3/*"]
 default-members = ["path/to/member2", "path/to/member3/foo"]
 ```
+
+When unspecified, the [root package](#root-package) will be used.
+In the case of a [virtual workspace](#virtual-workspace), all members will be used
+(as if `--workspace` were specified on the command-line).
 
 ## The `package` table
 

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -127,7 +127,7 @@ a [virtual workspace](#virtual-workspace), it will apply to all members (as if
 
 ## The `default-members` field
 
-The optional `default-members` key can be specified to set the members to
+The `default-members` key can be specified to set the members to
 operate on when in the workspace root and the package selection flags are not
 used:
 

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -80,10 +80,14 @@ edition = "2021"     # the edition, will have no effect on a resolver used in th
 authors = ["Alice <a@example.com>", "Bob <b@example.com>"]
 ```
 
-Note that in a virtual manifest the [`resolver = "2"`](resolver.md#resolver-versions)
-should be specified manually. It is usually deduced from the [`package.edition`][package-edition]
-field which is absent in virtual manifests and the edition field of a member
-won't affect the resolver used by the workspace.
+By having a workspace without a root package,
+
+- [`resolver`](resolver.md#resolver-versions) must be
+  set explicitly in virtual workspaces as they have no
+  [`package.edition`][package-edition] to infer it from
+  [resolver version](resolver.md#resolver-versions).
+- Commands run in the workspace root will run against all workspace
+  members by default, see [`default-members`](#the-default-members-field).
 
 ## The `members` and `exclude` fields 
 

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -135,6 +135,9 @@ members = ["path/to/member1", "path/to/member2", "path/to/member3/*"]
 default-members = ["path/to/member2", "path/to/member3/foo"]
 ```
 
+> Note: when a [root package](#root-package) is present,
+> you can only operate on it using `--package` and `--workspace` flags.
+
 When unspecified, the [root package](#root-package) will be used.
 In the case of a [virtual workspace](#virtual-workspace), all members will be used
 (as if `--workspace` were specified on the command-line).

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -127,7 +127,7 @@ a [virtual workspace](#virtual-workspace), it will apply to all members (as if
 
 ## The `default-members` field
 
-The `default-members` key can be specified to set the members to
+The `default-members` field specifies the members to
 operate on when in the workspace root and the package selection flags are not
 used:
 

--- a/src/doc/src/reference/workspaces.md
+++ b/src/doc/src/reference/workspaces.md
@@ -127,7 +127,7 @@ a [virtual workspace](#virtual-workspace), it will apply to all members (as if
 
 ## The `default-members` field
 
-The `default-members` field specifies the members to
+The `default-members` field specifies paths of [members](#the-members-and-exclude-fields) to
 operate on when in the workspace root and the package selection flags are not
 used:
 
@@ -136,8 +136,6 @@ used:
 members = ["path/to/member1", "path/to/member2", "path/to/member3/*"]
 default-members = ["path/to/member2", "path/to/member3/foo"]
 ```
-
-When specified, `default-members` must expand to a subset of `members`.
 
 ## The `package` table
 


### PR DESCRIPTION
### What does this PR try to resolve?

For a user to read the reference and to understand when each type of workspace might be right for them, they have to know to also read the section on Package Selection.

This reframes the section on needing to set `resolver = "2"` to being about differences when there isn't a root package and extends it to summarize a part of Package Selection, linking out to it. The hope is that this will make it all of the differences more discoverable without retreading too much of the same ground within Reference-style documentation.

Part of #13580

### How should we test and review this PR?


### Additional information

r? @weihanglo 