### PR TITLE
Make `level` field optional in the `[lints]` table

### DIFF
--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1490,9 +1490,9 @@ impl<'de> Deserialize<'de> for TomlLint {
 }
 
 impl TomlLint {
-    pub fn level(&self) -> TomlLintLevel {
+    pub fn level(&self) -> Option<TomlLintLevel> {
         match self {
-            Self::Level(level) => *level,
+            Self::Level(level) => Some(*level),
             Self::Config(config) => config.level,
         }
     }
@@ -1515,7 +1515,7 @@ impl TomlLint {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct TomlLintConfig {
-    pub level: TomlLintLevel,
+    pub level: Option<TomlLintLevel>,
     #[serde(default)]
     pub priority: i8,
     #[serde(flatten)]

--- a/crates/cargo-util-schemas/src/manifest/mod.rs
+++ b/crates/cargo-util-schemas/src/manifest/mod.rs
@@ -1500,7 +1500,7 @@ impl TomlLint {
     pub fn priority(&self) -> i8 {
         match self {
             Self::Level(_) => 0,
-            Self::Config(config) => config.priority,
+            Self::Config(config) => config.priority.unwrap_or(0),
         }
     }
 
@@ -1516,8 +1516,7 @@ impl TomlLint {
 #[serde(rename_all = "kebab-case")]
 pub struct TomlLintConfig {
     pub level: Option<TomlLintLevel>,
-    #[serde(default)]
-    pub priority: i8,
+    pub priority: Option<i8>,
     #[serde(flatten)]
     pub config: toml::Table,
 }

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -405,11 +405,15 @@ fn level_priority(
     }
 
     if let Some(defined_level) = pkg_lints.get(name) {
-        (
-            defined_level.level().into(),
-            LintLevelReason::Package,
-            defined_level.priority(),
-        )
+        if let Some(level) = defined_level.level() {
+            (
+                level.into(),
+                LintLevelReason::Package,
+                defined_level.priority(),
+            )
+        } else {
+            (unspecified_level, reason, 0)
+        }
     } else {
         (unspecified_level, reason, 0)
     }

--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -2292,7 +2292,21 @@ supported tools: {}",
                     }
                 }
             }
-            if config.level().is_none() && config.config().map(|c| c.is_empty()).unwrap_or(true) {
+            if matches!(
+                config,
+                manifest::TomlLint::Config(manifest::TomlLintConfig {
+                    priority: Some(_),
+                    level: None,
+                    ..
+                })
+            ) || matches!(
+                config,
+                manifest::TomlLint::Config(manifest::TomlLintConfig {
+                    priority: None,
+                    level: None,
+                    config,
+                }) if config.is_empty())
+            {
                 anyhow::bail!("`lints.{tool}.{name}` missing field `level`");
             }
         }

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -630,8 +630,9 @@ fn config_invalid_empty() {
         .build();
 
     p.cargo("check")
+        .with_status(101)
         .with_stderr_contains("[..]missing field `level`[..]")
-        .run_expect_error();
+        .run();
 }
 
 #[cargo_test(>=1.79, reason = "--check-cfg was stabilized in Rust 1.79")]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -509,7 +509,7 @@ fn config_simple() {
                 edition = "2015"
 
                 [lints.rust]
-                unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_foo)", "cfg(has_bar, values(\"yes\", \"no\"))"] }
+                unexpected_cfgs = { check-cfg = ['cfg(has_foo)', 'cfg(has_bar, values("yes", "no"))'] }
             "#,
         )
         .file("src/main.rs", "fn main() {}")
@@ -519,6 +519,8 @@ fn config_simple() {
         .with_stderr_contains(x!("rustc" => "cfg" of "has_foo"))
         .with_stderr_contains(x!("rustc" => "cfg" of "has_bar" with "yes" "no"))
         .with_stderr_does_not_contain("[..]unused manifest key[..]")
+        .with_stderr_does_not_contain("[..]missing field `level`[..]")
+        .with_stderr_does_not_contain("[..]unexpected_cfgs[..]")
         .run();
 }
 
@@ -532,7 +534,7 @@ fn config_workspace() {
                 members = ["foo/"]
 
                 [workspace.lints.rust]
-                unexpected_cfgs = { level = "warn", check-cfg = ["cfg(has_foo)"] }
+                unexpected_cfgs = { check-cfg = ["cfg(has_foo)"] }
             "#,
         )
         .file(
@@ -552,7 +554,7 @@ fn config_workspace() {
 
     p.cargo("check -v")
         .with_stderr_contains(x!("rustc" => "cfg" of "has_foo"))
-        .with_stderr_does_not_contain("unexpected_cfgs")
+        .with_stderr_does_not_contain("[..]unexpected_cfgs[..]")
         .run();
 }
 
@@ -583,7 +585,7 @@ fn config_workspace_not_inherited() {
 
     p.cargo("check -v")
         .with_stderr_does_not_contain(x!("rustc" => "cfg" of "has_foo"))
-        .with_stderr_does_not_contain("unexpected_cfgs")
+        .with_stderr_does_not_contain("[..]unexpected_cfgs[..]")
         .run();
 }
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -918,3 +918,34 @@ Caused by:
         )
         .run();
 }
+
+#[cargo_test]
+fn missing_field_level_only_priority_but_with_configs() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [lints.rust]
+                unsafe_code = { priority = 1, check-cfg = [] }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  `lints.rust.unsafe_code` missing field `level`
+",
+        )
+        .run();
+}

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -856,3 +856,65 @@ warning: `im_a_teapot` is specified
         )
         .run();
 }
+
+#[cargo_test]
+fn missing_field_level() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [lints.rust]
+                unsafe_code = { }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  `lints.rust.unsafe_code` missing field `level`
+",
+        )
+        .run();
+}
+
+#[cargo_test]
+fn missing_field_level_only_priority() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [lints.rust]
+                unsafe_code = { priority = 1 }
+            "#,
+        )
+        .file("src/main.rs", "fn main() {}")
+        .build();
+
+    p.cargo("check")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: failed to parse manifest at `[..]`
+
+Caused by:
+  `lints.rust.unsafe_code` missing field `level`
+",
+        )
+        .run();
+}


### PR DESCRIPTION
### What does this PR try to resolve?

This PR makes the `level` field in the individual lint under the `[lints]` optional if some other key (except `priority` since it would make sense to have it alone) is defined. The goal is to avoid a empty lint definition.

This is to allow special configs like `check-cfg` in the `unexpected_cfgs` to omit the `level` field.

Users would now be able to omit the `level` field, resulting in:
```diff
- unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_foo)'] }
+ unexpected_cfgs = { check-cfg = ['cfg(has_foo)'] }
```

### How should we test and review this PR?

Test putting removing the `level` field with/without this PR.

Reviewing this PR should be straightforward, look at the tests that change to see the effect of this change.

### Additional information

https://github.com/rust-lang/cargo/pull/13913#issuecomment-2115949246

r? @epage 
