### PR TITLE
docs: clarify dash replacement rule in target name

### DIFF
--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -151,7 +151,9 @@ The JSON output has the following format:
                     "crate_types": [
                         "bin"
                     ],
-                    /* The name of the target. */
+                    /* The name of the target.
+                       For lib targets, dashes will be replaced with underscores.
+                    */
                     "name": "my-package",
                     /* Absolute path to the root source file of the target. */
                     "src_path": "/path/to/my-package/src/main.rs",

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -147,7 +147,9 @@ OUTPUT FORMAT
                                "crate_types": [
                                    "bin"
                                ],
-                               /* The name of the target. */
+                               /* The name of the target.
+                                  For lib targets, dashes will be replaced with underscores.
+                               */
                                "name": "my-package",
                                /* Absolute path to the root source file of the target. */
                                "src_path": "/path/to/my-package/src/main.rs",

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -151,7 +151,9 @@ The JSON output has the following format:
                     "crate_types": [
                         "bin"
                     ],
-                    /* The name of the target. */
+                    /* The name of the target.
+                       For lib targets, dashes will be replaced with underscores.
+                    */
                     "name": "my-package",
                     /* Absolute path to the root source file of the target. */
                     "src_path": "/path/to/my-package/src/main.rs",

--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -14,9 +14,9 @@ configuring the settings for a target.
 
 The library target defines a "library" that can be used and linked by other
 libraries and executables. The filename defaults to `src/lib.rs`, and the name
-of the library defaults to the name of the package. A package can have only
-one library. The settings for the library can be [customized] in the `[lib]`
-table in `Cargo.toml`.
+of the library defaults to the name of the package, with any dashes replaced
+with underscores. A package can have only one library. The settings for the
+library can be [customized] in the `[lib]` table in `Cargo.toml`.
 
 ```toml
 # Example of customizing the library in Cargo.toml.
@@ -198,9 +198,10 @@ The `name` field specifies the name of the target, which corresponds to the
 filename of the artifact that will be generated. For a library, this is the
 crate name that dependencies will use to reference it.
 
-For the `[lib]` and the default binary (`src/main.rs`), this defaults to the
-name of the package, with any dashes replaced with underscores. For other
-[auto discovered](#target-auto-discovery) targets, it defaults to the
+For the library target, this defaults to the name of the package , with any
+dashes replaced with underscores. For the default binary (`src/main.rs`),
+it also defaults to the name of the package, with no replacement for dashes.
+For [auto discovered](#target-auto-discovery) targets, it defaults to the
 directory or file name.
 
 This is required for all targets except `[lib]`.

--- a/src/doc/src/reference/external-tools.md
+++ b/src/doc/src/reference/external-tools.md
@@ -97,8 +97,10 @@ structure:
         "crate_types": [
             "lib"
         ],
-        /* The name of the target. */
-        "name": "my-package",
+        /* The name of the target.
+           For lib targets, dashes will be replaced with underscores.
+        */
+        "name": "my_package",
         /* Absolute path to the root source file of the target. */
         "src_path": "/path/to/my-package/src/lib.rs",
         /* The Rust edition of the target.
@@ -152,7 +154,7 @@ following structure:
         "crate_types": [
             "lib"
         ],
-        "name": "my-package",
+        "name": "my_package",
         "src_path": "/path/to/my-package/src/lib.rs",
         "edition": "2018",
         "doc": true,

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -645,7 +645,7 @@ The following is a description of the JSON structure:
       "target": {
         "kind": ["lib"],
         "crate_types": ["lib"],
-        "name": "my-package",
+        "name": "my_package",
         "src_path": "/path/to/my-package/src/lib.rs",
         "edition": "2018",
         "test": true,

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -153,7 +153,9 @@ The JSON output has the following format:
                     "crate_types": [
                         "bin"
                     ],
-                    /* The name of the target. */
+                    /* The name of the target.
+                       For lib targets, dashes will be replaced with underscores.
+                    */
                     "name": "my\-package",
                     /* Absolute path to the root source file of the target. */
                     "src_path": "/path/to/my\-package/src/main.rs",


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

A follow-up of <https://github.com/rust-lang/cargo/issues/13867> and <https://github.com/rust-lang/cargo/pull/13882>.

This clarifies that dashes will be replaced in every JSON messages documentation we have.
Also fixes a documentation bug that Cargo in fact doesn't replace dashes for the default binary (`src/main.rs`).

### How should we test and review this PR?

Read the doc and suggest changes.


### Additional information

<!-- homu-ignore:end -->
