### PR TITLE
Remove `run_expect_error` to avoid tests incorrectly passing

### DIFF
--- a/crates/cargo-test-support/src/lib.rs
+++ b/crates/cargo-test-support/src/lib.rs
@@ -915,15 +915,6 @@ impl Execs {
         }
     }
 
-    #[track_caller]
-    pub fn run_expect_error(&mut self) {
-        self.ran = true;
-        let p = (&self.process_builder).clone().unwrap();
-        if self.match_process(&p).is_ok() {
-            panic!("test was expected to fail, but succeeded running {}", p);
-        }
-    }
-
     /// Runs the process, checks the expected output, and returns the first
     /// JSON object on stdout.
     #[track_caller]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -632,10 +632,11 @@ fn config_invalid_empty() {
         .build();
 
     p.cargo("check")
+        .with_status(101)
         .with_stderr_contains(
             "[..]missing field `level`[..] THIS RANDOM SENTENCE SHOULD FAIL THIS TEST BUT DIDN'T",
         )
-        .run_expect_error();
+        .run();
 }
 
 #[cargo_test(>=1.79, reason = "--check-cfg was stabilized in Rust 1.79")]

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -633,9 +633,7 @@ fn config_invalid_empty() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr_contains(
-            "[..]missing field `level`[..] THIS RANDOM SENTENCE SHOULD FAIL THIS TEST BUT DIDN'T",
-        )
+        .with_stderr_contains("[..]missing field `level`[..]")
         .run();
 }
 

--- a/tests/testsuite/check_cfg.rs
+++ b/tests/testsuite/check_cfg.rs
@@ -632,7 +632,9 @@ fn config_invalid_empty() {
         .build();
 
     p.cargo("check")
-        .with_stderr_contains("[..]missing field `level`[..]")
+        .with_stderr_contains(
+            "[..]missing field `level`[..] THIS RANDOM SENTENCE SHOULD FAIL THIS TEST BUT DIDN'T",
+        )
         .run_expect_error();
 }
 

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2936,6 +2936,9 @@ fn use_mtime_cache_in_cargo_home() {
         .with_stderr(
             "\
 [DIRTY] foo v0.5.0 ([CWD]): [..]
+
+    THIS RANDOM SENTENCE SHOULD FAIL THIS TEST BUT DIDN'T
+
 [CHECKING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]",
         )

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2933,6 +2933,7 @@ fn use_mtime_cache_in_cargo_home() {
     p.change_file("src/lib.rs", "illegal syntax");
     p.cargo("check -v")
         .env("CARGO_HOME", &cargo_home)
+        .with_status(101)
         .with_stderr(
             "\
 [DIRTY] foo v0.5.0 ([CWD]): [..]
@@ -2942,5 +2943,5 @@ fn use_mtime_cache_in_cargo_home() {
 [CHECKING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]",
         )
-        .run_expect_error();
+        .run();
 }

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2937,9 +2937,6 @@ fn use_mtime_cache_in_cargo_home() {
         .with_stderr(
             "\
 [DIRTY] foo v0.5.0 ([CWD]): [..]
-
-    THIS RANDOM SENTENCE SHOULD FAIL THIS TEST BUT DIDN'T
-
 [CHECKING] foo v0.5.0 ([CWD])
 [RUNNING] `rustc --crate-name foo --edition=2015 src/lib.rs [..]",
         )

--- a/tests/testsuite/freshness.rs
+++ b/tests/testsuite/freshness.rs
@@ -2934,7 +2934,7 @@ fn use_mtime_cache_in_cargo_home() {
     p.cargo("check -v")
         .env("CARGO_HOME", &cargo_home)
         .with_status(101)
-        .with_stderr(
+        .with_stderr_contains(
             "\
 [DIRTY] foo v0.5.0 ([CWD]): [..]
 [CHECKING] foo v0.5.0 ([CWD])


### PR DESCRIPTION
### What does this PR try to resolve?

Fixes #14076

### How should we test and review this PR?

I pushed commits separately so the CI status can show the reproduction and the fix:

- bc5d57c reproduce the bug: Its CI shouldn't have passed.
- 3c473b5 fixes the issue, so the CI for d9d11c4 is now correctly [failing tests](https://github.com/rust-lang/cargo/actions/runs/9529301554/job/26267905188#step:11:4072).
- Turns out these test already have regression. 79a7bf4 fixes them.

### Additional information

Thanks @weihanglo for suggesting the fix 3c473b5 in https://github.com/rust-lang/cargo/issues/14076#issuecomment-2169593172.