### PR TITLE
Add assert redactions

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -36,8 +36,9 @@
 //!   a problem.
 //! - Carriage returns are removed, which can help when running on Windows.
 
-use crate::diff;
+use crate::cross_compile::try_alternate;
 use crate::paths;
+use crate::{diff, rustc_host};
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use std::fmt;
@@ -173,6 +174,10 @@ fn add_common_redactions(subs: &mut snapbox::Redactions) {
         regex!("home/\\.cargo/registry/src/-(?<redacted>[a-z0-9]+)"),
     )
     .unwrap();
+    subs.insert("[HOST_TARGET]", rustc_host()).unwrap();
+    if let Some(alt_target) = try_alternate() {
+        subs.insert("[ALT_TARGET]", alt_target).unwrap();
+    }
 }
 
 static MIN_LITERAL_REDACTIONS: &[(&str, &str)] = &[

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -45,6 +45,15 @@ use std::path::Path;
 use std::str;
 use url::Url;
 
+/// This makes it easier to write regex replacements that are guaranteed to only
+/// get compiled once
+macro_rules! regex {
+    ($re:literal $(,)?) => {{
+        static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+        RE.get_or_init(|| regex::Regex::new($re).unwrap())
+    }};
+}
+
 /// Assertion policy for UI tests
 ///
 /// This emphasizes showing as much content as possible at the cost of more brittleness
@@ -139,29 +148,29 @@ fn add_common_redactions(subs: &mut snapbox::Redactions) {
     // For e2e tests
     subs.insert(
         "[ELAPSED]",
-        regex::Regex::new("[FINISHED].*in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
+        regex!("[FINISHED].*in (?<redacted>[0-9]+(\\.[0-9]+))s"),
     )
     .unwrap();
     // for UI tests
     subs.insert(
         "[ELAPSED]",
-        regex::Regex::new("Finished.*in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
+        regex!("Finished.*in (?<redacted>[0-9]+(\\.[0-9]+))s"),
     )
     .unwrap();
     // output from libtest
     subs.insert(
         "[ELAPSED]",
-        regex::Regex::new("; finished in (?<redacted>[0-9]+(\\.[0-9]+))s").unwrap(),
+        regex!("; finished in (?<redacted>[0-9]+(\\.[0-9]+))s"),
     )
     .unwrap();
     subs.insert(
         "[FILE_SIZE]",
-        regex::Regex::new("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B").unwrap(),
+        regex!("(?<redacted>[0-9]+(\\.[0-9]+)([a-zA-Z]i)?)B"),
     )
     .unwrap();
     subs.insert(
         "[HASH]",
-        regex::Regex::new("home/\\.cargo/registry/src/-(?<redacted>[a-z0-9]+)").unwrap(),
+        regex!("home/\\.cargo/registry/src/-(?<redacted>[a-z0-9]+)"),
     )
     .unwrap();
 }

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -194,6 +194,10 @@ static MIN_LITERAL_REDACTIONS: &[(&str, &str)] = &[
     ("[EXE]", std::env::consts::EXE_SUFFIX),
     ("[BROKEN_PIPE]", "Broken pipe (os error 32)"),
     ("[BROKEN_PIPE]", "The pipe is being closed. (os error 232)"),
+    // Unix message for exit status
+    ("[EXIT_STATUS]", "exit status"),
+    // Windows message for exit status
+    ("[EXIT_STATUS]", "exit code"),
 ];
 static E2E_LITERAL_REDACTIONS: &[(&str, &str)] = &[
     ("[RUNNING]", "     Running"),

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -174,6 +174,8 @@ fn add_common_redactions(subs: &mut snapbox::Redactions) {
         regex!("home/\\.cargo/registry/src/-(?<redacted>[a-z0-9]+)"),
     )
     .unwrap();
+    subs.insert("[HASH]", regex!("/[a-z0-9\\-_]+-(?<redacted>[0-9a-f]{16})"))
+        .unwrap();
     subs.insert("[HOST_TARGET]", rustc_host()).unwrap();
     if let Some(alt_target) = try_alternate() {
         subs.insert("[ALT_TARGET]", alt_target).unwrap();

--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -178,6 +178,16 @@ fn add_common_redactions(subs: &mut snapbox::Redactions) {
     if let Some(alt_target) = try_alternate() {
         subs.insert("[ALT_TARGET]", alt_target).unwrap();
     }
+    subs.insert(
+        "[AVG_ELAPSED]",
+        regex!("(?<redacted>[0-9]+(\\.[0-9]+)?) ns/iter"),
+    )
+    .unwrap();
+    subs.insert(
+        "[JITTER]",
+        regex!("ns/iter \\(\\+/- (?<redacted>[0-9]+(\\.[0-9]+)?)\\)"),
+    )
+    .unwrap();
 }
 
 static MIN_LITERAL_REDACTIONS: &[(&str, &str)] = &[

--- a/crates/cargo-test-support/src/cross_compile.rs
+++ b/crates/cargo-test-support/src/cross_compile.rs
@@ -209,18 +209,23 @@ pub fn native_arch() -> &'static str {
 ///
 /// Only use this function on tests that check `cross_compile::disabled`.
 pub fn alternate() -> &'static str {
+    try_alternate().expect("This test should be gated on cross_compile::disabled.")
+}
+
+/// A possible alternate target-triple to build with.
+pub(crate) fn try_alternate() -> Option<&'static str> {
     if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-        "x86_64-apple-darwin"
+        Some("x86_64-apple-darwin")
     } else if cfg!(target_os = "macos") {
-        "x86_64-apple-ios"
+        Some("x86_64-apple-ios")
     } else if cfg!(target_os = "linux") {
-        "i686-unknown-linux-gnu"
+        Some("i686-unknown-linux-gnu")
     } else if cfg!(all(target_os = "windows", target_env = "msvc")) {
-        "i686-pc-windows-msvc"
+        Some("i686-pc-windows-msvc")
     } else if cfg!(all(target_os = "windows", target_env = "gnu")) {
-        "i686-pc-windows-gnu"
+        Some("i686-pc-windows-gnu")
     } else {
-        panic!("This test should be gated on cross_compile::disabled.");
+        None
     }
 }
 

--- a/tests/testsuite/cargo_add/target/mod.rs
+++ b/tests/testsuite/cargo_add/target/mod.rs
@@ -28,7 +28,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("add")
-        .arg_line("my-package1 my-package2 --target i686-unknown-linux-gnu")
+        .arg_line("my-package1 my-package2 --target wasm32-unknown-unknown")
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_add/target/out/Cargo.toml
+++ b/tests/testsuite/cargo_add/target/out/Cargo.toml
@@ -5,6 +5,6 @@ name = "cargo-list-test-fixture"
 version = "0.0.0"
 edition = "2015"
 
-[target.i686-unknown-linux-gnu.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 my-package1 = "99999.0.0"
 my-package2 = "99999.0.0"

--- a/tests/testsuite/cargo_add/target/stderr.term.svg
+++ b/tests/testsuite/cargo_add/target/stderr.term.svg
@@ -20,9 +20,9 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">    Updating</tspan><tspan> `dummy-registry` index</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies for target `i686-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package1 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `i686-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-green bold">      Adding</tspan><tspan> my-package2 v99999.0.0 to dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="fg-green bold">     Locking</tspan><tspan> 3 packages to latest compatible versions</tspan>
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_target/out/Cargo.toml
+++ b/tests/testsuite/cargo_remove/invalid_target/out/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [target.x86_64-unknown-freebsd.build-dependencies]
 semver = "0.1.0"
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[target.wasm32-unknown-unknown.build-dependencies]
 semver = "0.1.0"
 
 [dependencies]
@@ -20,14 +20,14 @@ semver = "0.1"
 toml = "0.1"
 clippy = "0.4"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 dbus = "0.6.2"
 
 [dev-dependencies]
 regex = "0.1.1"
 serde = "1.0.90"
 
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 ncurses = "20.0"
 
 [features]

--- a/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target/stderr.term.svg
@@ -21,7 +21,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> dbus from dependencies for target `powerpc-unknown-linux-gnu`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.x86_64-unknown-linux-gnu.dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `dbus` could not be found in `target.powerpc-unknown-linux-gnu.dependencies`; it is present in `target.wasm32-unknown-unknown.dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/invalid_target_dep/mod.rs
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/mod.rs
@@ -28,7 +28,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("remove")
-        .args(["--target", "x86_64-unknown-linux-gnu", "toml"])
+        .args(["--target", "wasm32-unknown-unknown", "toml"])
         .current_dir(cwd)
         .assert()
         .code(101)

--- a/tests/testsuite/cargo_remove/invalid_target_dep/out/Cargo.toml
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/out/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [target.x86_64-unknown-freebsd.build-dependencies]
 semver = "0.1.0"
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[target.wasm32-unknown-unknown.build-dependencies]
 semver = "0.1.0"
 
 [dependencies]
@@ -20,14 +20,14 @@ semver = "0.1"
 toml = "0.1"
 clippy = "0.4"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 dbus = "0.6.2"
 
 [dev-dependencies]
 regex = "0.1.1"
 serde = "1.0.90"
 
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 ncurses = "20.0"
 
 [features]

--- a/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/invalid_target_dep/stderr.term.svg
@@ -19,9 +19,9 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies for target `x86_64-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> toml from dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `toml` could not be found in `target.x86_64-unknown-linux-gnu.dependencies`; it is present in `dependencies`</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-red bold">error</tspan><tspan class="bold">:</tspan><tspan> the dependency `toml` could not be found in `target.wasm32-unknown-unknown.dependencies`; it is present in `dependencies`</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/testsuite/cargo_remove/remove-target.in/Cargo.toml
+++ b/tests/testsuite/cargo_remove/remove-target.in/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [target.x86_64-unknown-freebsd.build-dependencies]
 semver = "0.1.0"
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[target.wasm32-unknown-unknown.build-dependencies]
 semver = "0.1.0"
 
 [dependencies]
@@ -20,14 +20,14 @@ semver = "0.1"
 toml = "0.1"
 clippy = "0.4"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 dbus = "0.6.2"
 
 [dev-dependencies]
 regex = "0.1.1"
 serde = "1.0.90"
 
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 ncurses = "20.0"
 
 [features]

--- a/tests/testsuite/cargo_remove/target/mod.rs
+++ b/tests/testsuite/cargo_remove/target/mod.rs
@@ -28,7 +28,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("remove")
-        .args(["--target", "x86_64-unknown-linux-gnu", "dbus"])
+        .args(["--target", "wasm32-unknown-unknown", "dbus"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_remove/target/out/Cargo.toml
+++ b/tests/testsuite/cargo_remove/target/out/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [target.x86_64-unknown-freebsd.build-dependencies]
 semver = "0.1.0"
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[target.wasm32-unknown-unknown.build-dependencies]
 semver = "0.1.0"
 
 [dependencies]
@@ -24,7 +24,7 @@ clippy = "0.4"
 regex = "0.1.1"
 serde = "1.0.90"
 
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 ncurses = "20.0"
 
 [features]

--- a/tests/testsuite/cargo_remove/target/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/target/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> dbus from dependencies for target `x86_64-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> dbus from dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/target_build/mod.rs
+++ b/tests/testsuite/cargo_remove/target_build/mod.rs
@@ -28,7 +28,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("remove")
-        .args(["--build", "--target", "x86_64-unknown-linux-gnu", "semver"])
+        .args(["--build", "--target", "wasm32-unknown-unknown", "semver"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_remove/target_build/out/Cargo.toml
+++ b/tests/testsuite/cargo_remove/target_build/out/Cargo.toml
@@ -17,14 +17,14 @@ semver = "0.1"
 toml = "0.1"
 clippy = "0.4"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 dbus = "0.6.2"
 
 [dev-dependencies]
 regex = "0.1.1"
 serde = "1.0.90"
 
-[target.x86_64-unknown-linux-gnu.dev-dependencies]
+[target.wasm32-unknown-unknown.dev-dependencies]
 ncurses = "20.0"
 
 [features]

--- a/tests/testsuite/cargo_remove/target_build/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/target_build/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies for target `x86_64-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> semver from build-dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>

--- a/tests/testsuite/cargo_remove/target_dev/mod.rs
+++ b/tests/testsuite/cargo_remove/target_dev/mod.rs
@@ -28,7 +28,7 @@ fn case() {
 
     snapbox::cmd::Command::cargo_ui()
         .arg("remove")
-        .args(["--dev", "--target", "x86_64-unknown-linux-gnu", "ncurses"])
+        .args(["--dev", "--target", "wasm32-unknown-unknown", "ncurses"])
         .current_dir(cwd)
         .assert()
         .success()

--- a/tests/testsuite/cargo_remove/target_dev/out/Cargo.toml
+++ b/tests/testsuite/cargo_remove/target_dev/out/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 [target.x86_64-unknown-freebsd.build-dependencies]
 semver = "0.1.0"
 
-[target.x86_64-unknown-linux-gnu.build-dependencies]
+[target.wasm32-unknown-unknown.build-dependencies]
 semver = "0.1.0"
 
 [dependencies]
@@ -20,7 +20,7 @@ semver = "0.1"
 toml = "0.1"
 clippy = "0.4"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
+[target.wasm32-unknown-unknown.dependencies]
 dbus = "0.6.2"
 
 [dev-dependencies]

--- a/tests/testsuite/cargo_remove/target_dev/stderr.term.svg
+++ b/tests/testsuite/cargo_remove/target_dev/stderr.term.svg
@@ -18,7 +18,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> ncurses from dev-dependencies for target `x86_64-unknown-linux-gnu`</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-green bold">    Removing</tspan><tspan> ncurses from dev-dependencies for target `wasm32-unknown-unknown`</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>


### PR DESCRIPTION
This was split out from #14048 so that the test changes in that PR do not block the redactions.

This adds auto-redactions for:
- A new `[HASH]` for `/<file>-<16 char hash>`
- `[HOST_TARGET]`
- `[ALT_TARGET]` 
  - Only added if cross-compilation is allowed for the target
- `[AVG_ELAPSED]`
  - For `bench` output 
- `[JITTER]`
  - For `bench` output

This also moves all common redactions to a function that `assert_e2e` and `assert_ui` call to reduce the amount of duplicate code and makes it so we only compile regex redactions once.

