### PR TITLE
Verify build-std resolve against original lockfile

### DIFF
--- a/src/cargo/core/resolver/encode.rs
+++ b/src/cargo/core/resolver/encode.rs
@@ -406,6 +406,10 @@ impl EncodableResolve {
             HashMap::new(),
         ))
     }
+
+    pub fn package(&self) -> Option<&Vec<EncodableDependency>> {
+        self.package.as_ref()
+    }
 }
 
 fn build_path_deps(ws: &Workspace<'_>) -> CargoResult<HashMap<String, SourceId>> {
@@ -487,6 +491,20 @@ pub struct EncodableDependency {
     checksum: Option<String>,
     dependencies: Option<Vec<EncodablePackageId>>,
     replace: Option<EncodablePackageId>,
+}
+
+impl EncodableDependency {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    pub fn dependencies(&self) -> Option<&Vec<EncodablePackageId>> {
+        self.dependencies.as_ref()
+    }
 }
 
 /// Pretty much equivalent to [`SourceId`] with a different serialization method.
@@ -572,6 +590,16 @@ pub struct EncodablePackageId {
     name: String,
     version: Option<String>,
     source: Option<EncodableSourceId>,
+}
+
+impl EncodablePackageId {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_ref().map(String::as_str)
+    }
 }
 
 impl fmt::Display for EncodablePackageId {

--- a/src/cargo/core/workspace.rs
+++ b/src/cargo/core/workspace.rs
@@ -622,6 +622,11 @@ impl<'gctx> Workspace<'gctx> {
         self.is_ephemeral
     }
 
+    pub fn set_ephemeral(&mut self, is_ephemeral: bool) -> &mut Workspace<'gctx> {
+        self.is_ephemeral = is_ephemeral;
+        self
+    }
+
     pub fn require_optional_deps(&self) -> bool {
         self.require_optional_deps
     }

--- a/tests/testsuite/mock-std/Cargo.lock
+++ b/tests/testsuite/mock-std/Cargo.lock
@@ -1,0 +1,97 @@
+# This file was handwritten.
+version = 3
+
+[[package]]
+name = "alloc"
+version = "0.1.0"
+dependencies = [
+ "core",
+ "registry-dep-using-core"
+]
+
+[[package]]
+name = "compiler_builtins"
+version = "0.1.0"
+
+[[package]]
+name = "core"
+version = "0.1.0"
+
+[[package]]
+name = "panic_unwind"
+version = "0.1.0"
+
+[[package]]
+name = "proc_macro"
+version = "0.1.0"
+
+[[package]]
+name = "registry-dep-using-alloc"
+version = "1.0.0"
+dependencies = [
+ "rustc-std-workspace-alloc",
+ "rustc-std-workspace-core"
+]
+
+[[package]]
+name = "registry-dep-using-core"
+version = "1.0.0"
+dependencies = [
+ "rustc-std-workspace-core"
+]
+
+[[package]]
+name = "registry-dep-using-std"
+version = "1.0.0"
+dependencies = [
+ "rustc-std-workspace-std",
+]
+
+[[package]]
+name = "rustc-std-workspace-alloc"
+version = "1.9.0"
+dependencies = [
+ "alloc"
+]
+
+[[package]]
+name = "rustc-std-workspace-core"
+version = "1.9.0"
+dependencies = [
+ "core"
+]
+
+[[package]]
+name = "rustc-std-workspace-std"
+version = "1.9.0"
+dependencies = [
+ "std"
+]
+
+[[package]]
+name = "std"
+version = "0.1.0"
+dependencies = [
+ "alloc",
+ "registry-dep-using-alloc"
+]
+
+[[package]]
+name = "sysroot"
+version = "0.1.0"
+dependencies = [
+  "proc_macro",
+  "std",
+  "test"
+]
+
+[[package]]
+name = "test"
+version = "0.1.0"
+dependencies = [
+ "compiler_builtins",
+ "panic_unwind",
+ "std",
+ "registry-dep-using-std"
+]
+

--- a/tests/testsuite/mock-std/library/alloc/Cargo.toml
+++ b/tests/testsuite/mock-std/library/alloc/Cargo.toml
@@ -5,4 +5,5 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
+core = { path = "../core" }
 registry-dep-using-core = { version = "*", features = ['mockbuild'] }

--- a/tests/testsuite/mock-std/library/std/Cargo.toml
+++ b/tests/testsuite/mock-std/library/std/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 
 [dependencies]
+alloc = { path = "../alloc" }
 registry-dep-using-alloc = { version = "*", features = ['mockbuild'] }
 
 [features]


### PR DESCRIPTION
### What does this PR try to resolve?

Ensures that the resolve of the standard library when using build-std is a subset of the lockfile from the library source, as per discussion on [rust-lang/wg-cargo-std-aware#38](https://github.com/rust-lang/wg-cargo-std-aware/issues/38). It is a runtime version of the test added here: https://github.com/rust-lang/cargo/pull/13404

Fixes https://github.com/rust-lang/wg-cargo-std-aware/issues/38

### How should we test and review this PR?

It can be manually tested by running cargo build -Zbuild-std --target=[host] and seeing the command succeed. I'm not sure what behaviour can exercise the negative test case.

### Additional information

Co-authored-by: Lawrence Tang [lawrence.tang@arm.com](mailto:lawrence.tang@arm.com)