### PR TITLE
fix(toml): Don't lose 'public' when inheriting a dep 

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -988,20 +988,13 @@ fn inner_dependency_inherit_with<'a>(
                 if let Some(false) = pkg_dep.default_features() {
                     default_features_msg(name, None, warnings);
                 }
-                if pkg_dep.optional.is_some()
-                    || pkg_dep.features.is_some()
-                    || pkg_dep.public.is_some()
-                {
-                    manifest::TomlDependency::Detailed(manifest::TomlDetailedDependency {
-                        version: Some(ws_version),
-                        optional: pkg_dep.optional,
-                        features: pkg_dep.features.clone(),
-                        public: pkg_dep.public,
-                        ..Default::default()
-                    })
-                } else {
-                    manifest::TomlDependency::Simple(ws_version)
-                }
+                manifest::TomlDependency::Detailed(manifest::TomlDetailedDependency {
+                    version: Some(ws_version),
+                    optional: pkg_dep.optional,
+                    features: pkg_dep.features.clone(),
+                    public: pkg_dep.public,
+                    ..Default::default()
+                })
             }
             manifest::TomlDependency::Detailed(ws_dep) => {
                 let mut merged_dep = ws_dep.clone();


### PR DESCRIPTION
### What does this PR try to resolve?

When inheriting a simple dep, we preserved the package dep's `public`
field but lost it when inheriting a detailed dep.

This was done by consolidating the code paths.  This also reduces the
risk of us doing this again in the future.

### How should we test and review this PR?

I didn't write tests for this specific case because I refactored the root cause away.

### Additional information

