### PR TITLE
style(test): Remove check-cfg warning

### DIFF
--- a/crates/cargo-test-support/build.rs
+++ b/crates/cargo-test-support/build.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::disallowed_methods)]
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(emulate_second_only_system)");
     println!(
         "cargo:rustc-env=NATIVE_ARCH={}",
         std::env::var("TARGET").unwrap()


### PR DESCRIPTION
This is currently breaking CI because we run effectively `RUSTDOCFLAGS=-Dwarnings cargo +nightly doc`

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
