### PR TITLE
chore(ci): Don't check `cargo` against beta channel

### DIFF
--- a/crates/xtask-bump-check/src/xtask.rs
+++ b/crates/xtask-bump-check/src/xtask.rs
@@ -118,10 +118,19 @@ fn bump_check(args: &clap::ArgMatches, gctx: &cargo::util::GlobalContext) -> Car
     let changed_members = changed(&ws, &repo, &base_commit, &head_commit)?;
     let status = |msg: &str| gctx.shell().status(STATUS, msg);
 
-    // Don't check against beta and stable branches,
-    // as the publish of these crates are not tied with Rust release process.
-    // See `TO_PUBLISH` in publish.py.
-    let crates_not_check_against_channels = ["home"];
+    let crates_not_check_against_channels = [
+        // High false positive rate between beta branch and requisite version bump soon after
+        //
+        // Low risk because we always bump the "major" version after beta branch; we are
+        // only losing out on checks for patch releases.
+        //
+        // Note: this is already skipped in `changed`
+        "cargo",
+        // Don't check against beta and stable branches,
+        // as the publish of these crates are not tied with Rust release process.
+        // See `TO_PUBLISH` in publish.py.
+        "home",
+    ];
 
     status(&format!("base commit `{}`", base_commit.id()))?;
     status(&format!("head commit `{}`", head_commit.id()))?;


### PR DESCRIPTION
We already only partially check it and it has been a source of false positives.

While there is trust in the job, contributors and maintainers go into the job assuming there is a problem and it takes time to break that assumption.

If we lose trust in the job, we then won't trust it when it fails for other reasons.

This also increases the risk of us not seeing other problems `bump-checks` is meant to find if the steps in the job get re-arranged to make this one of the early ones.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
