### PR TITLE
fix: using `--release/debug` and `--profile` together becomes an error

### DIFF
--- a/src/bin/cargo/commands/bench.rs
+++ b/src/bin/cargo/commands/bench.rs
@@ -63,7 +63,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         args.compile_options(gctx, CompileMode::Bench, Some(&ws), ProfileChecking::Custom)?;
 
     compile_opts.build_config.requested_profile =
-        args.get_profile_name(gctx, "bench", ProfileChecking::Custom)?;
+        args.get_profile_name("bench", ProfileChecking::Custom)?;
 
     let ops = TestOptions {
         no_run: args.flag("no-run"),

--- a/src/bin/cargo/commands/clean.rs
+++ b/src/bin/cargo/commands/clean.rs
@@ -146,7 +146,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         gctx,
         spec: values(args, "package"),
         targets: args.targets()?,
-        requested_profile: args.get_profile_name(gctx, "dev", ProfileChecking::Custom)?,
+        requested_profile: args.get_profile_name("dev", ProfileChecking::Custom)?,
         profile_specified: args.contains_id("profile") || args.flag("release"),
         doc: args.flag("doc"),
         dry_run: args.dry_run(),

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -85,10 +85,13 @@ pub fn cli() -> Command {
         )
         .arg_features()
         .arg_parallel()
-        .arg(flag(
-            "debug",
-            "Build in debug mode (with the 'dev' profile) instead of release mode",
-        ))
+        .arg(
+            flag(
+                "debug",
+                "Build in debug mode (with the 'dev' profile) instead of release mode",
+            )
+            .conflicts_with("profile"),
+        )
         .arg_redundant_default_mode("release", "install", "debug")
         .arg_profile("Install artifacts with the specified profile")
         .arg_target_triple("Build for the target triple")

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -196,7 +196,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     )?;
 
     compile_opts.build_config.requested_profile =
