### PR TITLE
Use `i32` rather than `usize` as "default integer" in library template

### DIFF
--- a/src/cargo/ops/cargo_new.rs
+++ b/src/cargo/ops/cargo_new.rs
@@ -876,7 +876,7 @@ fn main() {
 "
         } else {
             b"\
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/auto_git/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/auto_git/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/formats_source/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/formats_source/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
   left + right
 }
 

--- a/tests/testsuite/cargo_init/fossil_autodetect/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/fossil_autodetect/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/git_autodetect/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/git_autodetect/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/git_ignore_exists_no_conflicting_entries/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/ignores_failure_to_format_source/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/ignores_failure_to_format_source/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/in/src/lib.rs
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/in/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/inherit_workspace_package_table/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/inherit_workspace_package_table/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/mercurial_autodetect/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/mercurial_autodetect/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/pijul_autodetect/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/pijul_autodetect/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/simple_git/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/simple_git/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/simple_git_ignore_exists/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/simple_git_ignore_exists/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/simple_hg/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/simple_hg/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/simple_hg_ignore_exists/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/simple_hg_ignore_exists/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_init/simple_lib/out/src/lib.rs
+++ b/tests/testsuite/cargo_init/simple_lib/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/add_members_to_non_workspace/out/bar/src/lib.rs
+++ b/tests/testsuite/cargo_new/add_members_to_non_workspace/out/bar/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/in/src/lib.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_with_exclude_list/in/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/add_members_to_workspace_without_members/out/bar/src/lib.rs
+++ b/tests/testsuite/cargo_new/add_members_to_workspace_without_members/out/bar/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/in/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/in/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_lints/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_lints/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table.in/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table.in/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_edition/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_with_registry/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/in/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/in/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/inherit_workspace_package_table_without_version/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/in/src/lib.rs
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/in/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/out/src/lib.rs
+++ b/tests/testsuite/cargo_new/not_inherit_workspace_package_table_if_not_members/out/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn add(left: usize, right: usize) -> usize {
+pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -42,7 +42,7 @@ fn simple_lib() {
     let contents = fs::read_to_string(&lib).unwrap();
     assert_eq!(
         contents,
-        r#"pub fn add(left: usize, right: usize) -> usize {
+        r#"pub fn add(left: u64, right: u64) -> u64 {
     left + right
 }
 

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -5085,7 +5085,7 @@ fn cargo_test_set_out_dir_env_var() {
         .file(
             "src/lib.rs",
             r#"
-                pub fn add(left: usize, right: usize) -> usize {
+                pub fn add(left: u64, right: u64) -> u64 {
                     left + right
                 }
             "#,


### PR DESCRIPTION
`usize` was renamed from `uint` in order to convey that it's not the "default integer type". Guide new users to use `i32` instead of `usize`.