### PR TITLE
Cleanup linting system

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1506,7 +1506,7 @@ pub struct TomlLintConfig {
     pub priority: i8,
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
 #[serde(rename_all = "kebab-case")]
 pub enum TomlLintLevel {
     Forbid,

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -24,7 +24,7 @@ use crate::sources::{PathSource, CRATES_IO_INDEX, CRATES_IO_REGISTRY};
 use crate::util::edit_distance;
 use crate::util::errors::{CargoResult, ManifestError};
 use crate::util::interning::InternedString;
-use crate::util::lints::{check_implicit_features, unused_dependencies};
+use crate::util::lints::{check_im_a_teapot, check_implicit_features, unused_dependencies};
 use crate::util::toml::{read_manifest, InheritableFields};
 use crate::util::{
     context::CargoResolverConfig, context::CargoResolverPrecedence, context::ConfigRelativePath,
@@ -1206,6 +1206,7 @@ impl<'gctx> Workspace<'gctx> {
             .map(|(name, lint)| (name.replace('-', "_"), lint))
             .collect();
 
+        check_im_a_teapot(pkg, &path, &normalized_lints, &mut error_count, self.gctx)?;
         check_implicit_features(pkg, &path, &normalized_lints, &mut error_count, self.gctx)?;
         unused_dependencies(pkg, &path, &normalized_lints, &mut error_count, self.gctx)?;
         if error_count > 0 {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1159,7 +1159,9 @@ impl<'gctx> Workspace<'gctx> {
         for (path, maybe_pkg) in &self.packages.packages {
             let path = path.join("Cargo.toml");
             if let MaybePackage::Package(pkg) = maybe_pkg {
-                self.emit_lints(pkg, &path)?
+                if self.gctx.cli_unstable().cargo_lints {
+                    self.emit_lints(pkg, &path)?
+                }
             }
             let warnings = match maybe_pkg {
                 MaybePackage::Package(pkg) => pkg.manifest().warnings().warnings(),

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -123,7 +123,7 @@ impl Display for LintLevel {
 impl LintLevel {
     pub fn to_diagnostic_level(self) -> Level {
         match self {
-            LintLevel::Allow => Level::Note,
+            LintLevel::Allow => unreachable!("allow does not map to a diagnostic level"),
             LintLevel::Warn => Level::Warning,
             LintLevel::Deny => Level::Error,
             LintLevel::Forbid => Level::Error,

--- a/tests/testsuite/lints/unused_optional_dependencies/edition_2024/mod.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies/edition_2024/mod.rs
@@ -33,9 +33,10 @@ target-dep = { version = "0.1.0", optional = true }
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["edition2024"])
+        .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .current_dir(p.root())
         .arg("check")
+        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_matches(str![""])

--- a/tests/testsuite/lints/unused_optional_dependencies/renamed_deps/mod.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies/renamed_deps/mod.rs
@@ -32,9 +32,10 @@ target-dep = { version = "0.1.0", optional = true }
         .build();
 
     snapbox::cmd::Command::cargo_ui()
-        .masquerade_as_nightly_cargo(&["edition2024"])
+        .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .current_dir(p.root())
         .arg("check")
+        .arg("-Zcargo-lints")
         .assert()
         .success()
         .stdout_matches(str![""])

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -756,14 +756,14 @@ fn cargo_lints_nightly_required() {
         .file(
             "Cargo.toml",
             r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-                authors = []
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
 
-                [lints.cargo]
-                "unused-features" = "deny"
+[lints.cargo]
+im-a-teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -790,21 +790,24 @@ fn cargo_lints_no_z_flag() {
         .file(
             "Cargo.toml",
             r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-                authors = []
+cargo-features = ["test-dummy-unstable"]
 
-                [lints.cargo]
-                "unused-features" = "deny"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+im-a-teapot = true
+
+[lints.cargo]
+im-a-teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
         .build();
 
     foo.cargo("check")
-        .masquerade_as_nightly_cargo(&["-Zcargo-lints"])
+        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr(
             "\
 [WARNING] unused manifest key `lints.cargo` (may be supported in a future version)
@@ -819,27 +822,37 @@ consider passing `-Zcargo-lints` to enable this feature.
 
 #[cargo_test]
 fn cargo_lints_success() {
-    let foo = project()
+    let p = project()
         .file(
             "Cargo.toml",
             r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-                authors = []
+cargo-features = ["test-dummy-unstable"]
 
-                [lints.cargo]
-                "unused-features" = "deny"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+im-a-teapot = true
+
+[lints.cargo]
+im-a-teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
         .build();
 
-    foo.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["-Zcargo-lints"])
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr(
             "\
+warning: `im_a_teapot` is specified
+ --> Cargo.toml:9:1
+  |
+9 | im-a-teapot = true
+  | ------------------
+  |
+  = note: `cargo::im_a_teapot` is set to `warn`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
@@ -849,40 +862,37 @@ fn cargo_lints_success() {
 
 #[cargo_test]
 fn cargo_lints_underscore_supported() {
-    Package::new("bar", "0.1.0").publish();
     let foo = project()
         .file(
             "Cargo.toml",
             r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2021"
-                authors = []
+cargo-features = ["test-dummy-unstable"]
 
-                [lints.cargo]
-                "implicit_features" = "warn"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+im-a-teapot = true
 
-                [dependencies]
-                bar = { version = "0.1.0", optional = true }
+[lints.cargo]
+im_a_teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
         .build();
 
     foo.cargo("check -Zcargo-lints")
-        .masquerade_as_nightly_cargo(&["-Zcargo-lints"])
+        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr(
             "\
-warning: implicit features for optional dependencies is deprecated and will be unavailable in the 2024 edition
-  --> Cargo.toml:12:17
-   |
-12 |                 bar = { version = \"0.1.0\", optional = true }
-   |                 ---
-   |
-   = note: `cargo::implicit_features` is set to `warn`
-[UPDATING] `dummy-registry` index
-[LOCKING] [..]
+warning: `im_a_teapot` is specified
+ --> Cargo.toml:9:1
+  |
+9 | im-a-teapot = true
+  | ------------------
+  |
+  = note: `cargo::im_a_teapot` is set to `warn`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",


### PR DESCRIPTION
There are a number of problems with the current linting system, most notably that lints could run without `-Zcargo-lints` being set. This PR fixes that issue and a few others that are low-hanging fruit.