### PR TITLE
Error when unstable lints are specified but not enabled

### DIFF
--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -343,7 +343,7 @@ impl FromStr for Edition {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 enum Status {
     Stable,
     Unstable,
@@ -387,11 +387,11 @@ macro_rules! features {
             $(
                 $(#[$attr])*
                 #[doc = concat!("\n\n\nSee <https://doc.rust-lang.org/nightly/cargo/", $docs, ">.")]
-                pub fn $feature() -> &'static Feature {
+                pub const fn $feature() -> &'static Feature {
                     fn get(features: &Features) -> bool {
                         stab!($stab) == Status::Stable || features.$feature
                     }
-                    static FEAT: Feature = Feature {
+                    const FEAT: Feature = Feature {
                         name: stringify!($feature),
                         stability: stab!($stab),
                         version: $version,
@@ -512,6 +512,7 @@ features! {
 }
 
 /// Status and metadata for a single unstable feature.
+#[derive(Debug)]
 pub struct Feature {
     /// Feature name. This is valid Rust identifier so no dash only underscore.
     name: &'static str,

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -406,6 +406,10 @@ macro_rules! features {
             fn is_enabled(&self, features: &Features) -> bool {
                 (self.get)(features)
             }
+
+            pub(crate) fn name(&self) -> &str {
+                self.name
+            }
         }
 
         impl Features {

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -1078,3 +1078,33 @@ implicit-features = "warn"
         )
         .run();
 }
+
+#[cargo_test]
+fn check_feature_gated() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+
+[lints.cargo]
+im-a-teapot = "warn"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr(
+            "\
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] [..]
+",
+        )
+        .run();
+}

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -1164,7 +1164,20 @@ note: `cargo::im-a-teapot` was inherited
   | ----------------
   |
   = help: consider adding `cargo-features = [\"test-dummy-unstable\"]` to the top of the manifest
-error: encountered 1 errors(s) while verifying lints
+error: use of unstable lint `test-dummy-unstable`
+ --> Cargo.toml:7:1
+  |
+7 | test-dummy-unstable = { level = \"forbid\", priority = -1 }
+  | ^^^^^^^^^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+note: `cargo::test-dummy-unstable` was inherited
+ --> foo/Cargo.toml:9:1
+  |
+9 | workspace = true
+  | ----------------
+  |
+  = help: consider adding `cargo-features = [\"test-dummy-unstable\"]` to the top of the manifest
+error: encountered 2 errors(s) while verifying lints
 ",
         )
         .run();

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -1100,10 +1100,71 @@ im-a-teapot = "warn"
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
         .with_stderr(
             "\
-[CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] [..]
+error: use of unstable lint `im-a-teapot`
+ --> Cargo.toml:9:1
+  |
+9 | im-a-teapot = \"warn\"
+  | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+  = help: consider adding `cargo-features = [\"test-dummy-unstable\"]` to the top of the manifest
+error: encountered 1 errors(s) while verifying lints
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn check_feature_gated_workspace() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+members = ["foo"]
+
+[workspace.lints.cargo]
+im-a-teapot = { level = "warn", priority = 10 }
+test-dummy-unstable = { level = "forbid", priority = -1 }
+            "#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+
+[lints]
+workspace = true
+            "#,
+        )
+        .file("foo/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_status(101)
+        .with_stderr(
+            "\
+error: use of unstable lint `im-a-teapot`
+ --> Cargo.toml:6:1
+  |
+6 | im-a-teapot = { level = \"warn\", priority = 10 }
+  | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
+  |
+note: `cargo::im-a-teapot` was inherited
+ --> foo/Cargo.toml:9:1
+  |
+9 | workspace = true
+  | ----------------
+  |
+  = help: consider adding `cargo-features = [\"test-dummy-unstable\"]` to the top of the manifest
+error: encountered 1 errors(s) while verifying lints
 ",
         )
         .run();


### PR DESCRIPTION
In [#13797, it was noted that](https://github.com/rust-lang/cargo/pull/13797#discussion_r1578162057) the `im-a-teapot` lint should always be unstable. This PR makes it so that `im-a-teapot` is unstable, and it is an error to specify it without the `test-dummy-unstable` cargo feature.

It does this by adding a `feature-gate` field to `Lint` and `LintGroup` that optionally
puts the lint/lint group behind a feature. The `feature-gate` is then checked during the new `analyze_cargo_lints_table` step that runs across all lints (and groups) specified in `[lints.cargo]` or `[workspace.lints]` if the package is inheriting its lints from a workspace.

The error looks like the following:
No inherit
![No inherit](https://github.com/rust-lang/cargo/assets/23045215/c245af87-8623-42dc-9652-be461809bb30)
Inherited
![Inhrtited](https://github.com/rust-lang/cargo/assets/23045215/5a90b7c9-0e9e-4a07-ab0e-e2e43cca8991)

