### PR TITLE
test: set safe.directory for git repo in apache container

### DIFF
--- a/crates/cargo-test-support/containers/apache/Dockerfile
+++ b/crates/cargo-test-support/containers/apache/Dockerfile
@@ -6,6 +6,7 @@ COPY bar /repos/bar
 WORKDIR /repos/bar
 RUN git config --global user.email "testuser@example.com" &&\
     git config --global user.name "Test User" &&\
+    git config --system --add safe.directory '*' &&\
     git init -b master . &&\
     git add Cargo.toml src &&\
     git commit -m "Initial commit" &&\

--- a/crates/cargo-test-support/containers/apache/Dockerfile
+++ b/crates/cargo-test-support/containers/apache/Dockerfile
@@ -10,10 +10,9 @@ RUN git config --global user.email "testuser@example.com" &&\
     git init -b master . &&\
     git add Cargo.toml src &&\
     git commit -m "Initial commit" &&\
-    mv .git ../bar.git &&\
-    cd ../bar.git &&\
-    git config --bool core.bare true &&\
-    rm -rf ../bar
+    cd .. &&\
+    git clone --bare bar bar.git &&\
+    rm -rf bar
 WORKDIR /
 
 EXPOSE 443

--- a/crates/cargo-test-support/containers/sshd/Dockerfile
+++ b/crates/cargo-test-support/containers/sshd/Dockerfile
@@ -17,10 +17,9 @@ RUN git config --global user.email "testuser@example.com" &&\
     git init -b master . &&\
     git add Cargo.toml src &&\
     git commit -m "Initial commit" &&\
-    mv .git ../bar.git &&\
-    cd ../bar.git &&\
-    git config --bool core.bare true &&\
-    rm -rf ../bar
+    cd .. &&\
+    git clone --bare bar bar.git &&\
+    rm -rf bar
 WORKDIR /
 USER root
 


### PR DESCRIPTION
### What does this PR try to resolve?

Failure in container tests due to a new version of `git` package in Alpine Linux Package repository.

See also <https://github.com/rust-lang/cargo/pull/13913#issuecomment-2113712049>

### How should we test and review this PR?

Alpine Linux Package repository 3.19 just bumped git package to 2.43.4 from 2.43.0.
The docker image `httpd:2.4-alpine` we use in container tests failed due to the git version bump.
The `httpd` log shown that

```
240.10.0.1 - - [16/May/2024:03:52:36 +0000] "GET /repos/bar.git/info/refs?service=git-upload-pack HTTP/1.1" 500 -
[16/May/2024:03:52:36 +0000] 240.10.0.1 TLSv1.3 TLS_AES_256_GCM_SHA384 "GET /repos/bar.git/info/refs?service=git-upload-pack HTTP/1.1" -
fatal: detected dubious ownership in repository at '/repos/bar.git'
To add an exception for this directory, call:

        git config --global --add safe.directory /repos/bar.git
```

git/git@f4aa8c8bb11dae6e769cd930565173808cbb69c8 is likely the commit causing problems.

So I ended up adding `git config --system --add safe.directory '*'` to the Dockerfile of apache container.
Note that we need `--system` instead of `--global` because `httpd` are running under the other user www-data, not root.