### PR TITLE
test: migrate clean to snapbox

### DIFF
--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -825,6 +825,7 @@ fn clean_spec_reserved() {
         .run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn clean_dry_run() {
     // Basic `clean --dry-run` test.
@@ -866,15 +867,11 @@ fn clean_dry_run() {
     // Verify it didn't delete anything.
     let after = p.build_dir().ls_r();
     assert_eq!(before, after);
-    let path_stringify = |p: &PathBuf| format!("{}\n", p.to_str().unwrap());
-    let files = itertools::join(before.iter().map(path_stringify), "");
-    let re = regex::Regex::new("/(?<head>[a-z0-9\\-_]+)-([0-9a-f]{16})(?<tail>.*)").unwrap();
-    let expected = re.replace_all(&files, "/$head-[HASH]$tail");
-    let expected = expected.replace(p.build_dir().to_str().unwrap(), "[ROOT]/foo/target");
+    let expected = itertools::join(before.iter().map(|p| p.to_str().unwrap()), "\n");
     eprintln!("{expected}");
     // Verify the verbose output.
     p.cargo("clean --dry-run -v")
-        .with_stdout_data(expected.unordered())
+        .with_stdout_unordered(expected)
         .with_stderr_data(str![[r#"
 [SUMMARY] [FILE_NUM] files, [FILE_SIZE]B total
 [WARNING] no files deleted due to --dry-run

--- a/tests/testsuite/clean.rs
+++ b/tests/testsuite/clean.rs
@@ -1,9 +1,9 @@
 //! Tests for the `cargo clean` command.
 
-#![allow(deprecated)]
-
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
+use cargo_test_support::str;
 use cargo_test_support::{
     basic_bin_manifest, basic_manifest, git, main_file, project, project_in, rustc_host,
 };
@@ -38,7 +38,10 @@ fn different_dir() {
 
     p.cargo("clean")
         .cwd("src")
-        .with_stderr("[REMOVED] [..]")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
         .run();
     assert!(!p.build_dir().is_dir());
 }
@@ -88,7 +91,10 @@ fn clean_multiple_packages() {
 
     p.cargo("clean -p d1 -p d2")
         .cwd("src")
-        .with_stderr("[REMOVED] [..]")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
         .run();
     assert!(p.bin("foo").is_file());
     assert!(!d1_path.is_file());
@@ -235,17 +241,19 @@ fn clean_release() {
 
     p.cargo("clean -p foo").run();
     p.cargo("build --release")
-        .with_stderr("[FINISHED] [..]")
+        .with_stderr_data(str![[r#"
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("clean -p foo --release").run();
     p.cargo("build --release")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([..])
-[FINISHED] `release` profile [optimized] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `release` profile [optimized] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("build").run();
@@ -283,7 +291,12 @@ fn clean_doc() {
 
     assert!(doc_path.is_dir());
 
-    p.cargo("clean --doc").with_stderr("[REMOVED] [..]").run();
+    p.cargo("clean --doc")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
 
     assert!(!doc_path.is_dir());
     assert!(p.build_dir().is_dir());
@@ -326,15 +339,14 @@ fn build_script() {
     p.cargo("build").env("FIRST", "1").run();
     p.cargo("clean -p foo").run();
     p.cargo("build -v")
-        .with_stderr(
-            "\
-[COMPILING] foo v0.0.1 ([..])
+        .with_stderr_data(str![[r#"
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
 [RUNNING] `rustc [..] build.rs [..]`
-[RUNNING] `[..]build-script-build`
+[RUNNING] `[ROOT]/foo/target/debug/build/foo-[HASH]/build-script-build`
 [RUNNING] `rustc [..] src/main.rs [..]`
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -367,7 +379,12 @@ fn clean_git() {
         .build();
 
     p.cargo("build").run();
-    p.cargo("clean -p dep").with_stderr("[REMOVED] [..]").run();
+    p.cargo("clean -p dep")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
     p.cargo("build").run();
 }
 
@@ -393,7 +410,12 @@ fn registry() {
     Package::new("bar", "0.1.0").publish();
 
     p.cargo("build").run();
-    p.cargo("clean -p bar").with_stderr("[REMOVED] [..]").run();
+    p.cargo("clean -p bar")
+        .with_stderr_data(str![[r#"
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
+        .run();
     p.cargo("build").run();
 }
 
@@ -420,21 +442,21 @@ fn clean_verbose() {
     p.cargo("build").run();
     let mut expected = String::from(
         "\
-[REMOVING] [..]target/debug/.fingerprint/bar[..]
-[REMOVING] [..]target/debug/deps/libbar[..].rlib
-[REMOVING] [..]target/debug/deps/bar-[..].d
-[REMOVING] [..]target/debug/deps/libbar[..].rmeta
+[REMOVING] [ROOT]/foo/target/debug/.fingerprint/bar-[HASH]
+[REMOVING] [ROOT]/foo/target/debug/deps/libbar-[HASH].rlib
+[REMOVING] [ROOT]/foo/target/debug/deps/bar-[HASH].d
+[REMOVING] [ROOT]/foo/target/debug/deps/libbar-[HASH].rmeta
 ",
     );
     if cfg!(target_os = "macos") {
         // Rust 1.69 has changed so that split-debuginfo=unpacked includes unpacked for rlibs.
-        for obj in p.glob("target/debug/deps/bar-*.o") {
-            expected.push_str(&format!("[REMOVING] [..]{}\n", obj.unwrap().display()));
+        for _ in p.glob("target/debug/deps/bar-*.o") {
+            expected.push_str("[REMOVING] [ROOT]/foo/target/debug/deps/bar-[HASH][..].o\n");
         }
     }
-    expected.push_str("[REMOVED] [..] files, [..] total\n");
+    expected.push_str("[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total\n");
     p.cargo("clean -p bar --verbose")
-        .with_stderr_unordered(&expected)
+        .with_stderr_data(&expected.unordered())
         .run();
     p.cargo("build").run();
 }
@@ -614,21 +636,20 @@ fn clean_spec_version() {
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
         .with_status(101)
-        .with_stderr(
-            "\
-error: package ID specification `baz` did not match any packages
+        .with_stderr_data(str![[r#"
+[ERROR] package ID specification `baz` did not match any packages
 
-<tab>Did you mean `bar`?
-",
-        )
+	Did you mean `bar`?
+
+"#]])
         .run();
 
     p.cargo("clean -p bar:0.1.0")
-        .with_stderr(
-            "warning: version qualifier in `-p bar:0.1.0` is ignored, \
-            cleaning all versions of `bar` found\n\
-            [REMOVED] [..] files, [..] total",
-        )
+        .with_stderr_data(str![[r#"
+[WARNING] version qualifier in `-p bar:0.1.0` is ignored, cleaning all versions of `bar` found
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -670,21 +691,20 @@ fn clean_spec_partial_version() {
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
         .with_status(101)
-        .with_stderr(
-            "\
-error: package ID specification `baz` did not match any packages
+        .with_stderr_data(str![[r#"
+[ERROR] package ID specification `baz` did not match any packages
 
-<tab>Did you mean `bar`?
-",
-        )
+	Did you mean `bar`?
+
+"#]])
         .run();
 
     p.cargo("clean -p bar:0.1")
-        .with_stderr(
-            "warning: version qualifier in `-p bar:0.1` is ignored, \
-            cleaning all versions of `bar` found\n\
-            [REMOVED] [..] files, [..] total",
-        )
+        .with_stderr_data(str![[r#"
+[WARNING] version qualifier in `-p bar:0.1` is ignored, cleaning all versions of `bar` found
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -726,21 +746,20 @@ fn clean_spec_partial_version_ambiguous() {
     // Check suggestion for bad pkgid.
     p.cargo("clean -p baz")
         .with_status(101)
-        .with_stderr(
-            "\
-error: package ID specification `baz` did not match any packages
+        .with_stderr_data(str![[r#"
+[ERROR] package ID specification `baz` did not match any packages
 
-<tab>Did you mean `bar`?
-",
-        )
+	Did you mean `bar`?
+
+"#]])
         .run();
 
     p.cargo("clean -p bar:0")
-        .with_stderr(
-            "warning: version qualifier in `-p bar:0` is ignored, \
-            cleaning all versions of `bar` found\n\
-            [REMOVED] [..] files, [..] total",
-        )
+        .with_stderr_data(str![[r#"
+[WARNING] version qualifier in `-p bar:0` is ignored, cleaning all versions of `bar` found
+[REMOVED] [FILE_NUM] files, [FILE_SIZE]B total
+
+"#]])
         .run();
     let mut walker = walkdir::WalkDir::new(p.build_dir())
         .into_iter()
@@ -794,16 +813,15 @@ fn clean_spec_reserved() {
 
     // This should not rebuild bar.
     p.cargo("build -v --all-targets")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [FRESH] bar v1.0.0
-[COMPILING] foo v0.1.0 [..]
-[RUNNING] `rustc [..]
-[RUNNING] `rustc [..]
-[RUNNING] `rustc [..]
-[FINISHED] [..]
-",
-        )
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[RUNNING] `rustc [..]`
+[RUNNING] `rustc [..]`
+[RUNNING] `rustc [..]`
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -829,32 +847,39 @@ fn clean_dry_run() {
 
     // Start with no files.
     p.cargo("clean --dry-run")
-        .with_stdout("")
-        .with_stderr(
-            "[SUMMARY] 0 files\n\
-             [WARNING] no files deleted due to --dry-run",
-        )
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[SUMMARY] [FILE_NUM] files
+[WARNING] no files deleted due to --dry-run
+
+"#]])
         .run();
     p.cargo("check").run();
     let before = p.build_dir().ls_r();
     p.cargo("clean --dry-run")
-        .with_stderr(
-            "[SUMMARY] [..] files, [..] total\n\
-             [WARNING] no files deleted due to --dry-run",
-        )
+        .with_stderr_data(str![[r#"
+[SUMMARY] [FILE_NUM] files, [FILE_SIZE]B total
+[WARNING] no files deleted due to --dry-run
+
+"#]])
         .run();
     // Verify it didn't delete anything.
     let after = p.build_dir().ls_r();
     assert_eq!(before, after);
-    let expected = itertools::join(before.iter().map(|p| p.to_str().unwrap()), "\n");
+    let path_stringify = |p: &PathBuf| format!("{}\n", p.to_str().unwrap());
+    let files = itertools::join(before.iter().map(path_stringify), "");
+    let re = regex::Regex::new("/(?<head>[a-z0-9\\-_]+)-([0-9a-f]{16})(?<tail>.*)").unwrap();
+    let expected = re.replace_all(&files, "/$head-[HASH]$tail");
+    let expected = expected.replace(p.build_dir().to_str().unwrap(), "[ROOT]/foo/target");
     eprintln!("{expected}");
     // Verify the verbose output.
     p.cargo("clean --dry-run -v")
-        .with_stdout_unordered(expected)
-        .with_stderr(
-            "[SUMMARY] [..] files, [..] total\n\
-             [WARNING] no files deleted due to --dry-run",
-        )
+        .with_stdout_data(expected.unordered())
+        .with_stderr_data(str![[r#"
+[SUMMARY] [FILE_NUM] files, [FILE_SIZE]B total
+[WARNING] no files deleted due to --dry-run
+
+"#]])
         .run();
 }
 
@@ -864,7 +889,10 @@ fn doc_with_package_selection() {
     let p = project().file("src/lib.rs", "").build();
     p.cargo("clean --doc -p foo")
         .with_status(101)
-        .with_stderr("error: --doc cannot be used with -p")
+        .with_stderr_data(str![[r#"
+[ERROR] --doc cannot be used with -p
+
+"#]])
         .run();
 }
 
@@ -879,17 +907,16 @@ fn quiet_does_not_show_summary() {
 
     p.cargo("check").run();
     p.cargo("clean --quiet --dry-run")
-        .with_stdout("")
-        .with_stderr("")
+        .with_stdout_data("")
+        .with_stderr_data("")
         .run();
     // Verify exact same command without -q would actually display something.
     p.cargo("clean --dry-run")
-        .with_stdout("")
-        .with_stderr(
-            "\
-[SUMMARY] [..] files, [..] total
+        .with_stdout_data("")
+        .with_stderr_data(str![[r#"
+[SUMMARY] [FILE_NUM] files, [FILE_SIZE]B total
 [WARNING] no files deleted due to --dry-run
-",
-        )
+
+"#]])
         .run();
 }


### PR DESCRIPTION
Part of #14039, migrating `tests/testsuite/clean.rs` to snapbox.