### PR TITLE
Populate git information when building Cargo from Rust's source tarball

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -80,6 +80,37 @@ fn commit_info_from_git() -> Option<CommitInfo> {
     })
 }
 
+// The rustc source tarball is meant to contain all the source code to build an exact copy of the
+// toolchain, but it doesn't include the git repository itself. It wouldn't thus be possible to
+// populate the version information with the commit hash and the commit date.
+//
+// To work around this, the rustc build process obtains the git information when creating the
+// source tarball and writes it to the `git-commit-info` file. The build process actually creates
+// at least *two* of those files, one for Rust as a whole (in the root of the tarball) and one
+// specifically for Cargo (in src/tools/cargo). This function loads that file.
+//
+// The file is a newline-separated list of full commit hash, short commit hash, and commit date.
+fn commit_info_from_rustc_source_tarball() -> Option<CommitInfo> {
+    let path = Path::new("git-commit-info");
+    if !path.exists() {
+        return None;
+    }
+
+    // Dependency tracking is a nice to have for this (git doesn't do it), so if the path is not
+    // valid UTF-8 just avoid doing it rather than erroring out.
+    if let Some(utf8) = path.to_str() {
+        println!("cargo:rerun-if-changed={utf8}");
+    }
+
+    let content = std::fs::read_to_string(&path).ok()?;
+    let mut parts = content.split('\n').map(|s| s.to_string());
+    Some(CommitInfo {
+        hash: parts.next()?,
+        short_hash: parts.next()?,
+        date: parts.next()?,
+    })
+}
+
 fn commit_info() {
     // Var set by bootstrap whenever omit-git-hash is enabled in rust-lang/rust's config.toml.
     println!("cargo:rerun-if-env-changed=CFG_OMIT_GIT_HASH");
@@ -89,7 +120,7 @@ fn commit_info() {
         return;
     }
 
-    let Some(git) = commit_info_from_git() else {
+    let Some(git) = commit_info_from_git().or_else(commit_info_from_rustc_source_tarball) else {
         return;
     };
 


### PR DESCRIPTION
### What does this PR try to resolve?

Right now Cargo doesn't populate the commit hash or date in its version output when it's built from Rust's plain source tarball (like `rustc-1.77.2-src.tar.xz`). That's because Cargo's build script only looks for information in the `.git` directory, which is missing from that tarball.

I opened https://github.com/rust-lang/rust/pull/124553 to have bootstrap inject a `git-commit-info` file in `src/tools/cargo` when building the plain source tarball, containing the correct git information. This is the approach also used by the compiler.

This PR updates the build script to read the information from that file if there is no `.git` and the file is present.

### How should we test and review this PR?

To test the PR you need to move the `.git` directory somewhere else and create a `git-commit-info` file like this:

```
25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04
25ef9e3d8
2024-04-09
```

Then clearing the build cache and running `cargo run -- -vV` should show the git information in the `git-commit-info` file.

### Additional information

This PR can be merged independently from https://github.com/rust-lang/rust/pull/124553