### PR TITLE
fix(lints): Remove ability to specify `-` in lint name

### DIFF
--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -1161,7 +1161,6 @@ impl<'gctx> Workspace<'gctx> {
             .cloned()
             .unwrap_or_default()
             .into_iter()
-            .map(|(k, v)| (k.replace('-', "_"), v))
             .collect();
 
         for (path, maybe_pkg) in &self.packages.packages {
@@ -1214,10 +1213,6 @@ impl<'gctx> Workspace<'gctx> {
             .get("cargo")
             .cloned()
             .unwrap_or(manifest::TomlToolLints::default());
-        let normalized_lints = cargo_lints
-            .into_iter()
-            .map(|(name, lint)| (name.replace('-', "_"), lint))
-            .collect();
 
         // We should only be using workspace lints if the `[lints]` table is
         // present in the manifest, and `workspace` is set to `true`
@@ -1242,7 +1237,7 @@ impl<'gctx> Workspace<'gctx> {
         analyze_cargo_lints_table(
             pkg,
             &path,
-            &normalized_lints,
+            &cargo_lints,
             ws_cargo_lints,
             ws_contents,
             ws_document,
@@ -1252,7 +1247,7 @@ impl<'gctx> Workspace<'gctx> {
         check_im_a_teapot(
             pkg,
             &path,
-            &normalized_lints,
+            &cargo_lints,
             ws_cargo_lints,
             &mut error_count,
             self.gctx,
@@ -1260,7 +1255,7 @@ impl<'gctx> Workspace<'gctx> {
         check_implicit_features(
             pkg,
             &path,
-            &normalized_lints,
+            &cargo_lints,
             ws_cargo_lints,
             &mut error_count,
             self.gctx,
@@ -1268,7 +1263,7 @@ impl<'gctx> Workspace<'gctx> {
         unused_dependencies(
             pkg,
             &path,
-            &normalized_lints,
+            &cargo_lints,
             ws_cargo_lints,
             &mut error_count,
             self.gctx,

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -117,31 +117,21 @@ fn verify_feature_enabled(
     gctx: &GlobalContext,
 ) -> CargoResult<()> {
     if !manifest.unstable_features().is_enabled(feature_gate) {
-        let dash_name = lint_name.replace("_", "-");
         let dash_feature_name = feature_gate.name().replace("_", "-");
-        let title = format!("use of unstable lint `{}`", dash_name);
+        let title = format!("use of unstable lint `{}`", lint_name);
         let label = format!(
             "this is behind `{}`, which is not enabled",
             dash_feature_name
         );
-        let second_title = format!("`cargo::{}` was inherited", dash_name);
+        let second_title = format!("`cargo::{}` was inherited", lint_name);
         let help = format!(
             "consider adding `cargo-features = [\"{}\"]` to the top of the manifest",
             dash_feature_name
         );
         let message = match reason {
             LintLevelReason::Package => {
-                let span = get_span(
-                    manifest.document(),
-                    &["lints", "cargo", dash_name.as_str()],
-                    false,
-                )
-                .or(get_span(
-                    manifest.document(),
-                    &["lints", "cargo", lint_name],
-                    false,
-                ))
-                .unwrap();
+                let span =
+                    get_span(manifest.document(), &["lints", "cargo", lint_name], false).unwrap();
 
                 Level::Error
                     .title(&title)
@@ -156,14 +146,9 @@ fn verify_feature_enabled(
             LintLevelReason::Workspace => {
                 let lint_span = get_span(
                     ws_document,
-                    &["workspace", "lints", "cargo", dash_name.as_str()],
-                    false,
-                )
-                .or(get_span(
-                    ws_document,
                     &["workspace", "lints", "cargo", lint_name],
                     false,
-                ))
+                )
                 .unwrap();
                 let inherit_span_key =
                     get_span(manifest.document(), &["lints", "workspace"], false).unwrap();

--- a/tests/testsuite/lints/implicit_features/edition_2021_warn/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2021_warn/mod.rs
@@ -27,7 +27,7 @@ baz = { version = "0.1.0", optional = true }
 target-dep = { version = "0.1.0", optional = true }
 
 [lints.cargo]
-implicit-features = "warn"
+implicit_features = "warn"
 "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/lints/implicit_features/edition_2024/mod.rs
+++ b/tests/testsuite/lints/implicit_features/edition_2024/mod.rs
@@ -25,7 +25,7 @@ baz = { version = "0.1.0", optional = true }
 baz = ["dep:baz"]
 
 [lints.cargo]
-unused-optional-dependency = "allow"
+unused_optional_dependency = "allow"
 "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -1,2 +1,3 @@
 mod implicit_features;
+mod unknown_lints;
 mod unused_optional_dependencies;

--- a/tests/testsuite/lints/unknown_lints/default/mod.rs
+++ b/tests/testsuite/lints/unknown_lints/default/mod.rs
@@ -1,0 +1,33 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test]
+fn case() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+
+[lints.cargo]
+this-lint-does-not-exist = "warn"
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("-Zcargo-lints")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/unknown_lints/default/stderr.term.svg
+++ b/tests/testsuite/lints/unknown_lints/default/stderr.term.svg
@@ -1,0 +1,47 @@
+<svg width="740px" height="200px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .fg-green { fill: #00AA00 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unknown lint: `this-lint-does-not-exist`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> this-lint-does-not-exist = "warn"</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-bright-red bold"> ^^^^^^^^^^^^^^^^^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::unknown_lints` is set to `warn` by default</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-green bold">    Finished</tspan><tspan> [..]</tspan>
+</tspan>
+    <tspan x="10px" y="190px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/unknown_lints/inherited/mod.rs
+++ b/tests/testsuite/lints/unknown_lints/inherited/mod.rs
@@ -1,0 +1,43 @@
+use cargo_test_support::prelude::*;
+use cargo_test_support::str;
+use cargo_test_support::{file, project};
+
+#[cargo_test]
+fn case() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+[workspace]
+members = ["foo"]
+
+[workspace.lints.cargo]
+this-lint-does-not-exist = "warn"
+"#,
+        )
+        .file(
+            "foo/Cargo.toml",
+            r#"
+[package]
+name = "foo"
+version = "0.0.1"
+edition = "2015"
+authors = []
+
+[lints]
+workspace = true
+            "#,
+        )
+        .file("foo/src/lib.rs", "")
+        .build();
+
+    snapbox::cmd::Command::cargo_ui()
+        .masquerade_as_nightly_cargo(&["cargo-lints"])
+        .current_dir(p.root())
+        .arg("check")
+        .arg("-Zcargo-lints")
+        .assert()
+        .success()
+        .stdout_matches(str![""])
+        .stderr_matches(file!["stderr.term.svg"]);
+}

--- a/tests/testsuite/lints/unknown_lints/inherited/stderr.term.svg
+++ b/tests/testsuite/lints/unknown_lints/inherited/stderr.term.svg
@@ -1,0 +1,59 @@
+<svg width="740px" height="308px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { background: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-bright-red { fill: #FF5555 }
+    .fg-green { fill: #00AA00 }
+    .fg-yellow { fill: #AA5500 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="fg-yellow bold">warning</tspan><tspan>: </tspan><tspan class="bold">unknown lint: `this-lint-does-not-exist`</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> Cargo.toml:6:1</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-blue bold">6 |</tspan><tspan> this-lint-does-not-exist = "warn"</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-bright-red bold"> ^^^^^^^^^^^^^^^^^^^^^^^^</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">note</tspan><tspan>: </tspan><tspan class="bold">`cargo::this-lint-does-not-exist` was inherited</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan> </tspan><tspan class="fg-bright-blue bold">--&gt;</tspan><tspan> foo/Cargo.toml:9:1</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-blue bold">9 |</tspan><tspan> workspace = true</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-blue bold">  |</tspan><tspan class="fg-bright-green bold"> ----------------</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-blue bold">  |</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-blue bold">=</tspan><tspan> </tspan><tspan class="fg-bright-green bold">note</tspan><tspan>: `cargo::unknown_lints` is set to `warn` by default</tspan>
+</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-green bold">    Checking</tspan><tspan> foo v0.0.1 ([ROOT]/foo/foo)</tspan>
+</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-green bold">    Finished</tspan><tspan> [..]</tspan>
+</tspan>
+    <tspan x="10px" y="298px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/testsuite/lints/unknown_lints/mod.rs
+++ b/tests/testsuite/lints/unknown_lints/mod.rs
@@ -1,0 +1,2 @@
+mod default;
+mod inherited;

--- a/tests/testsuite/lints/unused_optional_dependencies/edition_2021/mod.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies/edition_2021/mod.rs
@@ -19,7 +19,7 @@ edition = "2021"
 bar = { version = "0.1.0", optional = true }
 
 [lints.cargo]
-implicit-features = "allow"
+implicit_features = "allow"
 "#,
         )
         .file("src/lib.rs", "")

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -762,7 +762,6 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
-im-a-teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -799,7 +798,6 @@ authors = []
 im-a-teapot = true
 
 [lints.cargo]
-im-a-teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -835,7 +833,7 @@ authors = []
 im-a-teapot = true
 
 [lints.cargo]
-im-a-teapot = "warn"
+im_a_teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -860,7 +858,7 @@ warning: `im_a_teapot` is specified
 }
 
 #[cargo_test]
-fn cargo_lints_underscore_supported() {
+fn cargo_lints_dashes_dont_get_rewritten() {
     let foo = project()
         .file(
             "Cargo.toml",
@@ -875,7 +873,7 @@ authors = []
 im-a-teapot = true
 
 [lints.cargo]
-im_a_teapot = "warn"
+im-a-teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -885,13 +883,6 @@ im_a_teapot = "warn"
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr(
             "\
-warning: `im_a_teapot` is specified
- --> Cargo.toml:9:1
-  |
-9 | im-a-teapot = true
-  | ------------------
-  |
-  = note: `cargo::im_a_teapot` is set to `warn` in `[lints]`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",
@@ -915,8 +906,8 @@ authors = []
 im-a-teapot = true
 
 [lints.cargo]
-im-a-teapot = { level = "warn", priority = 10 }
-test-dummy-unstable = { level = "forbid", priority = -1 }
+im_a_teapot = { level = "warn", priority = 10 }
+test_dummy_unstable = { level = "forbid", priority = -1 }
             "#,
         )
         .file("src/lib.rs", "")
@@ -948,8 +939,8 @@ fn workspace_cargo_lints() {
 cargo-features = ["test-dummy-unstable"]
 
 [workspace.lints.cargo]
-im-a-teapot = { level = "warn", priority = 10 }
-test-dummy-unstable = { level = "forbid", priority = -1 }
+im_a_teapot = { level = "warn", priority = 10 }
+test_dummy_unstable = { level = "forbid", priority = -1 }
 
 [package]
 name = "foo"
@@ -992,7 +983,7 @@ fn dont_always_inherit_workspace_lints() {
 members = ["foo"]
 
 [workspace.lints.cargo]
-im-a-teapot = "warn"
+im_a_teapot = "warn"
 "#,
         )
         .file(
@@ -1038,7 +1029,7 @@ edition = "2021"
 baz = { version = "0.1.0", optional = true }
 
 [lints.cargo]
-implicit-features = "warn"
+implicit_features = "warn"
 "#,
         )
         .file("src/lib.rs", "")
@@ -1056,7 +1047,7 @@ edition = "2021"
 bar = "0.1.0"
 
 [lints.cargo]
-implicit-features = "warn"
+implicit_features = "warn"
 "#,
         )
         .file("src/lib.rs", "")
@@ -1091,7 +1082,7 @@ edition = "2015"
 authors = []
 
 [lints.cargo]
-im-a-teapot = "warn"
+im_a_teapot = "warn"
             "#,
         )
         .file("src/lib.rs", "")
@@ -1102,10 +1093,10 @@ im-a-teapot = "warn"
         .with_status(101)
         .with_stderr(
             "\
-error: use of unstable lint `im-a-teapot`
+error: use of unstable lint `im_a_teapot`
  --> Cargo.toml:9:1
   |
-9 | im-a-teapot = \"warn\"
+9 | im_a_teapot = \"warn\"
   | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
   |
   = help: consider adding `cargo-features = [\"test-dummy-unstable\"]` to the top of the manifest
@@ -1125,8 +1116,8 @@ fn check_feature_gated_workspace() {
 members = ["foo"]
 
 [workspace.lints.cargo]
-im-a-teapot = { level = "warn", priority = 10 }
-test-dummy-unstable = { level = "forbid", priority = -1 }
+im_a_teapot = { level = "warn", priority = 10 }
+test_dummy_unstable = { level = "forbid", priority = -1 }
             "#,
         )
         .file(
@@ -1150,26 +1141,26 @@ workspace = true
         .with_status(101)
         .with_stderr(
             "\
-error: use of unstable lint `im-a-teapot`
+error: use of unstable lint `im_a_teapot`
  --> Cargo.toml:6:1
   |
-6 | im-a-teapot = { level = \"warn\", priority = 10 }
+6 | im_a_teapot = { level = \"warn\", priority = 10 }
   | ^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
   |
-note: `cargo::im-a-teapot` was inherited
+note: `cargo::im_a_teapot` was inherited
  --> foo/Cargo.toml:9:1
   |
 9 | workspace = true
   | ----------------
   |
   = help: consider adding `cargo-features = [\"test-dummy-unstable\"]` to the top of the manifest
-error: use of unstable lint `test-dummy-unstable`
+error: use of unstable lint `test_dummy_unstable`
  --> Cargo.toml:7:1
   |
-7 | test-dummy-unstable = { level = \"forbid\", priority = -1 }
+7 | test_dummy_unstable = { level = \"forbid\", priority = -1 }
   | ^^^^^^^^^^^^^^^^^^^ this is behind `test-dummy-unstable`, which is not enabled
   |
-note: `cargo::test-dummy-unstable` was inherited
+note: `cargo::test_dummy_unstable` was inherited
  --> foo/Cargo.toml:9:1
   |
 9 | workspace = true

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -883,6 +883,14 @@ im-a-teapot = "warn"
         .masquerade_as_nightly_cargo(&["cargo-lints", "test-dummy-unstable"])
         .with_stderr(
             "\
+warning: unknown lint: `im-a-teapot`
+  --> Cargo.toml:12:1
+   |
+12 | im-a-teapot = \"warn\"
+   | ^^^^^^^^^^^
+   |
+   = note: `cargo::unknown_lints` is set to `warn` by default
+   = help: there is a lint with a similar name: `im_a_teapot`
 [CHECKING] foo v0.0.1 ([CWD])
 [FINISHED] [..]
 ",


### PR DESCRIPTION
In a recent Cargo Team meeting, it was discussed whether our lint should use `-` or `_` and if we should rewrite the wrong form to the correct one. It was decided that Cargo would use `_` for lint names and would not convert `-` to `_` automatically; instead, we would warn about an "unknown lint" and mention the similarly named lint with `_`, if found.

The decision to ise `_` was made because it is the canonical representation, as well as [RFC #344](https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints) specifies:
> Use snake case in the same way you would for function names.

This PR implements these changes.

Note: This adds an `unknown_lints` lint, that tries to mirror [the lint `rustc` has with the same name](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unknown-lints).
