### PR TITLE
Silence the warning about forgetting the vendoring

### DIFF
--- a/src/cargo/sources/replaced.rs
+++ b/src/cargo/sources/replaced.rs
@@ -152,7 +152,7 @@ impl<'gctx> Source for ReplacedSource<'gctx> {
     }
 
     fn is_replaced(&self) -> bool {
-        true
+        !self.is_builtin_replacement()
     }
 
     fn add_to_yanked_whitelist(&mut self, pkgs: &[PackageId]) {

--- a/src/cargo/sources/source.rs
+++ b/src/cargo/sources/source.rs
@@ -146,6 +146,8 @@ pub trait Source {
     fn describe(&self) -> String;
 
     /// Returns whether a source is being replaced by another here.
+    ///
+    /// Builtin replacement of `crates.io` doesn't count as replacement here.
     fn is_replaced(&self) -> bool {
         false
     }


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
When sparse crates.io is used, dependencies from crates.io always come from `ReplacedSource`s, as the non-sparse crates.io gets replaced by the sparse one. As far as diagnostics go, this case shouldn't "count" as a replaced source.

I had trouble adding a test for this change, because the test harness replaces everything with a dummy registry.

Fixes #12802 
<!-- homu-ignore:end -->
