### PR TITLE
Update openssl-src to 111.28.2+1.1.1w

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2432,9 +2432,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.28.1+1.1.1w"
+version = "111.28.2+1.1.1w"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf7e82ffd6d3d6e6524216a0bfd85509f68b5b28354e8e7800057e44cefa9b4"
+checksum = "bb1830e20a48a975ca898ca8c1d036a36c3c6c5cb7dabc1c216706587857920f"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
### What does this PR try to resolve?

This PR is to fix the build of `loongarch64-unknown-linux-musl` target.

Update `openssl-src` from `111.28.1+1.1.1w` to `111.28.2+1.1.1w`.

### How should we test and review this PR?

Nothing special.

### Additional information

openssl-src diffs:  https://github.com/alexcrichton/openssl-src-rs/compare/cb7b3c8862f93f38a28c8200b88eb4c1be107323...8c19f63843c8cb84c8fd27fd6db8c1ff687d2da2
