### PR TITLE
Show description for user-installed binaries when running "cargo --list"

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -272,9 +272,7 @@ impl Registry {
         // so it will only be used if the current registry host is crates.io
         if self.host_is_crates_io() {
             self.handle.get(true)?;
-            let body = self
-                .req(&format!("/crates/{}", krate), None, Auth::Unauthorized)
-                .unwrap();
+            let body = self.req(&format!("/crates/{}", krate), None, Auth::Unauthorized)?;
             Ok(serde_json::from_str::<CrateInfo>(&body)?
                 .crate_info
                 .description)
@@ -413,8 +411,6 @@ impl Registry {
         if body.is_some() {
             headers.append("Content-Type: application/json")?;
         }
-
-        headers.append(&format!("User-Agent: cargo-cli"))?;
 
         if self.auth_required || authorized == Auth::Authorized {
             headers.append(&format!("Authorization: {}", self.token()?))?;

--- a/src/cargo/ops/mod.rs
+++ b/src/cargo/ops/mod.rs
@@ -55,7 +55,7 @@ pub mod cargo_remove;
 mod cargo_run;
 mod cargo_test;
 mod cargo_uninstall;
-mod common_for_install_and_uninstall;
+pub mod common_for_install_and_uninstall;
 mod fix;
 pub(crate) mod lockfile;
 pub(crate) mod registry;


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
<!-- homu-ignore:end -->

### What does this PR try to resolve?

I've noticed that when running `cargo --list`, user-installed subcommands wouldn't have a description. In order to resolve this, cargo will now communicate with the [crates.io] registry (if those packages were installed from [crates.io] ofc) and retrieve the package description from there. This also works if the binary name is different than the name of the package (for example, if a package installs multiple binaries)

### How should we test and review this PR?
 I've noticed that some test use the `--list` flag, so if they pass, this should be fine

### Additional information

[crates.io] allows someone to go to `https://crates.io/api/v1/crates/{crate}` and get info about this crate in a JSON format. However, from what I've found, this isn't standardized for other Rust registries, and so, if a subcommand was installed from another registry, it won't print a description. Please verify that this is the case. If not, I can remove the relevant checks for other registries.

**IMPORTANT**

I haven't fixed the relevant tests *yet*, so **DON'T** merge this immediately

[crates.io]: https://crates.io
