### PR TITLE
remove some legacy public dependency code from the resolver

### DIFF
--- a/src/cargo/core/resolver/conflict_cache.rs
+++ b/src/cargo/core/resolver/conflict_cache.rs
@@ -194,11 +194,6 @@ impl ConflictCache {
     /// `dep` is known to be unresolvable if
     /// all the `PackageId` entries are activated.
     pub fn insert(&mut self, dep: &Dependency, con: &ConflictMap) {
-        if con.values().any(|c| c.is_public_dependency()) {
-            // TODO: needs more info for back jumping
-            // for now refuse to cache it.
-            return;
-        }
         self.con_from_dep
             .entry(dep.clone())
             .or_insert_with(|| ConflictStoreTrie::Node(BTreeMap::new()))

--- a/src/cargo/core/resolver/errors.rs
+++ b/src/cargo/core/resolver/errors.rs
@@ -193,14 +193,6 @@ pub(super) fn activation_error(
                     );
                     // p == parent so the full path is redundant.
                 }
-                ConflictReason::PublicDependency(pkg_id) => {
-                    // TODO: This needs to be implemented.
-                    unimplemented!("pub dep {:?}", pkg_id);
-                }
-                ConflictReason::PubliclyExports(pkg_id) => {
-                    // TODO: This needs to be implemented.
-                    unimplemented!("pub exp {:?}", pkg_id);
-                }
             }
         }
 

--- a/src/cargo/core/resolver/mod.rs
+++ b/src/cargo/core/resolver/mod.rs
@@ -820,10 +820,6 @@ fn generalize_conflicting(
     let backtrack_critical_reason: ConflictReason =
         conflicting_activations[&backtrack_critical_id].clone();
 
-    if backtrack_critical_reason.is_public_dependency() {
-        return None;
-    }
-
     if cx
         .parents
         .is_path_from_to(&parent.package_id(), &backtrack_critical_id)

--- a/src/cargo/core/resolver/types.rs
+++ b/src/cargo/core/resolver/types.rs
@@ -300,12 +300,6 @@ pub enum ConflictReason {
     /// A dependency listed a feature for an optional dependency, but that
     /// optional dependency is "hidden" using namespaced `dep:` syntax.
     NonImplicitDependencyAsFeature(InternedString),
-
-    // TODO: needs more info for `activation_error`
-    // TODO: needs more info for `find_candidate`
-    /// pub dep error
-    PublicDependency(PackageId),
-    PubliclyExports(PackageId),
 }
 
 impl ConflictReason {
@@ -319,13 +313,6 @@ impl ConflictReason {
 
     pub fn is_required_dependency_as_features(&self) -> bool {
         matches!(self, ConflictReason::RequiredDependencyAsFeature(_))
-    }
-
-    pub fn is_public_dependency(&self) -> bool {
-        matches!(
-            self,
-            ConflictReason::PublicDependency(_) | ConflictReason::PubliclyExports(_)
-        )
     }
 }
 


### PR DESCRIPTION
These conflict reasons are no longer constructed, since we removed backtracking caused by public dependencies. Let's go ahead and remove them.

r? @epage