### PR TITLE
docs: fix several typos found by `typos-cli`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
   [#13664](https://github.com/rust-lang/cargo/pull/13664)
 - cargo-init: don't assign `target.name` in Cargo.toml if the value can be inferred.
   [#13606](https://github.com/rust-lang/cargo/pull/13606)
-- carog-package: normalize paths in `Cargo.toml`, including replacing `\` with `/`.
+- cargo-package: normalize paths in `Cargo.toml`, including replacing `\` with `/`.
   [#13729](https://github.com/rust-lang/cargo/pull/13729)
 - cargo-test: recategorize cargo test's `--doc` flag under “Target Selection”.
   [#13756](https://github.com/rust-lang/cargo/pull/13756)
@@ -1178,7 +1178,7 @@
   [#12332](https://github.com/rust-lang/cargo/pull/12332)
 - ❗️ `cargo login` no longer accept any token after the `--` syntax.
   Arguments after `--` are now reserved in the preparation of the new credential provider feature.
-  This introduces a regression that overlooks the `cargo login -- <token>` support in preivous versions.
+  This introduces a regression that overlooks the `cargo login -- <token>` support in previous versions.
   [#12499](https://github.com/rust-lang/cargo/pull/12499)
 - Make Cargo `--help` easier to browse.
   [#11905](https://github.com/rust-lang/cargo/pull/11905)

--- a/src/cargo/core/features.rs
+++ b/src/cargo/core/features.rs
@@ -27,7 +27,7 @@
 //!   * Good for: `.cargo/config.toml`, `config.json` index file (gate: `-Z`)
 //!
 //! For features that touch multiple parts of Cargo, multiple feature gating strategies (error,
-//! warn, ignore) and mechnisms (`-Z`, `cargo-features`) may be used.
+//! warn, ignore) and mechanisms (`-Z`, `cargo-features`) may be used.
 //!
 //! When adding new tests for your feature, usually the tests should go into a
 //! new module of the testsuite named after the feature. See
@@ -513,7 +513,7 @@ features! {
 
 /// Status and metadata for a single unstable feature.
 pub struct Feature {
-    /// Feature name. This is valid Rust identifer so no dash only underscore.
+    /// Feature name. This is valid Rust identifier so no dash only underscore.
     name: &'static str,
     stability: Status,
     /// Version that this feature was stabilized or removed.

--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -967,7 +967,7 @@ impl RegistryConfig {
     const NAME: &'static str = "config.json";
 }
 
-/// Get the maximum upack size that Cargo permits
+/// Get the maximum unpack size that Cargo permits
 /// based on a given `size` of your compressed file.
 ///
 /// Returns the larger one between `size * max compression ratio`

--- a/src/cargo/util/cache_lock.rs
+++ b/src/cargo/util/cache_lock.rs
@@ -513,7 +513,7 @@ impl CacheLocker {
     ///
     /// Note that `Shared` will return true if a `MutateExclusive` lock is
     /// held, since `MutateExclusive` is just an upgraded `Shared`. Likewise,
-    /// `DownlaodExclusive` will return true if a `MutateExclusive` lock is
+    /// `DownloadExclusive` will return true if a `MutateExclusive` lock is
     /// held since they overlap.
     pub fn is_locked(&self, mode: CacheLockMode) -> bool {
         let state = self.state.borrow();

--- a/src/doc/man/cargo-update.md
+++ b/src/doc/man/cargo-update.md
@@ -47,7 +47,7 @@ While not recommended, you can specify a yanked version of a package (nightly on
 When possible, try other non-yanked SemVer-compatible versions or seek help
 from the maintainers of the package.
 
-A compatible `pre-release` version can also be specified even when the version requirement in `Cargo.toml` doesn't contain any pre-release identifer (nightly only).
+A compatible `pre-release` version can also be specified even when the version requirement in `Cargo.toml` doesn't contain any pre-release identifier (nightly only).
 {{/option}}
 
 {{#option "`-w`" "`--workspace`" }}

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -42,7 +42,7 @@ OPTIONS
 
            A compatible pre-release version can also be specified even when the
            version requirement in Cargo.toml doesn’t contain any pre-release
-           identifer (nightly only).
+           identifier (nightly only).
 
        -w, --workspace
            Attempt to update only packages defined in the workspace. Other

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -43,7 +43,7 @@ revision (such as a SHA hash or tag).</p>
 <p>While not recommended, you can specify a yanked version of a package (nightly only).
 When possible, try other non-yanked SemVer-compatible versions or seek help
 from the maintainers of the package.</p>
-<p>A compatible <code>pre-release</code> version can also be specified even when the version requirement in <code>Cargo.toml</code> doesn’t contain any pre-release identifer (nightly only).</dd>
+<p>A compatible <code>pre-release</code> version can also be specified even when the version requirement in <code>Cargo.toml</code> doesn’t contain any pre-release identifier (nightly only).</dd>
 
 
 <dt class="option-term" id="option-cargo-update--w"><a class="option-anchor" href="#option-cargo-update--w"></a><code>-w</code></dt>

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -44,7 +44,7 @@ While not recommended, you can specify a yanked version of a package (nightly on
 When possible, try other non\-yanked SemVer\-compatible versions or seek help
 from the maintainers of the package.
 .sp
-A compatible \fBpre\-release\fR version can also be specified even when the version requirement in \fBCargo.toml\fR doesn\[cq]t contain any pre\-release identifer (nightly only).
+A compatible \fBpre\-release\fR version can also be specified even when the version requirement in \fBCargo.toml\fR doesn\[cq]t contain any pre\-release identifier (nightly only).
 .RE
 .sp
 \fB\-w\fR, 


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

While fixing <https://github.com/rust-lang/cargo/pull/13823#discussion_r1583136080>,
I ran [`typos-cli`](https://crates.io/crates/typos-cli) and found some more typos.


### How should we test and review this PR?

### Additional information

<!-- homu-ignore:end -->
