### PR TITLE
refactor: remove unnecessary branch for link binary on macOS

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -1286,10 +1286,6 @@ pub trait TestEnv: Sized {
             .env_remove("USER") // not set on some rust-lang docker images
             .env_remove("XDG_CONFIG_HOME") // see #2345
             .env_remove("OUT_DIR"); // see #13204
-        if cfg!(target_os = "macos") {
-            // Work-around a bug in macOS 10.15, see `link_or_copy` for details.
-            self = self.env("__CARGO_COPY_DONT_LINK_DO_NOT_USE_THIS", "1");
-        }
         if cfg!(windows) {
             self = self.env("USERPROFILE", paths::home());
         }


### PR DESCRIPTION


<!-- homu-ignore:start -->
### What does this PR try to resolve?

The other workaround branch should have covered that.

Found this during the review of <https://github.com/rust-lang/cargo/pull/13845>.
<!-- homu-ignore:end -->
