### PR TITLE
Keep lints updated

### DIFF
--- a/src/cargo/util/lints.rs
+++ b/src/cargo/util/lints.rs
@@ -14,8 +14,8 @@ use toml_edit::ImDocument;
 
 const LINT_GROUPS: &[LintGroup] = &[TEST_DUMMY_UNSTABLE];
 pub const LINTS: &[Lint] = &[
-    IM_A_TEAPOT,
     IMPLICIT_FEATURES,
+    IM_A_TEAPOT,
     UNKNOWN_LINTS,
     UNUSED_OPTIONAL_DEPENDENCY,
 ];
@@ -874,4 +874,43 @@ pub fn unused_dependencies(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use snapbox::ToDebug;
+
+    #[test]
+    fn ensure_sorted_lints() {
+        // This will be printed out if the fields are not sorted.
+        let location = std::panic::Location::caller();
+        println!("\nTo fix this test, sort `LINTS` in {}\n", location.file(),);
+
+        let actual = super::LINTS
+            .iter()
+            .map(|l| l.name.to_uppercase())
+            .collect::<Vec<_>>();
+
+        let mut expected = actual.clone();
+        expected.sort();
+        snapbox::assert_data_eq!(actual.to_debug(), expected.to_debug());
+    }
+
+    #[test]
+    fn ensure_sorted_lint_groups() {
+        // This will be printed out if the fields are not sorted.
+        let location = std::panic::Location::caller();
+        println!(
+            "\nTo fix this test, sort `LINT_GROUPS` in {}\n",
+            location.file(),
+        );
+        let actual = super::LINT_GROUPS
+            .iter()
+            .map(|l| l.name.to_uppercase())
+            .collect::<Vec<_>>();
+
+        let mut expected = actual.clone();
+        expected.sort();
+        snapbox::assert_data_eq!(actual.to_debug(), expected.to_debug());
+    }
 }


### PR DESCRIPTION
In #14024, [it was noted](https://github.com/rust-lang/cargo/pull/14024#pullrequestreview-2103598233) that we should probably have some automated way to ensure that `LINTS` stays up to date. I went ahead and did this, but I extended the idea to also include `LINT_GROUPS` and added support for ensuring they both stay sorted.


Error message for `LINTS` not being sorted:
![Screenshot from 2024-06-07 10-18-43](https://github.com/rust-lang/cargo/assets/23045215/aa44e25c-1bf9-4cba-8a1b-29458aa409f0)

Error message for missing `Lint`s:
![Screenshot from 2024-06-07 10-51-09](https://github.com/rust-lang/cargo/assets/23045215/8952d0aa-76e1-46b4-bccc-348400da6548)

