### PR TITLE
test(lints): Ensure unused optional dep fires for shadowed dep

### DIFF
--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -157,3 +157,45 @@ warning: unused optional dependency
         )
         .run();
 }
+
+#[cargo_test(nightly, reason = "edition2024 is not stable")]
+fn shadowed_optional_dep_is_unused_in_2024() {
+    Package::new("optional-dep", "0.1.0").publish();
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+cargo-features = ["edition2024"]
+[package]
+name = "foo"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+optional-dep = { version = "0.1.0", optional = true }
+
+[features]
+optional-dep = []
+"#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -Zcargo-lints")
+        .masquerade_as_nightly_cargo(&["cargo-lints", "edition2024"])
+        .with_stderr(
+            "\
+warning: unused optional dependency
+ --> Cargo.toml:9:1
+  |
+9 | optional-dep = { version = \"0.1.0\", optional = true }
+  | ------------
+  |
+  = note: `cargo::unused_optional_dependency` is set to `warn` by default
+  = help: remove the dependency or activate it in a feature with `dep:optional-dep`
+[CHECKING] foo v0.1.0 ([CWD])
+[FINISHED] [..]
+",
+        )
+        .run();
+}


### PR DESCRIPTION
This is a way to have an unused optional dependency before 2024 edition.
In prior editions, it is currently a hard error.
I'm tempted to switch that hard error to this lint in prior editions but at minimum, we need to make sure we don't make changes that cause this to revert back to a hard error on 2024+

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
