### PR TITLE
fix: proc-macro example from dep no longer affects feature resolution

### DIFF
--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -426,10 +426,12 @@ pub struct FeatureResolver<'a, 'gctx> {
     /// If this is `true`, then a non-default `feature_key` needs to be tracked while
     /// traversing the graph.
     ///
-    /// This is only here to avoid calling `is_proc_macro` when all feature
-    /// options are disabled (because `is_proc_macro` can trigger downloads).
-    /// This has to be separate from `FeatureOpts.decouple_host_deps` because
+    /// This is only here to avoid calling [`has_any_proc_macro`] when all feature
+    /// options are disabled (because [`has_any_proc_macro`] can trigger downloads).
+    /// This has to be separate from [`FeatureOpts::decouple_host_deps`] because
     /// `for_host` tracking is also needed for `itarget` to work properly.
+    ///
+    /// [`has_any_proc_macro`]: FeatureResolver::has_any_proc_macro
     track_for_host: bool,
     /// `dep_name?/feat_name` features that will be activated if `dep_name` is
     /// ever activated.
@@ -490,7 +492,7 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
         let member_features = self.ws.members_with_features(specs, cli_features)?;
         for (member, cli_features) in &member_features {
             let fvs = self.fvs_from_requested(member.package_id(), cli_features);
-            let fk = if self.track_for_host && self.is_proc_macro(member.package_id()) {
+            let fk = if self.track_for_host && self.has_any_proc_macro(member.package_id()) {
                 // Also activate for normal dependencies. This is needed if the
                 // proc-macro includes other targets (like binaries or tests),
                 // or running in `cargo test`. Note that in a workspace, if
@@ -852,7 +854,7 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
                         // for various targets which are either specified in the manifest
                         // or on the cargo command-line.
                         let lib_fk = if fk == FeaturesFor::default() {
-                            (self.track_for_host && (dep.is_build() || self.is_proc_macro(dep_id)))
+                            (self.track_for_host && (dep.is_build() || self.has_any_proc_macro(dep_id)))
                                 .then(|| FeaturesFor::HostDep)
                                 .unwrap_or_default()
                         } else {
@@ -957,7 +959,8 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
         }
     }
 
-    fn is_proc_macro(&self, package_id: PackageId) -> bool {
+    /// Whether the given package has any proc macro target, including proc-macro examples.
+    fn has_any_proc_macro(&self, package_id: PackageId) -> bool {
         self.package_set
             .get_one(package_id)
             .expect("packages downloaded")

--- a/src/cargo/core/resolver/features.rs
+++ b/src/cargo/core/resolver/features.rs
@@ -854,7 +854,7 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
                         // for various targets which are either specified in the manifest
                         // or on the cargo command-line.
                         let lib_fk = if fk == FeaturesFor::default() {
-                            (self.track_for_host && (dep.is_build() || self.has_any_proc_macro(dep_id)))
+                            (self.track_for_host && (dep.is_build() || self.has_proc_macro_lib(dep_id)))
                                 .then(|| FeaturesFor::HostDep)
                                 .unwrap_or_default()
                         } else {
@@ -965,5 +965,18 @@ impl<'a, 'gctx> FeatureResolver<'a, 'gctx> {
             .get_one(package_id)
             .expect("packages downloaded")
             .proc_macro()
+    }
+
+    /// Whether the given package is a proc macro lib target.
+    ///
+    /// This is useful for checking if a dependency is a proc macro,
+    /// as it is not possible to depend on a non-lib target as a proc-macro.
+    fn has_proc_macro_lib(&self, package_id: PackageId) -> bool {
+        self.package_set
+            .get_one(package_id)
+            .expect("packages downloaded")
+            .library()
+            .map(|lib| lib.proc_macro())
+            .unwrap_or_default()
     }
 }

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -2686,9 +2686,13 @@ fn dont_unify_proc_macro_example_from_dependency() {
         .build();
 
     p.cargo("check")
-        .with_status(101)
-        .with_stderr_contains(
-            "[..]activated_features for invalid package: features did not find PackageId [..]pm_helper[..]NormalOrDev[..]"
+        .with_stderr(
+            "\
+[LOCKING] 2 packages to latest compatible versions
+[CHECKING] pm_helper v0.0.0 ([CWD]/pm_helper)
+[CHECKING] foo v0.0.0 ([CWD])
+[FINISHED] `dev` [..]
+",
         )
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Previously when checking if a dependency is a proc-macro,
the v2 feature resolver for `proc-macro = true`
for every target of the dependency.
However, it's impossible to depend on a non-lib target as a proc-macro.

This fix switches to only check if `proc-macro = true` for `[lib]`
target for a dependency.

Fixes <https://github.com/rust-lang/cargo/issues/13726>.
 
### How should we test and review this PR?

Best reviewed commit-by-commit.

### Additional information

I didn't really fix the discrepancy between the behavior of example lib and the documentation, which was mentioned in <https://github.com/rust-lang/cargo/issues/13726#issuecomment-2101941480>.

Thanks @torhovland for the minimal test case.
<!-- homu-ignore:end -->
