### PR TITLE
test: migrate help to snapbox

### DIFF
--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -140,7 +140,11 @@ fn help_alias() {
     // The `empty-alias` returns an error.
     cargo_process("help empty-alias")
         .env("PATH", Path::new(""))
-        .with_stderr_data("[..] The subcommand 'empty-alias' wasn't recognized [..]")
+        .with_stderr_data("The subcommand 'empty-alias' wasn't recognized
+
+FIXME: #14076 This assertion isn't working, as this line should have caused a test failure but didn't.
+        ",
+        )
         .run_expect_error();
 
     // Because `simple-alias` aliases a subcommand with no arguments, help shows the manpage.

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -14,11 +14,6 @@ fn help() {
     cargo_process("help build").run();
     cargo_process("build -h").run();
     cargo_process("help help").run();
-    // Ensure that help output goes to stdout, not stderr.
-    cargo_process("search --help").with_stderr("").run();
-    cargo_process("search --help")
-        .with_stdout_contains("[..] --frozen [..]")
-        .run();
 }
 
 #[cargo_test]

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -155,18 +155,3 @@ fn help_alias() {
     let out = help_with_stdout_and_path("complex-alias", Path::new(""));
     assert_eq!(out, "`complex-alias` is aliased to `build --release`\n");
 }
-
-#[cargo_test]
-fn alias_z_flag_help() {
-    for cmd in ["build", "run", "check", "test", "b", "r", "c", "t"] {
-        cargo_process(&format!("{cmd} -Z help"))
-            .with_stdout_data(
-                "\
-...
-    -Z allow-features[..]  Allow *only* the listed unstable features
-...
-",
-            )
-            .run();
-    }
-}

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -1,6 +1,7 @@
 //! Tests for cargo's help output.
 
 use cargo_test_support::registry::Package;
+use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 use std::fs;
 use std::path::Path;
@@ -34,7 +35,10 @@ fn help_external_subcommand() {
         .publish();
     cargo_process("install cargo-fake-help").run();
     cargo_process("help fake-help")
-        .with_stdout_data("fancy help output\n")
+        .with_stdout_data(str![[r#"
+fancy help output
+
+"#]])
         .run();
 }
 
@@ -140,12 +144,17 @@ fn help_alias() {
     // The `empty-alias` returns an error.
     cargo_process("help empty-alias")
         .env("PATH", Path::new(""))
-        .with_stderr_data("The subcommand 'empty-alias' wasn't recognized
+        .with_status(101)
+        .with_stderr_data(str![[r#"
+[ERROR] no such command: `empty-alias`
 
-FIXME: #14076 This assertion isn't working, as this line should have caused a test failure but didn't.
-        ",
-        )
-        .run_expect_error();
+	Did you mean `empty-alias`?
+
+	View all installed commands with `cargo --list`
+	Find a package to install `empty-alias` with `cargo search cargo-empty-alias`
+
+"#]])
+        .run();
 
     // Because `simple-alias` aliases a subcommand with no arguments, help shows the manpage.
     help_with_man_and_path("", "simple-alias", "build", Path::new(""));

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -1,7 +1,5 @@
 //! Tests for cargo's help output.
 
-#![allow(deprecated)]
-
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 use std::fs;
@@ -17,9 +15,15 @@ fn help() {
     cargo_process("build -h").run();
     cargo_process("help help").run();
     // Ensure that help output goes to stdout, not stderr.
-    cargo_process("search --help").with_stderr("").run();
+    cargo_process("search --help").with_stderr_data("").run();
     cargo_process("search --help")
-        .with_stdout_contains("[..] --frozen [..]")
+        .with_stdout_data(
+            "\
+...
+[..] --frozen [..]
+...
+",
+        )
         .run();
 }
 
@@ -41,7 +45,7 @@ fn help_external_subcommand() {
         .publish();
     cargo_process("install cargo-fake-help").run();
     cargo_process("help fake-help")
-        .with_stdout("fancy help output\n")
+        .with_stdout_data("fancy help output\n")
         .run();
 }
 
@@ -147,7 +151,7 @@ fn help_alias() {
     // The `empty-alias` returns an error.
     cargo_process("help empty-alias")
         .env("PATH", Path::new(""))
-        .with_stderr_contains("[..]The subcommand 'empty-alias' wasn't recognized[..]")
+        .with_stderr_data("[..] The subcommand 'empty-alias' wasn't recognized [..]")
         .run_expect_error();
 
     // Because `simple-alias` aliases a subcommand with no arguments, help shows the manpage.
@@ -162,8 +166,12 @@ fn help_alias() {
 fn alias_z_flag_help() {
     for cmd in ["build", "run", "check", "test", "b", "r", "c", "t"] {
         cargo_process(&format!("{cmd} -Z help"))
-            .with_stdout_contains(
-                "    -Z allow-features[..]  Allow *only* the listed unstable features",
+            .with_stdout_data(
+                "\
+...
+    -Z allow-features[..]  Allow *only* the listed unstable features
+...
+",
             )
             .run();
     }

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -1,7 +1,6 @@
 //! Tests for cargo's help output.
 
 use cargo_test_support::registry::Package;
-use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 use std::fs;
 use std::path::Path;
@@ -16,11 +15,9 @@ fn help() {
     cargo_process("build -h").run();
     cargo_process("help help").run();
     // Ensure that help output goes to stdout, not stderr.
-    cargo_process("search --help").with_stderr(str![]).run();
+    cargo_process("search --help").with_stderr("").run();
     cargo_process("search --help")
-        .with_stdout_contains(str![[r#"
-HEY SNAPBOX, FIX THIS AUTOMATICALLY PLEASE
-"#]])
+        .with_stdout_contains("[..] --frozen [..]")
         .run();
 }
 

--- a/tests/testsuite/help.rs
+++ b/tests/testsuite/help.rs
@@ -1,6 +1,7 @@
 //! Tests for cargo's help output.
 
 use cargo_test_support::registry::Package;
+use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, cargo_exe, cargo_process, paths, process, project};
 use std::fs;
 use std::path::Path;
@@ -15,15 +16,11 @@ fn help() {
     cargo_process("build -h").run();
     cargo_process("help help").run();
     // Ensure that help output goes to stdout, not stderr.
-    cargo_process("search --help").with_stderr_data("").run();
+    cargo_process("search --help").with_stderr(str![]).run();
     cargo_process("search --help")
-        .with_stdout_data(
-            "\
-...
-[..] --frozen [..]
-...
-",
-        )
+        .with_stdout_contains(str![[r#"
+HEY SNAPBOX, FIX THIS AUTOMATICALLY PLEASE
+"#]])
         .run();
 }
 


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->

### What does this PR try to resolve?

Part of #14039.

Migrate `tests/testsuite/help.rs` to snapbox.

### How should we test and review this PR?

I followed #14039. The `#![allow(deprecated)]` was removed and `tests/testsuite/help.rs` is still passing.

### Additional information

~I accidentally noticed that [L155](https://github.com/rust-lang/cargo/pull/14060/files#diff-5a3eeb8da75123b44c76e8ecd96f6b78b9a921fb1f1ae5dcf6d1d229bc41bd7fL150-R155) would always pass despite the `.with_stderr_data("whatever I write here")`, either before or after this PR. It's probably related to `run_expect_error()`. Will investigate and open an issue.~ 👉 Filed #14076 


<!-- homu-ignore:end -->
