### PR TITLE
Make `git::use_the_cli` test truly locale independent

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2831,7 +2831,11 @@ From [..]
 [FINISHED] [..]
 ";
 
-    project.cargo("check -v").with_stderr(stderr).run();
+    project
+        .cargo("check -v")
+        .env("LC_ALL", "C")
+        .with_stderr(stderr)
+        .run();
     assert!(paths::home().join(".cargo/git/CACHEDIR.TAG").is_file());
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

The current `git::use_the_cli` test part the output of Git but that output is locale dependant, making it fail on my non-english system.

Specifically this part of the test is local-dependent:
```
From [..]
 * [new ref] [..] -> origin/HEAD[..]
```

Adding the `LC_ALL=C` env to the cargo invocation solve the issue, making the test locale independent.

### How should we test and review this PR?

Trying putting a different `LC_ALL` locale and the test will fail without this PR and will not fail with my PR.