### PR TITLE
test: migrate weak_dep_features, workspaces and yank to snapbox

### DIFF
--- a/tests/testsuite/weak_dep_features.rs
+++ b/tests/testsuite/weak_dep_features.rs
@@ -1,10 +1,9 @@
 //! Tests for weak-dep-features.
 
-#![allow(deprecated)]
-
 use super::features2::switch_to_resolver_2;
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::registry::{Dependency, Package, RegistryBuilder};
+use cargo_test_support::str;
 use cargo_test_support::{project, publish};
 use std::fmt::Write;
 
@@ -51,26 +50,24 @@ fn simple() {
     // It's a bit unfortunate that this has to download `bar`, but avoiding
     // that is extremely difficult.
     p.cargo("check --features f1")
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.0.0 [..]
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("check --features f1,bar")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [CHECKING] bar v1.0.0
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -107,21 +104,20 @@ fn deferred() {
         .build();
 
     p.cargo("check")
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep v1.0.0 [..]
-[DOWNLOADED] bar_activator v1.0.0 [..]
-[DOWNLOADED] bar v1.0.0 [..]
+[DOWNLOADED] dep v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [CHECKING] bar v1.0.0
 [CHECKING] dep v1.0.0
 [CHECKING] bar_activator v1.0.0
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -151,13 +147,14 @@ fn not_optional_dep() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr("\
-error: failed to parse manifest at `[ROOT]/foo/Cargo.toml`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
   feature `feat` includes `dep?/feat` with a `?`, but `dep` is not an optional dependency
   A non-optional dependency of the same name is defined; consider removing the `?` or changing the dependency to be optional
-")
+
+"#]])
         .run();
 }
 
@@ -187,27 +184,25 @@ fn optional_cli_syntax() {
 
     // Does not build bar.
     p.cargo("check --features bar?/feat")
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.0.0 [..]
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     // Builds bar.
     p.cargo("check --features bar?/feat,bar")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [CHECKING] bar v1.0.0
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     eprintln!("check V2 resolver");
@@ -215,23 +210,21 @@ fn optional_cli_syntax() {
     p.build_dir().rm_rf();
     // Does not build bar.
     p.cargo("check --features bar?/feat")
-        .with_stderr(
-            "\
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     // Builds bar.
     p.cargo("check --features bar?/feat,bar")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [CHECKING] bar v1.0.0
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -262,14 +255,12 @@ fn required_features() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
-[ERROR] invalid feature `bar?/feat` in required-features of target `foo`: \
-optional dependency with `?` is not allowed in required-features
-",
-        )
+[ERROR] invalid feature `bar?/feat` in required-features of target `foo`: optional dependency with `?` is not allowed in required-features
+
+"#]])
         .run();
 }
 
@@ -358,22 +349,21 @@ fn weak_with_host_decouple() {
         .build();
 
     p.cargo("run")
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 4 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] [..]
-[DOWNLOADED] [..]
-[DOWNLOADED] [..]
+[DOWNLOADED] common v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar_activator v1.0.0 (registry `dummy-registry`)
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
 [COMPILING] bar v1.0.0
 [COMPILING] common v1.0.0
 [COMPILING] bar_activator v1.0.0
-[COMPILING] foo v0.1.0 [..]
-[FINISHED] [..]
+[COMPILING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 [RUNNING] `target/debug/foo[EXE]`
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -405,49 +395,52 @@ fn weak_namespaced() {
         .build();
 
     p.cargo("check --features f1")
-        .with_stderr(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] bar v1.0.0 [..]
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[DOWNLOADED] bar v1.0.0 (registry `dummy-registry`)
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("tree -f")
         .arg("{p} feats:{f}")
-        .with_stdout("foo v0.1.0 ([ROOT]/foo) feats:")
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo) feats:
+
+"#]])
         .run();
 
     p.cargo("tree --features f1 -f")
         .arg("{p} feats:{f}")
-        .with_stdout("foo v0.1.0 ([ROOT]/foo) feats:f1")
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo) feats:f1
+
+"#]])
         .run();
 
     p.cargo("tree --features f1,f2 -f")
         .arg("{p} feats:{f}")
-        .with_stdout(
-            "\
+        .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo) feats:f1,f2
 └── bar v1.0.0 feats:feat
-",
-        )
+
+"#]])
         .run();
 
     // "bar" remains not-a-feature
     p.change_file("src/lib.rs", &require(&["f1", "f2"], &["bar"]));
 
     p.cargo("check --features f1,f2")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [CHECKING] bar v1.0.0
-[CHECKING] foo v0.1.0 [..]
-[FINISHED] [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -477,64 +470,66 @@ fn tree() {
         .build();
 
     p.cargo("tree --features f1")
-        .with_stdout("foo v0.1.0 ([ROOT]/foo)")
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+
+"#]])
         .run();
 
     p.cargo("tree --features f1,bar")
-        .with_stdout(
-            "\
+        .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
 └── bar v1.0.0
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("tree --features f1,bar -e features")
-        .with_stdout(
-            "\
+        .with_stdout_data(str![[r#"
 foo v0.1.0 ([ROOT]/foo)
-└── bar feature \"default\"
+└── bar feature "default"
     └── bar v1.0.0
-",
-        )
+
+"#]])
         .run();
 
     p.cargo("tree --features f1,bar -e features -i bar")
-        .with_stdout(
-            "\
+        .with_stdout_data(str![[r#"
 bar v1.0.0
-├── bar feature \"default\"
+├── bar feature "default"
 │   └── foo v0.1.0 ([ROOT]/foo)
-│       ├── foo feature \"bar\" (command-line)
-│       ├── foo feature \"default\" (command-line)
-│       └── foo feature \"f1\" (command-line)
-└── bar feature \"feat\"
-    └── foo feature \"f1\" (command-line)
-",
-        )
+│       ├── foo feature "bar" (command-line)
+│       ├── foo feature "default" (command-line)
+│       └── foo feature "f1" (command-line)
+└── bar feature "feat"
+    └── foo feature "f1" (command-line)
+
+"#]])
         .run();
 
     p.cargo("tree -e features --features bar?/feat")
-        .with_stdout("foo v0.1.0 ([ROOT]/foo)")
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo)
+
+"#]])
         .run();
 
     // This is a little strange in that it produces no output.
     // Maybe `cargo tree` should print a note about why?
     p.cargo("tree -e features -i bar --features bar?/feat")
-        .with_stdout("")
+        .with_stdout_data("")
         .run();
 
     p.cargo("tree -e features -i bar --features bar?/feat,bar")
-        .with_stdout(
-            "\
+        .with_stdout_data(str![[r#"
 bar v1.0.0
-├── bar feature \"default\"
+├── bar feature "default"
 │   └── foo v0.1.0 ([ROOT]/foo)
-│       ├── foo feature \"bar\" (command-line)
-│       └── foo feature \"default\" (command-line)
-└── bar feature \"feat\" (command-line)
-",
-        )
+│       ├── foo feature "bar" (command-line)
+│       └── foo feature "default" (command-line)
+└── bar feature "feat" (command-line)
+
+"#]])
         .run();
 }
 
@@ -569,22 +564,21 @@ fn publish() {
 
     p.cargo("publish")
         .replace_crates_io(registry.index_url())
-        .with_stderr(
-            "\
-[UPDATING] [..]
-[PACKAGING] foo v0.1.0 [..]
-[PACKAGED] [..]
-[VERIFYING] foo v0.1.0 [..]
-[UPDATING] [..]
-[COMPILING] foo v0.1.0 [..]
-[FINISHED] [..]
-[UPLOADING] foo v0.1.0 [..]
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+[PACKAGING] foo v0.1.0 ([ROOT]/foo)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.1.0 ([ROOT]/foo)
+[UPDATING] crates.io index
+[COMPILING] foo v0.1.0 ([ROOT]/foo/target/package/foo-0.1.0)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] foo v0.1.0 ([ROOT]/foo)
 [UPLOADED] foo v0.1.0 to registry `crates-io`
 [NOTE] waiting for `foo v0.1.0` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.1.0 at registry `crates-io`
-",
-        )
+
+"#]])
         .run();
 
     publish::validate_upload_with_contents(

--- a/tests/testsuite/workspaces.rs
+++ b/tests/testsuite/workspaces.rs
@@ -1,8 +1,7 @@
 //! Tests for workspaces.
 
-#![allow(deprecated)]
-
 use cargo_test_support::registry::Package;
+use cargo_test_support::str;
 use cargo_test_support::{basic_lib_manifest, basic_manifest, git, project, sleep_ms};
 use std::env;
 use std::fs;
@@ -112,22 +111,20 @@ fn non_virtual_default_members_build_other_member() {
         .build();
 
     p.cargo("check")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to latest compatible versions
-[CHECKING] baz v0.1.0 ([..])
-[..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[CHECKING] baz v0.1.0 ([ROOT]/foo/baz)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("check --manifest-path bar/Cargo.toml")
-        .with_stderr(
-            "\
-[CHECKING] bar v0.1.0 ([..])
-[..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -154,13 +151,12 @@ fn non_virtual_default_members_build_root_project() {
         .build();
 
     p.cargo("check")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[CHECKING] foo v0.1.0 ([..])
-[..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -365,13 +361,12 @@ fn same_names_in_workspace() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: two packages named `foo` in this workspace:
-- [..]Cargo.toml
-- [..]Cargo.toml
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] two packages named `foo` in this workspace:
+- [ROOT]/foo/bar/Cargo.toml
+- [ROOT]/foo/Cargo.toml
+
+"#]])
         .run();
 }
 
@@ -398,16 +393,15 @@ fn parent_doesnt_point_to_child() {
     p.cargo("check")
         .cwd("bar")
         .with_status(101)
-        .with_stderr(
-            "\
-error: current package believes it's in a workspace when it's not:
-current: [..]Cargo.toml
-workspace: [..]Cargo.toml
+        .with_stderr_data(str![[r#"
+[ERROR] current package believes it's in a workspace when it's not:
+current:   [ROOT]/foo/bar/Cargo.toml
+workspace: [ROOT]/foo/Cargo.toml
 
-this may be fixable [..]
-[..]
-",
-        )
+this may be fixable by ensuring that this crate is depended on by the workspace root: [ROOT]/foo/Cargo.toml
+Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
+
+"#]])
         .run();
 }
 
@@ -430,14 +424,13 @@ fn invalid_parent_pointer() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: failed to read `[..]Cargo.toml`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to read `[ROOT]/foo/foo/Cargo.toml`
 
 Caused by:
-  [..]
-",
-        )
+  [NOT_FOUND]
+
+"#]])
         .run();
 }
 
@@ -462,18 +455,17 @@ fn invalid_members() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to load manifest for workspace member `[..]/foo`
-referenced by workspace at `[..]/foo/Cargo.toml`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to load manifest for workspace member `[ROOT]/foo/foo`
+referenced by workspace at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  failed to read `[..]foo/foo/Cargo.toml`
+  failed to read `[ROOT]/foo/foo/Cargo.toml`
 
 Caused by:
-  [..]
-",
-        )
+  [NOT_FOUND]
+
+"#]])
         .run();
 }
 
@@ -533,13 +525,12 @@ fn two_roots() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: multiple workspace roots found in the same workspace:
-  [..]
-  [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] multiple workspace roots found in the same workspace:
+  [ROOT]/foo/bar
+  [ROOT]/foo
+
+"#]])
         .run();
 }
 
@@ -564,7 +555,10 @@ fn workspace_isnt_root() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr("error: root of a workspace inferred but wasn't a root: [..]")
+        .with_stderr_data(str![[r#"
+[ERROR] root of a workspace inferred but wasn't a root: [ROOT]/foo/bar/Cargo.toml
+
+"#]])
         .run();
 }
 
@@ -613,13 +607,12 @@ fn dangling_member() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: package `[..]` is a member of the wrong workspace
-expected: [..]
-actual: [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] package `[ROOT]/foo/bar/Cargo.toml` is a member of the wrong workspace
+expected: [ROOT]/foo/Cargo.toml
+actual:   [ROOT]/foo/baz/Cargo.toml
+
+"#]])
         .run();
 }
 
@@ -654,9 +647,10 @@ fn cycle() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "[ERROR] root of a workspace inferred but wasn't a root: [..]/foo/bar/Cargo.toml",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] root of a workspace inferred but wasn't a root: [ROOT]/foo/bar/Cargo.toml
+
+"#]])
         .run();
 }
 
@@ -700,18 +694,17 @@ fn share_dependencies() {
     Package::new("dep1", "0.1.8").publish();
 
     p.cargo("check")
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [ADDING] dep1 v0.1.3 (latest: v0.1.8)
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep1 v0.1.3 ([..])
+[DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
 [CHECKING] dep1 v0.1.3
-[CHECKING] foo v0.1.0 ([..])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -751,14 +744,13 @@ fn fetch_fetches_all() {
     Package::new("dep1", "0.1.3").publish();
 
     p.cargo("fetch")
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
 [LOCKING] 3 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep1 v0.1.3 ([..])
-",
-        )
+[DOWNLOADED] dep1 v0.1.3 (registry `dummy-registry`)
+
+"#]])
         .run();
 }
 
@@ -802,39 +794,37 @@ fn lock_works_for_everyone() {
     Package::new("dep2", "0.1.0").publish();
 
     p.cargo("generate-lockfile")
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
-[LOCKING] 4 packages to latest compatible versions",
-        )
+        .with_stderr_data(str![[r#"
+[UPDATING] `dummy-registry` index
+[LOCKING] 4 packages to latest compatible versions
+
+"#]])
         .run();
 
     Package::new("dep1", "0.1.1").publish();
     Package::new("dep2", "0.1.1").publish();
 
     p.cargo("check")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep2 v0.1.0 ([..])
+[DOWNLOADED] dep2 v0.1.0 (registry `dummy-registry`)
 [CHECKING] dep2 v0.1.0
-[CHECKING] foo v0.1.0 ([..])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[CHECKING] foo v0.1.0 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     p.cargo("check")
         .cwd("bar")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [DOWNLOADING] crates ...
-[DOWNLOADED] dep1 v0.1.0 ([..])
+[DOWNLOADED] dep1 v0.1.0 (registry `dummy-registry`)
 [CHECKING] dep1 v0.1.0
-[CHECKING] bar v0.1.0 ([..])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -891,17 +881,15 @@ fn virtual_misconfigure() {
     p.cargo("check")
         .cwd("bar")
         .with_status(101)
-        .with_stderr(
-            "\
-error: current package believes it's in a workspace when it's not:
-current:   [CWD]/Cargo.toml
-workspace: [..]Cargo.toml
+        .with_stderr_data(str![[r#"
+[ERROR] current package believes it's in a workspace when it's not:
+current:   [ROOT]/foo/bar/Cargo.toml
+workspace: [ROOT]/foo/Cargo.toml
 
-this may be fixable by adding `bar` to the `workspace.members` array of the \
-manifest located at: [..]
-[..]
-",
-        )
+this may be fixable by adding `bar` to the `workspace.members` array of the manifest located at: [ROOT]/foo/Cargo.toml
+Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
+
+"#]])
         .run();
 }
 
@@ -958,12 +946,11 @@ fn virtual_default_member_is_not_a_member() {
     let p = p.build();
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: package `[..]something-else` is listed in default-members but is not a member\n\
-for workspace at [..]Cargo.toml.
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] package `[ROOT]/foo/something-else` is listed in default-members but is not a member
+for workspace at [ROOT]/foo/Cargo.toml.
+
+"#]])
         .run();
 }
 
@@ -985,13 +972,12 @@ fn virtual_default_members_build_other_member() {
         .build();
 
     p.cargo("check --manifest-path bar/Cargo.toml")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 2 packages to latest compatible versions
-[CHECKING] bar v0.1.0 ([..])
-[..] Finished `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[CHECKING] bar v0.1.0 ([ROOT]/foo/bar)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -1006,12 +992,10 @@ fn virtual_build_no_members() {
     let p = p.build();
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: manifest path `[..]` contains no package: The manifest is virtual, \
-and the workspace has no members.
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] manifest path `[ROOT]/foo` contains no package: The manifest is virtual, and the workspace has no members.
+
+"#]])
         .run();
 }
 
@@ -1040,13 +1024,12 @@ fn include_virtual() {
     let p = p.build();
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: multiple workspace roots found in the same workspace:
-  [..]
-  [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] multiple workspace roots found in the same workspace:
+  [ROOT]/foo/bar
+  [ROOT]/foo
+
+"#]])
         .run();
 }
 
@@ -1119,21 +1102,18 @@ fn new_creates_members_list() {
         .file("src/lib.rs", "");
     let p = p.build();
 
-    p.cargo("new --lib bar")
-        .with_stderr("\
+    p.cargo("new --lib bar").with_stderr_data(str![[r#"
 [CREATING] library `bar` package
 [ADDING] `bar` as member of workspace at `[ROOT]/foo`
 [NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-")
-        .run();
+
+"#]]).run();
 }
 
 #[cargo_test]
 fn new_warning_with_corrupt_ws() {
     let p = project().file("Cargo.toml", "asdf").build();
-    p.cargo("new bar")
-        .with_stderr(
-            "\
+    p.cargo("new bar").with_stderr_data(str![[r#"
 [CREATING] binary (application) `bar` package
 [ERROR] expected `.`, `=`
  --> Cargo.toml:1:5
@@ -1144,9 +1124,8 @@ fn new_warning_with_corrupt_ws() {
 [WARNING] compiling this new package may not work due to invalid workspace configuration
 
 [NOTE] see more `Cargo.toml` keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-",
-        )
-        .run();
+
+"#]]).run();
 }
 
 #[cargo_test]
@@ -1251,7 +1230,11 @@ fn rebuild_please() {
     p.cargo("run")
         .cwd("bin")
         .with_status(101)
-        .with_stderr_contains("[..]assertion[..]")
+        .with_stderr_data(str![[r#"
+...
+assertion[..]
+...
+"#]])
         .run();
 }
 
@@ -1341,7 +1324,10 @@ fn you_cannot_generate_lockfile_for_empty_workspaces() {
 
     p.cargo("update")
         .with_status(101)
-        .with_stderr("error: you can't generate a lockfile for an empty workspace.")
+        .with_stderr_data(str![[r#"
+[ERROR] you can't generate a lockfile for an empty workspace.
+
+"#]])
         .run();
 }
 
@@ -1409,16 +1395,15 @@ fn error_if_parent_cargo_toml_is_invalid() {
     p.cargo("check")
         .cwd("bar")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [ERROR] expected `.`, `=`
  --> ../Cargo.toml:1:9
   |
 1 | Totally not a TOML file
   |         ^
   |
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -1745,12 +1730,11 @@ fn excluded_default_members_still_must_be_members() {
     let p = p.build();
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-error: package `[..]bar` is listed in default-members but is not a member\n\
-for workspace at [..]foo/Cargo.toml.
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] package `[ROOT]/foo/bar` is listed in default-members but is not a member
+for workspace at [ROOT]/foo/Cargo.toml.
+
+"#]])
         .run();
 }
 
@@ -1983,18 +1967,17 @@ fn glob_syntax_invalid_members() {
 
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to load manifest for workspace member `[..]/crates/bar`
-referenced by workspace at `[..]/Cargo.toml`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to load manifest for workspace member `[ROOT]/foo/crates/bar`
+referenced by workspace at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  failed to read `[..]foo/crates/bar/Cargo.toml`
+  failed to read `[ROOT]/foo/crates/bar/Cargo.toml`
 
 Caused by:
-  [..]
-",
-        )
+  [NOT_FOUND]
+
+"#]])
         .run();
 }
 
@@ -2065,15 +2048,14 @@ fn dep_used_with_separate_features() {
 
     // Build the entire workspace.
     p.cargo("build --workspace")
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [LOCKING] 3 packages to latest compatible versions
-[..]Compiling feat_lib v0.1.0 ([..])
-[..]Compiling caller1 v0.1.0 ([..])
-[..]Compiling caller2 v0.1.0 ([..])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+[COMPILING] feat_lib v0.1.0 ([ROOT]/foo/feat_lib)
+[COMPILING] caller1 v0.1.0 ([ROOT]/foo/caller1)
+[COMPILING] caller2 v0.1.0 ([ROOT]/foo/caller2)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     assert!(p.bin("caller1").is_file());
     assert!(p.bin("caller2").is_file());
@@ -2084,28 +2066,36 @@ fn dep_used_with_separate_features() {
     // will be enough.
     p.cargo("build")
         .cwd("caller1")
-        .with_stderr(
-            "\
-[..]Compiling feat_lib v0.1.0 ([..])
-[..]Compiling caller1 v0.1.0 ([..])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]
-",
-        )
+        .with_stderr_data(str![[r#"
+[COMPILING] feat_lib v0.1.0 ([ROOT]/foo/feat_lib)
+[COMPILING] caller1 v0.1.0 ([ROOT]/foo/caller1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 
     // Alternate building `caller2`/`caller1` a few times, just to make sure
     // features are being built separately. Should not rebuild anything.
     p.cargo("build")
         .cwd("caller2")
-        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("build")
         .cwd("caller1")
-        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
     p.cargo("build")
         .cwd("caller2")
-        .with_stderr("[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]")
+        .with_stderr_data(str![[r#"
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -2279,12 +2269,18 @@ fn ws_rustc_err() {
 
     p.cargo("rustc")
         .with_status(101)
-        .with_stderr("[ERROR] [..]against an actual package[..]")
+        .with_stderr_data(str![[r#"
+[ERROR] manifest path `[ROOT]/foo/Cargo.toml` is a virtual manifest, but this command requires running against an actual package in this workspace
+
+"#]])
         .run();
 
     p.cargo("rustdoc")
         .with_status(101)
-        .with_stderr("[ERROR] [..]against an actual package[..]")
+        .with_stderr_data(str![[r#"
+[ERROR] manifest path `[ROOT]/foo/Cargo.toml` is a virtual manifest, but this command requires running against an actual package in this workspace
+
+"#]])
         .run();
 }
 
@@ -2322,7 +2318,7 @@ fn ws_err_unused() {
             .build();
         p.cargo("check")
             .with_status(101)
-            .with_stderr(&format!(
+            .with_stderr_data(&format!(
                 "\
 [ERROR] failed to parse manifest at `[..]/foo/Cargo.toml`
 
@@ -2366,11 +2362,13 @@ fn ws_warn_unused() {
             .file("a/src/lib.rs", "")
             .build();
         p.cargo("check")
-            .with_stderr_contains(&format!(
+            .with_stderr_data(&format!(
                 "\
 [WARNING] {} for the non root package will be ignored, specify {} at the workspace root:
-package:   [..]/foo/a/Cargo.toml
-workspace: [..]/foo/Cargo.toml
+package:   [ROOT]/foo/a/Cargo.toml
+workspace: [ROOT]/foo/Cargo.toml
+[CHECKING] a v0.1.0 ([ROOT]/foo/a)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
 ",
                 name, name
             ))
@@ -2402,9 +2400,13 @@ fn ws_warn_path() {
         .file("a/src/lib.rs", "")
         .build();
 
-    p.cargo("check")
-        .with_stderr_contains("[WARNING] [..]/foo/a/Cargo.toml: the cargo feature `edition`[..]")
-        .run();
+    p.cargo("check").with_stderr_data(str![[r#"
+[WARNING] [ROOT]/foo/a/Cargo.toml: the cargo feature `edition` has been stabilized in the 1.31 release and is no longer necessary to be listed in the manifest
+  See https://doc.rust-lang.org/cargo/reference/manifest.html#the-edition-field for more information about using this feature.
+[CHECKING] foo v0.1.0 ([ROOT]/foo/a)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]]).run();
 }
 
 #[cargo_test]
@@ -2428,23 +2430,22 @@ fn invalid_missing() {
 
     p.cargo("check -q")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to get `x` as a dependency of package `foo v0.1.0 [..]`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to get `x` as a dependency of package `foo v0.1.0 ([ROOT]/foo)`
 
 Caused by:
   failed to load source for dependency `x`
 
 Caused by:
-  Unable to update [..]/foo/x
+  Unable to update [ROOT]/foo/x
 
 Caused by:
-  failed to read `[..]foo/x/Cargo.toml`
+  failed to read `[ROOT]/foo/x/Cargo.toml`
 
 Caused by:
-  [..]
-",
-        )
+  [NOT_FOUND]
+
+"#]])
         .run();
 }
 
@@ -2482,21 +2483,20 @@ fn member_dep_missing() {
 
     p.cargo("check -q")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to load manifest for workspace member `[..]/bar`
-referenced by workspace at `[..]/Cargo.toml`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to load manifest for workspace member `[ROOT]/foo/bar`
+referenced by workspace at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
   failed to load manifest for dependency `baz`
 
 Caused by:
-  failed to read `[..]foo/bar/baz/Cargo.toml`
+  failed to read `[ROOT]/foo/bar/baz/Cargo.toml`
 
 Caused by:
-  [..]
-",
-        )
+  [NOT_FOUND]
+
+"#]])
         .run();
 }
 
@@ -2619,11 +2619,10 @@ fn ensure_correct_workspace_when_nested() {
     let p = p.build();
     p.cargo("tree")
         .cwd("sub/foo")
-        .with_stdout(
-            "\
-foo v0.1.0 ([..]/foo/sub/foo)
-└── bar v0.1.0 ([..]/foo)\
-        ",
-        )
+        .with_stdout_data(str![[r#"
+foo v0.1.0 ([ROOT]/foo/sub/foo)
+└── bar v0.1.0 ([ROOT]/foo)
+
+"#]])
         .run();
 }

--- a/tests/testsuite/yank.rs
+++ b/tests/testsuite/yank.rs
@@ -1,12 +1,11 @@
 //! Tests for the `cargo yank` command.
 
-#![allow(deprecated)]
-
 use std::fs;
 
 use cargo_test_support::paths::CargoPathExt;
 use cargo_test_support::project;
 use cargo_test_support::registry;
+use cargo_test_support::str;
 
 fn setup(name: &str, version: &str) {
     let dir = registry::api_path().join(format!("api/v1/crates/{}/{}", name, version));
@@ -41,14 +40,15 @@ fn explicit_version() {
     p.cargo("yank --undo --version 0.0.1")
         .replace_crates_io(registry.index_url())
         .with_status(101)
-        .with_stderr(
-            "    Updating crates.io index
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
       Unyank foo@0.0.1
-error: failed to undo a yank from the registry at file:///[..]
+[ERROR] failed to undo a yank from the registry at [ROOTURL]/api
 
 Caused by:
-  EOF while parsing a value at line 1 column 0",
-        )
+  EOF while parsing a value at line 1 column 0
+
+"#]])
         .run();
 }
 
@@ -117,14 +117,15 @@ fn inline_version() {
     p.cargo("yank --undo foo@0.0.1")
         .replace_crates_io(registry.index_url())
         .with_status(101)
-        .with_stderr(
-            "    Updating crates.io index
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
       Unyank foo@0.0.1
-error: failed to undo a yank from the registry at file:///[..]
+[ERROR] failed to undo a yank from the registry at [ROOTURL]/api
 
 Caused by:
-  EOF while parsing a value at line 1 column 0",
-        )
+  EOF while parsing a value at line 1 column 0
+
+"#]])
         .run();
 }
 
@@ -149,7 +150,10 @@ fn version_required() {
 
     p.cargo("yank foo")
         .with_status(101)
-        .with_stderr("error: `--version` is required")
+        .with_stderr_data(str![[r#"
+[ERROR] `--version` is required
+
+"#]])
         .run();
 }
 
@@ -174,7 +178,10 @@ fn inline_version_without_name() {
 
     p.cargo("yank @0.0.1")
         .with_status(101)
-        .with_stderr("error: missing crate name for `@0.0.1`")
+        .with_stderr_data(str![[r#"
+[ERROR] missing crate name for `@0.0.1`
+
+"#]])
         .run();
 }
 
@@ -199,6 +206,9 @@ fn inline_and_explicit_version() {
 
     p.cargo("yank foo@0.0.1 --version 0.0.1")
         .with_status(101)
-        .with_stderr("error: cannot specify both `@0.0.1` and `--version`")
+        .with_stderr_data(str![[r#"
+[ERROR] cannot specify both `@0.0.1` and `--version`
+
+"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/weak_dep_features.rs`
- `tests/testsuite/workspaces.rs`
- `tests/testsuite/yank.rs`