### PR TITLE
zsh completion: allow setting custom registries for 'cargo add --registry'

### DIFF
--- a/src/etc/_cargo
+++ b/src/etc/_cargo
@@ -60,11 +60,18 @@ _cargo() {
         "--no-default-features[don't build the default features]"
     )
 
+    typeset -A registries_tmp
+    typeset -a registries
+    zstyle -a ":completion:${curcontext}:registries" registries registries_tmp
+    for key in ${(k)registries_tmp}; do
+        registries+=("$key:${registries_tmp[$key]}")
+    done
+
     msgfmt='--message-format=[specify error format]:error format [human]:(human json short)'
     triple='--target=[specify target triple]:target triple:_cargo_target_triple'
     target='--target-dir=[specify directory for all generated artifacts]:directory:_directories'
     manifest='--manifest-path=[specify path to manifest]:path:_directories'
-    registry='--registry=[specify registry to use]:registry'
+    registry='--registry=[specify registry to use]:registry:((${registries[@]}))'
 
     case $state in
         args)


### PR DESCRIPTION
### What does this PR try to resolve?

So far when I type in zsh `cargo add --regi<TAB>`, I get `cargo add --registry=` as suggestion. So far so good. But even though I have a private not-default registry configured in `~/.cargo/config.toml`, there is no further suggestion for what should come after the equal sign. My crates come basically from two registries in equal parts, so setting a default wouldn't help, as I still have to specify the registry on the command line half of the times. In the PR here, I read a zstyle where a user can specify custom registries. In my case, I can add
```
zstyle ':completion:*:complete:cargo:*:registries' registries "sevensense" "my employer"
```

In my .zshrc and get `sevensense` suggested. The format for the style is that of an associative array. I.e. for multiple registries:
```
zstyle ':completion:*:complete:cargo:*:registries' registries "wubbel" "I like wubbel" "wopper" "you can eat that at: Burger King" "yuhu" "the best"
```

And the tab completion would suggest
```
 > cargo add --registry=<TAB>
registry:
wubbel  -- I like wubbel
wopper  -- you can eat that at: Burger King
yuhu    -- the best
```

I also looked into reading the configured registries from `~/.cargo/config.toml` but afaiu `cargo` can't print them to the command line. I looked at https://github.com/z-shell/zsh-string-lib/tree/main but adding this as dependency seemed a bit too much complexity added.

*todo*: Having this code block where it is, is probably not optimal. Also, the intended usage should be documented somewhere, where users can find it, I'm open for suggestions.

### How should we test and review this PR?

`cargo add --registry=<TAB>` in zsh, with the _cargo completion in use, should not do anything with the style unset. With the style set as explained above, you should see that zsh suggests the registries, and completes other options as before.

I only tested `cargo add`, but also other commands take the --registry argument. I guess generally completion for more complex command lines with registry should be tested.