### PR TITLE
Add more documentation to `cargo::rustc-check-cfg`

### DIFF
--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -292,8 +292,13 @@ if foo_bar_condition {
 }
 ```
 
+For a more complete example see in the [build script examples][build-script-examples] page
+the [conditional compilation][conditional-compilation-example] example.
+
 [check-cfg-blog-post]: https://blog.rust-lang.org/2024/05/06/check-cfg.html
 [option-check-cfg]: ../../rustc/command-line-arguments.md#option-check-cfg
+[build-script-examples]: build-script-examples.md
+[conditional-compilation-example]: build-script-examples.md#conditional-compilation
 
 ### `cargo::rustc-env=VAR=VALUE` {#rustc-env}
 

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -264,6 +264,8 @@ the _reachable_ cfg expressions.
 For details on the syntax of `CHECK_CFG`, see `rustc` [`--check-cfg` flag][option-check-cfg].
 See also the [`unexpected_cfgs`][unexpected-cfgs] lint.
 
+> Note: `cargo:rustc-check-cfg` (single-colon) can be used if your MSRV is below Rust 1.77
+
 The instruction can be used like this:
 
 ```rust,no_run

--- a/src/doc/src/reference/build-scripts.md
+++ b/src/doc/src/reference/build-scripts.md
@@ -258,6 +258,8 @@ identifier, the value should be a string.
 
 ### `cargo::rustc-check-cfg=CHECK_CFG` {#rustc-check-cfg}
 
+*See the announcement [blog post][check-cfg-blog-post] for more a global view of the feature.*
+
 Add to the list of expected config names and values that is used when checking
 the _reachable_ cfg expressions.
 
@@ -290,6 +292,7 @@ if foo_bar_condition {
 }
 ```
 
+[check-cfg-blog-post]: https://blog.rust-lang.org/2024/05/06/check-cfg.html
 [option-check-cfg]: ../../rustc/command-line-arguments.md#option-check-cfg
 
 ### `cargo::rustc-env=VAR=VALUE` {#rustc-env}


### PR DESCRIPTION
This PR add more documentation to `cargo::rustc-check-cfg` by:
 1. mentioning `cargo:rustc-check-cfg` for MSRV
 2. it also add a link to [the check-cfg blog post](https://blog.rust-lang.org/2024/05/06/check-cfg.html) (since it gives a big overview of the feature in general)
 3. it also adds a link to the build-script-examples page where a more complete example for the use of `cargo::rustc-cfg` and `cargo::rustc-check-cfg` is displayed

Fixes https://github.com/rust-lang/cargo/issues/13868
r? @weihanglo
