### PR TITLE
refactor: Move diagnostic printing to Shell

### DIFF
--- a/src/cargo/core/shell.rs
+++ b/src/cargo/core/shell.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::io::prelude::*;
 use std::io::IsTerminal;
 
+use annotate_snippets::{Message, Renderer};
 use anstream::AutoStream;
 use anstyle::Style;
 
@@ -390,6 +391,19 @@ impl Shell {
         // ... but don't fail due to a closed pipe.
         drop(writeln!(self.out(), "{}", encoded));
         Ok(())
+    }
+
+    /// Prints the passed in [Message] to stderr
+    pub fn print_message(&mut self, message: Message<'_>) -> std::io::Result<()> {
+        let term_width = self
+            .err_width()
+            .diagnostic_terminal_width()
+            .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH);
+        writeln!(
+            self.err(),
+            "{}",
+            Renderer::styled().term_width(term_width).render(message)
+        )
     }
 }
 

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -3,7 +3,7 @@ use crate::core::FeatureValue::Dep;
 use crate::core::{Edition, FeatureValue, Package};
 use crate::util::interning::InternedString;
 use crate::{CargoResult, GlobalContext};
-use annotate_snippets::{Level, Renderer, Snippet};
+use annotate_snippets::{Level, Snippet};
 use cargo_util_schemas::manifest::{TomlLintLevel, TomlToolLints};
 use pathdiff::diff_paths;
 use std::collections::HashSet;
@@ -270,13 +270,8 @@ pub fn check_im_a_teapot(
                     .fold(true),
             )
             .footer(Level::Note.title(&emitted_reason));
-        let renderer = Renderer::styled().term_width(
-            gctx.shell()
-                .err_width()
-                .diagnostic_terminal_width()
-                .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
-        );
-        writeln!(gctx.shell().err(), "{}", renderer.render(message))?;
+
+        gctx.shell().print_message(message)?;
     }
     Ok(())
 }
@@ -367,13 +362,7 @@ pub fn check_implicit_features(
             ));
             message = message.footer(Level::Note.title(emitted_source.as_ref().unwrap()));
         }
-        let renderer = Renderer::styled().term_width(
-            gctx.shell()
-                .err_width()
-                .diagnostic_terminal_width()
-                .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
-        );
-        writeln!(gctx.shell().err(), "{}", renderer.render(message))?;
+        gctx.shell().print_message(message)?;
     }
     Ok(())
 }
@@ -476,13 +465,8 @@ pub fn unused_dependencies(
                         "remove the dependency or activate it in a feature with `dep:{name}`"
                     );
                     message = message.footer(Level::Help.title(&help));
-                    let renderer = Renderer::styled().term_width(
-                        gctx.shell()
-                            .err_width()
-                            .diagnostic_terminal_width()
-                            .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
-                    );
-                    writeln!(gctx.shell().err(), "{}", renderer.render(message))?;
+
+                    gctx.shell().print_message(message)?;
                 }
             }
         }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1,4 +1,4 @@
-use annotate_snippets::{Level, Renderer, Snippet};
+use annotate_snippets::{Level, Snippet};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -2343,13 +2343,7 @@ fn emit_diagnostic(
             .fold(true)
             .annotation(Level::Error.span(span)),
     );
-    let renderer = Renderer::styled().term_width(
-        gctx.shell()
-            .err_width()
-            .diagnostic_terminal_width()
-            .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
-    );
-    if let Err(err) = writeln!(gctx.shell().err(), "{}", renderer.render(message)) {
+    if let Err(err) = gctx.shell().print_message(message) {
         return err.into();
     }
     return AlreadyPrintedError::new(e.into()).into();


### PR DESCRIPTION
As I have been working on cargo's diagnostic system, I have disliked copying around the code for a new `Renderer`, and then emitting the diagnostic:
```rust
let renderer = Renderer::styled().term_width(
    gctx.shell()
        .err_width()
        .diagnostic_terminal_width()
        .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
);
writeln!(gctx.shell().err(), "{}", renderer.render(message))?;
```

Moving to a method on `Shell` helps mitigate the risk of updating duplicate code and missing one. It should also make it nearly impossible to get into scenarios where `gctx.shell()` is borrowed twice, leading to panics. This problem was one I ran into early on as I tried to write messages to `stderr` like so:
```rust
writeln!(
    gctx.shell().err(),
    "{}",
    Renderer::styled()
        .term_width(
            gctx.shell()
                .err_width()
                .diagnostic_terminal_width()
                .unwrap_or(annotate_snippets::renderer::DEFAULT_TERM_WIDTH),
        )
        .render(message)
)?;
```