### PR TITLE
fix:  improve message for inactive weak optional feature with edition2024

### DIFF
--- a/src/cargo/core/summary.rs
+++ b/src/cargo/core/summary.rs
@@ -304,6 +304,13 @@ fn build_feature_map(
 
                     // Validation of the feature name will be performed in the resolver.
                     if !is_any_dep {
+                        // editon2024 stops expose implicit features, which will strip weak optional dependencies from `dependencies`
+                        if *weak {
+                            bail!(
+                                "feature `{feature}` includes `{fv}`, activate it in a feature with `dep:{dep_name}` if `{dep_name}` is an enabled dependency"                               
+                            );
+                        }
+
                         bail!(
                             "feature `{}` includes `{}`, but `{}` is not a dependency",
                             feature,

--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -188,7 +188,7 @@ fn inactive_weak_optional_dep() {
 error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  feature `feat` includes `dep?/feat`, but `dep` is not a dependency
+  feature `feat` includes `dep?/feat`, activate it in a feature with `dep:dep` if `dep` is an enabled dependency
 ",
         )
         .run();
@@ -221,7 +221,7 @@ Caused by:
 error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  feature `feat` includes `dep?/feat`, but `dep` is not a dependency
+  feature `feat` includes `dep?/feat`, activate it in a feature with `dep:dep` if `dep` is an enabled dependency
 ",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This will improve the message for inactive weak optional feature with edition2024.

This doesn't distinguish whether the dependency had set, which needs to get the dependency from origin that will make more complex.

Fixes #14015 

### How should we test and review this PR?

one commit add the test, one commit fix and update the test

### Additional information


