### PR TITLE
Don't squash path dependencies with same package name

### DIFF
--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -3029,8 +3029,5 @@ fn patch_on_same_package_with_different_version() {
         )
         .run();
 
-    p.cargo("check").with_stderr("\
-[UPDATING] crates.io index
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-").run();
+    p.cargo("check").with_stderr("[FINISHED] [..]").run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fixes #13862

Dependencies with same package name in the `Cargo.lock` was squashed in `EncodableResolve::into_resolve()`.

e.g. In the problem reproduction repo's Cargo.lock, there are two entries:

```toml
[[package]]
name = "once_cell"
version = "0.1.0"

[[package]]
name = "once_cell"
version = "1.19.0"
```

However, they were squashed in `build_path_deps()`, then we endup getting two package ids with same path like this:

```
PackageId { name: "once_cell", version: "0.1.0", source: "pwd/vendor/once_cell_1_19" }
PackageId { name: "once_cell", version: "1.19.0", source: "pwd/vendor/once_cell_1_19" }
```

This package version inconsistency triggers patch update introduced in https://github.com/rust-lang/cargo/pull/8248 everytime you compile this crate.