### PR TITLE
Case insensitive file name matching when packaging files

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -4945,7 +4945,6 @@ fn issue_13722_each_file_should_only_be_added_once() {
         .file("src/main.rs", r#"fn main() { println!("hello"); }"#)
         .file("rEaDmE.Md", "")
         .file("lIcEnse", "")
-        .file("cArGo.Lock", "")
         .build();
 
     p.cargo("package").run();


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->

Fixes #13722.

Handles the readme and license files. The `Cargo.lock` file is trickier. There are a bunch of places in the code where the existence of `Cargo.lock` (case sensitive) is checked, including when packaging.

I think it should be OK to keep `Cargo.lock` out of this. While the readme and license files are typically created by the user, the `Cargo.lock` file is typically created by Cargo, hence casing should be consistent anyway.