### PR TITLE
fix(toml): Warn when edition is unuset, even when MSRV is unset 

### DIFF
--- a/src/cargo/util/toml/mod.rs
+++ b/src/cargo/util/toml/mod.rs
@@ -1154,8 +1154,8 @@ fn to_real_manifest(
         // so if they can't use a new edition, don't bother to tell them to set it.
         // This also avoids having to worry about whether `package.edition` is compatible with
         // their MSRV.
-        if msrv_edition != default_edition {
-            let tip = if msrv_edition == latest_edition {
+        if msrv_edition != default_edition || rust_version.is_none() {
+            let tip = if msrv_edition == latest_edition || rust_version.is_none() {
                 format!(" while the latest is {latest_edition}")
             } else {
                 format!(" while {msrv_edition} is compatible with `rust-version`")

--- a/tests/testsuite/artifact_dep.rs
+++ b/tests/testsuite/artifact_dep.rs
@@ -1544,6 +1544,7 @@ fn artifact_dep_target_specified() {
                 version = "0.0.0"
                 authors = []
                 resolver = "2"
+                edition = "2015"
 
                 [dependencies]
                 bindep = { path = "bindep", artifact = "bin", target = "$TARGET" }

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -126,6 +126,31 @@ fn edition_unstable() {
 }
 
 #[cargo_test]
+fn unset_edition_with_unset_rust_version() {
+    let p = project()
+        .file(
+            "Cargo.toml",
+            r#"
+                [package]
+                name = 'foo'
+                version = '0.1.0'
+            "#,
+        )
+        .file("src/lib.rs", "")
+        .build();
+
+    p.cargo("check -v")
+        .with_stderr(
+            "\
+[CHECKING] foo [..]
+[RUNNING] `rustc [..] --edition=2015 [..]`
+[FINISHED] [..]
+",
+        )
+        .run();
+}
+
+#[cargo_test]
 fn unset_edition_works_with_no_newer_compatible_edition() {
     let p = project()
         .file(

--- a/tests/testsuite/edition.rs
+++ b/tests/testsuite/edition.rs
@@ -142,6 +142,7 @@ fn unset_edition_with_unset_rust_version() {
     p.cargo("check -v")
         .with_stderr(
             "\
+[WARNING] no edition set: defaulting to the 2015 edition while the latest is 2021
 [CHECKING] foo [..]
 [RUNNING] `rustc [..] --edition=2015 [..]`
 [FINISHED] [..]

--- a/tests/testsuite/shell_quoting.rs
+++ b/tests/testsuite/shell_quoting.rs
@@ -15,6 +15,7 @@ fn features_are_quoted() {
             name = "foo"
             version = "0.1.0"
             authors = ["mikeyhew@example.com"]
+            edition = "2015"
 
             [features]
             some_feature = []


### PR DESCRIPTION
### What does this PR try to resolve?

This came up in #14108.  This got overlooked when we added the MSRV
limits to the warning.

Users can silence this by setting a very old MSRV.
I didn't bother finding a way to word a specialized message for this.
Wording for this case seemed hard and I figure someone in this situation
knows how to resolve it.
Instead, we are targeting the majority of users who aren't setting a
`package.rust-version` in the first place.

### How should we test and review this PR?



### Additional information
