### PR TITLE
fix(toml): Convert warnings that `licence` and `readme` files do not exist into errors

### DIFF
--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1943,8 +1943,7 @@ fn exclude_dot_files_and_directories_by_default() {
 
 #[cargo_test]
 fn empty_readme_path() {
-    // Warn but don't fail if `readme` is empty.
-    // Issue #11522.
+    // fail if `readme` is empty.
     let p = project()
         .file(
             "Cargo.toml",
@@ -1963,13 +1962,11 @@ fn empty_readme_path() {
         .build();
 
     p.cargo("package --no-verify")
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] readme `` does not appear to exist (relative to `[..]/foo`).
-Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[PACKAGING] foo v1.0.0 ([..]/foo)
-[PACKAGED] [..] files, [..] ([..] compressed)
+[ERROR] readme `` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`.
 ",
         )
         .run();
@@ -1977,8 +1974,7 @@ This may become a hard error in the future.
 
 #[cargo_test]
 fn invalid_readme_path() {
-    // Warn but don't fail if `readme` path is invalid.
-    // Issue #11522.
+    // fail if `readme` path is invalid.
     let p = project()
         .file(
             "Cargo.toml",
@@ -1997,13 +1993,11 @@ fn invalid_readme_path() {
         .build();
 
     p.cargo("package --no-verify")
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] readme `DOES-NOT-EXIST` does not appear to exist (relative to `[..]/foo`).
-Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[PACKAGING] foo v1.0.0 ([..]/foo)
-[PACKAGED] [..] files, [..] ([..] compressed)
+[ERROR] readme `DOES-NOT-EXIST` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`.
 ",
         )
         .run();
@@ -2011,8 +2005,7 @@ This may become a hard error in the future.
 
 #[cargo_test]
 fn readme_or_license_file_is_dir() {
-    // Test warning when `readme` or `license-file` is a directory, not a file.
-    // Issue #11522.
+    // Test error when `readme` or `license-file` is a directory, not a file.
     let p = project()
         .file(
             "Cargo.toml",
@@ -2031,16 +2024,13 @@ fn readme_or_license_file_is_dir() {
         .build();
 
     p.cargo("package --no-verify")
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] license-file `./src` does not appear to exist (relative to `[..]/foo`).
-Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[WARNING] readme `./src` does not appear to exist (relative to `[..]/foo`).
-Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[PACKAGING] foo v1.0.0 ([..]/foo)
-[PACKAGED] [..] files, [..] ([..] compressed)
+[ERROR] license-file `./src` does not appear to exist (relative to `[..]/foo`).
+Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`.
+readme `./src` does not appear to exist (relative to `[..]/foo`).
+Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`.
 ",
         )
         .run();
@@ -2048,8 +2038,7 @@ This may become a hard error in the future.
 
 #[cargo_test]
 fn empty_license_file_path() {
-    // Warn but don't fail if license-file is empty.
-    // Issue #11522.
+    // fail if license-file is empty.
     let p = project()
         .file(
             "Cargo.toml",
@@ -2067,15 +2056,13 @@ fn empty_license_file_path() {
         .build();
 
     p.cargo("package --no-verify")
+        .with_status(101)
         .with_stderr(
             "\
 [WARNING] manifest has no license or license-file.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-[WARNING] license-file `` does not appear to exist (relative to `[..]/foo`).
-Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[PACKAGING] foo v1.0.0 ([..]/foo)
-[PACKAGED] [..] files, [..] ([..] compressed)
+[ERROR] license-file `` does not appear to exist (relative to `[..]/foo`).
+Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`.
 ",
         )
         .run();
@@ -2101,13 +2088,11 @@ fn invalid_license_file_path() {
         .build();
 
     p.cargo("package --no-verify")
+        .with_status(101)
         .with_stderr(
             "\
-[WARNING] license-file `does-not-exist` does not appear to exist (relative to `[..]/foo`).
-Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[PACKAGING] foo v1.0.0 ([..]/foo)
-[PACKAGED] [..] files, [..] ([..] compressed)
+[ERROR] license-file `does-not-exist` does not appear to exist (relative to `[..]/foo`).
+Please update the license-file setting in the manifest at `[..]/foo/Cargo.toml`.
 ",
         )
         .run();

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -3,7 +3,7 @@
 use cargo_test_support::git::{self, repo};
 use cargo_test_support::paths;
 use cargo_test_support::registry::{self, Package, RegistryBuilder, Response};
-use cargo_test_support::{basic_manifest, no_such_file_err_msg, project, publish};
+use cargo_test_support::{basic_manifest, project, publish};
 use std::fs;
 use std::sync::{Arc, Mutex};
 
@@ -2134,54 +2134,6 @@ fn cratesio_source_replacement() {
 include `--registry dummy-registry` or `--registry crates-io`
 ",
         )
-        .run();
-}
-
-#[cargo_test]
-fn publish_with_missing_readme() {
-    // Use local registry for faster test times since no publish will occur
-    let registry = registry::init();
-
-    let p = project()
-        .file(
-            "Cargo.toml",
-            r#"
-                [package]
-                name = "foo"
-                version = "0.1.0"
-                edition = "2015"
-                authors = []
-                license = "MIT"
-                description = "foo"
-                homepage = "https://example.com/"
-                readme = "foo.md"
-            "#,
-        )
-        .file("src/lib.rs", "")
-        .build();
-
-    p.cargo("publish --no-verify")
-        .replace_crates_io(registry.index_url())
-        .with_status(101)
-        .with_stderr(&format!(
-            "\
-[UPDATING] [..]
-[WARNING] readme `foo.md` does not appear to exist (relative to `[..]/foo`).
-Please update the readme setting in the manifest at `[..]/foo/Cargo.toml`
-This may become a hard error in the future.
-[PACKAGING] foo v0.1.0 [..]
-[PACKAGED] [..] files, [..] ([..] compressed)
-[UPLOADING] foo v0.1.0 [..]
-[ERROR] failed to read `readme` file for package `foo v0.1.0 ([ROOT]/foo)`
-
-Caused by:
-  failed to read `[ROOT]/foo/foo.md`
-
-Caused by:
-  {}
-",
-            no_such_file_err_msg()
-        ))
         .run();
 }
 

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1146,7 +1146,7 @@ fn bad_license_file(registry: &TestRegistry) {
     p.cargo("publish -v")
         .replace_crates_io(registry.index_url())
         .with_status(101)
-        .with_stderr_contains("[ERROR] the license file `foo` does not exist")
+        .with_stderr_contains("[ERROR] license-file `foo` does not appear to exist ([..]).")
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

In this PR:
- Changed the warning to a hard error and modified the associated test function;
- Removed what should have been a redundant test function：`publish::publish_with_missing_readme`；
- Since `cargo publish` is preceded by the execution of `cargo package`, the error message in the test `function bad_license_file` needs to be modified.

issue: https://github.com/rust-lang/cargo/issues/13629#license-file-and-readme-pointing-to-a-non-existent-file.

### Additional information

It seems that this is not enough, the current situation is that `cargo package` warns if `package.readme` is an empty string or the wrong file location, but if I cancel `package.readme`, no warning is generated.

I'm wondering if I should judge `package.readme&licence` when executing `cargo package` and return an error if it doesn't exist?

As this has not been done before, your advice is sought.