### PR TITLE
chore(deps): update rust crate pulldown-cmark to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,9 +2748,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.10.3"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
+checksum = "8746739f11d39ce5ad5c2520a9b75285310dbfe78c541ccf832d38615765aec0"
 dependencies = [
  "bitflags 2.5.0",
  "memchr",
@@ -2760,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-escape"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d8f9aa0e3cbcfaf8bf00300004ee3b72f74770f9cbac93f6928771f613276b"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ pathdiff = "0.2.1"
 percent-encoding = "2.3.1"
 pkg-config = "0.3.30"
 proptest = "1.4.0"
-pulldown-cmark = { version = "0.10.3", default-features = false, features = ["html"] }
+pulldown-cmark = { version = "0.11.0", default-features = false, features = ["html"] }
 rand = "0.8.5"
 regex = "1.10.4"
 rusqlite = { version = "0.31.0", features = ["bundled"] }

--- a/crates/mdman/src/format/man.rs
+++ b/crates/mdman/src/format/man.rs
@@ -140,7 +140,7 @@ impl<'e> ManRenderer<'e> {
                                 suppress_paragraph = true;
                             }
                         }
-                        Tag::BlockQuote => {
+                        Tag::BlockQuote(_kind) => {
                             self.flush();
                             // .RS = move left margin over 3
                             // .ll = shrink line length
@@ -356,6 +356,8 @@ impl<'e> ManRenderer<'e> {
                 }
                 Event::TaskListMarker(_b) => unimplemented!(),
                 Event::InlineHtml(..) => unimplemented!(),
+                Event::InlineMath(..) => unimplemented!(),
+                Event::DisplayMath(..) => unimplemented!(),
             }
         }
         Ok(())

--- a/crates/mdman/src/format/text.rs
+++ b/crates/mdman/src/format/text.rs
@@ -137,7 +137,7 @@ impl<'e> TextRenderer<'e> {
                                 self.indent = (level as usize - 1) * 3 + 1;
                             }
                         }
-                        Tag::BlockQuote => {
+                        Tag::BlockQuote(_kind) => {
                             self.indent += 3;
                         }
                         Tag::CodeBlock(_kind) => {
@@ -347,6 +347,8 @@ impl<'e> TextRenderer<'e> {
                 }
                 Event::TaskListMarker(_b) => unimplemented!(),
                 Event::InlineHtml(..) => unimplemented!(),
+                Event::InlineMath(..) => unimplemented!(),
+                Event::DisplayMath(..) => unimplemented!(),
             }
         }
         Ok(())


### PR DESCRIPTION
<!-- homu-ignore:start -->

### What does this PR try to resolve?

close https://github.com/rust-lang/cargo/pull/13999

Bump the `pulldown-cmark` from `0.10.3` to `0.11.0`.

API changes:
1. `Tag::BlockQuote` -> `Tag::BlockQuote(_kind)`
2. Cover the new event `Event::InlineMath(..)` and `Event::DisplayMath(..)`

### How should we test and review this PR?

The test has been covered.

### Additional information
None

<!-- homu-ignore:end -->
