### PR TITLE
doc(cargo-package): explain no guarantee of vcs provenance

### DIFF
--- a/src/doc/man/cargo-package.md
+++ b/src/doc/man/cargo-package.md
@@ -61,6 +61,13 @@ Will generate a `.cargo_vcs_info.json` in the following format
 `path_in_vcs` will be set to a repo-relative path for packages
 in subdirectories of the version control repository.
 
+The compatibility of this file is maintained under the same policy
+as the JSON output of {{man "cargo-metadata" 1}}.
+
+Note that this file provides a best-effort snapshot of the VCS information.
+However, the provenance of the package is not verified.
+There is no guarantee that the source code in the tarball matches the VCS information.
+
 ## OPTIONS
 
 ### Package Options

--- a/src/doc/man/generated_txt/cargo-package.txt
+++ b/src/doc/man/generated_txt/cargo-package.txt
@@ -59,6 +59,14 @@ DESCRIPTION
        path_in_vcs will be set to a repo-relative path for packages in
        subdirectories of the version control repository.
 
+       The compatibility of this file is maintained under the same policy as
+       the JSON output of cargo-metadata(1).
+
+       Note that this file provides a best-effort snapshot of the VCS
+       information. However, the provenance of the package is not verified.
+       There is no guarantee that the source code in the tarball matches the
+       VCS information.
+
 OPTIONS
    Package Options
        -l, --list

--- a/src/doc/src/commands/cargo-package.md
+++ b/src/doc/src/commands/cargo-package.md
@@ -56,6 +56,13 @@ Will generate a `.cargo_vcs_info.json` in the following format
 `path_in_vcs` will be set to a repo-relative path for packages
 in subdirectories of the version control repository.
 
+The compatibility of this file is maintained under the same policy
+as the JSON output of [cargo-metadata(1)](cargo-metadata.html).
+
+Note that this file provides a best-effort snapshot of the VCS information.
+However, the provenance of the package is not verified.
+There is no guarantee that the source code in the tarball matches the VCS information.
+
 ## OPTIONS
 
 ### Package Options

--- a/src/etc/man/cargo-package.1
+++ b/src/etc/man/cargo-package.1
@@ -83,6 +83,13 @@ Will generate a \fB\&.cargo_vcs_info.json\fR in the following format
 .sp
 \fBpath_in_vcs\fR will be set to a repo\-relative path for packages
 in subdirectories of the version control repository.
+.sp
+The compatibility of this file is maintained under the same policy
+as the JSON output of \fBcargo\-metadata\fR(1).
+.sp
+Note that this file provides a best\-effort snapshot of the VCS information.
+However, the provenance of the package is not verified.
+There is no guarantee that the source code in the tarball matches the VCS information.
 .SH "OPTIONS"
 .SS "Package Options"
 .sp


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

Address the concern in <https://github.com/rust-lang/cargo/pull/13960#issuecomment-2137877905>.

Two things are called out:

* JSON compatibility is the same as the output of `cargo-metdata`, e.g. new fields can be added freely.
* The presence of `.cargo_vcs_info.json` doesn't mean Cargo has verified the package provenance.

### How should we test and review this PR?

`cargo run -- help package`?

### Additional information
<!-- homu-ignore:end -->
