### PR TITLE
feat: stabilize `cargo update --precise <yanked>`

### DIFF
--- a/src/cargo/sources/registry/mod.rs
+++ b/src/cargo/sources/registry/mod.rs
@@ -819,15 +819,10 @@ impl<'gctx> Source for RegistrySource<'gctx> {
                         callback(s);
                     } else if req.is_precise() {
                         precise_yanked_in_use = true;
-                        if self.gctx.cli_unstable().unstable_options {
-                            callback(s);
-                        }
+                        callback(s);
                     }
                 }))?;
             if precise_yanked_in_use {
-                self.gctx
-                    .cli_unstable()
-                    .fail_if_stable_opt("--precise <yanked-version>", 4225)?;
                 let name = dep.package_name();
                 let version = req
                     .precise_version()

--- a/src/doc/man/cargo-update.md
+++ b/src/doc/man/cargo-update.md
@@ -43,11 +43,12 @@ When used with _spec_, allows you to specify a specific version number to set
 the package to. If the package comes from a git repository, this can be a git
 revision (such as a SHA hash or tag).
 
-While not recommended, you can specify a yanked version of a package (nightly only).
+While not recommended, you can specify a yanked version of a package.
 When possible, try other non-yanked SemVer-compatible versions or seek help
 from the maintainers of the package.
 
-A compatible `pre-release` version can also be specified even when the version requirement in `Cargo.toml` doesn't contain any pre-release identifier (nightly only).
+A compatible `pre-release` version can also be specified even when the version
+requirement in `Cargo.toml` doesn't contain any pre-release identifier (nightly only).
 {{/option}}
 
 {{#option "`-w`" "`--workspace`" }}

--- a/src/doc/man/generated_txt/cargo-update.txt
+++ b/src/doc/man/generated_txt/cargo-update.txt
@@ -35,10 +35,9 @@ OPTIONS
            to set the package to. If the package comes from a git repository,
            this can be a git revision (such as a SHA hash or tag).
 
-           While not recommended, you can specify a yanked version of a package
-           (nightly only). When possible, try other non-yanked
-           SemVer-compatible versions or seek help from the maintainers of the
-           package.
+           While not recommended, you can specify a yanked version of a
+           package. When possible, try other non-yanked SemVer-compatible
+           versions or seek help from the maintainers of the package.
 
            A compatible pre-release version can also be specified even when the
            version requirement in Cargo.toml doesn’t contain any pre-release

--- a/src/doc/src/commands/cargo-update.md
+++ b/src/doc/src/commands/cargo-update.md
@@ -40,10 +40,11 @@ Cannot be used with <code>--precise</code>.</dd>
 <dd class="option-desc">When used with <em>spec</em>, allows you to specify a specific version number to set
 the package to. If the package comes from a git repository, this can be a git
 revision (such as a SHA hash or tag).</p>
-<p>While not recommended, you can specify a yanked version of a package (nightly only).
+<p>While not recommended, you can specify a yanked version of a package.
 When possible, try other non-yanked SemVer-compatible versions or seek help
 from the maintainers of the package.</p>
-<p>A compatible <code>pre-release</code> version can also be specified even when the version requirement in <code>Cargo.toml</code> doesn’t contain any pre-release identifier (nightly only).</dd>
+<p>A compatible <code>pre-release</code> version can also be specified even when the version
+requirement in <code>Cargo.toml</code> doesn’t contain any pre-release identifier (nightly only).</dd>
 
 
 <dt class="option-term" id="option-cargo-update--w"><a class="option-anchor" href="#option-cargo-update--w"></a><code>-w</code></dt>

--- a/src/etc/man/cargo-update.1
+++ b/src/etc/man/cargo-update.1
@@ -40,11 +40,12 @@ When used with \fIspec\fR, allows you to specify a specific version number to se
 the package to. If the package comes from a git repository, this can be a git
 revision (such as a SHA hash or tag).
 .sp
-While not recommended, you can specify a yanked version of a package (nightly only).
+While not recommended, you can specify a yanked version of a package.
 When possible, try other non\-yanked SemVer\-compatible versions or seek help
 from the maintainers of the package.
 .sp
-A compatible \fBpre\-release\fR version can also be specified even when the version requirement in \fBCargo.toml\fR doesn\[cq]t contain any pre\-release identifier (nightly only).
+A compatible \fBpre\-release\fR version can also be specified even when the version
+requirement in \fBCargo.toml\fR doesn\[cq]t contain any pre\-release identifier (nightly only).
 .RE
 .sp
 \fB\-w\fR, 

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1450,26 +1450,6 @@ fn precise_yanked() {
     assert!(lockfile.contains("\nname = \"bar\"\nversion = \"0.1.0\""));
 
     p.cargo("update --precise 0.1.1 bar")
-        .with_status(101)
-        .with_stderr(
-            "\
-[UPDATING] `dummy-registry` index
-[ERROR] failed to get `bar` as a dependency of package `foo v0.0.0 ([CWD])`
-
-Caused by:
-  failed to query replaced source registry `crates-io`
-
-Caused by:
-  the `--precise <yanked-version>` flag is unstable[..]
-  See [..]
-  See [..]
-",
-        )
-        .run();
-
-    p.cargo("update --precise 0.1.1 bar")
-        .masquerade_as_nightly_cargo(&["--precise <yanked-version>"])
-        .arg("-Zunstable-options")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index
@@ -1511,8 +1491,6 @@ fn precise_yanked_multiple_presence() {
     assert!(lockfile.contains("\nname = \"bar\"\nversion = \"0.1.0\""));
 
     p.cargo("update --precise 0.1.1 bar")
-        .masquerade_as_nightly_cargo(&["--precise <yanked-version>"])
-        .arg("-Zunstable-options")
         .with_stderr(
             "\
 [UPDATING] `dummy-registry` index


### PR DESCRIPTION
### What does this PR try to resolve?

Stabilize `cargo update --precise <yanked>`.

The cargo team has discussed the stabilization in the meeting today.
The interface of this is quite small and not as controversial as `--precise <pre-release>`,
since there is no version requirement operators involved.
We'd like to move forward and stabilize this part.

Note that `--precise <yanked>` allows using yanked version only for the specified package, 
We leave the cascading allowing yanked versions (e.g. <https://github.com/rust-lang/cargo/issues/4225#issuecomment-1930353693>) as a future extension.

### How should we test and review this PR?

Check if any adjustment needed for warnings and CLI help text.

### Additional information

cc <https://github.com/rust-lang/cargo/issues/4225>.
