### PR TITLE
Silence warnings running embedded unittests.

### DIFF
--- a/src/cargo/util/toml/embedded.rs
+++ b/src/cargo/util/toml/embedded.rs
@@ -265,12 +265,12 @@ mod test_expand {
 
     macro_rules! si {
         ($i:expr) => {{
-            expand_manifest(
-                $i,
-                std::path::Path::new("/home/me/test.rs"),
-                &GlobalContext::default().unwrap(),
-            )
-            .unwrap_or_else(|err| panic!("{}", err))
+            let shell = crate::Shell::from_write(Box::new(Vec::new()));
+            let cwd = std::env::current_dir().unwrap();
+            let home = home::cargo_home_with_cwd(&cwd).unwrap();
+            let gctx = GlobalContext::new(shell, cwd, home);
+            expand_manifest($i, std::path::Path::new("/home/me/test.rs"), &gctx)
+                .unwrap_or_else(|err| panic!("{}", err))
         }};
     }
 


### PR DESCRIPTION
The `util::toml::embedded::test_expand` unittests were printing warnings directly to stderr, circumventing the libtest override. They were displaying ``warning: `package.edition` is unspecified, defaulting to `2021` ``. That warning doesn't look particularly important for those tests, so this changes it to swallow the output.

We may want to have some kind of utility function for generating a GlobalContext for testing purposes that does this, since this is a repeated pattern.
