### PR TITLE
Using the latest `glob` crate to adapt to the patterns with `windows verbatim DISK prefix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,8 +1852,7 @@ dependencies = [
 [[package]]
 name = "glob"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+source = "git+https://github.com/rust-lang/glob.git?rev=47c0cf3d03c56608f4371a3a832ec752c1af328f#47c0cf3d03c56608f4371a3a832ec752c1af328f"
 
 [[package]]
 name = "globset"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ flate2 = { version = "1.0.30", default-features = false, features = ["zlib"] }
 git2 = "0.18.3"
 git2-curl = "0.19.0"
 gix = { version = "0.62.0", default-features = false, features = ["blocking-http-transport-curl", "progress-tree", "revision", "parallel", "dirwalk"] }
-glob = "0.3.1"
+glob = { git = "https://github.com/rust-lang/glob.git", rev = "47c0cf3d03c56608f4371a3a832ec752c1af328f" }
 handlebars = { version = "5.1.2", features = ["dir_source"] }
 hex = "0.4.3"
 hmac = "0.12.1"

--- a/tests/testsuite/cargo_metadata/help/mod.rs
+++ b/tests/testsuite/cargo_metadata/help/mod.rs
@@ -12,3 +12,26 @@ fn case() {
         .stdout_matches(file!["stdout.term.svg"])
         .stderr_matches(str![""]);
 }
+
+#[cfg(windows)]
+#[cargo_test]
+fn windows_verbatim_disk_case() {
+    // `canonicalize` func on Windows will return a path starts with `r"\\?\"`,
+    // which is called as `Verbatim disk prefix`.
+    // See: https://doc.rust-lang.org/std/path/enum.Prefix.html#variant.VerbatimDisk
+    snapbox::cmd::Command::cargo_ui()
+        .arg("metadata")
+        .args([
+            "--manifest-path",
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("Cargo.toml")
+                .canonicalize()
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "--no-deps",
+            "--offline",
+        ])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
Hi guys.

I had installed the [cargo_modules](https://crates.io/crates/cargo-modules) crate which can support to use the `cargo modules` subcommand to fetch the project's metadata.

And I had pulled down the `rust-lang/cargo` repo's sourcecodes, and I exec `cargo modules structure` under this repo (🤣Indeliberately), and I got an error:
![image](https://github.com/rust-lang/cargo/assets/24818903/2c47784e-7c97-4409-a290-161cd8621f46)

![image](https://github.com/rust-lang/cargo/assets/24818903/ecc08f8a-8146-49b7-96b9-1b4ebbbbb6c0)

The error indicates it fails to read the sub crates `crates/*`'s metadata.

Hmmmm... Seems something wrong with the `glob-like` patterns.

After debugged the [cargo_modules](https://github.com/regexident/cargo-modules)'s source code and `cargo`'s source code, finally I found this is an issue of the crate [glob](https://crates.io/crates/glob) on windows only, it fails to get the valid sub paths from invoking `glob(r"\\?\E:\Codes\Source\cargo\crates\*\Cargo.toml")`, the pattern's prefix is called [VerbatimDisk characters](https://doc.rust-lang.org/std/path/enum.Prefix.html#variant.VerbatimDisk).


After debugged the source codes of the crate `glob`: [repo](https://github.com/rust-lang/glob), I did some fixes about it but finally I found the sourcecodes do already fixed this issue in this [commit](https://github.com/rust-lang/glob/commit/b9184052271d500fb1cbcb52a7201fddead6711f) in the past year.

So I updated the `cargo`'s `Cargo.toml` to point out the `glob`'s rev.

If someday the `glob` crate had a newer version, e.g. `0.3.2` with the latest sourcodes, we can back to use the semver of it in the `Cargo.toml` file😉.

BTW, I had rose up an [issue](https://github.com/rust-lang/glob/issues/145) to notice the `glob` team to publish a newer version.
