### PR TITLE
Add where lint was set

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1180,6 +1180,21 @@ impl<'gctx> Workspace<'gctx> {
     }
 
     pub fn emit_lints(&self, pkg: &Package, path: &Path) -> CargoResult<()> {
+        let ws_lints = self
+            .root_maybe()
+            .workspace_config()
+            .inheritable()
+            .and_then(|i| i.lints().ok())
+            .unwrap_or_default();
+
+        let ws_cargo_lints = ws_lints
+            .get("cargo")
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(k, v)| (k.replace('-', "_"), v))
+            .collect();
+
         let mut error_count = 0;
         let toml_lints = pkg
             .manifest()
@@ -1197,9 +1212,30 @@ impl<'gctx> Workspace<'gctx> {
             .map(|(name, lint)| (name.replace('-', "_"), lint))
             .collect();
 
-        check_im_a_teapot(pkg, &path, &normalized_lints, &mut error_count, self.gctx)?;
-        check_implicit_features(pkg, &path, &normalized_lints, &mut error_count, self.gctx)?;
-        unused_dependencies(pkg, &path, &normalized_lints, &mut error_count, self.gctx)?;
+        check_im_a_teapot(
+            pkg,
+            &path,
+            &normalized_lints,
+            &ws_cargo_lints,
+            &mut error_count,
+            self.gctx,
+        )?;
+        check_implicit_features(
+            pkg,
+            &path,
+            &normalized_lints,
+            &ws_cargo_lints,
+            &mut error_count,
+            self.gctx,
+        )?;
+        unused_dependencies(
+            pkg,
+            &path,
+            &normalized_lints,
+            &ws_cargo_lints,
+            &mut error_count,
+            self.gctx,
+        )?;
         if error_count > 0 {
             Err(crate::util::errors::AlreadyPrintedError::new(anyhow!(
                 "encountered {error_count} errors(s) while running lints"

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -411,15 +411,7 @@ fn resolve_toml(
         }
         resolved_toml.target = (!resolved_target.is_empty()).then_some(resolved_target);
 
-        let resolved_lints = original_toml
-            .lints
-            .clone()
-            .map(|value| lints_inherit_with(value, || inherit()?.lints()))
-            .transpose()?;
-        resolved_toml.lints = resolved_lints.map(|lints| manifest::InheritableLints {
-            workspace: false,
-            lints,
-        });
+        resolved_toml.lints = original_toml.lints.clone();
 
         let resolved_badges = original_toml
             .badges
@@ -803,7 +795,7 @@ impl InheritableFields {
     }
 
     /// Gets the field `workspace.lint`.
-    fn lints(&self) -> CargoResult<manifest::TomlLints> {
+    pub fn lints(&self) -> CargoResult<manifest::TomlLints> {
         let Some(val) = &self.lints else {
             bail!("`workspace.lints` was not defined");
         };
@@ -1284,18 +1276,18 @@ fn to_real_manifest(
         }
     }
 
-    verify_lints(
-        resolved_toml.resolved_lints().expect("previously resolved"),
-        gctx,
-        warnings,
-    )?;
-    let default = manifest::TomlLints::default();
-    let rustflags = lints_to_rustflags(
-        resolved_toml
-            .resolved_lints()
-            .expect("previously resolved")
-            .unwrap_or(&default),
-    );
+    let resolved_lints = resolved_toml
+        .lints
+        .clone()
+        .map(|value| {
+            lints_inherit_with(value, || {
+                load_inheritable_fields(gctx, manifest_file, &workspace_config)?.lints()
+            })
+        })
+        .transpose()?;
+
+    verify_lints(resolved_lints.as_ref(), gctx, warnings)?;
+    let rustflags = lints_to_rustflags(&resolved_lints.unwrap_or_default());
 
     let metadata = ManifestMetadata {
         description: resolved_package

--- a/tests/testsuite/lints/implicit_features/edition_2021_warn/stderr.term.svg
+++ b/tests/testsuite/lints/implicit_features/edition_2021_warn/stderr.term.svg
@@ -33,7 +33,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::implicit_features` is set to `warn`</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::implicit_features` is set to `warn` in `[lints]`</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">implicit features for optional dependencies is deprecated and will be unavailable in the 2024 edition</tspan>
 </tspan>

--- a/tests/testsuite/lints/unused_optional_dependencies/edition_2024/stderr.term.svg
+++ b/tests/testsuite/lints/unused_optional_dependencies/edition_2024/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::unused_optional_dependency` is set to `warn`</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::unused_optional_dependency` is set to `warn` by default</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>: remove the dependency or activate it in a feature with `dep:bar`</tspan>
 </tspan>

--- a/tests/testsuite/lints/unused_optional_dependencies/renamed_deps/stderr.term.svg
+++ b/tests/testsuite/lints/unused_optional_dependencies/renamed_deps/stderr.term.svg
@@ -34,7 +34,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::unused_optional_dependency` is set to `warn`</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::unused_optional_dependency` is set to `warn` by default</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>: remove the dependency or activate it in a feature with `dep:bar`</tspan>
 </tspan>

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -939,3 +939,46 @@ error: `im_a_teapot` is specified
         )
         .run();
 }
+
+#[cargo_test]
+fn workspace_cargo_lints() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+cargo-features = ["test-dummy-unstable"]
+
+[workspace.lints.cargo]
+im-a-teapot = { level = "warn", priority = 10 }
+test-dummy-unstable = { level = "forbid", priority = -1 }
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+im-a-teapot = true
+
+[lints]
+workspace = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
+        .with_status(101)
+        .with_stderr(
+            "\
+error: `im_a_teapot` is specified
+  --> Cargo.toml:13:1
+   |
+13 | im-a-teapot = true
+   | ^^^^^^^^^^^^^^^^^^
+   |
+   = note: `cargo::im_a_teapot` is set to `forbid`
+",
+        )
+        .run();
+}

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -852,7 +852,7 @@ warning: `im_a_teapot` is specified
 9 | im-a-teapot = true
   | ------------------
   |
-  = note: `cargo::im_a_teapot` is set to `warn`
+  = note: `cargo::im_a_teapot` is set to `warn` in `[lints]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
@@ -892,7 +892,7 @@ warning: `im_a_teapot` is specified
 9 | im-a-teapot = true
   | ------------------
   |
-  = note: `cargo::im_a_teapot` is set to `warn`
+  = note: `cargo::im_a_teapot` is set to `warn` in `[lints]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
@@ -934,7 +934,7 @@ error: `im_a_teapot` is specified
 9 | im-a-teapot = true
   | ^^^^^^^^^^^^^^^^^^
   |
-  = note: `cargo::im_a_teapot` is set to `forbid`
+  = note: `cargo::im_a_teapot` is set to `forbid` in `[lints]`
 ",
         )
         .run();
@@ -977,7 +977,7 @@ error: `im_a_teapot` is specified
 13 | im-a-teapot = true
    | ^^^^^^^^^^^^^^^^^^
    |
-   = note: `cargo::im_a_teapot` is set to `forbid`
+   = note: `cargo::im_a_teapot` is set to `forbid` in `[workspace.lints]`
 ",
         )
         .run();


### PR DESCRIPTION
`rustc` and `clippy` both show why the lint was emitted and where the level was set the first time it was emitted for a package. We already showed why the list was being emitted but did not show where the lint level was set. This PR adds where the lint was set at.