### PR TITLE
fix: improve message for inactive weak optional feature with edition2024 through unused dep collection

### DIFF
--- a/src/cargo/util/context/mod.rs
+++ b/src/cargo/util/context/mod.rs
@@ -2031,7 +2031,7 @@ impl ConfigError {
     }
 
     fn is_missing_field(&self) -> bool {
-        self.error.downcast_ref::<MissingField>().is_some()
+        self.error.downcast_ref::<MissingFieldError>().is_some()
     }
 
     fn missing(key: &ConfigKey) -> ConfigError {
@@ -2067,15 +2067,15 @@ impl fmt::Display for ConfigError {
 }
 
 #[derive(Debug)]
-struct MissingField(String);
+struct MissingFieldError(String);
 
-impl fmt::Display for MissingField {
+impl fmt::Display for MissingFieldError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "missing field `{}`", self.0)
     }
 }
 
-impl std::error::Error for MissingField {}
+impl std::error::Error for MissingFieldError {}
 
 impl serde::de::Error for ConfigError {
     fn custom<T: fmt::Display>(msg: T) -> Self {
@@ -2087,7 +2087,7 @@ impl serde::de::Error for ConfigError {
 
     fn missing_field(field: &'static str) -> Self {
         ConfigError {
-            error: anyhow::Error::new(MissingField(field.to_string())),
+            error: anyhow::Error::new(MissingFieldError(field.to_string())),
             definition: None,
         }
     }

--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -199,7 +199,11 @@ fn verify_feature_enabled(
     Ok(())
 }
 
-fn get_span(document: &ImDocument<String>, path: &[&str], get_value: bool) -> Option<Range<usize>> {
+pub fn get_span(
+    document: &ImDocument<String>,
+    path: &[&str],
+    get_value: bool,
+) -> Option<Range<usize>> {
     let mut table = document.as_item().as_table_like()?;
     let mut iter = path.into_iter().peekable();
     while let Some(key) = iter.next() {
@@ -240,7 +244,7 @@ fn get_span(document: &ImDocument<String>, path: &[&str], get_value: bool) -> Op
 
 /// Gets the relative path to a manifest from the current working directory, or
 /// the absolute path of the manifest if a relative path cannot be constructed
-fn rel_cwd_manifest_path(path: &Path, gctx: &GlobalContext) -> String {
+pub fn rel_cwd_manifest_path(path: &Path, gctx: &GlobalContext) -> String {
     diff_paths(path, gctx.cwd())
         .unwrap_or_else(|| path.to_path_buf())
         .display()

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -256,10 +256,13 @@ fn invalid6() {
     p.cargo("check --features foo")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[ERROR] feature `foo` includes `bar/baz`, but `bar` is not a dependency
+ --> Cargo.toml:9:23
+  |
+9 |                 foo = ["bar/baz"]
+  |                       ^^^^^^^^^^^
+  |
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  feature `foo` includes `bar/baz`, but `bar` is not a dependency
 
 "#]])
         .run();
@@ -288,10 +291,13 @@ fn invalid7() {
     p.cargo("check --features foo")
         .with_status(101)
         .with_stderr_data(str![[r#"
+[ERROR] feature `foo` includes `bar/baz`, but `bar` is not a dependency
+ --> Cargo.toml:9:23
+  |
+9 |                 foo = ["bar/baz"]
+  |                       ^^^^^^^^^^^
+  |
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  feature `foo` includes `bar/baz`, but `bar` is not a dependency
 
 "#]])
         .run();

--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -254,10 +254,13 @@ fn inactive_weak_optional_dep() {
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .with_status(101)
         .with_stderr_data(str![[r#"
+[ERROR] feature `foo_feature` includes `dep_name?/dep_feature`, but `dep_name` is not a dependency
+  --> Cargo.toml:11:27
+   |
+11 |             foo_feature = ["dep_name?/dep_feature"]
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  feature `foo_feature` includes `dep_name?/dep_feature`, but `dep_name` is not a dependency
 
 "#]])
         .run();
@@ -287,10 +290,18 @@ Caused by:
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .with_status(101)
         .with_stderr_data(str![[r#"
+[ERROR] feature `foo_feature` includes `dep_name?/dep_feature`, but `dep_name` is not a dependency
+  --> Cargo.toml:12:31
+   |
+ 9 |                 dep_name = { version = "0.1.0", optional = true }
+   |                 -------- `dep_name` is an unused optional dependency since no feature enables it
+10 | 
+11 |                 [features]
+12 |                 foo_feature = ["dep_name?/dep_feature"]
+   |                               ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [HELP] enable the dependency with `dep:dep_name`
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  feature `foo_feature` includes `dep_name?/dep_feature`, but missing `dep:dep_name` to activate it
 
 "#]])
         .run();
@@ -319,10 +330,18 @@ Caused by:
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
         .with_status(101)
         .with_stderr_data(str![[r#"
+[ERROR] feature `foo_feature` includes `dep_name?/dep_feature`, but `dep_name` is not a dependency
+  --> Cargo.toml:12:27
+   |
+ 9 |             dep_name = { version = "0.1.0", optional = true }
+   |             -------- `dep_name` is an unused optional dependency since no feature enables it
+10 | 
+11 |             [features]
+12 |             foo_feature = ["dep_name?/dep_feature"]
+   |                           ^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = [HELP] enable the dependency with `dep:dep_name`
 [ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
-
-Caused by:
-  feature `foo_feature` includes `dep_name?/dep_feature`, but missing `dep:dep_name` to activate it
 
 "#]])
         .run();

--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 use cargo_test_support::str;
@@ -34,34 +32,33 @@ target-dep = { version = "0.1.0", optional = true }
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
-        .with_stderr(
-            "\
-warning: unused optional dependency
+        .with_stderr_data(str![[r#"
+[WARNING] unused optional dependency
  --> Cargo.toml:9:1
   |
-9 | bar = { version = \"0.1.0\", optional = true }
+9 | bar = { version = "0.1.0", optional = true }
   | ---
   |
-  = note: `cargo::unused_optional_dependency` is set to `warn` by default
-  = help: remove the dependency or activate it in a feature with `dep:bar`
-warning: unused optional dependency
+  = [NOTE] `cargo::unused_optional_dependency` is set to `warn` by default
+  = [HELP] remove the dependency or activate it in a feature with `dep:bar`
+[WARNING] unused optional dependency
   --> Cargo.toml:12:1
    |
-12 | baz = { version = \"0.1.0\", optional = true }
+12 | baz = { version = "0.1.0", optional = true }
    | ---
    |
-   = help: remove the dependency or activate it in a feature with `dep:baz`
-warning: unused optional dependency
+   = [HELP] remove the dependency or activate it in a feature with `dep:baz`
+[WARNING] unused optional dependency
   --> Cargo.toml:15:1
    |
-15 | target-dep = { version = \"0.1.0\", optional = true }
+15 | target-dep = { version = "0.1.0", optional = true }
    | ----------
    |
-   = help: remove the dependency or activate it in a feature with `dep:target-dep`
-[CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] [..]
-",
-        )
+   = [HELP] remove the dependency or activate it in a feature with `dep:target-dep`
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -89,14 +86,13 @@ implicit_features = "allow"
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints"])
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
-[CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -130,34 +126,33 @@ target-dep = { version = "0.1.0", optional = true }
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
-        .with_stderr(
-            "\
-warning: unused optional dependency
+        .with_stderr_data(str![[r#"
+[WARNING] unused optional dependency
  --> Cargo.toml:9:1
   |
-9 | bar = { version = \"0.1.0\", optional = true }
+9 | bar = { version = "0.1.0", optional = true }
   | ---
   |
-  = note: `cargo::unused_optional_dependency` is set to `warn` by default
-  = help: remove the dependency or activate it in a feature with `dep:bar`
-warning: unused optional dependency
+  = [NOTE] `cargo::unused_optional_dependency` is set to `warn` by default
+  = [HELP] remove the dependency or activate it in a feature with `dep:bar`
+[WARNING] unused optional dependency
   --> Cargo.toml:12:1
    |
-12 | baz = { version = \"0.2.0\", package = \"bar\", optional = true }
+12 | baz = { version = "0.2.0", package = "bar", optional = true }
    | ---
    |
-   = help: remove the dependency or activate it in a feature with `dep:baz`
-warning: unused optional dependency
+   = [HELP] remove the dependency or activate it in a feature with `dep:baz`
+[WARNING] unused optional dependency
   --> Cargo.toml:15:1
    |
-15 | target-dep = { version = \"0.1.0\", optional = true }
+15 | target-dep = { version = "0.1.0", optional = true }
    | ----------
    |
-   = help: remove the dependency or activate it in a feature with `dep:target-dep`
-[CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] [..]
-",
-        )
+   = [HELP] remove the dependency or activate it in a feature with `dep:target-dep`
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -186,20 +181,19 @@ optional-dep = []
 
     p.cargo("check -Zcargo-lints")
         .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
-        .with_stderr(
-            "\
-warning: unused optional dependency
+        .with_stderr_data(str![[r#"
+[WARNING] unused optional dependency
  --> Cargo.toml:9:1
   |
-9 | optional-dep = { version = \"0.1.0\", optional = true }
+9 | optional-dep = { version = "0.1.0", optional = true }
   | ------------
   |
-  = note: `cargo::unused_optional_dependency` is set to `warn` by default
-  = help: remove the dependency or activate it in a feature with `dep:optional-dep`
-[CHECKING] foo v0.1.0 ([CWD])
-[FINISHED] [..]
-",
-        )
+  = [NOTE] `cargo::unused_optional_dependency` is set to `warn` by default
+  = [HELP] remove the dependency or activate it in a feature with `dep:optional-dep`
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Collect the unused dependencies to check whether a weak optional dependency had set. Then we can improve the message when weak optional dependency inactive. 

Fixes https://github.com/rust-lang/cargo/issues/14015

### How should we test and review this PR?

One commit test added, one commit fixed and updated

### Additional information
Part of https://github.com/rust-lang/cargo/issues/14039
- migrate `tests/testsuite/lints/unused_optional_dependencies.rs` to snapshot 

And rename `MissingField` to `MissingFieldError`


