### PR TITLE
Include `lints.rust.unexpected_cfgs.check-cfg` in the fingerprint

### DIFF
--- a/src/cargo/core/compiler/fingerprint/mod.rs
+++ b/src/cargo/core/compiler/fingerprint/mod.rs
@@ -80,6 +80,7 @@
 //! config settings[^5]                        | ✓           |
 //! is_std                                     |             | ✓
 //! `[lints]` table[^6]                        | ✓           |
+//! `[lints.rust.unexpected_cfgs.check-cfg]`   | ✓           |
 //!
 //! [^1]: Build script and bin dependencies are not included.
 //!
@@ -1420,12 +1421,34 @@ fn calculate_normal(
     }
     .to_vec();
 
+    // Include all the args from `[lints.rust.unexpected_cfgs.check-cfg]`
+    //
+    // HACK(#13975): duplicating the lookup logic here until `--check-cfg` is supported
+    // on Cargo's MSRV and we can centralize the logic in `lints_to_rustflags`
+    let mut lint_check_cfg = Vec::new();
+    if let Ok(Some(lints)) = unit.pkg.manifest().resolved_toml().resolved_lints() {
+        if let Some(rust_lints) = lints.get("rust") {
+            if let Some(unexpected_cfgs) = rust_lints.get("unexpected_cfgs") {
+                if let Some(config) = unexpected_cfgs.config() {
+                    if let Some(check_cfg) = config.get("check-cfg") {
+                        if let Ok(check_cfgs) =
+                            toml::Value::try_into::<Vec<String>>(check_cfg.clone())
+                        {
+                            lint_check_cfg = check_cfgs;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     let profile_hash = util::hash_u64((
         &unit.profile,
         unit.mode,
         build_runner.bcx.extra_args_for(unit),
         build_runner.lto[unit],
         unit.pkg.manifest().lint_rustflags(),
+        lint_check_cfg,
     ));
     // Include metadata since it is exposed as environment variables.
     let m = unit.pkg.manifest().metadata();

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -824,3 +824,49 @@ fn config_features_and_build_script() {
         .with_stderr_contains(x!("rustc" => "cfg" of "docsrs")) // Cargo well known
         .run();
 }
+
+#[cargo_test(>=1.79, reason = "--check-cfg was stabilized in Rust 1.79")]
+fn config_fingerprint() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = "foo"
+                version = "0.1.0"
+                edition = "2015"
+
+                [lints.rust]
+                unexpected_cfgs = { level = "warn", check-cfg = ["cfg(bar)"] }
+            "#,
+        )
+        .file("src/lib.rs", "fn entry() {}")
+        .build();
+
+    p.cargo("check -v")
+        .with_stderr_contains(x!("rustc" => "cfg" of "bar"))
+        .run();
+
+    p.cargo("check -v")
+        .with_stderr_does_not_contain("[..]rustc[..]")
+        .run();
+
+    // checking that changing the `-check-cfg` config does not invalid the fingerprint
+    // FIXME: This should change the fingerprint
+    p.change_file(
+        "Cargo.toml",
+        r#"
+            [package]
+            name = "foo"
+            version = "0.1.0"
+            edition = "2015"
+
+            [lints.rust]
+            unexpected_cfgs = { level = "warn", check-cfg = ["cfg(bar)", "cfg(foo)"] }
+        "#,
+    );
+
+    p.cargo("check -v")
+        .with_stderr_does_not_contain("[..]rustc[..]")
+        .run();
+}

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -851,8 +851,7 @@ fn config_fingerprint() {
         .with_stderr_does_not_contain("[..]rustc[..]")
         .run();
 
-    // checking that changing the `-check-cfg` config does not invalid the fingerprint
-    // FIXME: This should change the fingerprint
+    // checking that changing the `check-cfg` config does invalid the fingerprint
     p.change_file(
         "Cargo.toml",
         r#"
@@ -867,6 +866,10 @@ fn config_fingerprint() {
     );
 
     p.cargo("check -v")
-        .with_stderr_does_not_contain("[..]rustc[..]")
+        // we check that the fingerprint is indeed dirty
+        .with_stderr_contains("[..]Dirty[..]the profile configuration changed")
+        // that cause rustc to be called again with the new check-cfg args
+        .with_stderr_contains(x!("rustc" => "cfg" of "bar"))
+        .with_stderr_contains(x!("rustc" => "cfg" of "foo"))
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

When changing the `--check-cfg` args in the `lints.rust.unexpected_cfgs.check-cfg` lint config, the build should be restarted as the arguments we pass to the compiler change, and they can change the diagnostics output by generating new or removing some `unexpected_cfgs` warning(s).

### How should we test and review this PR?

Look at the before and after test (separate commit).

### Additional information

Similar to https://github.com/rust-lang/cargo/pull/13012 which did that for the declared features.
Contrary to that PR, I didn't add a new `DirtyReason` variant, since even the `[lints]` table didn't get one.

r? @epage