### PR TITLE
fix(lints): Add unknown_lints to lints list

### DIFF
--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -13,7 +13,12 @@ use std::path::Path;
 use toml_edit::ImDocument;
 
 const LINT_GROUPS: &[LintGroup] = &[TEST_DUMMY_UNSTABLE];
-const LINTS: &[Lint] = &[IM_A_TEAPOT, IMPLICIT_FEATURES, UNUSED_OPTIONAL_DEPENDENCY];
+const LINTS: &[Lint] = &[
+    IM_A_TEAPOT,
+    IMPLICIT_FEATURES,
+    UNKNOWN_LINTS,
+    UNUSED_OPTIONAL_DEPENDENCY,
+];
 
 pub fn analyze_cargo_lints_table(
     pkg: &Package,


### PR DESCRIPTION
When working on the linting system, I noticed that `UNKNOWN_LINTS` was not in the list of all lints, when it probably should be.
