### PR TITLE
Fix target entry in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-target
-Cargo.lock
+/target
+/Cargo.lock
 /config.stamp
 /Makefile
 /config.mk
-src/doc/build
-src/etc/*.pyc
-src/registry/target
+/src/doc/build
+/src/etc/*.pyc
+/src/registry/target
 rustc
 __pycache__
 .idea/


### PR DESCRIPTION
The directories at:
* https://github.com/rust-lang/cargo/tree/master/tests/testsuite/cargo_remove/target
* https://github.com/rust-lang/cargo/tree/master/tests/testsuite/cargo_add/target

Are getting picked up by the `target` entry in .gitignore, causing git to ignore any extra files added to those directories.
A minor issue I know, but I still think its worth fixing.

## Alternative

An alternative solution would be to rename those directories which I'm more than happy to do.
But I think we are better off just changing .gitignore as that is more future proof.