### PR TITLE
WIP: feat(crates-io): add the downloads API

### DIFF
--- a/crates/crates-io/lib.rs
+++ b/crates/crates-io/lib.rs
@@ -103,6 +103,18 @@ pub struct Warnings {
 }
 
 #[derive(Deserialize)]
+pub struct VersionDownload {
+    pub version: i32,
+    pub downloads: i32,
+    pub date: String,
+}
+
+#[derive(Deserialize)]
+pub struct VersionDownloads {
+    pub version_downloads: Vec<VersionDownload>,
+}
+
+#[derive(Deserialize)]
 struct R {
     ok: bool,
 }
@@ -368,6 +380,11 @@ impl Registry {
         let body = self.put(&format!("/crates/{}/{}/unyank", krate, version), &[])?;
         assert!(serde_json::from_str::<R>(&body)?.ok);
         Ok(())
+    }
+
+    pub fn downloads(&mut self, krate: &str, version: &str) -> Result<VersionDownloads> {
+        let body = self.get(&format!("/crates/{}/{}/downloads", krate, version))?;
+        Ok(serde_json::from_str::<VersionDownloads>(&body)?)
     }
 
     fn put(&mut self, path: &str, b: &[u8]) -> Result<String> {


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Ref https://github.com/hi-rustin/cargo-information/issues/20

To report the crates.io metrics on cargo-information, a new API is required to obtain the download count from crates.io.

So in this PR, I added the downloads API to the `crates-io` crate.

### How should we test and review this PR?

[ ] I will test it on the cargo information side as an integration test case.

### Additional information

r? @ghost

<!-- homu-ignore:end -->
