### PR TITLE
ci: exclude semver check for `cargo` against referenced commit

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -178,6 +178,8 @@ fn bump_check(args: &clap::ArgMatches, gctx: &cargo::util::GlobalContext) -> Car
         let mut cmd = ProcessBuilder::new("cargo");
         cmd.arg("semver-checks")
             .arg("--workspace")
+            // We don't want to confuse contributors when a new beta just branched off
+            .args(&["--exclude", "cargo"])
             .args(&["--exclude", "cargo-test-macro"]) // FIXME: Remove once 1.79 is stable.
             .args(&["--exclude", "cargo-test-support"]) // FIXME: Remove once 1.79 is stable.
             .arg("--baseline-rev")


### PR DESCRIPTION
### What does this PR try to resolve?

We always bump major versions for `cargo` package,
so the risk of shipping breaking change should be zero.

We still verify against crates.io as a sanity check.

### How should we test and review this PR?

Check if CI is all green.

### Additional information

See also https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/What.20is.20the.20reason.20for.20this.20error.3F/near/436053158
