### PR TITLE
refactor(toml): extract dependency-to-source-id to function

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1897,15 +1897,15 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
     let new_source_id = match (
         orig.git.as_ref(),
         orig.path.as_ref(),
-        orig.registry.as_ref(),
+        orig.registry.as_deref(),
         orig.registry_index.as_ref(),
     ) {
-        (Some(_), _, Some(_), _) | (Some(_), _, _, Some(_)) => bail!(
+        (Some(_git), _, Some(_registry), _) | (Some(_git), _, _, Some(_registry)) => bail!(
             "dependency ({}) specification is ambiguous. \
                  Only one of `git` or `registry` is allowed.",
             name_in_toml
         ),
-        (_, _, Some(_), Some(_)) => bail!(
+        (_, _, Some(_registry), Some(_registry_index)) => bail!(
             "dependency ({}) specification is ambiguous. \
                  Only one of `registry` or `registry-index` is allowed.",
             name_in_toml

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1910,15 +1910,14 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
                  Only one of `registry` or `registry-index` is allowed.",
             name_in_toml
         ),
-        (Some(git), maybe_path, _, _) => {
-            if maybe_path.is_some() {
-                bail!(
-                    "dependency ({}) specification is ambiguous. \
-                         Only one of `git` or `path` is allowed.",
-                    name_in_toml
-                );
-            }
-
+        (Some(_git), Some(_path), _, _) => {
+            bail!(
+                "dependency ({}) specification is ambiguous. \
+                     Only one of `git` or `path` is allowed.",
+                name_in_toml
+            );
+        }
+        (Some(git), None, _, _) => {
             let n_details = [&orig.branch, &orig.tag, &orig.rev]
                 .iter()
                 .filter(|d| d.is_some())

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1901,20 +1901,17 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
         orig.registry_index.as_ref(),
     ) {
         (Some(_git), _, Some(_registry), _) | (Some(_git), _, _, Some(_registry)) => bail!(
-            "dependency ({}) specification is ambiguous. \
+            "dependency ({name_in_toml}) specification is ambiguous. \
                  Only one of `git` or `registry` is allowed.",
-            name_in_toml
         ),
         (_, _, Some(_registry), Some(_registry_index)) => bail!(
-            "dependency ({}) specification is ambiguous. \
+            "dependency ({name_in_toml}) specification is ambiguous. \
                  Only one of `registry` or `registry-index` is allowed.",
-            name_in_toml
         ),
         (Some(_git), Some(_path), None, None) => {
             bail!(
-                "dependency ({}) specification is ambiguous. \
+                "dependency ({name_in_toml}) specification is ambiguous. \
                      Only one of `git` or `path` is allowed.",
-                name_in_toml
             );
         }
         (Some(git), None, None, None) => {
@@ -1925,9 +1922,8 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
 
             if n_details > 1 {
                 bail!(
-                    "dependency ({}) specification is ambiguous. \
+                    "dependency ({name_in_toml}) specification is ambiguous. \
                          Only one of `branch`, `tag` or `rev` is allowed.",
-                    name_in_toml
                 );
             }
 
@@ -1942,12 +1938,11 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
 
             if let Some(fragment) = loc.fragment() {
                 let msg = format!(
-                    "URL fragment `#{}` in git URL is ignored for dependency ({}). \
+                    "URL fragment `#{fragment}` in git URL is ignored for dependency ({name_in_toml}). \
                         If you were trying to specify a specific git revision, \
-                        use `rev = \"{}\"` in the dependency declaration.",
-                    fragment, name_in_toml, fragment
+                        use `rev = \"{fragment}\"` in the dependency declaration.",
                 );
-                manifest_ctx.warnings.push(msg)
+                manifest_ctx.warnings.push(msg);
             }
 
             SourceId::for_git(&loc, reference)?

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1894,7 +1894,7 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
     name_in_toml: &str,
     manifest_ctx: &mut ManifestContext<'_, '_>,
 ) -> CargoResult<SourceId> {
-    let new_source_id = match (
+    match (
         orig.git.as_ref(),
         orig.path.as_ref(),
         orig.registry.as_deref(),
@@ -1945,7 +1945,7 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
                 manifest_ctx.warnings.push(msg);
             }
 
-            SourceId::for_git(&loc, reference)?
+            SourceId::for_git(&loc, reference)
         }
         (None, Some(path), _, _) => {
             let path = path.resolve(manifest_ctx.gctx);
@@ -1960,20 +1960,18 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
             if manifest_ctx.source_id.is_path() {
                 let path = manifest_ctx.root.join(path);
                 let path = paths::normalize_path(&path);
-                SourceId::for_path(&path)?
+                SourceId::for_path(&path)
             } else {
-                manifest_ctx.source_id
+                Ok(manifest_ctx.source_id)
             }
         }
-        (None, None, Some(registry), None) => SourceId::alt_registry(manifest_ctx.gctx, registry)?,
+        (None, None, Some(registry), None) => SourceId::alt_registry(manifest_ctx.gctx, registry),
         (None, None, None, Some(registry_index)) => {
             let url = registry_index.into_url()?;
-            SourceId::for_registry(&url)?
+            SourceId::for_registry(&url)
         }
-        (None, None, None, None) => SourceId::crates_io(manifest_ctx.gctx)?,
-    };
-
-    Ok(new_source_id)
+        (None, None, None, None) => SourceId::crates_io(manifest_ctx.gctx),
+    }
 }
 
 pub trait ResolveToPath {

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1910,14 +1910,14 @@ fn to_dependency_source_id<P: ResolveToPath + Clone>(
                  Only one of `registry` or `registry-index` is allowed.",
             name_in_toml
         ),
-        (Some(_git), Some(_path), _, _) => {
+        (Some(_git), Some(_path), None, None) => {
             bail!(
                 "dependency ({}) specification is ambiguous. \
                      Only one of `git` or `path` is allowed.",
                 name_in_toml
             );
         }
-        (Some(git), None, _, _) => {
+        (Some(git), None, None, None) => {
             let n_details = [&orig.branch, &orig.tag, &orig.rev]
                 .iter()
                 .filter(|d| d.is_some())


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Miscellaneous refactors around extracting dependency-to-source-id to a function.

This is a side effect when trying to rebase #13779.

### How should we test and review this PR?

Should be more readable IMO?

### Additional information
<!-- homu-ignore:end -->
