### PR TITLE
fix: emit 1.77 syntax error only when msrv is incompatible

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -724,10 +724,9 @@ impl BuildOutput {
             pkg_descr: &str,
             msrv: &Option<RustVersion>,
         ) -> CargoResult<()> {
-            let new_syntax_added_in = &RustVersion::from_str("1.77.0")?;
-
             if let Some(msrv) = msrv {
-                if msrv < new_syntax_added_in {
+                let new_syntax_added_in = RustVersion::from_str("1.77.0")?;
+                if !new_syntax_added_in.is_compatible_with(msrv.as_partial()) {
                     bail!(
                         "the `cargo::` syntax for build script output instructions was added in \
                         Rust 1.77.0, but the minimum supported Rust version of `{pkg_descr}` is {msrv}.\n\

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -5503,6 +5503,44 @@ for more information about build script outputs.
 }
 
 #[cargo_test]
+fn test_new_syntax_with_compatible_partial_msrv() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                edition = "2015"
+                build = "build.rs"
+                rust-version = "1.77"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo::metadata=foo=bar");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[COMPILING] foo [..]
+[ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
+but the minimum supported Rust version of `foo v0.0.0 ([ROOT]/foo)` is 1.77.
+See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
+for more information about build script outputs.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn test_old_syntax_with_old_msrv() {
     let p = project()
         .file(

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -5527,14 +5527,9 @@ fn test_new_syntax_with_compatible_partial_msrv() {
         .build();
 
     p.cargo("check")
-        .with_status(101)
         .with_stderr_contains(
             "\
 [COMPILING] foo [..]
-[ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
-but the minimum supported Rust version of `foo v0.0.0 ([ROOT]/foo)` is 1.77.
-See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
-for more information about build script outputs.
 ",
         )
         .run();


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Fixes #13807

### How should we test and review this PR?

Didn't really think hard if `package.rust-version` contains prelrease version

### Additional information


<!-- homu-ignore:end -->
