### PR TITLE
Fix some documentation misspellings

### DIFF
--- a/src/doc/man/cargo-bench.md
+++ b/src/doc/man/cargo-bench.md
@@ -90,7 +90,7 @@ in the manifest settings. Setting examples to `bench = true` will build and
 run the example as a benchmark, replacing the example's `main` function with
 the libtest harness.
 
-Setting targets to `bench = false` will stop them from being bencharmked by
+Setting targets to `bench = false` will stop them from being benchmarked by
 default. Target selection options that take a target by name (such as
 `--example foo`) ignore the `bench` flag and will always benchmark the given
 target.

--- a/src/doc/man/cargo-metadata.md
+++ b/src/doc/man/cargo-metadata.md
@@ -27,7 +27,7 @@ for a Rust API for reading the metadata.
 
 Within the same output format version, the compatibility is maintained, except
 some scenarios. The following is a non-exhaustive list of changes that are not
-considersed as incompatible:
+considered as incompatible:
 
 * **Adding new fields** — New fields will be added when needed. Reserving this
   helps Cargo evolve without bumping the format version too often.

--- a/src/doc/man/cargo-vendor.md
+++ b/src/doc/man/cargo-vendor.md
@@ -25,7 +25,7 @@ Cargo treats vendored sources as read-only as it does to registry and git source
 If you intend to modify a crate from a remote source,
 use `[patch]` or a `path` dependency pointing to a local copy of that crate.
 Cargo will then correctly handle the crate on incremental rebuilds,
-as it knowns that it is no longer a read-only dependency.
+as it knows that it is no longer a read-only dependency.
 
 ## OPTIONS
 

--- a/src/doc/man/generated_txt/cargo-bench.txt
+++ b/src/doc/man/generated_txt/cargo-bench.txt
@@ -124,7 +124,7 @@ OPTIONS
        build and run the example as a benchmark, replacing the example’s main
        function with the libtest harness.
 
-       Setting targets to bench = false will stop them from being bencharmked
+       Setting targets to bench = false will stop them from being benchmarked
        by default. Target selection options that take a target by name (such as
        --example foo) ignore the bench flag and will always benchmark the given
        target.

--- a/src/doc/man/generated_txt/cargo-metadata.txt
+++ b/src/doc/man/generated_txt/cargo-metadata.txt
@@ -22,7 +22,7 @@ OUTPUT FORMAT
    Compatibility
        Within the same output format version, the compatibility is maintained,
        except some scenarios. The following is a non-exhaustive list of changes
-       that are not considersed as incompatible:
+       that are not considered as incompatible:
 
        o  Adding new fields — New fields will be added when needed. Reserving
           this helps Cargo evolve without bumping the format version too often.

--- a/src/doc/man/generated_txt/cargo-vendor.txt
+++ b/src/doc/man/generated_txt/cargo-vendor.txt
@@ -22,7 +22,7 @@ DESCRIPTION
        git sources. If you intend to modify a crate from a remote source, use
        [patch] or a path dependency pointing to a local copy of that crate.
        Cargo will then correctly handle the crate on incremental rebuilds, as
-       it knowns that it is no longer a read-only dependency.
+       it knows that it is no longer a read-only dependency.
 
 OPTIONS
    Vendor Options

--- a/src/doc/src/commands/cargo-bench.md
+++ b/src/doc/src/commands/cargo-bench.md
@@ -138,7 +138,7 @@ in the manifest settings. Setting examples to `bench = true` will build and
 run the example as a benchmark, replacing the example's `main` function with
 the libtest harness.
 
-Setting targets to `bench = false` will stop them from being bencharmked by
+Setting targets to `bench = false` will stop them from being benchmarked by
 default. Target selection options that take a target by name (such as
 `--example foo`) ignore the `bench` flag and will always benchmark the given
 target.

--- a/src/doc/src/commands/cargo-metadata.md
+++ b/src/doc/src/commands/cargo-metadata.md
@@ -27,7 +27,7 @@ for a Rust API for reading the metadata.
 
 Within the same output format version, the compatibility is maintained, except
 some scenarios. The following is a non-exhaustive list of changes that are not
-considersed as incompatible:
+considered as incompatible:
 
 * **Adding new fields** — New fields will be added when needed. Reserving this
   helps Cargo evolve without bumping the format version too often.

--- a/src/doc/src/commands/cargo-vendor.md
+++ b/src/doc/src/commands/cargo-vendor.md
@@ -25,7 +25,7 @@ Cargo treats vendored sources as read-only as it does to registry and git source
 If you intend to modify a crate from a remote source,
 use `[patch]` or a `path` dependency pointing to a local copy of that crate.
 Cargo will then correctly handle the crate on incremental rebuilds,
-as it knowns that it is no longer a read-only dependency.
+as it knows that it is no longer a read-only dependency.
 
 ## OPTIONS
 

--- a/src/doc/src/reference/unstable.md
+++ b/src/doc/src/reference/unstable.md
@@ -1812,5 +1812,5 @@ See [Registry Authentication](registry-authentication.md) documentation for deta
 The `-Z check-cfg` feature has been stabilized in the 1.80 release by making it the
 default behavior.
 
-See the [build script documentation](build-scripts.md#rustc-check-cfg) for informations
+See the [build script documentation](build-scripts.md#rustc-check-cfg) for information
 about specifying custom cfgs.

--- a/src/etc/man/cargo-bench.1
+++ b/src/etc/man/cargo-bench.1
@@ -148,7 +148,7 @@ in the manifest settings. Setting examples to \fBbench = true\fR will build and
 run the example as a benchmark, replacing the example\[cq]s \fBmain\fR function with
 the libtest harness.
 .sp
-Setting targets to \fBbench = false\fR will stop them from being bencharmked by
+Setting targets to \fBbench = false\fR will stop them from being benchmarked by
 default. Target selection options that take a target by name (such as
 \fB\-\-example foo\fR) ignore the \fBbench\fR flag and will always benchmark the given
 target.

--- a/src/etc/man/cargo-metadata.1
+++ b/src/etc/man/cargo-metadata.1
@@ -22,7 +22,7 @@ for a Rust API for reading the metadata.
 .SS "Compatibility"
 Within the same output format version, the compatibility is maintained, except
 some scenarios. The following is a non\-exhaustive list of changes that are not
-considersed as incompatible:
+considered as incompatible:
 .sp
 .RS 4
 \h'-04'\(bu\h'+02'\fBAdding new fields\fR \[em] New fields will be added when needed. Reserving this

--- a/src/etc/man/cargo-vendor.1
+++ b/src/etc/man/cargo-vendor.1
@@ -23,7 +23,7 @@ Cargo treats vendored sources as read\-only as it does to registry and git sourc
 If you intend to modify a crate from a remote source,
 use \fB[patch]\fR or a \fBpath\fR dependency pointing to a local copy of that crate.
 Cargo will then correctly handle the crate on incremental rebuilds,
-as it knowns that it is no longer a read\-only dependency.
+as it knows that it is no longer a read\-only dependency.
 .SH "OPTIONS"
 .SS "Vendor Options"
 .sp


### PR DESCRIPTION
This is a repost of #13903 with a few other fixes.