### PR TITLE
Fix docs for unstable script feature

### DIFF
--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1239,10 +1239,10 @@ fn main() {}
 A user may optionally specify a manifest in a `cargo` code fence in a module-level comment, like:
 ````rust
 #!/usr/bin/env -S cargo +nightly -Zscript
-```cargo
+---cargo
 [dependencies]
 clap = { version = "4.2", features = ["derive"] }
-```
+---
 
 use clap::Parser;
 


### PR DESCRIPTION
### What does this PR try to resolve?
* [Recent change](https://github.com/rust-lang/cargo/pull/13861) to accepted syntax in the script feature is not reflected in the documentation.

### How should we test and review this PR?
* Verify that this documentation is consistent with syntax expected.

### Additional information
N/A
