### PR TITLE
test: migrate testsuites to snapbox

### DIFF
--- a/tests/testsuite/death.rs
+++ b/tests/testsuite/death.rs
@@ -1,7 +1,5 @@
 //! Tests for ctrl-C handling.
 
-#![allow(deprecated)]
-
 use cargo_test_support::{project, slow_cpu_multiplier};
 use std::fs;
 use std::io::{self, Read};

--- a/tests/testsuite/precise_pre_release.rs
+++ b/tests/testsuite/precise_pre_release.rs
@@ -1,8 +1,6 @@
 //! Tests for selecting pre-release versions with `update --precise`.
 
-#![allow(deprecated)]
-
-use cargo_test_support::project;
+use cargo_test_support::{project, str};
 
 #[cargo_test]
 fn requires_nightly_cargo() {
@@ -29,16 +27,17 @@ fn requires_nightly_cargo() {
         .with_status(101)
         // This error is suffering from #12579 but still demonstrates that updating to
         // a pre-release does not work on stable
-        .with_stderr(
-            r#"[UPDATING] `dummy-registry` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [ERROR] failed to select a version for the requirement `my-dependency = "^0.1.1"`
 candidate versions found which didn't match: 0.1.2-pre.0
 location searched: `dummy-registry` index (which is replacing registry `crates-io`)
 required by package `package v0.0.0 ([ROOT]/foo)`
 if you are looking for the prerelease package it needs to be specified explicitly
     my-dependency = { version = "0.1.2-pre.0" }
-perhaps a crate was updated and forgotten to be re-vendored?"#,
-        )
+perhaps a crate was updated and forgotten to be re-vendored?
+
+"#]])
         .run()
 }
 
@@ -65,11 +64,11 @@ fn update_pre_release() {
 
     p.cargo("update my-dependency --precise 0.1.2-pre.0 -Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
-        .with_stderr(
-            r#"[UPDATING] `dummy-registry` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [UPDATING] my-dependency v0.1.1 -> v0.1.2-pre.0
-"#,
-        )
+
+"#]])
         .run();
     let lockfile = p.read_lockfile();
     assert!(lockfile.contains("\nname = \"my-dependency\"\nversion = \"0.1.2-pre.0\""));
@@ -98,20 +97,20 @@ fn update_pre_release_differ() {
 
     p.cargo("update -p my-dependency --precise 0.1.2-pre.0 -Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
-        .with_stderr(
-            r#"[UPDATING] `dummy-registry` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [DOWNGRADING] my-dependency v0.1.2 -> v0.1.2-pre.0
-"#,
-        )
+
+"#]])
         .run();
 
     p.cargo("update -p my-dependency --precise 0.1.2-pre.1 -Zunstable-options")
         .masquerade_as_nightly_cargo(&["precise-pre-release"])
-        .with_stderr(
-            r#"[UPDATING] `dummy-registry` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [UPDATING] my-dependency v0.1.2-pre.0 -> v0.1.2-pre.1
-"#,
-        )
+
+"#]])
         .run();
 
     let lockfile = p.read_lockfile();

--- a/tests/testsuite/verify_project.rs
+++ b/tests/testsuite/verify_project.rs
@@ -1,12 +1,6 @@
 //! Tests for the `cargo verify-project` command.
 
-#![allow(deprecated)]
-
-use cargo_test_support::{basic_bin_manifest, main_file, project};
-
-fn verify_project_success_output() -> String {
-    r#"{"success":"true"}"#.into()
-}
+use cargo_test_support::{basic_bin_manifest, main_file, project, str};
 
 #[cargo_test]
 fn cargo_verify_project_path_to_cargo_toml_relative() {
@@ -17,7 +11,10 @@ fn cargo_verify_project_path_to_cargo_toml_relative() {
 
     p.cargo("verify-project --manifest-path foo/Cargo.toml")
         .cwd(p.root().parent().unwrap())
-        .with_stdout(verify_project_success_output())
+        .with_stdout_data(str![[r#"
+{"success":"true"}
+
+"#]])
         .run();
 }
 
@@ -31,7 +28,10 @@ fn cargo_verify_project_path_to_cargo_toml_absolute() {
     p.cargo("verify-project --manifest-path")
         .arg(p.root().join("Cargo.toml"))
         .cwd(p.root().parent().unwrap())
-        .with_stdout(verify_project_success_output())
+        .with_stdout_data(str![[r#"
+{"success":"true"}
+
+"#]])
         .run();
 }
 
@@ -43,7 +43,10 @@ fn cargo_verify_project_cwd() {
         .build();
 
     p.cargo("verify-project")
-        .with_stdout(verify_project_success_output())
+        .with_stdout_data(str![[r#"
+{"success":"true"}
+
+"#]])
         .run();
 }
 
@@ -65,11 +68,17 @@ fn cargo_verify_project_honours_unstable_features() {
 
     p.cargo("verify-project")
         .masquerade_as_nightly_cargo(&["test-dummy-unstable"])
-        .with_stdout(verify_project_success_output())
+        .with_stdout_data(str![[r#"
+{"success":"true"}
+
+"#]])
         .run();
 
     p.cargo("verify-project")
         .with_status(1)
-        .with_json(r#"{"invalid":"failed to parse manifest at `[CWD]/Cargo.toml`"}"#)
+        .with_stdout_data(str![[r#"
+{"invalid":"failed to parse manifest at `[..]`"}
+
+"#]])
         .run();
 }

--- a/tests/testsuite/version.rs
+++ b/tests/testsuite/version.rs
@@ -1,7 +1,5 @@
 //! Tests for displaying the cargo version.
 
-#![allow(deprecated)]
-
 use cargo_test_support::{cargo_process, project};
 
 #[cargo_test]
@@ -9,15 +7,15 @@ fn simple() {
     let p = project().build();
 
     p.cargo("version")
-        .with_stdout(&format!("cargo {}\n", cargo::version()))
+        .with_stdout_data(&format!("cargo {}\n", cargo::version()))
         .run();
 
     p.cargo("--version")
-        .with_stdout(&format!("cargo {}\n", cargo::version()))
+        .with_stdout_data(&format!("cargo {}\n", cargo::version()))
         .run();
 
     p.cargo("-V")
-        .with_stdout(&format!("cargo {}\n", cargo::version()))
+        .with_stdout_data(&format!("cargo {}\n", cargo::version()))
         .run();
 }
 
@@ -53,10 +51,19 @@ fn version_works_with_bad_target_dir() {
 fn verbose() {
     // This is mainly to check that it doesn't explode.
     cargo_process("-vV")
-        .with_stdout_contains(&format!("cargo {}", cargo::version()))
-        .with_stdout_contains("host: [..]")
-        .with_stdout_contains("libgit2: [..]")
-        .with_stdout_contains("libcurl: [..]")
-        .with_stdout_contains("os: [..]")
+        .with_stdout_data(format!(
+            "\
+cargo {}
+release: [..]
+commit-hash: [..]
+commit-date: [..]
+host: [HOST_TARGET]
+libgit2: [..] (sys:[..] [..])
+libcurl: [..] (sys:[..] [..])
+...
+os: [..]
+",
+            cargo::version()
+        ))
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate the following testsuites to snapbox:

- tests/testsuite/death.rs
- ~~tests/testsuite/locate_project.rs~~ see https://github.com/rust-lang/cargo/pull/14091#discussion_r1646183025
- tests/testsuite/message_format.rs
- tests/testsuite/precise_pre_release.rs
- tests/testsuite/verify_project.rs
- tests/testsuite/version.rs

### How should we test and review this PR?

N/A

### Additional information

N/A