### PR TITLE
Support OUT_DIR located in `\\?\` path on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,9 +5,12 @@ use std::path::Path;
 use std::process::Command;
 
 fn main() {
+    println!("cargo:rustc-check-cfg=cfg(host_os, values(\"windows\"))");
+
     commit_info();
     compress_man();
     windows_manifest();
+
     // ALLOWED: Accessing environment during build time shouldn't be prohibited.
     #[allow(clippy::disallowed_methods)]
     let target = std::env::var("TARGET").unwrap();
@@ -45,6 +48,13 @@ fn compress_man() {
     add_files(Path::new("src/doc/man/generated_txt"), OsStr::new("txt"));
     let encoder = ar.into_inner().unwrap();
     encoder.finish().unwrap();
+
+    // ALLOWED: Accessing environment during build time shouldn't be prohibited.
+    #[allow(clippy::disallowed_methods)]
+    let host = std::env::var("HOST").unwrap();
+    if let Some("windows") = host.split('-').nth(2) {
+        println!("cargo:rustc-cfg=host_os=\"windows\"");
+    }
 }
 
 struct CommitInfo {

--- a/src/bin/cargo/commands/help.rs
+++ b/src/bin/cargo/commands/help.rs
@@ -10,7 +10,11 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
+#[cfg(not(host_os = "windows"))]
 const COMPRESSED_MAN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/man.tgz"));
+
+#[cfg(host_os = "windows")]
+const COMPRESSED_MAN: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "\\man.tgz"));
 
 pub fn cli() -> Command {
     subcommand("help")


### PR DESCRIPTION
### What does this PR try to resolve?

See https://github.com/rust-lang/rust/issues/75075. If cargo.exe is compiled on Windows with a target dir that begins with "\\\\?\\", the build fails with an error similar to the one seen in https://github.com/tokio-rs/tokio/actions/runs/9075609753/job/24936610110.

```console
error: couldn't read \\?\D:\a\tokio\tokio\target\debug\build\rustversion-2d44b26e828f2c8d\out/version.expr: The filename, directory name, or volume label syntax is incorrect. (os error 123)
   --> C:\Users\runneradmin/.cargo\registry\src\index.crates.io-6f17d22bba15001f\rustversion-1.0.16\src/lib.rs:186:30
    |
186 | const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.expr"));
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Normally in Windows paths `/` works just as well as `\`, but from [Maximum Path Length Limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation): _File I/O functions in the Windows API convert "/" to "\\" as part of converting the name to an NT-style name, **except when using the "\\\\?\\" prefix** as detailed in the following sections_.

### How should we test and review this PR?

This should be "if it compiles, it works" and Cargo's CI already has coverage on Windows. We can look into what Tokio's CI was doing to trigger the "\\\\?\\" case in GitHub Actions and try to reproduce it in Cargo's CI if desired.

### Additional information

Future work: I hope that someone can make a successful proposal for something like `include_bytes!(concat!(env!("OUT_DIR") / "man.tgz"))` that works in a cross-platform manner by using the correct path separator for rustc's host OS.