### PR TITLE
fix(toml): remove `lib.plugin` key support and make it warning

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1223,7 +1223,6 @@ pub struct TomlTarget {
     pub doctest: Option<bool>,
     pub bench: Option<bool>,
     pub doc: Option<bool>,
-    pub plugin: Option<bool>,
     pub doc_scrape_examples: Option<bool>,
     pub proc_macro: Option<bool>,
     #[serde(rename = "proc_macro")]

--- a/src/cargo/core/manifest.rs
+++ b/src/cargo/core/manifest.rs
@@ -905,7 +905,7 @@ impl Target {
     pub fn documented(&self) -> bool {
         self.inner.doc
     }
-    // A plugin, proc-macro, or build-script.
+    // A proc-macro or build-script.
     pub fn for_host(&self) -> bool {
         self.inner.for_host
     }

--- a/src/cargo/util/toml/targets.rs
+++ b/src/cargo/util/toml/targets.rs
@@ -188,17 +188,6 @@ fn to_lib_target(
     let path = lib.path.as_ref().expect("previously resolved");
     let path = package_root.join(&path.0);
 
-    if lib.plugin == Some(true) {
-        warnings.push(format!(
-            "support for rustc plugins has been removed from rustc. \
-            library `{}` should not specify `plugin = true`",
-            name_or_panic(lib)
-        ));
-        warnings.push(format!(
-            "support for `plugin = true` will be removed from cargo in the future"
-        ));
-    }
-
     // Per the Macros 1.1 RFC:
     //
     // > Initially if a crate is compiled with the `proc-macro` crate type
@@ -208,8 +197,8 @@ fn to_lib_target(
     //
     // A plugin requires exporting plugin_registrar so a crate cannot be
     // both at once.
-    let crate_types = match (lib.crate_types(), lib.plugin, lib.proc_macro()) {
-        (Some(kinds), _, _)
+    let crate_types = match (lib.crate_types(), lib.proc_macro()) {
+        (Some(kinds), _)
             if kinds.contains(&CrateType::Dylib.as_str().to_owned())
                 && kinds.contains(&CrateType::Cdylib.as_str().to_owned()) =>
         {
@@ -218,14 +207,7 @@ fn to_lib_target(
                 name_or_panic(lib)
             ));
         }
-        (Some(kinds), _, _) if kinds.contains(&"proc-macro".to_string()) => {
-            if let Some(true) = lib.plugin {
-                // This is a warning to retain backwards compatibility.
-                warnings.push(format!(
-                    "proc-macro library `{}` should not specify `plugin = true`",
-                    name_or_panic(lib)
-                ));
-            }
+        (Some(kinds), _) if kinds.contains(&"proc-macro".to_string()) => {
             warnings.push(format!(
                 "library `{}` should only specify `proc-macro = true` instead of setting `crate-type`",
                 name_or_panic(lib)
@@ -235,13 +217,9 @@ fn to_lib_target(
             }
             vec![CrateType::ProcMacro]
         }
-        (_, Some(true), Some(true)) => {
-            anyhow::bail!("`lib.plugin` and `lib.proc-macro` cannot both be `true`")
-        }
-        (Some(kinds), _, _) => kinds.iter().map(|s| s.into()).collect(),
-        (None, Some(true), _) => vec![CrateType::Dylib],
-        (None, _, Some(true)) => vec![CrateType::ProcMacro],
-        (None, _, _) => vec![CrateType::Lib],
+        (Some(kinds), _) => kinds.iter().map(|s| s.into()).collect(),
+        (None, Some(true)) => vec![CrateType::ProcMacro],
+        (None, _) => vec![CrateType::Lib],
     };
 
     let mut target = Target::lib_target(name_or_panic(lib), crate_types, path, edition);
@@ -863,11 +841,8 @@ fn configure(toml: &TomlTarget, target: &mut Target) -> CargoResult<()> {
             Some(false) => RustdocScrapeExamples::Disabled,
             Some(true) => RustdocScrapeExamples::Enabled,
         })
-        .set_for_host(match (toml.plugin, toml.proc_macro()) {
-            (None, None) => t2.for_host(),
-            (Some(true), _) | (_, Some(true)) => true,
-            (Some(false), _) | (_, Some(false)) => false,
-        });
+        .set_for_host(toml.proc_macro().unwrap_or_else(|| t2.for_host()));
+
     if let Some(edition) = toml.edition.clone() {
         target.set_edition(
             edition

--- a/src/doc/src/reference/cargo-targets.md
+++ b/src/doc/src/reference/cargo-targets.md
@@ -184,7 +184,6 @@ test = true            # Is tested by default.
 doctest = true         # Documentation examples are tested by default.
 bench = true           # Is benchmarked by default.
 doc = true             # Is documented by default.
-plugin = false         # Used as a compiler plugin (deprecated).
 proc-macro = false     # Set to `true` for a proc-macro library.
 harness = true         # Use libtest harness.
 edition = "2015"       # The edition of the target.
@@ -247,7 +246,7 @@ libraries and binaries.
 
 ### The `plugin` field
 
-This field is used for `rustc` plugins, which are being deprecated.
+This option is deprecated and unused.
 
 ### The `proc-macro` field
 

--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -299,7 +299,7 @@ Cargo includes the following paths:
   Cargo to properly set the environment if additional libraries on the system
   are needed in the search path.
 * The base output directory, such as `target/debug`, and the "deps" directory.
-  This is mostly for legacy support of `rustc` compiler plugins.
+  This is mostly for support of proc-macros.
 * The rustc sysroot library path. This generally is not important to most
   users.
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -2178,61 +2178,6 @@ fn shared_dep_with_a_build_script() {
 }
 
 #[cargo_test]
-fn transitive_dep_host() {
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.5.0"
-                edition = "2015"
-                authors = []
-                build = "build.rs"
-
-                [build-dependencies.b]
-                path = "b"
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .file("build.rs", "fn main() {}")
-        .file(
-            "a/Cargo.toml",
-            r#"
-                [package]
-                name = "a"
-                version = "0.5.0"
-                edition = "2015"
-                authors = []
-                links = "foo"
-                build = "build.rs"
-            "#,
-        )
-        .file("a/build.rs", "fn main() {}")
-        .file("a/src/lib.rs", "")
-        .file(
-            "b/Cargo.toml",
-            r#"
-                [package]
-                name = "b"
-                version = "0.5.0"
-                edition = "2015"
-                authors = []
-
-                [lib]
-                name = "b"
-                plugin = true
-
-                [dependencies.a]
-                path = "../a"
-            "#,
-        )
-        .file("b/src/lib.rs", "")
-        .build();
-    p.cargo("build").run();
-}
-
-#[cargo_test]
 fn test_a_lib_with_a_build_command() {
     let p = project()
         .file(

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -884,47 +884,6 @@ fn build_script_only_host() {
 }
 
 #[cargo_test]
-fn plugin_build_script_right_arch() {
-    if cross_compile::disabled() {
-        return;
-    }
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-                edition = "2015"
-                authors = []
-                build = "build.rs"
-
-                [lib]
-                name = "foo"
-                plugin = true
-            "#,
-        )
-        .file("build.rs", "fn main() {}")
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("build -v --target")
-        .arg(cross_compile::alternate())
-        .with_stderr(
-            "\
-[WARNING] support for rustc plugins has been removed from rustc. library `foo` should not specify `plugin = true`
-[WARNING] support for `plugin = true` will be removed from cargo in the future
-[COMPILING] foo v0.0.1 ([..])
-[RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[..]/build-script-build`
-[RUNNING] `rustc [..] src/lib.rs [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
-        .run();
-}
-
-#[cargo_test]
 fn build_script_with_platform_specific_dependencies() {
     if cross_compile::disabled() {
         return;

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -346,6 +346,28 @@ fn proc_macro_crate_type_warning() {
 }
 
 #[cargo_test]
+fn lib_plugin_unused_key_warning() {
+    let foo = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+                [lib]
+                plugin = true
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    foo.cargo("check")
+        .with_stderr_contains("[WARNING] unused manifest key: lib.plugin")
+        .run();
+}
+
+#[cargo_test]
 fn proc_macro_crate_type_warning_plugin() {
     let foo = project()
         .file(
@@ -357,23 +379,15 @@ fn proc_macro_crate_type_warning_plugin() {
                 edition = "2015"
                 [lib]
                 crate-type = ["proc-macro"]
-                plugin = true
             "#,
         )
         .file("src/lib.rs", "")
         .build();
 
     foo.cargo("check")
-        .with_stderr_contains(
-            "[WARNING] support for rustc plugins has been removed from rustc. \
-            library `foo` should not specify `plugin = true`")
-        .with_stderr_contains(
-            "[WARNING] support for `plugin = true` will be removed from cargo in the future")
-        .with_stderr_contains(
-            "[WARNING] proc-macro library `foo` should not specify `plugin = true`")
-        .with_stderr_contains(
-            "[WARNING] library `foo` should only specify `proc-macro = true` instead of setting `crate-type`")
-        .run();
+    .with_stderr_contains(
+        "[WARNING] library `foo` should only specify `proc-macro = true` instead of setting `crate-type`")
+    .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1,9 +1,7 @@
 //! Tests for setting custom rustc flags.
 
 use cargo_test_support::registry::Package;
-use cargo_test_support::{
-    basic_lib_manifest, basic_manifest, paths, project, project_in_home, rustc_host,
-};
+use cargo_test_support::{basic_manifest, paths, project, project_in_home, rustc_host};
 use std::fs;
 
 #[cargo_test]
@@ -101,76 +99,6 @@ fn env_rustflags_build_script_dep() {
     let _bar = project()
         .at("bar")
         .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
-        .file(
-            "src/lib.rs",
-            r#"
-                fn bar() { }
-                #[cfg(not(foo))]
-                fn bar() { }
-            "#,
-        )
-        .build();
-
-    foo.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
-}
-
-#[cargo_test]
-fn env_rustflags_plugin() {
-    // RUSTFLAGS should be passed to rustc for plugins
-    // when --target is not specified.
-    // In this test if --cfg foo is not passed the build will fail.
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-            "#,
-        )
-        .file(
-            "src/lib.rs",
-            r#"
-                fn main() { }
-                #[cfg(not(foo))]
-                fn main() { }
-            "#,
-        )
-        .build();
-
-    p.cargo("check").env("RUSTFLAGS", "--cfg foo").run();
-}
-
-#[cargo_test]
-fn env_rustflags_plugin_dep() {
-    // RUSTFLAGS should be passed to rustc for plugins
-    // when --target is not specified.
-    // In this test if --cfg foo is not passed the build will fail.
-    let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-
-                [dependencies.bar]
-                path = "../bar"
-            "#,
-        )
-        .file("src/lib.rs", "fn foo() {}")
-        .build();
-    let _bar = project()
-        .at("bar")
-        .file("Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "src/lib.rs",
             r#"
@@ -328,84 +256,6 @@ fn env_rustflags_build_script_dep_with_target() {
     let _bar = project()
         .at("bar")
         .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
-        .file(
-            "src/lib.rs",
-            r#"
-                fn bar() { }
-                #[cfg(foo)]
-                fn bar() { }
-            "#,
-        )
-        .build();
-
-    let host = rustc_host();
-    foo.cargo("check --target")
-        .arg(host)
-        .env("RUSTFLAGS", "--cfg foo")
-        .run();
-}
-
-#[cargo_test]
-fn env_rustflags_plugin_with_target() {
-    // RUSTFLAGS should not be passed to rustc for plugins
-    // when --target is specified.
-    // In this test if --cfg foo is passed the build will fail.
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-            "#,
-        )
-        .file(
-            "src/lib.rs",
-            r#"
-                fn main() { }
-                #[cfg(foo)]
-                fn main() { }
-            "#,
-        )
-        .build();
-
-    let host = rustc_host();
-    p.cargo("check --target")
-        .arg(host)
-        .env("RUSTFLAGS", "--cfg foo")
-        .run();
-}
-
-#[cargo_test]
-fn env_rustflags_plugin_dep_with_target() {
-    // RUSTFLAGS should not be passed to rustc for plugins
-    // when --target is specified.
-    // In this test if --cfg foo is passed the build will fail.
-    let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-
-                [dependencies.bar]
-                path = "../bar"
-            "#,
-        )
-        .file("src/lib.rs", "fn foo() {}")
-        .build();
-    let _bar = project()
-        .at("bar")
-        .file("Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "src/lib.rs",
             r#"
@@ -584,90 +434,6 @@ fn build_rustflags_build_script_dep() {
 }
 
 #[cargo_test]
-fn build_rustflags_plugin() {
-    // RUSTFLAGS should be passed to rustc for plugins
-    // when --target is not specified.
-    // In this test if --cfg foo is not passed the build will fail.
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-            "#,
-        )
-        .file(
-            "src/lib.rs",
-            r#"
-                fn main() { }
-                #[cfg(not(foo))]
-                fn main() { }
-            "#,
-        )
-        .file(
-            ".cargo/config.toml",
-            r#"
-            [build]
-            rustflags = ["--cfg", "foo"]
-            "#,
-        )
-        .build();
-
-    p.cargo("check").run();
-}
-
-#[cargo_test]
-fn build_rustflags_plugin_dep() {
-    // RUSTFLAGS should be passed to rustc for plugins
-    // when --target is not specified.
-    // In this test if --cfg foo is not passed the build will fail.
-    let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-
-                [dependencies.bar]
-                path = "../bar"
-            "#,
-        )
-        .file("src/lib.rs", "fn foo() {}")
-        .file(
-            ".cargo/config.toml",
-            r#"
-            [build]
-            rustflags = ["--cfg", "foo"]
-            "#,
-        )
-        .build();
-    let _bar = project()
-        .at("bar")
-        .file("Cargo.toml", &basic_lib_manifest("bar"))
-        .file(
-            "src/lib.rs",
-            r#"
-                fn bar() { }
-                #[cfg(not(foo))]
-                fn bar() { }
-            "#,
-        )
-        .build();
-
-    foo.cargo("check").run();
-}
-
-#[cargo_test]
 fn build_rustflags_normal_source_with_target() {
     let p = project()
         .file("src/lib.rs", "")
@@ -786,92 +552,6 @@ fn build_rustflags_build_script_dep_with_target() {
     let _bar = project()
         .at("bar")
         .file("Cargo.toml", &basic_manifest("bar", "0.0.1"))
-        .file(
-            "src/lib.rs",
-            r#"
-                fn bar() { }
-                #[cfg(foo)]
-                fn bar() { }
-            "#,
-        )
-        .build();
-
-    let host = rustc_host();
-    foo.cargo("check --target").arg(host).run();
-}
-
-#[cargo_test]
-fn build_rustflags_plugin_with_target() {
-    // RUSTFLAGS should not be passed to rustc for plugins
-    // when --target is specified.
-    // In this test if --cfg foo is passed the build will fail.
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-            "#,
-        )
-        .file(
-            "src/lib.rs",
-            r#"
-                fn main() { }
-                #[cfg(foo)]
-                fn main() { }
-            "#,
-        )
-        .file(
-            ".cargo/config.toml",
-            r#"
-            [build]
-            rustflags = ["--cfg", "foo"]
-            "#,
-        )
-        .build();
-
-    let host = rustc_host();
-    p.cargo("check --target").arg(host).run();
-}
-
-#[cargo_test]
-fn build_rustflags_plugin_dep_with_target() {
-    // RUSTFLAGS should not be passed to rustc for plugins
-    // when --target is specified.
-    // In this test if --cfg foo is passed the build will fail.
-    let foo = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.0.1"
-
-                [lib]
-                name = "foo"
-                plugin = true
-
-                [dependencies.bar]
-                path = "../bar"
-            "#,
-        )
-        .file("src/lib.rs", "fn foo() {}")
-        .file(
-            ".cargo/config.toml",
-            r#"
-            [build]
-            rustflags = ["--cfg", "foo"]
-            "#,
-        )
-        .build();
-    let _bar = project()
-        .at("bar")
-        .file("Cargo.toml", &basic_lib_manifest("bar"))
         .file(
             "src/lib.rs",
             r#"


### PR DESCRIPTION
### What does this PR try to resolve?

Remove `lib.plugin` key, making it an "unused key" warning.

Remove some of the tests, which should look useless (I hope I'm understanding this 

- [x] Remove key, and related tests.
- [x] Adjust the documentation about the plugin.
- [ ] Some of the comments and function names have not yet finished being modified.

part of #13629

Closes #13246 