-        args.get_profile_name(gctx, "release", ProfileChecking::Custom)?;
+        args.get_profile_name("release", ProfileChecking::Custom)?;
 
     if args.flag("list") {
         ops::install_list(root, gctx)?;

--- a/src/bin/cargo/commands/test.rs
+++ b/src/bin/cargo/commands/test.rs
@@ -74,7 +74,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         args.compile_options(gctx, CompileMode::Test, Some(&ws), ProfileChecking::Custom)?;
 
     compile_opts.build_config.requested_profile =
-        args.get_profile_name(gctx, "test", ProfileChecking::Custom)?;
+        args.get_profile_name("test", ProfileChecking::Custom)?;
 
     // `TESTNAME` is actually an argument of the test binary, but it's
     // important, so we explicitly mention it and reconfigure.

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -289,20 +289,26 @@ fn rustc_check() {
 
     // Verify compatible usage of --profile with --release, issue #7488
     foo.cargo("rustc --profile check --release -- --emit=metadata")
-        .with_status(101)
+        .with_status(1)
         .with_stderr(
             "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
+[ERROR] the argument '--profile <PROFILE-NAME>' cannot be used with '--release'
+
+Usage: cargo[EXE] rustc --profile <PROFILE-NAME> [ARGS]...
+
+For more information, try '--help'.",
         )
         .run();
 
     foo.cargo("rustc --profile test --release -- --emit=metadata")
-        .with_status(101)
+        .with_status(1)
         .with_stderr(
             "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
+[ERROR] the argument '--profile <PROFILE-NAME>' cannot be used with '--release'
+
+Usage: cargo[EXE] rustc --profile <PROFILE-NAME> [ARGS]...
+
+For more information, try '--help'.",
         )
         .run();
 }

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -289,8 +289,21 @@ fn rustc_check() {
 
     // Verify compatible usage of --profile with --release, issue #7488
     foo.cargo("rustc --profile check --release -- --emit=metadata")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
+        )
         .run();
+
     foo.cargo("rustc --profile test --release -- --emit=metadata")
+        .with_status(101)
+        .with_stderr(
+            "\
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
+        )
         .run();
 }
 

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -380,85 +380,38 @@ fn conflicting_usage() {
         .build();
 
     p.cargo("build --profile=dev --release")
-        .with_status(101)
+        .with_status(1)
         .with_stderr(
             "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
+[ERROR] the argument '--profile <PROFILE-NAME>' cannot be used with '--release'
+
+Usage: cargo[EXE] build --profile <PROFILE-NAME>
+
+For more information, try '--help'.",
         )
         .run();
 
     p.cargo("install --profile=release --debug")
-        .with_status(101)
+        .with_status(1)
         .with_stderr(
             "\
-error: the `--debug` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
-        )
-        .run();
+[ERROR] the argument '--profile <PROFILE-NAME>' cannot be used with '--debug'
 
-    p.cargo("rustc --profile=dev --release")
-        .with_status(101)
-        .with_stderr(
-            "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.
-",
+Usage: cargo[EXE] install --profile <PROFILE-NAME> [CRATE[@<VER>]]...
+
+For more information, try '--help'.",
         )
         .run();
 
     p.cargo("check --profile=dev --release")
-        .with_status(101)
+        .with_status(1)
         .with_stderr(
             "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
-        )
-        .run();
+[ERROR] the argument '--profile <PROFILE-NAME>' cannot be used with '--release'
 
-    p.cargo("check --profile=test --release")
-        .with_status(101)
-        .with_stderr(
-            "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
-        )
-        .run();
+Usage: cargo[EXE] check --profile <PROFILE-NAME>
 
-    // This is OK since the two are the same.
-    p.cargo("rustc --profile=release --release")
-        .with_status(101)
-        .with_stderr(
-            "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
-        )
-        .run();
-
-    p.cargo("build --profile=release --release")
-        .with_status(101)
-        .with_stderr(
-            "\
-error: the `--release` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
-        )
-        .run();
-
-    p.cargo("install --path . --profile=dev --debug")
-        .with_status(101)
-        .with_stderr(
-            "\
-error: the `--debug` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
-        )
-        .run();
-
-    p.cargo("install --path . --profile=release --debug")
-        .with_status(101)
-        .with_stderr(
-            "\
-error: the `--debug` flag can not be specified with the `--profile` flag
-Please remove one of the flags.",
+For more information, try '--help'.",
         )
         .run();
 }

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -383,10 +383,8 @@ fn conflicting_usage() {
         .with_status(101)
         .with_stderr(
             "\
-error: conflicting usage of --profile=dev and --release
-The `--release` flag is the same as `--profile=release`.
-Remove one flag or the other to continue.
-",
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
@@ -394,21 +392,17 @@ Remove one flag or the other to continue.
         .with_status(101)
         .with_stderr(
             "\
-error: conflicting usage of --profile=release and --debug
-The `--debug` flag is the same as `--profile=dev`.
-Remove one flag or the other to continue.
-",
+error: the `--debug` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
     p.cargo("rustc --profile=dev --release")
+        .with_status(101)
         .with_stderr(
             "\
-warning: the `--release` flag should not be specified with the `--profile` flag
-The `--release` flag will be ignored.
-This was historically accepted, but will become an error in a future release.
-[COMPILING] foo [..]
-[FINISHED] `dev` profile [..]
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.
 ",
         )
         .run();
@@ -417,52 +411,45 @@ This was historically accepted, but will become an error in a future release.
         .with_status(101)
         .with_stderr(
             "\
-error: conflicting usage of --profile=dev and --release
-The `--release` flag is the same as `--profile=release`.
-Remove one flag or the other to continue.
-",
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
     p.cargo("check --profile=test --release")
+        .with_status(101)
         .with_stderr(
             "\
-warning: the `--release` flag should not be specified with the `--profile` flag
-The `--release` flag will be ignored.
-This was historically accepted, but will become an error in a future release.
-[CHECKING] foo [..]
-[FINISHED] `test` profile [..]
-",
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
     // This is OK since the two are the same.
     p.cargo("rustc --profile=release --release")
+        .with_status(101)
         .with_stderr(
             "\
-[COMPILING] foo [..]
-[FINISHED] `release` profile [..]
-",
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
     p.cargo("build --profile=release --release")
+        .with_status(101)
         .with_stderr(
             "\
-[FINISHED] `release` profile [..]
-",
+error: the `--release` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
     p.cargo("install --path . --profile=dev --debug")
+        .with_status(101)
         .with_stderr(
             "\
-[INSTALLING] foo [..]
-[FINISHED] `dev` profile [..]
-[INSTALLING] [..]
-[INSTALLED] [..]
-[WARNING] be sure to add [..]
-",
+error: the `--debug` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 
@@ -470,10 +457,8 @@ This was historically accepted, but will become an error in a future release.
         .with_status(101)
         .with_stderr(
             "\
-error: conflicting usage of --profile=release and --debug
-The `--debug` flag is the same as `--profile=dev`.
-Remove one flag or the other to continue.
-",
+error: the `--debug` flag can not be specified with the `--profile` flag
+Please remove one of the flags.",
         )
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

part of #13629 

issue https://github.com/rust-lang/cargo/issues/13629#release-is-ignored-when-paired-with-profile


