### PR TITLE
test: migrate `git_(gc|shallow)` to snapbox

### DIFF
--- a/tests/testsuite/git_gc.rs
+++ b/tests/testsuite/git_gc.rs
@@ -1,7 +1,5 @@
 //! Tests for git garbage collection.
 
-#![allow(deprecated)]
-
 use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;

--- a/tests/testsuite/git_shallow.rs
+++ b/tests/testsuite/git_shallow.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use crate::git_gc::find_index;
 use cargo_test_support::registry::Package;
 use cargo_test_support::{basic_manifest, git, paths, project};


### PR DESCRIPTION
This PR is intentionally trivial to make sure I understand the contribution process :)

Migrating files:

- `tests/testsuite/git_gc.rs`
- `tests/testsuite/git_shallow.rs`

Tested with `SNAPSHOTS=overwrite cargo test`.

Part of https://github.com/rust-lang/cargo/issues/14039.