### PR TITLE
Fix wrong type of rustc-flags in documentation

### DIFF
--- a/src/doc/src/reference/config.md
+++ b/src/doc/src/reference/config.md
@@ -170,7 +170,7 @@ rustflags = ["…", "…"]  # custom flags for `rustc`
 [target.<triple>.<links>] # `links` build script override
 rustc-link-lib = ["foo"]
 rustc-link-search = ["/path/to/foo"]
-rustc-flags = ["-L", "/some/path"]
+rustc-flags = "-L /some/path"
 rustc-cfg = ['key="value"']
 rustc-env = {key = "value"}
 rustc-cdylib-link-arg = ["…"]


### PR DESCRIPTION
When I tried to add some custom configuration according to the documentation in https://doc.rust-lang.org/cargo/reference/config.html#configuration-format, I encountered the following error:

```
error: expected a string, but found a array for `rustc-flags` in /xxx/.cargo/config.toml
```

I believe the type of `rustc-flags` should be a string:

https://github.com/rust-lang/cargo/blob/95b921ba592ec968d4638e124f5273bb42a25528/src/doc/src/reference/config.md?plain=1#L1243-L1253