### PR TITLE
refactor: misc refactors for `ops::resolve`

### DIFF
--- a/src/cargo/core/resolver/resolve.rs
+++ b/src/cargo/core/resolver/resolve.rs
@@ -205,7 +205,7 @@ impl Resolve {
         self.graph.path_to_top(pkg)
     }
 
-    pub fn register_used_patches(&mut self, patches: &[Summary]) {
+    pub fn register_used_patches<'a>(&mut self, patches: impl Iterator<Item = &'a Summary>) {
         for summary in patches {
             if !self.graph.contains(&summary.package_id()) {
                 self.unused_patches.push(summary.package_id())

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -416,7 +416,6 @@ pub fn resolve_with_previous<'gctx>(
         None => root_replace.to_vec(),
     };
 
-    ws.preload(registry);
     let mut resolved = resolver::resolve(
         &summaries,
         &replace,

--- a/src/cargo/ops/resolve.rs
+++ b/src/cargo/ops/resolve.rs
@@ -412,12 +412,9 @@ pub fn resolve_with_previous<'gctx>(
         ResolveVersion::with_rust_version(ws.rust_version()),
         Some(ws.gctx()),
     )?;
-    let patches: Vec<_> = registry
-        .patches()
-        .values()
-        .flat_map(|v| v.iter().cloned())
-        .collect();
-    resolved.register_used_patches(&patches[..]);
+
+    let patches = registry.patches().values().flat_map(|v| v.iter());
+    resolved.register_used_patches(patches);
 
     if register_patches && !resolved.unused_patches().is_empty() {
         emit_warnings_of_unused_patches(ws, &resolved, registry)?;


### PR DESCRIPTION
### What does this PR try to resolve?

This is a preparation for another `-Zpatch-files` experiment,
so that the future PR can move things around easier without too many conflicts.

### How should we test and review this PR?

Generally they shouldn't affect anything existing behavior.
a6230e348b786420e83cc8220e0d8f4c61084a12 might be a bit dubious,
though I believe preloading workspace members is kinda idempotent
and registering patches/lockfile never cares about it.

### Additional information
