### PR TITLE
fix: support IPv6-only network for cargo fix

### DIFF
--- a/src/cargo/util/diagnostic_server.rs
+++ b/src/cargo/util/diagnostic_server.rs
@@ -16,6 +16,7 @@ use tracing::warn;
 
 use crate::core::Edition;
 use crate::util::errors::CargoResult;
+use crate::util::network::LOCALHOST;
 use crate::util::GlobalContext;
 
 const DIAGNOSTICS_SERVER_VAR: &str = "__CARGO_FIX_DIAGNOSTICS_SERVER";
@@ -266,7 +267,7 @@ pub struct StartedServer {
 
 impl RustfixDiagnosticServer {
     pub fn new() -> Result<Self, Error> {
-        let listener = TcpListener::bind("127.0.0.1:0")
+        let listener = TcpListener::bind(&LOCALHOST[..])
             .with_context(|| "failed to bind TCP listener to manage locking")?;
         let addr = listener.local_addr()?;
 

--- a/src/cargo/util/lockserver.rs
+++ b/src/cargo/util/lockserver.rs
@@ -20,6 +20,8 @@ use std::thread::{self, JoinHandle};
 
 use anyhow::{Context, Error};
 
+use crate::util::network::LOCALHOST;
+
 pub struct LockServer {
     listener: TcpListener,
     addr: SocketAddr,
@@ -44,7 +46,7 @@ struct ServerClient {
 
 impl LockServer {
     pub fn new() -> Result<LockServer, Error> {
-        let listener = TcpListener::bind("127.0.0.1:0")
+        let listener = TcpListener::bind(&LOCALHOST[..])
             .with_context(|| "failed to bind TCP listener to manage locking")?;
         let addr = listener.local_addr()?;
         Ok(LockServer {

--- a/src/cargo/util/network/mod.rs
+++ b/src/cargo/util/network/mod.rs
@@ -1,11 +1,22 @@
 //! Utilities for networking.
 
+use std::net::Ipv4Addr;
+use std::net::Ipv6Addr;
+use std::net::SocketAddr;
+use std::net::SocketAddrV4;
+use std::net::SocketAddrV6;
 use std::task::Poll;
 
 pub mod http;
 pub mod proxy;
 pub mod retry;
 pub mod sleep;
+
+/// LOCALHOST constants for both IPv4 and IPv6.
+pub const LOCALHOST: [SocketAddr; 2] = [
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
+    SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0)),
+];
 
 pub trait PollExt<T> {
     fn expect(self, msg: &str) -> T;


### PR DESCRIPTION


<!-- homu-ignore:start -->

### What does this PR try to resolve?

To coordinate diagnositcs between different cargo-as-rustc-proxies,
`cargo fix` launches a diagnostc server on localhost.
However, the TCP server was hard-coded with an IPv4 address 127.0.0.1,
which didn't work with IPv6-only network.

This commit fixes the issue by attempting to bind both IPv4 and IPv6
localhost addessses.

Fixes #13906

### How should we test and review this PR?

I have no idea how to test it. Maybe in Docker follow the [IPv6 network setup guide](https://docs.docker.com/config/daemon/ipv6/), and disable IPv4 stack? Or create a VM that is completely IPv6-only.

I've manually tested it on a macbook. Use at your on risk:

```console
$ ifconfig lo0
# make sure lo0 have both IPv4 and IPv6, and back up if needed
$ ifconfig lo0 inet delete
$ cargo clippy --fix # the original cargo should fail; this patch should pass
$ ifconfig lo0 inet 127.0.0.1 # restore
```

### Additional information
<!-- homu-ignore:end -->
