### PR TITLE
pragmatically compare timestamps (as suggested by kornelski)

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1887,9 +1887,9 @@ where
         None
     };
 
-    let mut truncated_precision_count : u64 = 0;
+    let mut truncated_precision_count: u64 = 0;
     let mut total_checked: u64 = 0;
-    let mut first : Option<StaleItem> = None;
+    let mut first: Option<StaleItem> = None;
     for path in paths {
         let path = path.as_ref();
 
@@ -1941,12 +1941,12 @@ where
         let fresh = if truncated_precision {
             truncated_precision_count += 1;
             if first.is_none() {
-               first = Some(StaleItem::ChangedFile {
-                   reference: reference.to_path_buf(),
-                   reference_mtime,
-                   stale: path.to_path_buf(),
-                   stale_mtime: path_mtime,
-               }); 
+                first = Some(StaleItem::ChangedFile {
+                    reference: reference.to_path_buf(),
+                    reference_mtime,
+                    stale: path.to_path_buf(),
+                    stale_mtime: path_mtime,
+                });
             }
             path_mtime.unix_seconds() <= reference_mtime.unix_seconds()
         } else {

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1952,6 +1952,13 @@ where
         });
     }
 
+    // If a few files in many have a .0ns mtime then still regard them as changed files.
+    if total_checked > 1 && truncated_precision_count == 1 {
+        return first;
+    } else if truncated_precision_count > 0 {
+        debug!("ignoring files that look changed due to mtime precision differences");
+    }
+
     debug!(
         "all paths up-to-date relative to {:?} mtime={}",
         reference, reference_mtime

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1927,7 +1927,19 @@ where
         // if equal, files were changed just after a previous build finished.
         // Unfortunately this became problematic when (in #6484) cargo switch to more accurately
         // measuring the start time of builds.
-        if path_mtime <= reference_mtime {
+        //
+        // Additionally, the build can span different volumes, some which support high-precision
+        // file timestamps and some that don't (e.g. mounted Docker volumes). This can make
+        // one of the timestamps lose the nanosecond part and appear up to a second in the past.
+        let truncated_precision = path_mtime.nanoseconds() == 0 || reference_mtime.nanoseconds() == 0;
+
+        let fresh = if truncated_precision {
+            path_mtime.unix_seconds() <= reference_mtime.unix_seconds()
+        } else {
+            path_mtime <= reference_mtime
+        };
+
+        if fresh {
             continue;
         }
 

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1965,7 +1965,7 @@ where
         });
     }
 
-    // If a few files in many have a .0ns mtime then still regard them as changed files.
+    // If one file in many has a .0ns mtime then still regard it as a changed file.
     if total_checked > 1 && truncated_precision_count == 1 {
         return first;
     } else if truncated_precision_count > 0 {

--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -1931,7 +1931,8 @@ where
         // Additionally, the build can span different volumes, some which support high-precision
         // file timestamps and some that don't (e.g. mounted Docker volumes). This can make
         // one of the timestamps lose the nanosecond part and appear up to a second in the past.
-        let truncated_precision = path_mtime.nanoseconds() == 0 || reference_mtime.nanoseconds() == 0;
+        let truncated_precision =
+            path_mtime.nanoseconds() == 0 || reference_mtime.nanoseconds() == 0;
 
         let fresh = if truncated_precision {
             path_mtime.unix_seconds() <= reference_mtime.unix_seconds()


### PR DESCRIPTION
AKA 'make docker great again'.

Fixes #12060 (as coded here: https://github.com/rust-lang/cargo/compare/master...kornelski:cargo:nanotime )

Let's cut out needless rebuilds. (Thank you @kornelski for suggesting this)

If we are concerned about backward compatibility, we can put this behind a nightly only flag so this slight behaviour change is not the default.