### PR TITLE
fix(toml): Validate crates_types/proc-macro for bin like others 

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -333,6 +333,7 @@ fn resolve_toml(
             edition,
             original_package.autobins,
             warnings,
+            errors,
             resolved_toml.lib.is_some(),
         )?);
         resolved_toml.example = Some(targets::resolve_examples(
@@ -1070,7 +1071,7 @@ fn to_real_manifest(
     manifest_file: &Path,
     gctx: &GlobalContext,
     warnings: &mut Vec<String>,
-    errors: &mut Vec<String>,
+    _errors: &mut Vec<String>,
 ) -> CargoResult<Manifest> {
     let embedded = is_embedded(manifest_file);
     let package_root = manifest_file.parent().unwrap();
@@ -1212,7 +1213,6 @@ fn to_real_manifest(
         edition,
         &resolved_package.metabuild,
         warnings,
-        errors,
     )?;
 
     if targets.iter().all(|t| t.is_custom_build()) {

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -277,8 +277,8 @@ pub fn resolve_bins(
 
     for bin in &mut bins {
         validate_bin_name(bin, warnings)?;
-        validate_bin_crate_types(bin, warnings, errors)?;
-        validate_bin_proc_macro(bin, warnings, errors)?;
+        validate_bin_crate_types(bin, edition, warnings, errors)?;
+        validate_bin_proc_macro(bin, edition, warnings, errors)?;
 
         let path = target_path(bin, &inferred, "bin", package_root, edition, &mut |_| {
             if let Some(legacy_path) = legacy_bin_path(package_root, name_or_panic(bin), has_lib) {
@@ -1057,7 +1057,8 @@ fn validate_target_name(
 
 fn validate_bin_proc_macro(
     target: &TomlTarget,
-    _warnings: &mut Vec<String>,
+    edition: Edition,
+    warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
 ) -> CargoResult<()> {
     if target.proc_macro() == Some(true) {
@@ -1067,6 +1068,8 @@ fn validate_bin_proc_macro(
                  set `true`",
             name
         ));
+    } else {
+        validate_proc_macro(target, "binary", edition, warnings)?;
     }
     Ok(())
 }
@@ -1090,7 +1093,8 @@ fn validate_proc_macro(
 
 fn validate_bin_crate_types(
     target: &TomlTarget,
-    _warnings: &mut Vec<String>,
+    edition: Edition,
+    warnings: &mut Vec<String>,
     errors: &mut Vec<String>,
 ) -> CargoResult<()> {
     if let Some(crate_types) = target.crate_types() {
@@ -1102,6 +1106,8 @@ fn validate_bin_crate_types(
                 name,
                 crate_types.join(", ")
             ));
+        } else {
+            validate_crate_types(target, "binary", edition, warnings)?;
         }
     }
     Ok(())

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -321,15 +321,7 @@ fn to_bin_targets(
         }
 
         validate_bin_crate_types(bin, warnings, errors)?;
-
-        if bin.proc_macro() == Some(true) {
-            let name = name_or_panic(bin);
-            errors.push(format!(
-                "the target `{}` is a binary and can't have `proc-macro` \
-                 set `true`",
-                name
-            ));
-        }
+        validate_bin_proc_macro(bin, warnings, errors)?;
     }
 
     validate_unique_names(&bins, "binary")?;
@@ -1066,6 +1058,22 @@ fn name_or_panic(target: &TomlTarget) -> &str {
         .name
         .as_deref()
         .unwrap_or_else(|| panic!("target name is required"))
+}
+
+fn validate_bin_proc_macro(
+    target: &TomlTarget,
+    _warnings: &mut Vec<String>,
+    errors: &mut Vec<String>,
+) -> CargoResult<()> {
+    if target.proc_macro() == Some(true) {
+        let name = name_or_panic(target);
+        errors.push(format!(
+            "the target `{}` is a binary and can't have `proc-macro` \
+                 set `true`",
+            name
+        ));
+    }
+    Ok(())
 }
 
 fn validate_proc_macro(

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -141,10 +141,10 @@ pub fn resolve_lib(
     let Some(mut lib) = lib else { return Ok(None) };
     lib.name
         .get_or_insert_with(|| package_name.replace("-", "_"));
+
     // Check early to improve error messages
     validate_lib_name(&lib, warnings)?;
 
-    // Checking the original lib
     validate_proc_macro(&lib, "library", edition, warnings)?;
     validate_crate_types(&lib, "library", edition, warnings)?;
 
@@ -276,7 +276,9 @@ pub fn resolve_bins(
     );
 
     for bin in &mut bins {
+        // Check early to improve error messages
         validate_bin_name(bin, warnings)?;
+
         validate_bin_crate_types(bin, edition, warnings, errors)?;
         validate_bin_proc_macro(bin, edition, warnings, errors)?;
 
@@ -587,7 +589,9 @@ fn resolve_targets_with_legacy_path(
     );
 
     for target in &toml_targets {
+        // Check early to improve error messages
         validate_target_name(target, target_kind_human, target_kind, warnings)?;
+
         validate_proc_macro(target, target_kind_human, edition, warnings)?;
         validate_crate_types(target, target_kind_human, edition, warnings)?;
     }

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1852,7 +1852,7 @@ Caused by:
 }
 
 #[cargo_test]
-fn proc_macro2() {
+fn lib_proc_macro2() {
     let foo = project()
         .file(
             "Cargo.toml",
@@ -1879,7 +1879,7 @@ fn proc_macro2() {
 }
 
 #[cargo_test(nightly, reason = "edition2024 is not stable")]
-fn proc_macro2_2024() {
+fn lib_proc_macro2_2024() {
     let foo = project()
         .file(
             "Cargo.toml",
@@ -1913,7 +1913,7 @@ Caused by:
 }
 
 #[cargo_test]
-fn proc_macro2_conflict() {
+fn lib_proc_macro2_conflict() {
     let foo = project()
         .file(
             "Cargo.toml",

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1137,6 +1137,100 @@ fn lib_crate_type2_conflict() {
 }
 
 #[cargo_test]
+fn bin_crate_type2() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2015"
+                authors = ["wycats@example.com"]
+
+                [[bin]]
+                name = "foo"
+                path = "src/main.rs"
+                crate_type = []
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.5.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn bin_crate_type2_2024() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["edition2024"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2024"
+                authors = ["wycats@example.com"]
+
+                [[bin]]
+                name = "foo"
+                path = "src/main.rs"
+                crate_type = []
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check")
+        .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_stderr(
+            "\
+[CHECKING] foo v0.5.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bin_crate_type2_conflict() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2015"
+                authors = ["wycats@example.com"]
+
+                [[bin]]
+                name = "foo"
+                path = "src/main.rs"
+                crate_type = []
+                crate-type = []
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+    p.cargo("check")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.5.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn examples_crate_type2() {
     let p = project()
         .file(
@@ -1934,6 +2028,103 @@ fn lib_proc_macro2_conflict() {
         .with_stderr_contains(
             "\
 [WARNING] `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` library target
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bin_proc_macro2() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2015"
+                authors = ["wycats@example.com"]
+
+                [[bin]]
+                name = "foo"
+                path = "src/main.rs"
+                proc_macro = false
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    foo.cargo("check")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.5.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn bin_proc_macro2_2024() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                cargo-features = ["edition2024"]
+
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2015"
+                authors = ["wycats@example.com"]
+
+                [[bin]]
+                name = "foo"
+                path = "src/main.rs"
+                proc_macro = false
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    foo.cargo("check")
+        .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_stderr(
+            "\
+[CHECKING] foo v0.5.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn bin_proc_macro2_conflict() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2015"
+                authors = ["wycats@example.com"]
+
+                [[bin]]
+                name = "foo"
+                path = "src/main.rs"
+                proc-macro = false
+                proc_macro = false
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    foo.cargo("check")
+        .with_stderr(
+            "\
+[CHECKING] foo v0.5.0 ([CWD])
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
         )
         .run();

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1159,6 +1159,8 @@ fn bin_crate_type2() {
     p.cargo("check")
         .with_stderr(
             "\
+[WARNING] `crate_type` is deprecated in favor of `crate-type` and will not work in the 2024 edition
+(in the `foo` binary target)
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
@@ -1190,10 +1192,14 @@ fn bin_crate_type2_2024() {
         .build();
     p.cargo("check")
         .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_status(101)
         .with_stderr(
             "\
-[CHECKING] foo v0.5.0 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  `crate_type` is unsupported as of the 2024 edition; instead use `crate-type`
+  (in the `foo` binary target)
 ",
         )
         .run();
@@ -1223,6 +1229,7 @@ fn bin_crate_type2_conflict() {
     p.cargo("check")
         .with_stderr(
             "\
+[WARNING] `crate_type` is redundant with `crate-type`, preferring `crate-type` in the `foo` binary target
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
@@ -2057,6 +2064,8 @@ fn bin_proc_macro2() {
     foo.cargo("check")
         .with_stderr(
             "\
+[WARNING] `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
+(in the `foo` binary target)
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",
@@ -2075,7 +2084,7 @@ fn bin_proc_macro2_2024() {
                 [package]
                 name = "foo"
                 version = "0.5.0"
-                edition = "2015"
+                edition = "2024"
                 authors = ["wycats@example.com"]
 
                 [[bin]]
@@ -2089,10 +2098,14 @@ fn bin_proc_macro2_2024() {
 
     foo.cargo("check")
         .masquerade_as_nightly_cargo(&["edition2024"])
+        .with_status(101)
         .with_stderr(
             "\
-[CHECKING] foo v0.5.0 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
+[ERROR] failed to parse manifest at `[CWD]/Cargo.toml`
+
+Caused by:
+  `proc_macro` is unsupported as of the 2024 edition; instead use `proc-macro`
+  (in the `foo` binary target)
 ",
         )
         .run();
@@ -2123,6 +2136,7 @@ fn bin_proc_macro2_conflict() {
     foo.cargo("check")
         .with_stderr(
             "\
+[WARNING] `proc_macro` is redundant with `proc-macro`, preferring `proc-macro` in the `foo` binary target
 [CHECKING] foo v0.5.0 ([CWD])
 [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
 ",


### PR DESCRIPTION
### What does this PR try to resolve?

This is all refactors on my way to skipping inferring of targets when it isn't needed.  Along the way, I made the target validation more consistent

### How should we test and review this PR?



### Additional information

