### PR TITLE
test: clean up unnecessary uses of `match_exact`

### DIFF
--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1,7 +1,7 @@
 //! Tests specific to artifact dependencies, designated using
 //! the new `dep = { artifact = "bin", … }` syntax in manifests.
 
-use cargo_test_support::compare::match_exact;
+use cargo_test_support::compare;
 use cargo_test_support::registry::{Package, RegistryBuilder};
 use cargo_test_support::{
     basic_bin_manifest, basic_manifest, cross_compile, project, publish, registry, rustc_host,
@@ -593,9 +593,9 @@ fn build_script_with_bin_artifacts() {
         .run();
 
     let build_script_output = build_script_output_string(&p, "foo");
-    let msg = "we need the binary directory for this artifact along with all binary paths";
+    // we need the binary directory for this artifact along with all binary paths
     if cfg!(target_env = "msvc") {
-        match_exact(
+        compare::assert_match_exact(
             "[..]/artifact/bar-[..]/bin/baz.exe\n\
              [..]/artifact/bar-[..]/staticlib/bar-[..].lib\n\
              [..]/artifact/bar-[..]/cdylib/bar.dll\n\
@@ -603,13 +603,9 @@ fn build_script_with_bin_artifacts() {
              [..]/artifact/bar-[..]/bin/bar.exe\n\
              [..]/artifact/bar-[..]/bin/bar.exe",
             &build_script_output,
-            msg,
-            "",
-            None,
         )
-        .unwrap();
     } else {
-        match_exact(
+        compare::assert_match_exact(
             "[..]/artifact/bar-[..]/bin/baz-[..]\n\
              [..]/artifact/bar-[..]/staticlib/libbar-[..].a\n\
              [..]/artifact/bar-[..]/cdylib/[..]bar.[..]\n\
@@ -617,11 +613,7 @@ fn build_script_with_bin_artifacts() {
              [..]/artifact/bar-[..]/bin/bar-[..]\n\
              [..]/artifact/bar-[..]/bin/bar-[..]",
             &build_script_output,
-            msg,
-            "",
-            None,
         )
-        .unwrap();
     }
 
     assert!(
@@ -783,31 +775,22 @@ fn build_script_with_selected_dashed_bin_artifact_and_lib_true() {
         .run();
 
     let build_script_output = build_script_output_string(&p, "foo");
-    let msg = "we need the binary directory for this artifact and the binary itself";
-
+    // we need the binary directory for this artifact and the binary itself
     if cfg!(target_env = "msvc") {
-        cargo_test_support::compare::match_exact(
+        compare::assert_match_exact(
             &format!(
                 "[..]/artifact/bar-baz-[..]/bin\n\
                  [..]/artifact/bar-baz-[..]/bin/baz_suffix{}",
                 std::env::consts::EXE_SUFFIX,
             ),
             &build_script_output,
-            msg,
-            "",
-            None,
-        )
-        .unwrap();
+        );
     } else {
-        cargo_test_support::compare::match_exact(
+        compare::assert_match_exact(
             "[..]/artifact/bar-baz-[..]/bin\n\
         [..]/artifact/bar-baz-[..]/bin/baz_suffix-[..]",
             &build_script_output,
-            msg,
-            "",
-            None,
-        )
-        .unwrap();
+        );
     }
 
     assert!(
@@ -1757,14 +1740,7 @@ fn allow_dep_renames_with_multiple_versions() {
         .with_stderr_contains("[COMPILING] foo [..]")
         .run();
     let build_script_output = build_script_output_string(&p, "foo");
-    match_exact(
-        "0.5.0\n1.0.0",
-        &build_script_output,
-        "build script output",
-        "",
-        None,
-    )
-    .unwrap();
+    compare::assert_match_exact("0.5.0\n1.0.0", &build_script_output);
 }
 
 #[cargo_test]
@@ -3240,26 +3216,18 @@ fn build_only_specified_artifact_library() {
         .cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
-    match_exact(
+    compare::assert_match_exact(
         "cdylib present: true\nstaticlib present: false",
         &build_script_output_string(&cdylib, "foo"),
-        "build script output",
-        "",
-        None,
-    )
-    .unwrap();
+    );
 
     let staticlib = create_project("staticlib");
     staticlib
         .cargo("build -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .run();
-    match_exact(
+    compare::assert_match_exact(
         "cdylib present: false\nstaticlib present: true",
         &build_script_output_string(&staticlib, "foo"),
-        "build script output",
-        "",
-        None,
-    )
-    .unwrap();
+    );
 }

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -6,7 +6,7 @@ use cargo::util::context::{
 };
 use cargo::CargoResult;
 use cargo_test_support::compare;
-use cargo_test_support::{panic_error, paths, project, symlink_supported, t};
+use cargo_test_support::{paths, project, symlink_supported, t};
 use cargo_util_schemas::manifest::TomlTrimPaths;
 use cargo_util_schemas::manifest::TomlTrimPathsValue;
 use cargo_util_schemas::manifest::{self as cargo_toml, TomlDebugInfo, VecStringOrBool as VSOB};
@@ -222,14 +222,7 @@ pub fn assert_error<E: Borrow<anyhow::Error>>(error: E, msgs: &str) {
         })
         .collect::<Vec<_>>()
         .join("\n\n");
-    assert_match(msgs, &causes);
-}
-
-#[track_caller]
-pub fn assert_match(expected: &str, actual: &str) {
-    if let Err(e) = compare::match_exact(expected, actual, "output", "", None) {
-        panic_error("", e);
-    }
+    compare::assert_match_exact(msgs, &causes);
 }
 
 #[cargo_test]
@@ -297,7 +290,7 @@ f1 = 1
     let expected = "\
 [WARNING] `[ROOT]/.cargo/config` is deprecated in favor of `config.toml`
 [NOTE] if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`";
-    assert_match(expected, &output);
+    compare::assert_match_exact(expected, &output);
 }
 
 #[cargo_test]
@@ -323,7 +316,7 @@ f1 = 1
 
     // It should NOT have warned for the symlink.
     let output = read_output(gctx);
-    assert_match("", &output);
+    compare::assert_match_exact("", &output);
 }
 
 #[cargo_test]
@@ -349,7 +342,7 @@ f1 = 1
 
     // It should NOT have warned for the symlink.
     let output = read_output(gctx);
-    assert_match("", &output);
+    compare::assert_match_exact("", &output);
 }
 
 #[cargo_test]
@@ -375,7 +368,7 @@ f1 = 1
 
     // It should NOT have warned for this situation.
     let output = read_output(gctx);
-    assert_match("", &output);
+    compare::assert_match_exact("", &output);
 }
 
 #[cargo_test]
@@ -405,7 +398,7 @@ f1 = 2
     let expected = "\
 [WARNING] both `[..]/.cargo/config` and `[..]/.cargo/config.toml` exist. Using `[..]/.cargo/config`
 ";
-    assert_match(expected, &output);
+    compare::assert_match_exact(expected, &output);
 }
 
 #[cargo_test]
@@ -439,7 +432,7 @@ unused = 456
     let expected = "\
 warning: unused config key `S.unused` in `[..]/.cargo/config.toml`
 ";
-    assert_match(expected, &output);
+    compare::assert_match_exact(expected, &output);
 }
 
 #[cargo_test]

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -1,10 +1,10 @@
 //! Tests for the --config CLI option.
 
 use super::config::{
-    assert_error, assert_match, read_output, write_config_at, write_config_toml,
-    GlobalContextBuilder,
+    assert_error, read_output, write_config_at, write_config_toml, GlobalContextBuilder,
 };
 use cargo::util::context::Definition;
+use cargo_test_support::compare;
 use cargo_test_support::paths;
 use std::{collections::HashMap, fs};
 
@@ -344,7 +344,7 @@ fn unused_key() {
     let expected = "\
 warning: unused config key `build.unused` in `--config cli option`
 ";
-    assert_match(expected, &output);
+    compare::assert_match_exact(expected, &output);
 }
 
 #[cargo_test]


### PR DESCRIPTION
It was found during the review of <https://github.com/rust-lang/cargo/pull/13842#discussion_r1591789376>

We should be happy using `assert_match_exact` directly.
The extra arguments to `match_exact` are not necessary for those test cases.
