### PR TITLE
Temporarily fix standard_lib tests on linux.

### DIFF
--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -96,8 +96,19 @@ fn setup() -> Setup {
                         args.push(env::var("REAL_SYSROOT").unwrap());
                     } else if args.iter().any(|arg| arg == "--target") {
                         // build-std target unit
-                        args.push("--sysroot".to_string());
-                        args.push("/path/to/nowhere".to_string());
+                        //
+                        // This `--sysroot` is here to disable the sysroot lookup,
+                        // to ensure nothing is required.
+                        // See https://github.com/rust-lang/wg-cargo-std-aware/issues/31
+                        // for more information on this.
+                        //
+                        // FIXME: this is broken on x86_64-unknown-linux-gnu
+                        // due to https://github.com/rust-lang/rust/pull/124129,
+                        // because it requires lld in the sysroot. See
+                        // https://github.com/rust-lang/rust/issues/125246 for
+                        // more information.
+                        // args.push("--sysroot".to_string());
+                        // args.push("/path/to/nowhere".to_string());
                     } else {
                         // host unit, do not use sysroot
                     }


### PR DESCRIPTION
This fixes the standard_lib tests which are broken in the latest nightly. The latest nightly now requires rust-lld to be in the sysroot for x86_64-unknown-linux-gnu. This broke these tests which were trying to verify that the standard library is not required. This temporarily removes this validation, but we should have some way of enforcing it (https://github.com/rust-lang/wg-cargo-std-aware/issues/31).

cc https://github.com/rust-lang/rust/issues/125246
