### PR TITLE
Old syntax suggestion

### DIFF
--- a/src/cargo/core/compiler/custom_build.rs
+++ b/src/cargo/core/compiler/custom_build.rs
@@ -737,10 +737,12 @@ impl BuildOutput {
                 let new_syntax_added_in = RustVersion::from_str("1.77.0")?;
                 if !new_syntax_added_in.is_compatible_with(msrv.as_partial()) {
                     let old_syntax_suggestion = if has_reserved_prefix(flag) {
-                        format!("Consider using the old `cargo:` syntax in front of `{flag}`.\n")
+                        format!(
+                            "Switch to the old `cargo:{flag}` syntax (note the single colon).\n"
+                        )
                     } else if flag.starts_with("metadata=") {
                         let old_format_flag = flag.strip_prefix("metadata=").unwrap();
-                        format!("Consider using the old `cargo:{old_format_flag}` syntax instead of `cargo::{flag}` (note the single colon).\n")
+                        format!("Switch to the old `cargo:{old_format_flag}` syntax instead of `cargo::{flag}` (note the single colon).\n")
                     } else {
                         String::new()
                     };

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -5541,7 +5541,7 @@ fn test_new_syntax_with_old_msrv_and_reserved_prefix() {
 [COMPILING] foo [..]
 error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
 but the minimum supported Rust version of `foo v0.5.0 ([ROOT]/foo)` is 1.60.0.
-Consider using the old `cargo:` syntax in front of `rustc-check-cfg=`.
+Consider using the old `cargo:` syntax in front of `rustc-check-cfg=cfg(foo)`.
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
 ",

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -5501,7 +5501,7 @@ fn test_new_syntax_with_old_msrv() {
 [COMPILING] foo [..]
 [ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
 but the minimum supported Rust version of `foo v0.5.0 ([ROOT]/foo)` is 1.60.0.
-Consider using the old `cargo:foo=bar` syntax instead of `cargo::metadata=foo=bar` (note the single colon).
+Switch to the old `cargo:foo=bar` syntax instead of `cargo::metadata=foo=bar` (note the single colon).
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
 ",
@@ -5542,7 +5542,7 @@ fn test_new_syntax_with_old_msrv_and_reserved_prefix() {
 [COMPILING] foo [..]
 [ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
 but the minimum supported Rust version of `foo v0.5.0 ([ROOT]/foo)` is 1.60.0.
-Consider using the old `cargo:` syntax in front of `rustc-check-cfg=cfg(foo)`.
+Switch to the old `cargo:rustc-check-cfg=cfg(foo)` syntax (note the single colon).
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
 ",

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -625,7 +625,7 @@ fn custom_build_invalid_host_config_feature_flag() {
         .with_status(101)
         .with_stderr_contains(
             "\
-error: the -Zhost-config flag requires the -Ztarget-applies-to-host flag to be set
+[ERROR] the -Zhost-config flag requires the -Ztarget-applies-to-host flag to be set
 ",
         )
         .run();
@@ -1038,7 +1038,7 @@ fn links_duplicates() {
 
     p.cargo("build").with_status(101)
                        .with_stderr("\
-error: failed to select a version for `a-sys`.
+[ERROR] failed to select a version for `a-sys`.
     ... required by package `foo v0.5.0 ([..])`
 versions that meet the requirements `*` are: 0.5.0
 
@@ -1163,7 +1163,7 @@ fn links_duplicates_deep_dependency() {
 
     p.cargo("build").with_status(101)
                        .with_stderr("\
-error: failed to select a version for `a-sys`.
+[ERROR] failed to select a version for `a-sys`.
     ... required by package `a v0.5.0 ([..])`
     ... which satisfies path dependency `a` of package `foo v0.5.0 ([..])`
 versions that meet the requirements `*` are: 0.5.0
@@ -4508,7 +4508,7 @@ fn links_duplicates_with_cycle() {
 
     p.cargo("build").with_status(101)
                        .with_stderr("\
-error: failed to select a version for `a`.
+[ERROR] failed to select a version for `a`.
     ... required by package `foo v0.5.0 ([..])`
 versions that meet the requirements `*` are: 0.5.0
 
@@ -5315,7 +5315,7 @@ fn wrong_output() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-error: invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo::example`
+[ERROR] invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo::example`
 Expected a line with `cargo::KEY=VALUE` with an `=` character, but none was found.
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
@@ -5405,7 +5405,7 @@ fn test_invalid_old_syntax() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-error: invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo:foo`
+[ERROR] invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo:foo`
 Expected a line with `cargo:KEY=VALUE` with an `=` character, but none was found.
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
@@ -5434,7 +5434,7 @@ fn test_invalid_new_syntax() {
         .with_stderr(
             "\
 [COMPILING] foo [..]
-error: invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo::metadata=foo`
+[ERROR] invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo::metadata=foo`
 Expected a line with `cargo::metadata=KEY=VALUE` with an `=` character, but none was found.
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
@@ -5459,7 +5459,7 @@ for more information about build script outputs.
         .with_stderr(
             "\
 [COMPILING] foo [..]
-error: invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo::foo=bar`
+[ERROR] invalid output in build script of `foo v0.0.1 ([ROOT]/foo)`: `cargo::foo=bar`
 Unknown key: `foo`.
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
@@ -5499,8 +5499,9 @@ fn test_new_syntax_with_old_msrv() {
         .with_stderr_contains(
             "\
 [COMPILING] foo [..]
-error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
+[ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
 but the minimum supported Rust version of `foo v0.5.0 ([ROOT]/foo)` is 1.60.0.
+Consider using the old `cargo:foo=bar` syntax instead of `cargo::metadata=foo=bar` (note the single colon).
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
 ",
@@ -5539,9 +5540,49 @@ fn test_new_syntax_with_old_msrv_and_reserved_prefix() {
         .with_stderr_contains(
             "\
 [COMPILING] foo [..]
-error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
+[ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
 but the minimum supported Rust version of `foo v0.5.0 ([ROOT]/foo)` is 1.60.0.
 Consider using the old `cargo:` syntax in front of `rustc-check-cfg=cfg(foo)`.
+See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
+for more information about build script outputs.
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn test_new_syntax_with_old_msrv_and_unknown_prefix() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.5.0"
+                edition = "2015"
+                authors = []
+                build = "build.rs"
+                rust-version = "1.60.0"
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .file(
+            "build.rs",
+            r#"
+                fn main() {
+                    println!("cargo::foo=bar");
+                }
+            "#,
+        )
+        .build();
+
+    p.cargo("build")
+        .with_status(101)
+        .with_stderr_contains(
+            "\
+[COMPILING] foo [..]
+[ERROR] the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, \
+but the minimum supported Rust version of `foo v0.5.0 ([ROOT]/foo)` is 1.60.0.
 See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script \
 for more information about build script outputs.
 ",


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fixes #13868.

The build error in the issue will now include a suggestion:

```
   Compiling zerocopy v0.8.0-alpha.9
error: the `cargo::` syntax for build script output instructions was added in Rust 1.77.0, but the minimum supported Rust version of `zerocopy v0.8.0-alpha.9` is 1.56.0.
Consider using the old `cargo:` syntax in front of `rustc-check-cfg=`.
See https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script for more information about build script outputs.
```

The suggestion is only included for reserved prefixes.

A test has been added.