### PR TITLE
tests: Migrate alt_registry to snapbox

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3230,6 +3230,7 @@ dependencies = [
  "filetime",
  "normalize-line-endings",
  "regex",
+ "serde",
  "serde_json",
  "similar",
  "snapbox-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ version = "0.2.1"
 
 [[package]]
 name = "cargo-test-support"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 shell-escape = "0.1.5"
 supports-hyperlinks = "3.0.0"
-snapbox = { version = "0.6.9", features = ["diff", "dir", "term-svg", "regex"] }
+snapbox = { version = "0.6.9", features = ["diff", "dir", "term-svg", "regex", "json"] }
 tar = { version = "0.4.40", default-features = false }
 tempfile = "3.10.1"
 thiserror = "1.0.59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,7 +91,7 @@ sha1 = "0.10.6"
 sha2 = "0.10.8"
 shell-escape = "0.1.5"
 supports-hyperlinks = "3.0.0"
-snapbox = { version = "0.6.5", features = ["diff", "dir", "term-svg", "regex"] }
+snapbox = { version = "0.6.9", features = ["diff", "dir", "term-svg", "regex"] }
 tar = { version = "0.4.40", default-features = false }
 tempfile = "3.10.1"
 thiserror = "1.0.59"

--- a/crates/cargo-test-support/Cargo.toml
+++ b/crates/cargo-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-test-support"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version = "1.78"  # MSRV:1
 license.workspace = true

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -97,6 +97,11 @@ pub fn assert_ui() -> snapbox::Assert {
         regex::Regex::new("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B").unwrap(),
     )
     .unwrap();
+    subs.insert(
+        "[HASH]",
+        regex::Regex::new("home/\\.cargo/registry/src/-(?<redacted>[a-z0-9]+)").unwrap(),
+    )
+    .unwrap();
     snapbox::Assert::new()
         .action_env(snapbox::assert::DEFAULT_ACTION_ENV)
         .redact_with(subs)
@@ -154,6 +159,11 @@ pub fn assert_e2e() -> snapbox::Assert {
     subs.insert(
         "[FILE_SIZE]",
         regex::Regex::new("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B").unwrap(),
+    )
+    .unwrap();
+    subs.insert(
+        "[HASH]",
+        regex::Regex::new("home/\\.cargo/registry/src/-(?<redacted>[a-z0-9]+)").unwrap(),
     )
     .unwrap();
     snapbox::Assert::new()

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -92,6 +92,11 @@ pub fn assert_ui() -> snapbox::Assert {
         regex::Regex::new("Finished.*in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
     )
     .unwrap();
+    subs.insert(
+        "[FILE_SIZE]",
+        regex::Regex::new("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B").unwrap(),
+    )
+    .unwrap();
     snapbox::Assert::new()
         .action_env(snapbox::assert::DEFAULT_ACTION_ENV)
         .redact_with(subs)
@@ -144,6 +149,11 @@ pub fn assert_e2e() -> snapbox::Assert {
     subs.insert(
         "[ELAPSED]",
         regex::Regex::new("[FINISHED].*in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
+    )
+    .unwrap();
+    subs.insert(
+        "[FILE_SIZE]",
+        regex::Regex::new("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B").unwrap(),
     )
     .unwrap();
     snapbox::Assert::new()

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -908,6 +908,7 @@ impl Execs {
         }
     }
 
+    #[track_caller]
     fn verify_checks_output(&self, stdout: &[u8], stderr: &[u8]) {
         if self.expect_exit_code.unwrap_or(0) != 0
             && self.expect_stdout.is_none()
@@ -934,6 +935,7 @@ impl Execs {
         }
     }
 
+    #[track_caller]
     fn match_process(&self, process: &ProcessBuilder) -> Result<RawOutput> {
         println!("running {}", process);
         let res = if self.stream_output {
@@ -984,6 +986,7 @@ impl Execs {
         }
     }
 
+    #[track_caller]
     fn match_output(&self, code: Option<i32>, stdout: &[u8], stderr: &[u8]) -> Result<()> {
         self.verify_checks_output(stdout, stderr);
         let stdout = std::str::from_utf8(stdout).expect("stdout is not utf8");

--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -559,6 +559,7 @@ impl Execs {
 
     /// Verifies that stdout is equal to the given lines.
     /// See [`compare`] for supported patterns.
+    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected)`")]
     pub fn with_stdout<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout = Some(expected.to_string());
         self
@@ -566,6 +567,7 @@ impl Execs {
 
     /// Verifies that stderr is equal to the given lines.
     /// See [`compare`] for supported patterns.
+    #[deprecated(note = "replaced with `Execs::with_stderr_data(expected)`")]
     pub fn with_stderr<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr = Some(expected.to_string());
         self
@@ -613,6 +615,7 @@ impl Execs {
     /// its output.
     ///
     /// See [`compare`] for supported patterns.
+    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected)`")]
     pub fn with_stdout_contains<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_contains.push(expected.to_string());
         self
@@ -622,6 +625,7 @@ impl Execs {
     /// its output.
     ///
     /// See [`compare`] for supported patterns.
+    #[deprecated(note = "replaced with `Execs::with_stderr_data(expected)`")]
     pub fn with_stderr_contains<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_contains.push(expected.to_string());
         self
@@ -631,6 +635,7 @@ impl Execs {
     /// its output, and should be repeated `number` times.
     ///
     /// See [`compare`] for supported patterns.
+    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected)`")]
     pub fn with_stdout_contains_n<S: ToString>(&mut self, expected: S, number: usize) -> &mut Self {
         self.expect_stdout_contains_n
             .push((expected.to_string(), number));
@@ -642,6 +647,7 @@ impl Execs {
     /// See [`compare`] for supported patterns.
     ///
     /// See note on [`Self::with_stderr_does_not_contain`].
+    #[deprecated]
     pub fn with_stdout_does_not_contain<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_not_contains.push(expected.to_string());
         self
@@ -656,6 +662,7 @@ impl Execs {
     /// your test will pass without verifying the correct behavior. If
     /// possible, write the test first so that it fails, and then implement
     /// your fix/feature to make it pass.
+    #[deprecated]
     pub fn with_stderr_does_not_contain<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_not_contains.push(expected.to_string());
         self
@@ -665,6 +672,7 @@ impl Execs {
     /// ignoring the order of the lines.
     ///
     /// See [`Execs::with_stderr_unordered`] for more details.
+    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected.unordered())`")]
     pub fn with_stdout_unordered<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stdout_unordered.push(expected.to_string());
         self
@@ -691,6 +699,7 @@ impl Execs {
     ///
     /// This will randomly fail if the other crate name is `bar`, and the
     /// order changes.
+    #[deprecated(note = "replaced with `Execs::with_stderr_data(expected.unordered())`")]
     pub fn with_stderr_unordered<S: ToString>(&mut self, expected: S) -> &mut Self {
         self.expect_stderr_unordered.push(expected.to_string());
         self
@@ -718,6 +727,7 @@ impl Execs {
     ///
     /// Be careful writing the `without` fragments, see note in
     /// `with_stderr_does_not_contain`.
+    #[deprecated]
     pub fn with_stderr_line_without<S: ToString>(
         &mut self,
         with: &[S],
@@ -750,6 +760,7 @@ impl Execs {
     /// - The order of arrays is ignored.
     /// - Strings support patterns described in [`compare`].
     /// - Use `"{...}"` to match any object.
+    #[deprecated(note = "replaced with `Execs::with_stdout_data(expected.json_lines())`")]
     pub fn with_json(&mut self, expected: &str) -> &mut Self {
         self.expect_json = Some(expected.to_string());
         self
@@ -764,6 +775,7 @@ impl Execs {
     /// what you are doing.
     ///
     /// See `with_json` for more detail.
+    #[deprecated]
     pub fn with_json_contains_unordered(&mut self, expected: &str) -> &mut Self {
         match &mut self.expect_json_contains_unordered {
             None => self.expect_json_contains_unordered = Some(expected.to_string()),

--- a/tests/build-std/main.rs
+++ b/tests/build-std/main.rs
@@ -19,6 +19,7 @@
 //! Otherwise the tests are skipped.
 
 #![allow(clippy::disallowed_methods)]
+#![allow(deprecated)]
 
 use cargo_test_support::*;
 use std::env;

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -1,7 +1,5 @@
 //! -Zadvanced-env tests
 
-#![allow(deprecated)]
-
 use cargo_test_support::{paths, project, registry::Package};
 
 #[cargo_test]

--- a/tests/testsuite/advanced_env.rs
+++ b/tests/testsuite/advanced_env.rs
@@ -1,5 +1,7 @@
 //! -Zadvanced-env tests
 
+#![allow(deprecated)]
+
 use cargo_test_support::{paths, project, registry::Package};
 
 #[cargo_test]

--- a/tests/testsuite/alt_registry.rs
+++ b/tests/testsuite/alt_registry.rs
@@ -1,5 +1,7 @@
 //! Tests for alternative registries.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::publish::validate_alt_upload;
 use cargo_test_support::registry::{self, Package, RegistryBuilder};

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1,6 +1,8 @@
 //! Tests specific to artifact dependencies, designated using
 //! the new `dep = { artifact = "bin", … }` syntax in manifests.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::registry::{Package, RegistryBuilder};
 use cargo_test_support::str;

--- a/tests/testsuite/artifact_dir.rs
+++ b/tests/testsuite/artifact_dir.rs
@@ -1,5 +1,7 @@
 //! Tests for --artifact-dir flag.
 
+#![allow(deprecated)]
+
 use cargo_test_support::sleep_ms;
 use cargo_test_support::{basic_manifest, project};
 use std::env;

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -1,5 +1,7 @@
 //! Tests for some invalid .cargo/config files.
 
+#![allow(deprecated)]
+
 use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{basic_manifest, project, rustc_host};

--- a/tests/testsuite/bad_manifest_path.rs
+++ b/tests/testsuite/bad_manifest_path.rs
@@ -1,5 +1,7 @@
 //! Tests for invalid --manifest-path arguments.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_bin_manifest, main_file, project};
 
 #[track_caller]

--- a/tests/testsuite/bench.rs
+++ b/tests/testsuite/bench.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo bench` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
 

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::install::{
     assert_has_installed_exe, assert_has_not_installed_exe, cargo_home,
 };

--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo build` command.
 
+#![allow(deprecated)]
+
 use cargo::{
     core::compiler::CompileMode,
     core::{Shell, Workspace},

--- a/tests/testsuite/build_plan.rs
+++ b/tests/testsuite/build_plan.rs
@@ -1,5 +1,7 @@
 //! Tests for --build-plan feature.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_bin_manifest, basic_manifest, main_file, project};
 

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -1,5 +1,7 @@
 //! Tests for build.rs scripts.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;

--- a/tests/testsuite/build_script_env.rs
+++ b/tests/testsuite/build_script_env.rs
@@ -1,5 +1,7 @@
 //! Tests for build.rs rerun-if-env-changed and rustc-env
 
+#![allow(deprecated)]
+
 use cargo_test_support::basic_manifest;
 use cargo_test_support::project;
 use cargo_test_support::sleep_ms;

--- a/tests/testsuite/build_script_extra_link_arg.rs
+++ b/tests/testsuite/build_script_extra_link_arg.rs
@@ -4,6 +4,8 @@
 // because MSVC link.exe just gives a warning on unknown flags (how helpful!),
 // and other linkers will return an error.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
 

--- a/tests/testsuite/cache_lock.rs
+++ b/tests/testsuite/cache_lock.rs
@@ -1,5 +1,7 @@
 //! Tests for `CacheLock`.
 
+#![allow(deprecated)]
+
 use crate::config::GlobalContextBuilder;
 use cargo::util::cache_lock::{CacheLockMode, CacheLocker};
 use cargo_test_support::paths::{self, CargoPathExt};

--- a/tests/testsuite/cache_messages.rs
+++ b/tests/testsuite/cache_messages.rs
@@ -1,5 +1,7 @@
 //! Tests for caching compiler diagnostics.
 
+#![allow(deprecated)]
+
 use super::messages::raw_rustc_output;
 use cargo_test_support::tools;
 use cargo_test_support::{basic_manifest, is_coarse_mtime, project, registry::Package, sleep_ms};

--- a/tests/testsuite/cargo_alias_config.rs
+++ b/tests/testsuite/cargo_alias_config.rs
@@ -1,5 +1,7 @@
 //! Tests for `[alias]` config command aliases.
 
+#![allow(deprecated)]
+
 use std::env;
 
 use cargo_test_support::tools::echo_subcommand;

--- a/tests/testsuite/cargo_command.rs
+++ b/tests/testsuite/cargo_command.rs
@@ -1,5 +1,7 @@
 //! Tests for custom cargo commands and other global command features.
 
+#![allow(deprecated)]
+
 use std::env;
 use std::fs;
 use std::io::Read;

--- a/tests/testsuite/cargo_config/mod.rs
+++ b/tests/testsuite/cargo_config/mod.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo config` command.
 
+#![allow(deprecated)]
+
 use super::config::write_config_at;
 use cargo_test_support::paths;
 use std::fs;

--- a/tests/testsuite/cargo_env_config.rs
+++ b/tests/testsuite/cargo_env_config.rs
@@ -1,5 +1,7 @@
 //! Tests for `[env]` config.
 
+#![allow(deprecated)]
+
 use cargo_test_support::basic_manifest;
 use cargo_test_support::{basic_bin_manifest, project};
 

--- a/tests/testsuite/cargo_features.rs
+++ b/tests/testsuite/cargo_features.rs
@@ -1,5 +1,7 @@
 //! Tests for `cargo-features` definitions.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{project, registry};
 

--- a/tests/testsuite/cargo_targets.rs
+++ b/tests/testsuite/cargo_targets.rs
@@ -1,5 +1,7 @@
 //! Tests specifically related to target handling (lib, bins, examples, tests, benches).
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/cfg.rs
+++ b/tests/testsuite/cfg.rs
@@ -1,5 +1,7 @@
 //! Tests for cfg() expressions.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_manifest, project};

--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo check` command.
 
+#![allow(deprecated)]
+
 use std::fmt::{self, Write};
 
 use crate::messages::raw_rustc_output;

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -1,5 +1,7 @@
 //! Tests for Cargo usage of rustc `--check-cfg`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_manifest, project};
 
 macro_rules! x {

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo clean` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{

--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -3,6 +3,8 @@
 //! Ideally these should never happen, but I don't think we'll ever be able to
 //! prevent all collisions.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, cross_compile, project};
 use std::env;

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -1,5 +1,7 @@
 //! Tests for running multiple `cargo` processes at the same time.
 
+#![allow(deprecated)]
+
 use std::fs;
 use std::net::TcpListener;
 use std::process::Stdio;

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,5 +1,7 @@
 //! Tests for config settings.
 
+#![allow(deprecated)]
+
 use cargo::core::features::{GitFeatures, GitoxideFeatures};
 use cargo::core::{PackageIdSpec, Shell};
 use cargo::util::context::{

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -1,5 +1,7 @@
 //! Tests for the --config CLI option.
 
+#![allow(deprecated)]
+
 use super::config::{
     assert_error, read_output, write_config_at, write_config_toml, GlobalContextBuilder,
 };

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -1,5 +1,7 @@
 //! Tests for `include` config field.
 
+#![allow(deprecated)]
+
 use super::config::{assert_error, write_config_at, write_config_toml, GlobalContextBuilder};
 use cargo_test_support::{no_such_file_err_msg, project};
 

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -1,5 +1,7 @@
 //! Tests for corrupt git repos.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths;
 use cargo_test_support::{basic_manifest, git, project};
 use cargo_util::paths as cargopaths;

--- a/tests/testsuite/credential_process.rs
+++ b/tests/testsuite/credential_process.rs
@@ -1,5 +1,7 @@
 //! Tests for credential-process.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::{Package, TestRegistry};
 use cargo_test_support::{basic_manifest, cargo_process, paths, project, registry, Project};
 

--- a/tests/testsuite/cross_compile.rs
+++ b/tests/testsuite/cross_compile.rs
@@ -2,6 +2,8 @@
 //!
 //! See `cargo_test_support::cross_compile` for more detail.
 
+#![allow(deprecated)]
+
 use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_bin_manifest, basic_manifest, cross_compile, project};
 

--- a/tests/testsuite/cross_publish.rs
+++ b/tests/testsuite/cross_publish.rs
@@ -1,5 +1,7 @@
 //! Tests for publishing using the `--target` flag.
 
+#![allow(deprecated)]
+
 use std::fs::File;
 
 use cargo_test_support::{cross_compile, project, publish, registry};

--- a/tests/testsuite/custom_target.rs
+++ b/tests/testsuite/custom_target.rs
@@ -1,5 +1,7 @@
 //! Tests for custom json target specifications.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_manifest, project};
 use std::fs;
 

--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -1,5 +1,7 @@
 //! Tests for ctrl-C handling.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{project, slow_cpu_multiplier};
 use std::fs;
 use std::io::{self, Read};

--- a/tests/testsuite/dep_info.rs
+++ b/tests/testsuite/dep_info.rs
@@ -1,6 +1,8 @@
 //! Tests for dep-info files. This includes the dep-info file Cargo creates in
 //! the output directory, and the ones stored in the fingerprint.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::Package;

--- a/tests/testsuite/diagnostics.rs
+++ b/tests/testsuite/diagnostics.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/direct_minimal_versions.rs
+++ b/tests/testsuite/direct_minimal_versions.rs
@@ -2,6 +2,8 @@
 //!
 //! Note: Some tests are located in the resolver-tests package.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -1,5 +1,7 @@
 //! Tests for directory sources.
 
+#![allow(deprecated)]
+
 use std::collections::HashMap;
 use std::fs;
 use std::str;

--- a/tests/testsuite/doc.rs
+++ b/tests/testsuite/doc.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo doc` command.
 
+#![allow(deprecated)]
+
 use cargo::core::compiler::RustDocFingerprint;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;

--- a/tests/testsuite/docscrape.rs
+++ b/tests/testsuite/docscrape.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo doc` command with `-Zrustdoc-scrape-examples`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test(nightly, reason = "rustdoc scrape examples flags are unstable")]

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -1,5 +1,7 @@
 //! Tests for edition setting.
 
+#![allow(deprecated)]
+
 use cargo::core::Edition;
 use cargo_test_support::{basic_lib_manifest, project};
 

--- a/tests/testsuite/error.rs
+++ b/tests/testsuite/error.rs
@@ -1,5 +1,7 @@
 //! General error tests that don't belong anywhere else.
 
+#![allow(deprecated)]
+
 use cargo_test_support::cargo_process;
 
 #[cargo_test]

--- a/tests/testsuite/features.rs
+++ b/tests/testsuite/features.rs
@@ -1,5 +1,7 @@
 //! Tests for `[features]` table.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::{basic_manifest, project};

--- a/tests/testsuite/features2.rs
+++ b/tests/testsuite/features2.rs
@@ -1,5 +1,7 @@
 //! Tests for the new feature resolver.
 
+#![allow(deprecated)]
+
 use cargo_test_support::cross_compile::{self, alternate};
 use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;

--- a/tests/testsuite/features_namespaced.rs
+++ b/tests/testsuite/features_namespaced.rs
@@ -1,5 +1,7 @@
 //! Tests for namespaced features.
 
+#![allow(deprecated)]
+
 use super::features2::switch_to_resolver_2;
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};
 use cargo_test_support::{project, publish};

--- a/tests/testsuite/fetch.rs
+++ b/tests/testsuite/fetch.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo fetch` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::rustc_host;
 use cargo_test_support::{basic_manifest, cross_compile, project};

--- a/tests/testsuite/fix.rs
+++ b/tests/testsuite/fix.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo fix` command.
 
+#![allow(deprecated)]
+
 use cargo::core::Edition;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git::{self, init};

--- a/tests/testsuite/fix_n_times.rs
+++ b/tests/testsuite/fix_n_times.rs
@@ -14,6 +14,8 @@
 //! The [`expect_fix_runs_rustc_n_times`] function handles setting everything
 //! up, and verifying the results.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_manifest, paths, project, tools, Execs};
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -1,5 +1,7 @@
 //! Tests for fingerprinting (rebuild detection).
 
+#![allow(deprecated)]
+
 use filetime::FileTime;
 use std::fs::{self, OpenOptions};
 use std::io;

--- a/tests/testsuite/future_incompat_report.rs
+++ b/tests/testsuite/future_incompat_report.rs
@@ -7,6 +7,8 @@
 //! So we pick some random lint that will likely always be the same
 //! over time.
 
+#![allow(deprecated)]
+
 use super::config::write_config_toml;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, project, Project};

--- a/tests/testsuite/generate_lockfile.rs
+++ b/tests/testsuite/generate_lockfile.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo generate-lockfile` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::{Package, RegistryBuilder};
 use cargo_test_support::{basic_manifest, paths, project, ProjectBuilder};
 use std::fs;

--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -1,5 +1,7 @@
 //! Tests for git support.
 
+#![allow(deprecated)]
+
 use std::fs;
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};

--- a/tests/testsuite/git_auth.rs
+++ b/tests/testsuite/git_auth.rs
@@ -1,5 +1,7 @@
 //! Tests for git authentication.
 
+#![allow(deprecated)]
+
 use std::collections::HashSet;
 use std::io::prelude::*;
 use std::io::BufReader;

--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -1,5 +1,7 @@
 //! Tests for git garbage collection.
 
+#![allow(deprecated)]
+
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::git_gc::find_index;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, git, paths, project};

--- a/tests/testsuite/glob_targets.rs
+++ b/tests/testsuite/glob_targets.rs
@@ -1,5 +1,7 @@
 //! Tests for target filter flags with glob patterns.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{project, Project};
 
 #[cargo_test]

--- a/tests/testsuite/global_cache_tracker.rs
+++ b/tests/testsuite/global_cache_tracker.rs
@@ -6,6 +6,8 @@
 //! what happens when time passes. The [`days_ago_unix`] and
 //! [`months_ago_unix`] functions help with setting this value.
 
+#![allow(deprecated)]
+
 use super::config::GlobalContextBuilder;
 use cargo::core::global_cache_tracker::{self, DeferredGlobalLastUse, GlobalCacheTracker};
 use cargo::util::cache_lock::CacheLockMode;

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -1,5 +1,7 @@
 //! Tests for cargo's help output.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 use std::fs;

--- a/tests/testsuite/https.rs
+++ b/tests/testsuite/https.rs
@@ -3,6 +3,8 @@
 //! Note that these tests will generally require setting CARGO_CONTAINER_TESTS
 //! or CARGO_PUBLIC_NETWORK_TESTS.
 
+#![allow(deprecated)]
+
 use cargo_test_support::containers::Container;
 use cargo_test_support::project;
 

--- a/tests/testsuite/inheritable_workspace_fields.rs
+++ b/tests/testsuite/inheritable_workspace_fields.rs
@@ -1,4 +1,6 @@
 //! Tests for inheriting Cargo.toml fields with field.workspace = true
+#![allow(deprecated)]
+
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};
 use cargo_test_support::{
     basic_lib_manifest, basic_manifest, git, path2url, paths, project, publish, registry,

--- a/tests/testsuite/install.rs
+++ b/tests/testsuite/install.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo install` command.
 
+#![allow(deprecated)]
+
 use std::fs::{self, OpenOptions};
 use std::io::prelude::*;
 use std::path::Path;

--- a/tests/testsuite/install_upgrade.rs
+++ b/tests/testsuite/install_upgrade.rs
@@ -1,5 +1,7 @@
 //! Tests for `cargo install` where it upgrades a package if it is out-of-date.
 
+#![allow(deprecated)]
+
 use cargo::core::PackageId;
 use std::collections::BTreeSet;
 use std::env;

--- a/tests/testsuite/jobserver.rs
+++ b/tests/testsuite/jobserver.rs
@@ -1,5 +1,7 @@
 //! Tests for the jobserver protocol.
 
+#![allow(deprecated)]
+
 use cargo_util::is_ci;
 use std::env;
 use std::net::TcpListener;

--- a/tests/testsuite/lints/implicit_features.rs
+++ b/tests/testsuite/lints/implicit_features.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/lints/mod.rs
+++ b/tests/testsuite/lints/mod.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/lints/unknown_lints.rs
+++ b/tests/testsuite/lints/unknown_lints.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/lints/unused_optional_dependencies.rs
+++ b/tests/testsuite/lints/unused_optional_dependencies.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/lints_table.rs
+++ b/tests/testsuite/lints_table.rs
@@ -1,5 +1,7 @@
 //! Tests for `[lints]`
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/list_availables.rs
+++ b/tests/testsuite/list_availables.rs
@@ -1,6 +1,8 @@
 //! Tests for packages/target filter flags giving suggestions on which
 //! packages/targets are available.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 const EXAMPLE: u8 = 1 << 0;

--- a/tests/testsuite/local_registry.rs
+++ b/tests/testsuite/local_registry.rs
@@ -1,5 +1,7 @@
 //! Tests for local-registry sources.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::{registry_path, Package};
 use cargo_test_support::{basic_manifest, project, t};

--- a/tests/testsuite/locate_project.rs
+++ b/tests/testsuite/locate_project.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo locate-project` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/lockfile_compat.rs
+++ b/tests/testsuite/lockfile_compat.rs
@@ -1,5 +1,7 @@
 //! Tests for supporting older versions of the Cargo.lock file format.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git;
 use cargo_test_support::registry::Package;

--- a/tests/testsuite/login.rs
+++ b/tests/testsuite/login.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo login` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::{self, RegistryBuilder};

--- a/tests/testsuite/logout.rs
+++ b/tests/testsuite/logout.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo logout` command.
 
+#![allow(deprecated)]
+
 use super::login::check_token;
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::TestRegistry;

--- a/tests/testsuite/lto.rs
+++ b/tests/testsuite/lto.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo::core::compiler::Lto;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, project, Project};

--- a/tests/testsuite/member_discovery.rs
+++ b/tests/testsuite/member_discovery.rs
@@ -1,5 +1,7 @@
 //! Tests for workspace member discovery.
 
+#![allow(deprecated)]
+
 use cargo::core::{Shell, Workspace};
 use cargo::util::context::GlobalContext;
 

--- a/tests/testsuite/member_errors.rs
+++ b/tests/testsuite/member_errors.rs
@@ -1,5 +1,7 @@
 //! Tests for workspace member errors.
 
+#![allow(deprecated)]
+
 use cargo::core::resolver::ResolveError;
 use cargo::core::{compiler::CompileMode, Shell, Workspace};
 use cargo::ops::{self, CompileOptions};

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -1,5 +1,7 @@
 //! Tests for --message-format flag.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_lib_manifest, basic_manifest, project};
 
 #[cargo_test]

--- a/tests/testsuite/messages.rs
+++ b/tests/testsuite/messages.rs
@@ -2,6 +2,8 @@
 //!
 //! Tests for message caching can be found in `cache_messages`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{process, project, Project};
 use cargo_util::ProcessError;
 

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -1,5 +1,7 @@
 //! Tests for the metabuild feature (declarative build scripts).
 
+#![allow(deprecated)]
+
 use cargo_test_support::{
     basic_lib_manifest, basic_manifest, is_coarse_mtime, project, registry::Package, rustc_host,
     Project,

--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo metadata` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;

--- a/tests/testsuite/minimal_versions.rs
+++ b/tests/testsuite/minimal_versions.rs
@@ -2,6 +2,8 @@
 //!
 //! Note: Some tests are located in the resolver-tests package.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/multitarget.rs
+++ b/tests/testsuite/multitarget.rs
@@ -1,5 +1,7 @@
 //! Tests for multiple `--target` flags to subcommands
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_manifest, cross_compile, project, rustc_host};
 
 #[cargo_test]

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -1,5 +1,7 @@
 //! Tests for network configuration.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/new.rs
+++ b/tests/testsuite/new.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo new` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths;
 use std::env;

--- a/tests/testsuite/offline.rs
+++ b/tests/testsuite/offline.rs
@@ -1,5 +1,7 @@
 //! Tests for --offline flag.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{
     basic_manifest, git, main_file, path2url, project,
     registry::{Package, RegistryBuilder},

--- a/tests/testsuite/old_cargos.rs
+++ b/tests/testsuite/old_cargos.rs
@@ -10,6 +10,8 @@
 //! cargo test --test testsuite -- old_cargos --nocapture --ignored
 //! ```
 
+#![allow(deprecated)]
+
 use cargo::CargoResult;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::{self, Dependency, Package};

--- a/tests/testsuite/open_namespaces.rs
+++ b/tests/testsuite/open_namespaces.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::RegistryBuilder;
 

--- a/tests/testsuite/owner.rs
+++ b/tests/testsuite/owner.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo owner` command.
 
+#![allow(deprecated)]
+
 use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;

--- a/tests/testsuite/package.rs
+++ b/tests/testsuite/package.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo package` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::publish::validate_crate_contents;
 use cargo_test_support::registry::{self, Package};

--- a/tests/testsuite/package_features.rs
+++ b/tests/testsuite/package_features.rs
@@ -1,5 +1,7 @@
 //! Tests for feature selection on the command-line.
 
+#![allow(deprecated)]
+
 use super::features2::switch_to_resolver_2;
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::{basic_manifest, project};

--- a/tests/testsuite/patch.rs
+++ b/tests/testsuite/patch.rs
@@ -1,5 +1,7 @@
 //! Tests for `[patch]` table source replacement.
 
+#![allow(deprecated)]
+
 use cargo_test_support::git;
 use cargo_test_support::paths;
 use cargo_test_support::registry::{self, Package};

--- a/tests/testsuite/path.rs
+++ b/tests/testsuite/path.rs
@@ -1,5 +1,7 @@
 //! Tests for `path` dependencies.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::{self, CargoPathExt};
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, main_file, project};

--- a/tests/testsuite/paths.rs
+++ b/tests/testsuite/paths.rs
@@ -1,5 +1,7 @@
 //! Tests for `paths` overrides.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, project};
 

--- a/tests/testsuite/pkgid.rs
+++ b/tests/testsuite/pkgid.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo pkgid` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::basic_lib_manifest;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git;

--- a/tests/testsuite/precise_pre_release.rs
+++ b/tests/testsuite/precise_pre_release.rs
@@ -1,5 +1,7 @@
 //! Tests for selecting pre-release versions with `update --precise`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/proc_macro.rs
+++ b/tests/testsuite/proc_macro.rs
@@ -1,5 +1,7 @@
 //! Tests for proc-macros.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/profile_config.rs
+++ b/tests/testsuite/profile_config.rs
@@ -1,5 +1,7 @@
 //! Tests for profiles defined in config files.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, paths, project};

--- a/tests/testsuite/profile_custom.rs
+++ b/tests/testsuite/profile_custom.rs
@@ -1,5 +1,7 @@
 //! Tests for named profiles.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::{basic_lib_manifest, project};
 

--- a/tests/testsuite/profile_overrides.rs
+++ b/tests/testsuite/profile_overrides.rs
@@ -1,5 +1,7 @@
 //! Tests for profile overrides (build-override and per-package overrides).
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, project};
 

--- a/tests/testsuite/profile_targets.rs
+++ b/tests/testsuite/profile_targets.rs
@@ -2,6 +2,8 @@
 //! example, the `test` profile applying to test targets, but not other
 //! targets, etc.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_manifest, project, Project};
 
 fn all_target_project() -> Project {

--- a/tests/testsuite/profile_trim_paths.rs
+++ b/tests/testsuite/profile_trim_paths.rs
@@ -1,5 +1,7 @@
 //! Tests for `-Ztrim-paths`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::basic_manifest;
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::git;

--- a/tests/testsuite/profiles.rs
+++ b/tests/testsuite/profiles.rs
@@ -1,5 +1,7 @@
 //! Tests for profiles.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{project, rustc_host};
 use std::env;

--- a/tests/testsuite/progress.rs
+++ b/tests/testsuite/progress.rs
@@ -1,5 +1,7 @@
 //! Tests for progress bar.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/pub_priv.rs
+++ b/tests/testsuite/pub_priv.rs
@@ -1,5 +1,7 @@
 //! Tests for public/private dependencies.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::{Dependency, Package};
 

--- a/tests/testsuite/publish.rs
+++ b/tests/testsuite/publish.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo publish` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::git::{self, repo};
 use cargo_test_support::paths;
 use cargo_test_support::registry::{self, Package, RegistryBuilder, Response};

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -1,5 +1,7 @@
 //! Tests for including `Cargo.lock` when publishing/packaging.
 
+#![allow(deprecated)]
+
 use std::fs::File;
 
 use cargo_test_support::registry::Package;

--- a/tests/testsuite/read_manifest.rs
+++ b/tests/testsuite/read_manifest.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo read-manifest` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_bin_manifest, main_file, project};
 
 fn manifest_output(readme_value: &str) -> String {

--- a/tests/testsuite/registry.rs
+++ b/tests/testsuite/registry.rs
@@ -1,5 +1,7 @@
 //! Tests for normal registry dependencies.
 
+#![allow(deprecated)]
+
 use cargo::core::SourceId;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths::{self, CargoPathExt};

--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -1,5 +1,7 @@
 //! Tests for registry authentication.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::registry::{Package, RegistryBuilder, Token};
 use cargo_test_support::str;

--- a/tests/testsuite/rename_deps.rs
+++ b/tests/testsuite/rename_deps.rs
@@ -1,5 +1,7 @@
 //! Tests for renaming dependencies.
 
+#![allow(deprecated)]
+
 use cargo_test_support::git;
 use cargo_test_support::paths;
 use cargo_test_support::registry::{self, Package};

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -1,5 +1,7 @@
 //! Tests for `[replace]` table source replacement.
 
+#![allow(deprecated)]
+
 use cargo_test_support::git;
 use cargo_test_support::paths;
 use cargo_test_support::registry::Package;

--- a/tests/testsuite/required_features.rs
+++ b/tests/testsuite/required_features.rs
@@ -1,5 +1,7 @@
 //! Tests for targets with `required-features`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::install::{
     assert_has_installed_exe, assert_has_not_installed_exe, cargo_home,
 };

--- a/tests/testsuite/run.rs
+++ b/tests/testsuite/run.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo run` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{
     basic_bin_manifest, basic_lib_manifest, basic_manifest, project, Project,
 };

--- a/tests/testsuite/rust_version.rs
+++ b/tests/testsuite/rust_version.rs
@@ -1,5 +1,7 @@
 //! Tests for targets with `rust-version`.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{cargo_process, project, registry::Package};
 
 #[cargo_test]

--- a/tests/testsuite/rustc.rs
+++ b/tests/testsuite/rustc.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo rustc` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, basic_manifest, project};
 
 const CARGO_RUSTC_ERROR: &str =

--- a/tests/testsuite/rustc_info_cache.rs
+++ b/tests/testsuite/rustc_info_cache.rs
@@ -1,5 +1,7 @@
 //! Tests for the cache file for the rustc version info.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_bin_manifest, paths::CargoPathExt};
 use cargo_test_support::{basic_manifest, project};
 use std::env;

--- a/tests/testsuite/rustdoc.rs
+++ b/tests/testsuite/rustdoc.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo rustdoc` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_manifest, cross_compile, project};
 
 #[cargo_test]

--- a/tests/testsuite/rustdoc_extern_html.rs
+++ b/tests/testsuite/rustdoc_extern_html.rs
@@ -1,5 +1,7 @@
 //! Tests for the -Zrustdoc-map feature.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::{self, Package};
 use cargo_test_support::{paths, project, Project};
 

--- a/tests/testsuite/rustdocflags.rs
+++ b/tests/testsuite/rustdocflags.rs
@@ -1,5 +1,7 @@
 //! Tests for setting custom rustdoc flags.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::rustc_host;
 use cargo_test_support::rustc_host_env;

--- a/tests/testsuite/rustflags.rs
+++ b/tests/testsuite/rustflags.rs
@@ -1,5 +1,7 @@
 //! Tests for setting custom rustc flags.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, paths, project, project_in_home, rustc_host};
 use std::fs;

--- a/tests/testsuite/rustup.rs
+++ b/tests/testsuite/rustup.rs
@@ -1,5 +1,7 @@
 //! Tests for Cargo's behavior under Rustup.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::{home, root, CargoPathExt};
 use cargo_test_support::{cargo_process, process, project};
 use std::env;

--- a/tests/testsuite/script.rs
+++ b/tests/testsuite/script.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use cargo_test_support::basic_manifest;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/search.rs
+++ b/tests/testsuite/search.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo search` command.
 
+#![allow(deprecated)]
+
 use cargo::util::cache_lock::CacheLockMode;
 use cargo_test_support::cargo_process;
 use cargo_test_support::paths;

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -2,6 +2,8 @@
 //! in the output, their arguments are quoted properly
 //! so that the command can be run in a terminal.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 
 #[cargo_test]

--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -1,5 +1,7 @@
 //! Tests for `[source]` table (source replacement).
 
+#![allow(deprecated)]
+
 use std::fs;
 
 use cargo_test_support::registry::{Package, RegistryBuilder, TestRegistry};

--- a/tests/testsuite/ssh.rs
+++ b/tests/testsuite/ssh.rs
@@ -5,6 +5,8 @@
 //!
 //! NOTE: The container tests almost certainly won't work on Windows.
 
+#![allow(deprecated)]
+
 use cargo_test_support::containers::{Container, ContainerHandle, MkFile};
 use cargo_test_support::git::cargo_uses_gitoxide;
 use cargo_test_support::{paths, process, project, Project};

--- a/tests/testsuite/standard_lib.rs
+++ b/tests/testsuite/standard_lib.rs
@@ -4,6 +4,8 @@
 //! rebuild the real one. There is a separate integration test `build-std`
 //! which builds the real thing, but that should be avoided if possible.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::{Dependency, Package};
 use cargo_test_support::ProjectBuilder;
 use cargo_test_support::{paths, project, rustc_host, Execs};

--- a/tests/testsuite/test.rs
+++ b/tests/testsuite/test.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo test` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{

--- a/tests/testsuite/timings.rs
+++ b/tests/testsuite/timings.rs
@@ -1,5 +1,7 @@
 //! Tests for --timings.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/tool_paths.rs
+++ b/tests/testsuite/tool_paths.rs
@@ -1,5 +1,7 @@
 //! Tests for configuration values that point to programs.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_lib_manifest, project, rustc_host, rustc_host_env};
 
 #[cargo_test]

--- a/tests/testsuite/tree.rs
+++ b/tests/testsuite/tree.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo tree` command.
 
+#![allow(deprecated)]
+
 use super::features2::switch_to_resolver_2;
 use cargo_test_support::cross_compile::{self, alternate};
 use cargo_test_support::registry::{Dependency, Package};

--- a/tests/testsuite/tree_graph_features.rs
+++ b/tests/testsuite/tree_graph_features.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo tree` command with -e features option.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::{Dependency, Package};
 

--- a/tests/testsuite/unit_graph.rs
+++ b/tests/testsuite/unit_graph.rs
@@ -1,5 +1,7 @@
 //! Tests for --unit-graph option.
 
+#![allow(deprecated)]
+
 use cargo_test_support::project;
 use cargo_test_support::registry::Package;
 

--- a/tests/testsuite/update.rs
+++ b/tests/testsuite/update.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo update` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::registry::{self};
 use cargo_test_support::registry::{Dependency, Package};

--- a/tests/testsuite/vendor.rs
+++ b/tests/testsuite/vendor.rs
@@ -4,6 +4,8 @@
 //! "fake" crates.io is used. Otherwise `vendor` would download the crates.io
 //! index from the network.
 
+#![allow(deprecated)]
+
 use std::fs;
 
 use cargo_test_support::compare::assert_e2e;

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo verify-project` command.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{basic_bin_manifest, main_file, project};
 
 fn verify_project_success_output() -> String {

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -1,5 +1,7 @@
 //! Tests for displaying the cargo version.
 
+#![allow(deprecated)]
+
 use cargo_test_support::{cargo_process, project};
 
 #[cargo_test]

--- a/tests/testsuite/warn_on_failure.rs
+++ b/tests/testsuite/warn_on_failure.rs
@@ -1,5 +1,7 @@
 //! Tests for whether or not warnings are displayed for build scripts.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{project, Project};
 

--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -1,5 +1,7 @@
 //! Tests for weak-dep-features.
 
+#![allow(deprecated)]
+
 use super::features2::switch_to_resolver_2;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1,5 +1,7 @@
 //! Tests for workspaces.
 
+#![allow(deprecated)]
+
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, project, sleep_ms};
 use std::env;

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -1,5 +1,7 @@
 //! Tests for the `cargo yank` command.
 
+#![allow(deprecated)]
+
 use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;


### PR DESCRIPTION
### What does this PR try to resolve?

The overall goal is to enable the use of snapshot testing on as many cargo tests as possible to reduce the burden when having to touch a lot of tests.  Towards that aim, this PR
- Adds snapshot testing to `cargo_test_support::Execs`
- Migrates `alt_registry` tests over as an example (and to vet it)

I've taken the approach of deprecating all other output assertions on `Execs` with `#[allow(deprecated)]` in every test file.  This let's us easily identity what files haven't been migrated, what in a file needs migration, and helps prevent a file from regressing.  This should make it easier to do a gradual migration that (as many people as they want) can chip in.  It comes at the cost of losing visibility into deprecated items we use.  Hopefully we won't be in this intermediate state for too long.

To reduce manual touch ups of snapshots, I've added some regex redactions.  My main concern with the `FILE_SIZE` redaction was when we test for specific sizes.  That shouldn't be a problem because we don't use `Execs::with_stderr` to test those but we capture the output and have a custom asserter for it.

### How should we test and review this PR?

Yes, this puts us in an intermediate state which isn't ideal but much better than one person trying to do all of this in a single branch / PR.

The main risk is that we'll hit a snag with snapbox being able to support our needs.  We got away with a lot because everything was custom, down to the diffing algorithm.  This is why I at least started with `alt_registry` to get a feel for what problems we might have.  There will likely be some we uncover.  I'm fairly confident that we can resolve them in some way, 

### Additional information

This is a continuation of the work done in #13980.