### PR TITLE
fix(lints): Prevent inheritance from bring exposed for published packages

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -492,7 +492,15 @@ fn resolve_toml(
         }
         resolved_toml.target = (!resolved_target.is_empty()).then_some(resolved_target);
 
-        resolved_toml.lints = original_toml.lints.clone();
+        let resolved_lints = original_toml
+            .lints
+            .clone()
+            .map(|value| lints_inherit_with(value, || inherit()?.lints()))
+            .transpose()?;
+        resolved_toml.lints = resolved_lints.map(|lints| manifest::InheritableLints {
+            workspace: false,
+            lints,
+        });
 
         resolved_toml.badges = original_toml.badges.clone();
     } else {
@@ -1336,18 +1344,18 @@ fn to_real_manifest(
         }
     }
 
-    let resolved_lints = resolved_toml
-        .lints
-        .clone()
-        .map(|value| {
-            lints_inherit_with(value, || {
-                load_inheritable_fields(gctx, manifest_file, &workspace_config)?.lints()
-            })
-        })
-        .transpose()?;
-
-    verify_lints(resolved_lints.as_ref(), gctx, warnings)?;
-    let rustflags = lints_to_rustflags(&resolved_lints.unwrap_or_default());
+    verify_lints(
+        resolved_toml.resolved_lints().expect("previously resolved"),
+        gctx,
+        warnings,
+    )?;
+    let default = manifest::TomlLints::default();
+    let rustflags = lints_to_rustflags(
+        resolved_toml
+            .resolved_lints()
+            .expect("previously resolved")
+            .unwrap_or(&default),
+    );
 
     let metadata = ManifestMetadata {
         description: resolved_package

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -975,7 +975,7 @@ error: `im_a_teapot` is specified
 13 | im-a-teapot = true
    | ^^^^^^^^^^^^^^^^^^
    |
-   = note: `cargo::im_a_teapot` is set to `forbid` in `[workspace.lints]`
+   = note: `cargo::im_a_teapot` is set to `forbid` in `[lints]`
 ",
         )
         .run();


### PR DESCRIPTION
#13843 demonstrated a regression caused by #13801, where we started to keep `[lints]` and `[workspace.lints]` separate, and not truly resolve `[lints]`. This was a nice thing to have and made it easier to tell when a lint came from a workspace. The downside of doing so is the lints table would not get resolved when vendoring or publishing. 

To fix this issue, I reverted the change for keeping `[lints]` and `[workspace.lints]` separate and modified how cargo's linting system figures out where a lint is coming from. Due to this change, we no longer specify that a lint was set by `[workspace.lints]`, only `[lints]`. It is true that a lint level is set by `[lints]` always, as it would've had to specify the lint outright or specify that it was inheriting it, seeing that, I do not think this is a regression in diagnostic quality. I still manage to keep the ability to render a lint's location in the workspace's manifest when running ` analyze_cargo_lints_table`, which I am pleased about.