### PR TITLE
Load `libsecret` by its `SONAME`, `libsecret-1.so.0`

### DIFF
--- a/credential/cargo-credential-libsecret/src/lib.rs
+++ b/credential/cargo-credential-libsecret/src/lib.rs
@@ -115,7 +115,7 @@ mod linux {
             let secret_password_store_sync: Symbol<'_, SecretPasswordStoreSync>;
             let secret_password_clear_sync: Symbol<'_, SecretPasswordClearSync>;
             unsafe {
-                lib = Library::new("libsecret-1.so").context(
+                lib = Library::new("libsecret-1.so.0").context(
                     "failed to load libsecret: try installing the `libsecret` \
                     or `libsecret-1-0` package with the system package manager",
                 )?;


### PR DESCRIPTION
The library name `libsecret-1.so` is only found in `-dev` or `-devel` packages on many distros, and it's usually only a symlink. For example, this is what I have on Fedora:

    /usr/lib64/libsecret-1.so -> libsecret-1.so.0
    /usr/lib64/libsecret-1.so.0 -> libsecret-1.so.0.0.0
    /usr/lib64/libsecret-1.so.0.0.0

    $ rpm -qf /usr/lib64/libsecret*
    libsecret-devel-0.21.4-2.fc40.x86_64
    libsecret-0.21.4-2.fc40.x86_64
    libsecret-0.21.4-2.fc40.x86_64

The middle `libsecret-1.so.0` filename matches the actual `SONAME` in the library, which you can see with `readelf -d`, and this is what programs built directly against this library will use. It's a better choice for dynamic loaders too, so devel packages aren't needed.
