### PR TITLE
Add failing test: artifact_dep_target_specified

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1497,6 +1497,55 @@ foo v0.0.0 ([CWD])
         )
         .run();
 }
+
+#[cargo_test]
+fn artifact_dep_target_specified() {
+    if cross_compile::disabled() {
+        return;
+    }
+    let target = cross_compile::alternate();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            &r#"
+                [package]
+                name = "foo"
+                version = "0.0.0"
+                authors = []
+                resolver = "2"
+
+                [dependencies]
+                bindep = { path = "bindep", artifact = "bin", target = "$TARGET" }
+            "#
+            .replace("$TARGET", target),
+        )
+        .file("src/lib.rs", "")
+        .file("bindep/Cargo.toml", &basic_manifest("bindep", "0.0.0"))
+        .file("bindep/src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stderr_contains(
+            r#"[COMPILING] bindep v0.0.0 ([CWD]/bindep)
+[CHECKING] foo v0.0.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]"#,
+        )
+        .with_status(0)
+        .run();
+
+    // TODO: This command currently fails due to a bug in cargo but it should be fixed so that it succeeds in the future.
+    p.cargo("tree -Z bindeps")
+        .masquerade_as_nightly_cargo(&["bindeps"])
+        .with_stdout("")
+        .with_stderr_contains(
+            r#"activated_features for invalid package: features did not find PackageId { name: "bindep", version: "0.0.0", source: "[..]" } NormalOrDev"#
+        )
+        .with_status(101)
+        .run();
+}
+
 #[cargo_test]
 fn targets_are_picked_up_from_non_workspace_artifact_deps() {
     if cross_compile::disabled() {


### PR DESCRIPTION
This PR pulls the failing test out of https://github.com/rust-lang/cargo/pull/13207

[During review](https://github.com/rust-lang/cargo/pull/13207#discussion_r1543463395), it was requested there be a previous commit with a failing test.
It will be a while before I have the time to address the other issues with the PR, so I figured for now we should land this failing test first.