### PR TITLE
fix(lint): Warn not Error on unsupported lint tool

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2231,8 +2231,13 @@ fn verify_lints(
     for (tool, lints) in lints {
         let supported = ["cargo", "clippy", "rust", "rustdoc"];
         if !supported.contains(&tool.as_str()) {
-            let supported = supported.join(", ");
-            anyhow::bail!("unsupported `{tool}` in `[lints]`, must be one of {supported}")
+            let message = format!(
+                "unrecognized lint tool `lints.{tool}`, specifying unrecognized tools may break in the future.
+supported tools: {}",
+                supported.join(", "),
+            );
+            warnings.push(message);
+            continue;
         }
         if tool == "cargo" && !gctx.cli_unstable().cargo_lints {
             warn_for_cargo_lint_feature(gctx, warnings);

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -105,13 +105,12 @@ fn fail_on_invalid_tool() {
         .build();
 
     foo.cargo("check")
-        .with_status(101)
         .with_stderr(
             "\
-[..]
-
-Caused by:
-  unsupported `super-awesome-linter` in `[lints]`, must be one of cargo, clippy, rust, rustdoc
+[WARNING] [CWD]/Cargo.toml: unrecognized lint tool `lints.super-awesome-linter`, specifying unrecognized tools may break in the future.
+supported tools: cargo, clippy, rust, rustdoc
+[CHECKING] foo v0.0.1 ([CWD])
+[FINISHED] [..]
 ",
         )
         .run();


### PR DESCRIPTION
In a recent Cargo Team meeting, it was decided to lessen the error on an unsupported tool in `[lints]` to a warning. This PR implements that change.