### PR TITLE
Fix: Build only the specified artifact library when multiple types are available

### DIFF
--- a/src/cargo/core/compiler/unit_dependencies.rs
+++ b/src/cargo/core/compiler/unit_dependencies.rs
@@ -24,7 +24,7 @@ use crate::core::compiler::unit_graph::{UnitDep, UnitGraph};
 use crate::core::compiler::{
     CompileKind, CompileMode, CrateType, RustcTargetData, Unit, UnitInterner,
 };
-use crate::core::dependency::{Artifact, ArtifactTarget, DepKind};
+use crate::core::dependency::{Artifact, ArtifactKind, ArtifactTarget, DepKind};
 use crate::core::profiles::{Profile, Profiles, UnitFor};
 use crate::core::resolver::features::{FeaturesFor, ResolvedFeatures};
 use crate::core::resolver::Resolve;
@@ -555,17 +555,20 @@ fn artifact_targets_to_unit_deps(
     let ret =
         match_artifacts_kind_with_targets(dep, artifact_pkg.targets(), parent.pkg.name().as_str())?
             .into_iter()
-            .map(|(_artifact_kind, target)| target)
-            .flat_map(|target| {
+            .flat_map(|(artifact_kind, target)| {
                 // We split target libraries into individual units, even though rustc is able
-                // to produce multiple kinds in an single invocation for the sole reason that
+                // to produce multiple kinds in a single invocation for the sole reason that
                 // each artifact kind has its own output directory, something we can't easily
                 // teach rustc for now.
                 match target.kind() {
                     TargetKind::Lib(kinds) => Box::new(
                         kinds
                             .iter()
-                            .filter(|tk| matches!(tk, CrateType::Cdylib | CrateType::Staticlib))
+                            .filter(move |tk| match (tk, artifact_kind) {
+                                (CrateType::Cdylib, ArtifactKind::Cdylib) => true,
+                                (CrateType::Staticlib, ArtifactKind::Staticlib) => true,
+                                _ => false,
+                            })
                             .map(|target_kind| {
                                 new_unit_dep(
                                     state,

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -3241,7 +3241,7 @@ fn build_only_specified_artifact_library() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
     match_exact(
-        "cdylib present: true\nstaticlib present: true",
+        "cdylib present: true\nstaticlib present: false",
         &build_script_output_string(&cdylib, "foo"),
         "build script output",
         "",
@@ -3255,7 +3255,7 @@ fn build_only_specified_artifact_library() {
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
     match_exact(
-        "cdylib present: true\nstaticlib present: true",
+        "cdylib present: false\nstaticlib present: true",
         &build_script_output_string(&staticlib, "foo"),
         "build script output",
         "",


### PR DESCRIPTION
### What does this PR try to resolve?
Fixes #12109. 

#### TL;DR:
A crate `bar` exposes it's library as both a `staticlib` and a `cdylib`. A second crate `foo` specifies an artifact dependency of type `staticlib` on `bar`, meaning cargo should build `bar` as a `staticlib` and expose certain environment variables (e.g. `CARGO_STATICLIB_FILE_BAR`). However, due to a bug, cargo ends up building (and exposing the associated environment variables) for both the `staticlib` and `cdylib`. 

The same happens if `foo` specifies an artifact dependency of type `cdylib`; both artifact types are built.

### How should we test and review this PR?
The first commit introduces a test which reproduces the issue, the second commit introduces the fix. This setup was recommended by @ehuss.

### Additional information
Artifact dependencies: https://rust-lang.github.io/rfcs/3028-cargo-binary-dependencies.html

#### TL;DR
If a crate `foo` requests an artifact dependency of kind <artifact_kind> from a crate `bar` then the following happens:

- `bar` is built with crate-type <artifact_kind> and a directory is created at `target/<profile>/deps/artifact/bar-<build_hash_or_something>/<artifact_kind>`. The binary artifact is placed in this directory.
- Cargo exposes certain environment variables, the most important for this PR is `CARGO_<artifact_kind>_FILE_BAR`, which points to the binary artifact that was specified. This environment variable is available at compile time for normal dependencies and at runtime for build-dependencies.

If multiple artifact-kinds are requested cargo will create a unit for each, and so they will all be built separately.