### PR TITLE
fix(toml): On 2024 Edition, disallow ignored `default-features` when inheriting

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -683,6 +683,13 @@ impl TomlDependency {
         }
     }
 
+    pub fn default_features(&self) -> Option<bool> {
+        match self {
+            TomlDependency::Detailed(d) => d.default_features(),
+            TomlDependency::Simple(..) => None,
+        }
+    }
+
     pub fn unused_keys(&self) -> Vec<String> {
         match self {
             TomlDependency::Simple(_) => vec![],

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -970,7 +970,11 @@ fn inner_dependency_inherit_with<'a>(
     package_root: &Path,
     warnings: &mut Vec<String>,
 ) -> CargoResult<manifest::TomlDependency> {
-    fn default_features_msg(label: &str, ws_def_feat: Option<bool>, warnings: &mut Vec<String>) {
+    fn deprecated_ws_default_features(
+        label: &str,
+        ws_def_feat: Option<bool>,
+        warnings: &mut Vec<String>,
+    ) {
         let ws_def_feat = match ws_def_feat {
             Some(true) => "true",
             Some(false) => "false",
@@ -1014,12 +1018,12 @@ fn inner_dependency_inherit_with<'a>(
             // workspace: default-features = true should ignore member
             // default-features
             (Some(false), Some(true)) => {
-                default_features_msg(name, Some(true), warnings);
+                deprecated_ws_default_features(name, Some(true), warnings);
             }
             // member: default-features = false and
             // workspace: dep = "1.0" should ignore member default-features
             (Some(false), None) => {
-                default_features_msg(name, None, warnings);
+                deprecated_ws_default_features(name, None, warnings);
             }
             _ => {}
         }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -970,22 +970,6 @@ fn inner_dependency_inherit_with<'a>(
     package_root: &Path,
     warnings: &mut Vec<String>,
 ) -> CargoResult<manifest::TomlDependency> {
-    fn deprecated_ws_default_features(
-        label: &str,
-        ws_def_feat: Option<bool>,
-        warnings: &mut Vec<String>,
-    ) {
-        let ws_def_feat = match ws_def_feat {
-            Some(true) => "true",
-            Some(false) => "false",
-            None => "not specified",
-        };
-        warnings.push(format!(
-            "`default-features` is ignored for {label}, since `default-features` was \
-                {ws_def_feat} for `workspace.dependencies.{label}`, \
-                this could become a hard error in the future"
-        ))
-    }
     inherit()?.get_dependency(name, package_root).map(|ws_dep| {
         let mut merged_dep = match ws_dep {
             manifest::TomlDependency::Simple(ws_version) => manifest::TomlDetailedDependency {
@@ -1042,6 +1026,23 @@ fn inner_dependency_inherit_with<'a>(
         merged_dep.public = *public;
         manifest::TomlDependency::Detailed(merged_dep)
     })
+}
+
+fn deprecated_ws_default_features(
+    label: &str,
+    ws_def_feat: Option<bool>,
+    warnings: &mut Vec<String>,
+) {
+    let ws_def_feat = match ws_def_feat {
+        Some(true) => "true",
+        Some(false) => "false",
+        None => "not specified",
+    };
+    warnings.push(format!(
+        "`default-features` is ignored for {label}, since `default-features` was \
+                {ws_def_feat} for `workspace.dependencies.{label}`, \
+                this could become a hard error in the future"
+    ))
 }
 
 #[tracing::instrument(skip_all)]

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -2753,12 +2753,7 @@ dep_df_false = { version = "0.1.0", default-features = false }
 [MIGRATING] pkg_default/Cargo.toml from 2021 edition to 2024
 [MIGRATING] pkg_df_true/Cargo.toml from 2021 edition to 2024
 [MIGRATING] pkg_df_false/Cargo.toml from 2021 edition to 2024
-[WARNING] [CWD]/pkg_df_false/Cargo.toml: `default-features` is ignored for dep_df_true, since `default-features` was true for `workspace.dependencies.dep_df_true`, this could become a hard error in the future
-[WARNING] [CWD]/pkg_df_false/Cargo.toml: `default-features` is ignored for dep_simple, since `default-features` was not specified for `workspace.dependencies.dep_simple`, this could become a hard error in the future
-[WARNING] [CWD]/pkg_df_false/Cargo.toml: `default-features` is ignored for dep_df_true, since `default-features` was true for `workspace.dependencies.dep_df_true`, this could become a hard error in the future
-[WARNING] [CWD]/pkg_df_false/Cargo.toml: `default-features` is ignored for dep_simple, since `default-features` was not specified for `workspace.dependencies.dep_simple`, this could become a hard error in the future
-[WARNING] [CWD]/pkg_df_false/Cargo.toml: `default-features` is ignored for dep_df_true, since `default-features` was true for `workspace.dependencies.dep_df_true`, this could become a hard error in the future
-[WARNING] [CWD]/pkg_df_false/Cargo.toml: `default-features` is ignored for dep_simple, since `default-features` was not specified for `workspace.dependencies.dep_simple`, this could become a hard error in the future
+[FIXED] pkg_df_false/Cargo.toml (6 fixes)
 [UPDATING] `dummy-registry` index
 [LOCKING] 6 packages to latest compatible versions
 [DOWNLOADING] crates ...
@@ -2790,18 +2785,18 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dep_simple = { workspace = true, default-features = false }
-dep_df_true = { workspace = true, default-features = false }
+dep_simple = { workspace = true}
+dep_df_true = { workspace = true}
 dep_df_false = { workspace = true, default-features = false }
 
 [build-dependencies]
-dep_simple = { workspace = true, default-features = false }
-dep_df_true = { workspace = true, default-features = false }
+dep_simple = { workspace = true}
+dep_df_true = { workspace = true}
 dep_df_false = { workspace = true, default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dep_simple = { workspace = true, default-features = false }
-dep_df_true = { workspace = true, default-features = false }
+dep_simple = { workspace = true}
+dep_df_true = { workspace = true}
 dep_df_false = { workspace = true, default-features = false }
 "#
     );

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1553,19 +1553,16 @@ fn warn_inherit_def_feat_true_member_def_feat_false_2024_edition() {
 
     p.cargo("check")
         .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \
-true for `workspace.dependencies.dep`, this could become a hard error in the future
-[UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest Rust [..] compatible versions
-[DOWNLOADING] crates ...
-[DOWNLOADED] fancy_dep v0.2.4 ([..])
-[DOWNLOADED] dep v0.1.0 ([..])
-[CHECKING] fancy_dep v0.2.4
-[CHECKING] dep v0.1.0
-[CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  error inheriting `dep` from workspace root manifest's `workspace.dependencies.dep`
+
+Caused by:
+  `default-features = false` cannot override workspace's `default-features`
 ",
         )
         .run();
@@ -1656,19 +1653,16 @@ fn warn_inherit_simple_member_def_feat_false_2024_edition() {
 
     p.cargo("check")
         .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \
-not specified for `workspace.dependencies.dep`, this could become a hard error in the future
-[UPDATING] `dummy-registry` index
-[LOCKING] 3 packages to latest compatible versions
-[DOWNLOADING] crates ...
-[DOWNLOADED] fancy_dep v0.2.4 ([..])
-[DOWNLOADED] dep v0.1.0 ([..])
-[CHECKING] fancy_dep v0.2.4
-[CHECKING] dep v0.1.0
-[CHECKING] bar v0.2.0 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  error inheriting `dep` from workspace root manifest's `workspace.dependencies.dep`
+
+Caused by:
+  `default-features = false` cannot override workspace's `default-features`
 ",
         )
         .run();

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1518,6 +1518,59 @@ true for `workspace.dependencies.dep`, this could become a hard error in the fut
         .run();
 }
 
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn warn_inherit_def_feat_true_member_def_feat_false_2024_edition() {
+    Package::new("dep", "0.1.0")
+        .feature("default", &["fancy_dep"])
+        .add_dep(Dependency::new("fancy_dep", "0.2").optional(true))
+        .file("src/lib.rs", "")
+        .publish();
+
+    Package::new("fancy_dep", "0.2.4").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["edition2024"]
+
+            [package]
+            name = "bar"
+            version = "0.2.0"
+            edition = "2024"
+            authors = []
+            [dependencies]
+            dep = { workspace = true, default-features = false }
+
+            [workspace]
+            members = []
+            [workspace.dependencies]
+            dep = { version = "0.1.0", default-features = true }
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_stderr(
+            "\
+[WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \
+true for `workspace.dependencies.dep`, this could become a hard error in the future
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest Rust [..] compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] fancy_dep v0.2.4 ([..])
+[DOWNLOADED] dep v0.1.0 ([..])
+[CHECKING] fancy_dep v0.2.4
+[CHECKING] dep v0.1.0
+[CHECKING] bar v0.2.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
 #[cargo_test]
 fn warn_inherit_simple_member_def_feat_false() {
     Package::new("dep", "0.1.0")
@@ -1550,6 +1603,59 @@ fn warn_inherit_simple_member_def_feat_false() {
         .build();
 
     p.cargo("check")
+        .with_stderr(
+            "\
+[WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \
+not specified for `workspace.dependencies.dep`, this could become a hard error in the future
+[UPDATING] `dummy-registry` index
+[LOCKING] 3 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] fancy_dep v0.2.4 ([..])
+[DOWNLOADED] dep v0.1.0 ([..])
+[CHECKING] fancy_dep v0.2.4
+[CHECKING] dep v0.1.0
+[CHECKING] bar v0.2.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn warn_inherit_simple_member_def_feat_false_2024_edition() {
+    Package::new("dep", "0.1.0")
+        .feature("default", &["fancy_dep"])
+        .add_dep(Dependency::new("fancy_dep", "0.2").optional(true))
+        .file("src/lib.rs", "")
+        .publish();
+
+    Package::new("fancy_dep", "0.2.4").publish();
+
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+            cargo-features = ["edition2024"]
+
+            [package]
+            name = "bar"
+            version = "0.2.0"
+            edition = "2024"
+            authors = []
+            [dependencies]
+            dep = { workspace = true, default-features = false }
+
+            [workspace]
+            members = []
+            [workspace.dependencies]
+            dep = "0.1.0"
+        "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["edition2024"])
         .with_stderr(
             "\
 [WARNING] [CWD]/Cargo.toml: `default-features` is ignored for dep, since `default-features` was \


### PR DESCRIPTION
### What does this PR try to resolve?

This is part of rust-lang/rust#123754

This is a follow up to #11409 which tweaked how we do inheritance of default-features, including warning when `default-features = false` is ignored.  This turns those warnings into an error.

### How should we test and review this PR?



### Additional information

