### PR TITLE
test: Migrate tests/testsuite/co*.rs to snapbox

### DIFF
--- a/tests/testsuite/collisions.rs
+++ b/tests/testsuite/collisions.rs
@@ -3,9 +3,9 @@
 //! Ideally these should never happen, but I don't think we'll ever be able to
 //! prevent all collisions.
 
-#![allow(deprecated)]
-
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
+use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, cross_compile, project};
 use std::env;
 
@@ -52,13 +52,15 @@ fn collision_dylib() {
     // `j=1` is required because on Windows you'll get an error due to
     // two processes writing to the file at the same time.
     p.cargo("build -j=1")
-        .with_stderr_contains(&format!("\
+        .with_stderr_data(&format!("\
+...
 [WARNING] output filename collision.
-The lib target `a` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([..]/foo/a)`.
-Colliding filename is: [..]/foo/target/debug/deps/{}a{}
+The lib target `a` in package `b v1.0.0 ([ROOT]/foo/b)` has the same output filename as the lib target `a` in package `a v1.0.0 ([ROOT]/foo/a)`.
+Colliding filename is: [ROOT]/foo/target/debug/deps/{}a{}
 The targets should have unique names.
 Consider changing their names to be unique or compiling them separately.
 This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
+...
 ", env::consts::DLL_PREFIX, env::consts::DLL_SUFFIX))
         .run();
 }
@@ -83,14 +85,17 @@ fn collision_example() {
     // `j=1` is required because on Windows you'll get an error due to
     // two processes writing to the file at the same time.
     p.cargo("build --examples -j=1")
-        .with_stderr_contains("\
+        .with_stderr_data(str![[r#"
+...
 [WARNING] output filename collision.
-The example target `ex1` in package `b v1.0.0 ([..]/foo/b)` has the same output filename as the example target `ex1` in package `a v1.0.0 ([..]/foo/a)`.
-Colliding filename is: [..]/foo/target/debug/examples/ex1[EXE]
+The example target `ex1` in package `b v1.0.0 ([ROOT]/foo/b)` has the same output filename as the example target `ex1` in package `a v1.0.0 ([ROOT]/foo/a)`.
+Colliding filename is: [ROOT]/foo/target/debug/examples/ex1[EXE]
 The targets should have unique names.
 Consider changing their names to be unique or compiling them separately.
 This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
-")
+...
+
+"#]])
         .run();
 }
 
@@ -112,14 +117,16 @@ fn collision_export() {
     // same time.
     p.cargo("build -j1 --artifact-dir=out -Z unstable-options --bins --examples")
         .masquerade_as_nightly_cargo(&["artifact-dir"])
-        .with_stderr_contains("\
+        .with_stderr_data(str![[r#"
 [WARNING] `--artifact-dir` filename collision.
-The example target `foo` in package `foo v1.0.0 ([..]/foo)` has the same output filename as the bin target `foo` in package `foo v1.0.0 ([..]/foo)`.
-Colliding filename is: [..]/foo/out/foo[EXE]
+The example target `foo` in package `foo v1.0.0 ([ROOT]/foo)` has the same output filename as the bin target `foo` in package `foo v1.0.0 ([ROOT]/foo)`.
+Colliding filename is: [ROOT]/foo/out/foo[EXE]
 The exported filenames should be unique.
 Consider changing their names to be unique or compiling them separately.
 This may become a hard error in the future; see <https://github.com/rust-lang/cargo/issues/6313>.
-")
+...
+
+"#]])
         .run();
 }
 
@@ -155,17 +162,17 @@ fn collision_doc() {
         .build();
 
     p.cargo("doc -j=1")
-        .with_stderr_contains(
-            "\
+        .with_stderr_data(str![[r#"
+...
 [WARNING] output filename collision.
-The lib target `foo` in package `foo2 v0.1.0 ([..]/foo/foo2)` has the same output \
-filename as the lib target `foo` in package `foo v0.1.0 ([..]/foo)`.
-Colliding filename is: [..]/foo/target/doc/foo/index.html
+The lib target `foo` in package `foo2 v0.1.0 ([ROOT]/foo/foo2)` has the same output filename as the lib target `foo` in package `foo v0.1.0 ([ROOT]/foo)`.
+Colliding filename is: [ROOT]/foo/target/doc/foo/index.html
 The targets should have unique names.
 This is a known bug where multiple crates with the same name use
 the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
-",
-        )
+...
+
+"#]])
         .run();
 }
 
@@ -196,27 +203,30 @@ fn collision_doc_multiple_versions() {
 
     // Should only document bar 2.0, should not document old-dep.
     p.cargo("doc")
-        .with_stderr_unordered(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(
+            str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest compatible versions
 [ADDING] bar v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v2.0.0 [..]
-[DOWNLOADED] bar v1.0.0 [..]
-[DOWNLOADED] old-dep v1.0.0 [..]
+[DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] old-dep v1.0.0 (registry `dummy-registry`)
 [CHECKING] old-dep v1.0.0
 [CHECKING] bar v2.0.0
 [CHECKING] bar v1.0.0
 [DOCUMENTING] bar v2.0.0
-[FINISHED] [..]
-[DOCUMENTING] foo v0.1.0 [..]
-[GENERATED] [CWD]/target/doc/foo/index.html
-",
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
+[GENERATED] [ROOT]/foo/target/doc/foo/index.html
+
+"#]]
+            .unordered(),
         )
         .run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn collision_doc_host_target_feature_split() {
     // Same dependency built twice due to different features.
@@ -371,35 +381,39 @@ fn collision_doc_profile_split() {
     // This is unordered because in rare cases `pm` may start
     // building in-between the two `common`.
     p.cargo("build -v")
-        .with_stderr_unordered(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(
+            str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] common v1.0.0 [..]
+[DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
 [COMPILING] common v1.0.0
 [RUNNING] `rustc --crate-name common [..]
 [RUNNING] `rustc --crate-name common [..]
-[COMPILING] pm v0.1.0 [..]
+[COMPILING] pm v0.1.0 ([ROOT]/foo/pm)
 [RUNNING] `rustc --crate-name pm [..]
-[COMPILING] foo v0.1.0 [..]
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
 [RUNNING] `rustc --crate-name foo [..]
-[FINISHED] [..]
-",
+[FINISHED] `dev` profile [optimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]
+            .unordered(),
         )
         .run();
 
     // Should only document common once, no warnings.
     p.cargo("doc")
-        .with_stderr_unordered(
-            "\
+        .with_stderr_data(
+            str![[r#"
 [CHECKING] common v1.0.0
 [DOCUMENTING] common v1.0.0
-[DOCUMENTING] pm v0.1.0 [..]
-[DOCUMENTING] foo v0.1.0 [..]
-[FINISHED] [..]
-[GENERATED] [CWD]/target/doc/foo/index.html
-",
+[DOCUMENTING] pm v0.1.0 ([ROOT]/foo/pm)
+[DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [optimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/foo/index.html
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -428,27 +442,28 @@ fn collision_doc_sources() {
         .build();
 
     p.cargo("doc -j=1")
-        .with_stderr_unordered(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(
+            str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.0.0 [..]
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [WARNING] output filename collision.
-The lib target `bar` in package `bar v1.0.0` has the same output filename as \
-the lib target `bar` in package `bar v1.0.0 ([..]/foo/bar)`.
-Colliding filename is: [..]/foo/target/doc/bar/index.html
+The lib target `bar` in package `bar v1.0.0` has the same output filename as the lib target `bar` in package `bar v1.0.0 ([ROOT]/foo/bar)`.
+Colliding filename is: [ROOT]/foo/target/doc/bar/index.html
 The targets should have unique names.
 This is a known bug where multiple crates with the same name use
 the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
-[CHECKING] bar v1.0.0 [..]
-[DOCUMENTING] bar v1.0.0 [..]
+[CHECKING] bar v1.0.0 ([ROOT]/foo/bar)
+[DOCUMENTING] bar v1.0.0 ([ROOT]/foo/bar)
 [DOCUMENTING] bar v1.0.0
 [CHECKING] bar v1.0.0
-[DOCUMENTING] foo v0.1.0 [..]
-[FINISHED] [..]
-[GENERATED] [CWD]/target/doc/foo/index.html
-",
+[DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/foo/index.html
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -484,23 +499,25 @@ fn collision_doc_target() {
 
     p.cargo("doc --target")
         .arg(cross_compile::alternate())
-        .with_stderr_unordered(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(
+            str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest compatible versions
 [ADDING] bar v1.0.0 (latest: v2.0.0)
 [DOWNLOADING] crates ...
-[DOWNLOADED] orphaned v1.0.0 [..]
-[DOWNLOADED] bar v2.0.0 [..]
-[DOWNLOADED] bar v1.0.0 [..]
+[DOWNLOADED] orphaned v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v2.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] orphaned v1.0.0
 [DOCUMENTING] bar v2.0.0
 [CHECKING] bar v2.0.0
 [CHECKING] bar v1.0.0
-[DOCUMENTING] foo v0.1.0 [..]
-[FINISHED] [..]
-[GENERATED] [CWD]/target/[..]/doc/foo/index.html
-",
+[DOCUMENTING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/[ALT_TARGET]/doc/foo/index.html
+
+"#]]
+            .unordered(),
         )
         .run();
 }
@@ -553,24 +570,25 @@ fn collision_with_root() {
         .build();
 
     p.cargo("doc -j=1")
-        .with_stderr_unordered("\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] foo-macro v1.0.0 [..]
-warning: output filename collision.
-The lib target `foo_macro` in package `foo-macro v1.0.0` has the same output filename as the lib target `foo_macro` in package `foo-macro v1.0.0 [..]`.
-Colliding filename is: [CWD]/target/doc/foo_macro/index.html
+[DOWNLOADED] foo-macro v1.0.0 (registry `dummy-registry`)
+[WARNING] output filename collision.
+The lib target `foo_macro` in package `foo-macro v1.0.0` has the same output filename as the lib target `foo_macro` in package `foo-macro v1.0.0 ([ROOT]/foo/foo-macro)`.
+Colliding filename is: [ROOT]/foo/target/doc/foo_macro/index.html
 The targets should have unique names.
 This is a known bug where multiple crates with the same name use
 the same path; see <https://github.com/rust-lang/cargo/issues/6313>.
 [CHECKING] foo-macro v1.0.0
 [DOCUMENTING] foo-macro v1.0.0
-[CHECKING] abc v1.0.0 [..]
-[DOCUMENTING] foo-macro v1.0.0 [..]
-[DOCUMENTING] abc v1.0.0 [..]
-[FINISHED] [..]
-[GENERATED] [CWD]/target/doc/abc/index.html and 1 other file
-")
+[CHECKING] abc v1.0.0 ([ROOT]/foo/abc)
+[DOCUMENTING] foo-macro v1.0.0 ([ROOT]/foo/foo-macro)
+[DOCUMENTING] abc v1.0.0 ([ROOT]/foo/abc)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[GENERATED] [ROOT]/foo/target/doc/abc/index.html and 1 other file
+
+"#]].unordered())
         .run();
 }

--- a/tests/testsuite/concurrent.rs
+++ b/tests/testsuite/concurrent.rs
@@ -1,7 +1,5 @@
 //! Tests for running multiple `cargo` processes at the same time.
 
-#![allow(deprecated)]
-
 use std::fs;
 use std::net::TcpListener;
 use std::process::Stdio;
@@ -13,6 +11,7 @@ use cargo_test_support::cargo_process;
 use cargo_test_support::git;
 use cargo_test_support::install::{assert_has_installed_exe, cargo_home};
 use cargo_test_support::registry::Package;
+use cargo_test_support::str;
 use cargo_test_support::{basic_manifest, execs, project, slow_cpu_multiplier};
 
 fn pkg(name: &str, vers: &str) {
@@ -433,20 +432,20 @@ fn debug_release_ok() {
     let a = a.join().unwrap();
 
     execs()
-        .with_stderr_contains(
-            "\
-[COMPILING] foo v0.0.1 [..]
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+...
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run_output(&a);
     execs()
-        .with_stderr_contains(
-            "\
-[COMPILING] foo v0.0.1 [..]
-[FINISHED] `release` profile [optimized] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+...
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]])
         .run_output(&b);
 }
 

--- a/tests/testsuite/config.rs
+++ b/tests/testsuite/config.rs
@@ -1,7 +1,5 @@
 //! Tests for config settings.
 
-#![allow(deprecated)]
-
 use cargo::core::features::{GitFeatures, GitoxideFeatures};
 use cargo::core::{PackageIdSpec, Shell};
 use cargo::util::context::{
@@ -1616,7 +1614,10 @@ fn cargo_target_empty_env() {
 
     project.cargo("check")
         .env("CARGO_TARGET_DIR", "")
-        .with_stderr("error: the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable")
+        .with_stderr_data(str![[r#"
+[ERROR] the target directory is set to an empty string in the `CARGO_TARGET_DIR` environment variable
+
+"#]])
         .with_status(101)
         .run()
 }

--- a/tests/testsuite/config_cli.rs
+++ b/tests/testsuite/config_cli.rs
@@ -1,7 +1,5 @@
 //! Tests for the --config CLI option.
 
-#![allow(deprecated)]
-
 use super::config::{
     assert_error, read_output, write_config_at, write_config_toml, GlobalContextBuilder,
 };

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -1,8 +1,7 @@
 //! Tests for `include` config field.
 
-#![allow(deprecated)]
-
 use super::config::{assert_error, write_config_at, write_config_toml, GlobalContextBuilder};
+use cargo_test_support::str;
 use cargo_test_support::{no_such_file_err_msg, project};
 
 #[cargo_test]
@@ -68,24 +67,22 @@ fn works_with_cli() {
     );
     let p = project().file("src/lib.rs", "").build();
     p.cargo("check -v")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.0.1 [..]
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]-W unused`
-[FINISHED] [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("check -v -Z config-include")
         .masquerade_as_nightly_cargo(&["config-include"])
-        .with_stderr(
-            "\
-[DIRTY] foo v0.0.1 ([..]): the rustflags changed
-[CHECKING] foo v0.0.1 [..]
+        .with_stderr_data(str![[r#"
+[DIRTY] foo v0.0.1 ([ROOT]/foo): the rustflags changed
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..]-W unsafe-code -W unused`
-[FINISHED] [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 

--- a/tests/testsuite/corrupt_git.rs
+++ b/tests/testsuite/corrupt_git.rs
@@ -1,7 +1,5 @@
 //! Tests for corrupt git repos.
 
-#![allow(deprecated)]
-
 use cargo_test_support::paths;
 use cargo_test_support::{basic_manifest, git, project};
 use cargo_util::paths as cargopaths;


### PR DESCRIPTION
Migrating files:

- tests/testsuite/collisions.rs
  - `with_stderr_does_not_contain` in test `collision_doc_host_target_feature_split`
- tests/testsuite/concurrent.rs
- tests/testsuite/config.rs
- tests/testsuite/config_cli.rs
- tests/testsuite/config_include.rs
- tests/testsuite/corrupt_git.rs

Testing with command `SNAPSHOTS=overwrite cargo test collisions::` or so.

Part of #14039
