### PR TITLE
fix: adjust custom err from cert-check due to libgit2 1.8 change

### DIFF
--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -33,7 +33,7 @@ fn self_signed_should_fail() {
     let err_msg = if cfg!(target_os = "macos") {
         "untrusted connection error; class=Ssl (16); code=Certificate (-17)"
     } else if cfg!(unix) {
-        "the SSL certificate is invalid; class=Ssl (16); code=Certificate (-17)"
+        "the SSL certificate is invalid; class=Ssl (16)[..]"
     } else if cfg!(windows) {
         "user cancelled certificate check; class=Http (34); code=Certificate (-17)"
     } else {


### PR DESCRIPTION


<!-- homu-ignore:start -->

### What does this PR try to resolve?

libgit2 disallows overriding errors from certificate check since v1.8.0,
so we store the error additionally and unwrap it later.

### How should we test and review this PR?

I believe it is due to this change: https://github.com/libgit2/libgit2/commit/9a9f220119d9647a352867b24b0556195cb26548

Actually, in the doc of `git_error_set` it does state that the custom message might [be overridden by libgit2 internals](https://github.com/libgit2/libgit2/blob/6c5520f334e5652d5f0476c00a3188d1d97754e7/include/git2/sys/errors.h#L24-L28).

I am not sure if this should be fixed in upstream libgit2 or by our own,
but it's better to do it now then waiting for libgit2 1.8.2

### Additional information

r? ehuss

<!-- homu-ignore:end -->
