### PR TITLE
Allowing '--extern' usage in build scripts and in config files

### DIFF
--- a/src/cargo/core/compiler/mod.rs
+++ b/src/cargo/core/compiler/mod.rs
@@ -462,7 +462,7 @@ fn rustc(
         Ok(())
     }));
 
-    // Add all relevant `-L` and `-l` flags from dependencies (now calculated and
+    // Add all relevant `-L`, `-l` and `--extern` flags from dependencies (now calculated and
     // present in `state`) to the command provided.
     fn add_native_deps(
         rustc: &mut ProcessBuilder,
@@ -484,6 +484,10 @@ fn rustc(
             }
 
             if key.0 == current_id {
+                for extern_ in output.library_externs.iter() {
+                    rustc.arg("--extern").arg(extern_);
+                }
+
                 if pass_l_flag {
                     for name in output.library_links.iter() {
                         rustc.arg("-l").arg(name);

--- a/src/cargo/util/context/target.rs
+++ b/src/cargo/util/context/target.rs
@@ -158,9 +158,10 @@ fn parse_links_overrides(
                 "rustc-flags" => {
                     let flags = value.string(key)?;
                     let whence = format!("target config `{}.{}` (in {})", target_key, key, flags.1);
-                    let (paths, links) = BuildOutput::parse_rustc_flags(flags.0, &whence)?;
+                    let (paths, links, externs) = BuildOutput::parse_rustc_flags(flags.0, &whence)?;
                     output.library_paths.extend(paths);
                     output.library_links.extend(links);
+                    output.library_externs.extend(externs);
                 }
                 "rustc-link-lib" => {
                     let list = value.list(key)?;

--- a/tests/testsuite/bad_config.rs
+++ b/tests/testsuite/bad_config.rs
@@ -2960,7 +2960,7 @@ fn bad_target_links_overrides() {
     p.cargo("check")
         .with_status(101)
         .with_stderr_data(str![[r"
-[ERROR] Only `-l` and `-L` flags are allowed in target config `target.[..].rustc-flags` (in [..]foo/.cargo/config.toml): `foo`
+[ERROR] Only `-l`, `-L` and `--extern` flags are allowed in target config `target.[..].rustc-flags` (in [..]foo/.cargo/config.toml): `foo`
 
 "]])
         .run();

--- a/tests/testsuite/build_script.rs
+++ b/tests/testsuite/build_script.rs
@@ -842,7 +842,7 @@ fn custom_build_script_wrong_rustc_flags() {
     p.cargo("build")
         .with_status(101)
         .with_stderr_contains(
-            "[ERROR] Only `-l` and `-L` flags are allowed in build script of `foo v0.5.0 ([CWD])`: \
+            "[ERROR] Only `-l`, `-L` and `--extern` flags are allowed in build script of `foo v0.5.0 ([CWD])`: \
              `-aaa -bbb`",
         )
         .run();


### PR DESCRIPTION
### What does this PR try to resolve?

This PR implements #14065, allowing build scripts to automatically set dependencies, an important requirement for codegen tools.