### PR TITLE
test: Add auto-redaction for not found error

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -201,6 +201,18 @@ static MIN_LITERAL_REDACTIONS: &[(&str, &str)] = &[
     ("[EXE]", std::env::consts::EXE_SUFFIX),
     ("[BROKEN_PIPE]", "Broken pipe (os error 32)"),
     ("[BROKEN_PIPE]", "The pipe is being closed. (os error 232)"),
+    // Unix message for an entity was not found
+    ("[NOT_FOUND]", "No such file or directory (os error 2)"),
+    // Windows message for an entity was not found
+    (
+        "[NOT_FOUND]",
+        "The system cannot find the file specified. (os error 2)",
+    ),
+    (
+        "[NOT_FOUND]",
+        "The system cannot find the path specified. (os error 3)",
+    ),
+    ("[NOT_FOUND]", "program not found"),
     // Unix message for exit status
     ("[EXIT_STATUS]", "exit status"),
     // Windows message for exit status

--- a/tests/testsuite/config_include.rs
+++ b/tests/testsuite/config_include.rs
@@ -1,8 +1,8 @@
 //! Tests for `include` config field.
 
 use super::config::{assert_error, write_config_at, write_config_toml, GlobalContextBuilder};
+use cargo_test_support::project;
 use cargo_test_support::str;
-use cargo_test_support::{no_such_file_err_msg, project};
 
 #[cargo_test]
 fn gated() {
@@ -162,8 +162,7 @@ Caused by:
   failed to read configuration file `[..]/.cargo/missing.toml`
 
 Caused by:
-  {}",
-            no_such_file_err_msg()
+  [NOT_FOUND]",
         ),
     );
 }
@@ -270,8 +269,7 @@ Caused by:
   failed to read configuration file `[..]/foobar.toml`
 
 Caused by:
-  {}",
-            no_such_file_err_msg()
+  [NOT_FOUND]"
         ),
     );
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR introduces auto-redaction for error messages related to "entity not found" across various platforms, as discussed in https://github.com/rust-lang/cargo/pull/14111#discussion_r1649176792.