### PR TITLE
fix(cargo-lints): Don't always inherit workspace lints

### DIFF
--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -88,7 +88,7 @@ impl Lint {
     pub fn level(
         &self,
         pkg_lints: &TomlToolLints,
-        ws_lints: &TomlToolLints,
+        ws_lints: Option<&TomlToolLints>,
         edition: Edition,
     ) -> (LintLevel, LintLevelReason) {
         self.groups
@@ -188,7 +188,7 @@ fn level_priority(
     default_level: LintLevel,
     edition_lint_opts: Option<(Edition, LintLevel)>,
     pkg_lints: &TomlToolLints,
-    ws_lints: &TomlToolLints,
+    ws_lints: Option<&TomlToolLints>,
     edition: Edition,
 ) -> (LintLevel, LintLevelReason, i8) {
     let (unspecified_level, reason) = if let Some(level) = edition_lint_opts
@@ -211,7 +211,7 @@ fn level_priority(
             LintLevelReason::Package,
             defined_level.priority(),
         )
-    } else if let Some(defined_level) = ws_lints.get(name) {
+    } else if let Some(defined_level) = ws_lints.and_then(|l| l.get(name)) {
         (
             defined_level.level().into(),
             LintLevelReason::Workspace,
@@ -234,7 +234,7 @@ pub fn check_im_a_teapot(
     pkg: &Package,
     path: &Path,
     pkg_lints: &TomlToolLints,
-    ws_lints: &TomlToolLints,
+    ws_lints: Option<&TomlToolLints>,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -306,7 +306,7 @@ pub fn check_implicit_features(
     pkg: &Package,
     path: &Path,
     pkg_lints: &TomlToolLints,
-    ws_lints: &TomlToolLints,
+    ws_lints: Option<&TomlToolLints>,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
@@ -390,7 +390,7 @@ pub fn unused_dependencies(
     pkg: &Package,
     path: &Path,
     pkg_lints: &TomlToolLints,
-    ws_lints: &TomlToolLints,
+    ws_lints: Option<&TomlToolLints>,
     error_count: &mut usize,
     gctx: &GlobalContext,
 ) -> CargoResult<()> {

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -982,3 +982,50 @@ error: `im_a_teapot` is specified
         )
         .run();
 }
+
+#[cargo_test]
+fn dont_always_inherit_workspace_lints() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+members = ["foo"]
+
+[workspace.lints.cargo]
+im-a-teapot = "warn"
+"#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+cargo-features = ["test-dummy-unstable"]
+
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+im-a-teapot = true
+"#,
+        )
+        .file("foo/src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .with_stderr(
+            "\
+warning: `im_a_teapot` is specified
+ --> foo/Cargo.toml:9:1
+  |
+9 | im-a-teapot = true
+  | ------------------
+  |
+  = note: `cargo::im_a_teapot` is set to `warn` in `[workspace.lints]`
+[CHECKING] foo v0.0.1 ([CWD]/foo)
+[FINISHED] [..]
+",
+        )
+        .run();
+}

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -1016,13 +1016,6 @@ im-a-teapot = true
         .masquerade_as_nightly_cargo(&["cargo-lints"])
         .with_stderr(
             "\
-warning: `im_a_teapot` is specified
- --> foo/Cargo.toml:9:1
-  |
-9 | im-a-teapot = true
-  | ------------------
-  |
-  = note: `cargo::im_a_teapot` is set to `warn` in `[workspace.lints]`
 [CHECKING] foo v0.0.1 ([CWD]/foo)
 [FINISHED] [..]
 ",


### PR DESCRIPTION
When working on changes for #13805, I noticed that we always passed the contents of `[workspace.lints.cargo]` into the currently implemented lints,  even if `[lints]` was not specified or did not contain `workspace = true`. This PR makes it so we only pass in the workspace cargo lints if `[lints]` contains `workspace = true`.

You can verify this change by looking at the first commit, where I added a test showing the current behavior, and looking at the second commit and seeing the test output no longer shows a warning about specifying `im-a-teapot`.
