### PR TITLE
test: migrate binary_name to snapbox

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -92,6 +92,12 @@ pub fn assert_ui() -> snapbox::Assert {
         regex::Regex::new("Finished.*in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
     )
     .unwrap();
+    // output from libtest
+    subs.insert(
+        "[ELAPSED]",
+        regex::Regex::new("; finished in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
+    )
+    .unwrap();
     subs.insert(
         "[FILE_SIZE]",
         regex::Regex::new("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B").unwrap(),
@@ -154,6 +160,12 @@ pub fn assert_e2e() -> snapbox::Assert {
     subs.insert(
         "[ELAPSED]",
         regex::Regex::new("[FINISHED].*in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
+    )
+    .unwrap();
+    // output from libtest
+    subs.insert(
+        "[ELAPSED]",
+        regex::Regex::new("; finished in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
     )
     .unwrap();
     subs.insert(

--- a/tests/testsuite/binary_name.rs
+++ b/tests/testsuite/binary_name.rs
@@ -1,9 +1,11 @@
-#![allow(deprecated)]
+//! Tests for `cargo-features = ["different-binary-name"]`.
 
-use cargo_test_support::install::{
-    assert_has_installed_exe, assert_has_not_installed_exe, cargo_home,
-};
+use cargo_test_support::install::assert_has_installed_exe;
+use cargo_test_support::install::assert_has_not_installed_exe;
+use cargo_test_support::install::cargo_home;
+use cargo_test_support::prelude::*;
 use cargo_test_support::project;
+use cargo_test_support::str;
 
 #[cargo_test]
 fn gated() {
@@ -29,7 +31,17 @@ fn gated() {
     p.cargo("build")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
         .with_status(101)
-        .with_stderr_contains("[..]feature `different-binary-name` is required")
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+
+Caused by:
+  feature `different-binary-name` is required
+
+  The package requires the Cargo feature called `different-binary-name`, but that feature is not stabilized in this version of Cargo ([..]).
+  Consider adding `cargo-features = ["different-binary-name"]` to the top of Cargo.toml (above the [package] table) to tell Cargo you are opting in to use this unstable feature.
+  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#different-binary-name for more information about the status of this feature.
+
+"#]])
         .run();
 }
 
@@ -97,12 +109,11 @@ fn binary_name1() {
     // Run cargo second time, to verify fingerprint.
     p.cargo("build -p foo -v")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
-        .with_stderr(
-            "\
-[FRESH] foo [..]
-[FINISHED] [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[FRESH] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     // Run cargo clean.
@@ -180,19 +191,30 @@ fn binary_name2() {
     // Check if `cargo test` works
     p.cargo("test")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [..]
-[RUNNING] [..] (target/debug/deps/foo-[..][EXE])",
-        )
-        .with_stdout_contains("test tests::check_crabs ... ok")
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `test` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[RUNNING] unittests src/main.rs (target/debug/deps/foo-[..][EXE])
+
+"#]])
+        .with_stdout_data(str![[r#"
+
+running 1 test
+test tests::check_crabs ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in [ELAPSED]s
+
+
+"#]])
         .run();
 
     // Check if `cargo run` is able to execute the binary
     p.cargo("run")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
-        .with_stdout("Hello, crabs!")
+        .with_stdout_data(str![[r#"
+Hello, crabs!
+
+"#]])
         .run();
 
     p.cargo("install")
@@ -202,7 +224,10 @@ fn binary_name2() {
     assert_has_installed_exe(cargo_home(), "007bar");
 
     p.cargo("uninstall")
-        .with_stderr("[REMOVING] [ROOT]/home/.cargo/bin/007bar[EXE]")
+        .with_stderr_data(str![[r#"
+[REMOVING] [ROOT]/home/.cargo/bin/007bar[EXE]
+
+"#]])
         .masquerade_as_nightly_cargo(&["different-binary-name"])
         .run();
 
@@ -253,7 +278,10 @@ fn check_env_vars() {
         .run();
     p.cargo("run")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
-        .with_stdout("007bar")
+        .with_stdout_data(str![[r#"
+007bar
+
+"#]])
         .run();
     p.cargo("test")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
@@ -284,25 +312,13 @@ fn check_msg_format_json() {
         .file("src/main.rs", "fn main() { assert!(true) }")
         .build();
 
-    let output = r#"
-{
-    "reason": "compiler-artifact",
-    "package_id": "path+file:///[..]/foo#0.0.1",
-    "manifest_path": "[CWD]/Cargo.toml",
-    "target": "{...}",
-    "profile": "{...}",
-    "features": [],
-    "filenames": "{...}",
-    "executable": "[ROOT]/foo/target/debug/007bar[EXE]",
-    "fresh": false
-}
-
-{"reason":"build-finished", "success":true}
-"#;
-
     // Run cargo build.
     p.cargo("build --message-format=json")
         .masquerade_as_nightly_cargo(&["different-binary-name"])
-        .with_json(output)
+        .with_stdout_data(str![[r#"
+{"executable":"[ROOT]/foo/target/debug/007bar[EXE]","features":[],"filenames":"{...}","fresh":false,"manifest_path":"[ROOT]/foo/Cargo.toml","package_id":"path+[ROOTURL]/foo#0.0.1","profile":"{...}","reason":"compiler-artifact","target":"{...}"}
+{"reason":"build-finished","success":true}
+
+"#]].json_lines())
         .run();
 }


### PR DESCRIPTION
<!-- homu-ignore:start -->
### What does this PR try to resolve?

Part of <https://github.com/rust-lang/cargo/issues/14039>.

Migrate `tests/testsuite/binary_name.rs` to snapbox.

### How should we test and review this PR?

Two things need to beware of

* A new redaction is added: `[ELAPSED]` for libtest output.
* Snapbox's [`JsonLines`](https://docs.rs/snapbox/0.6.10/snapbox/data/enum.DataFormat.html#variant.JsonLines) doesn't seems to support pretty printed JSON.

### Additional information
<!-- homu-ignore:end -->
