### PR TITLE
Add more high level traces

### DIFF
--- a/src/cargo/core/compiler/build_context/target_info.rs
+++ b/src/cargo/core/compiler/build_context/target_info.rs
@@ -152,6 +152,7 @@ impl TargetInfo {
     /// invocation is cached by [`Rustc::cached_output`].
     ///
     /// Search `Tricky` to learn why querying `rustc` several times is needed.
+    #[tracing::instrument(skip_all)]
     pub fn new(
         gctx: &GlobalContext,
         requested_kinds: &[CompileKind],
@@ -878,6 +879,7 @@ pub struct RustcTargetData<'gctx> {
 }
 
 impl<'gctx> RustcTargetData<'gctx> {
+    #[tracing::instrument(skip_all)]
     pub fn new(
         ws: &Workspace<'gctx>,
         requested_kinds: &[CompileKind],

--- a/src/cargo/core/package.rs
+++ b/src/cargo/core/package.rs
@@ -654,6 +654,7 @@ impl<'a, 'gctx> Downloads<'a, 'gctx> {
     /// Returns `None` if the package is queued up for download and will
     /// eventually be returned from `wait_for_download`. Returns `Some(pkg)` if
     /// the package is ready and doesn't need to be downloaded.
+    #[tracing::instrument(skip_all)]
     pub fn start(&mut self, id: PackageId) -> CargoResult<Option<&'a Package>> {
         self.start_inner(id)
             .with_context(|| format!("failed to download `{}`", id))
@@ -793,6 +794,7 @@ impl<'a, 'gctx> Downloads<'a, 'gctx> {
     /// # Panics
     ///
     /// This function will panic if there are no remaining downloads.
+    #[tracing::instrument(skip_all)]
     pub fn wait(&mut self) -> CargoResult<&'a Package> {
         let (dl, data) = loop {
             assert_eq!(self.pending.len(), self.pending_ids.len());


### PR DESCRIPTION
This accounts for more time when running rustc (which turns out to be a significant amount of time).

I'm less sure about the start/wait calls but I'm seeing very different results from different builds of `cargo` and some have some large amounts of unaccounted time that I want to dig into (and callgrind and and samply haven't helped).

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
