### PR TITLE
fix(toml): Remove unstable rejrected frontmatter syntax for cargo script

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -185,7 +185,7 @@ fn sanitize_name(name: &str) -> String {
 struct Source<'s> {
     shebang: Option<&'s str>,
     info: Option<&'s str>,
-    frontmatter: Option<String>,
+    frontmatter: Option<&'s str>,
     content: &'s str,
 }
 
@@ -234,14 +234,11 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
         0 => {
             return Ok(source);
         }
-        1 if tick_char == '#' => {
-            // Attribute
-            return Ok(source);
-        }
-        2 if tick_char == '#' => {
-            return split_prefix_source(source, "##");
-        }
         1 | 2 => {
+            if tick_char == '#' {
+                // Attribute
+                return Ok(source);
+            }
             anyhow::bail!("found {tick_end} `{tick_char}` in rust frontmatter, expected at least 3")
         }
         _ => source.content.split_at(tick_end),
@@ -255,7 +252,7 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
     let Some((frontmatter, content)) = source.content.split_once(fence_pattern) else {
         anyhow::bail!("no closing `{fence_pattern}` found for frontmatter");
     };
-    source.frontmatter = Some(frontmatter.to_owned());
+    source.frontmatter = Some(frontmatter);
     source.content = content;
 
     let (line, content) = source
@@ -268,22 +265,6 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
     }
     source.content = content;
 
-    Ok(source)
-}
-
-fn split_prefix_source<'s>(mut source: Source<'s>, prefix: &str) -> CargoResult<Source<'s>> {
-    let mut frontmatter = String::new();
-    while let Some(rest) = source.content.strip_prefix(prefix) {
-        if !rest.is_empty() && !rest.starts_with(' ') {
-            anyhow::bail!("frontmatter must have a space between `##` and the content");
-        }
-        let (line, rest) = rest.split_once('\n').unwrap_or((rest, ""));
-        frontmatter.push_str("  ");
-        frontmatter.push_str(line);
-        frontmatter.push('\n');
-        source.content = rest;
-    }
-    source.frontmatter = Some(frontmatter);
     Ok(source)
 }
 
@@ -394,7 +375,7 @@ fn main() {}
     }
 
     #[test]
-    fn test_dash_fence() {
+    fn test_dash() {
         snapbox::assert_matches(
             r#"[[bin]]
 name = "test-"
@@ -427,7 +408,7 @@ fn main() {}
     }
 
     #[test]
-    fn test_hash_fence() {
+    fn test_hash() {
         snapbox::assert_matches(
             r#"[[bin]]
 name = "test-"
@@ -454,37 +435,6 @@ strip = true
 [dependencies]
 time="0.1.25"
 ###
-fn main() {}
-"#),
-        );
-    }
-
-    #[test]
-    fn test_hash_prefix() {
-        snapbox::assert_matches(
-            r#"[[bin]]
-name = "test-"
-path = [..]
-
-[dependencies]
-time = "0.1.25"
-
-[package]
-autobenches = false
-autobins = false
-autoexamples = false
-autotests = false
-build = false
-edition = "2021"
-name = "test-"
-
-[profile.release]
-strip = true
-
-[workspace]
-"#,
-            si!(r#"## [dependencies]
-## time="0.1.25"
 fn main() {}
 "#),
         );

--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -218,12 +218,7 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
     }
 
     // Experiment: let us try which char works better
-    let tick_char = source
-        .content
-        .chars()
-        .filter(|c| ['`', '#', '-'].contains(c))
-        .next()
-        .unwrap_or('`');
+    let tick_char = '-';
 
     let tick_end = source
         .content
@@ -235,10 +230,6 @@ fn split_source(input: &str) -> CargoResult<Source<'_>> {
             return Ok(source);
         }
         1 | 2 => {
-            if tick_char == '#' {
-                // Attribute
-                return Ok(source);
-            }
             anyhow::bail!("found {tick_end} `{tick_char}` in rust frontmatter, expected at least 3")
         }
         _ => source.content.split_at(tick_end),
@@ -332,10 +323,10 @@ strip = true
 
 [workspace]
 "#,
-            si!(r#"```cargo
+            si!(r#"---cargo
 [dependencies]
 time="0.1.25"
-```
+---
 fn main() {}
 "#),
         );
@@ -365,76 +356,10 @@ strip = true
 
 [workspace]
 "#,
-            si!(r#"```
-[dependencies]
-time="0.1.25"
-```
-fn main() {}
-"#),
-        );
-    }
-
-    #[test]
-    fn test_dash() {
-        snapbox::assert_matches(
-            r#"[[bin]]
-name = "test-"
-path = [..]
-
-[dependencies]
-time = "0.1.25"
-
-[package]
-autobenches = false
-autobins = false
-autoexamples = false
-autotests = false
-build = false
-edition = "2021"
-name = "test-"
-
-[profile.release]
-strip = true
-
-[workspace]
-"#,
             si!(r#"---
 [dependencies]
 time="0.1.25"
 ---
-fn main() {}
-"#),
-        );
-    }
-
-    #[test]
-    fn test_hash() {
-        snapbox::assert_matches(
-            r#"[[bin]]
-name = "test-"
-path = [..]
-
-[dependencies]
-time = "0.1.25"
-
-[package]
-autobenches = false
-autobins = false
-autoexamples = false
-autotests = false
-build = false
-edition = "2021"
-name = "test-"
-
-[profile.release]
-strip = true
-
-[workspace]
-"#,
-            si!(r#"###
-[dependencies]
-time="0.1.25"
-###
 fn main() {}
 "#),
         );

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -210,10 +210,10 @@ fn requires_z_flag() {
 #[cargo_test]
 fn clean_output_with_edition() {
     let script = r#"#!/usr/bin/env cargo
-```cargo
+---
 [package]
 edition = "2018"
-```
+---
 
 fn main() {
     println!("Hello world!");
@@ -241,9 +241,9 @@ fn main() {
 #[cargo_test]
 fn warning_without_edition() {
     let script = r#"#!/usr/bin/env cargo
-```cargo
+---
 [package]
-```
+---
 
 fn main() {
     println!("Hello world!");
@@ -714,10 +714,10 @@ fn did_you_mean_command_stable() {
 fn test_name_same_as_dependency() {
     Package::new("script", "1.0.0").publish();
     let script = r#"#!/usr/bin/env cargo
-```cargo
+---
 [dependencies]
 script = "1.0.0"
-```
+---
 
 fn main() {
     println!("Hello world!");
@@ -751,10 +751,10 @@ fn main() {
 #[cargo_test]
 fn test_path_dep() {
     let script = r#"#!/usr/bin/env cargo
-```cargo
+---
 [dependencies]
 bar.path = "./bar"
-```
+---
 
 fn main() {
     println!("Hello world!");


### PR DESCRIPTION
### What does this PR try to resolve?

With rust-lang/rfcs#3503 approved, we no longer need to allow easy, high fidelity experiments with alternative cargo script syntax.

### How should we test and review this PR?



### Additional information

We still need to improve the experience for users writing bad syntax but that can come later.