### PR TITLE
Change tests to support `rustc` wording changes

### DIFF
--- a/tests/testsuite/check.rs
+++ b/tests/testsuite/check.rs
@@ -347,7 +347,8 @@ fn rustc_check_err() {
         .with_status(101)
         .with_stderr_contains("[CHECKING] bar [..]")
         .with_stderr_contains("[CHECKING] foo [..]")
-        .with_stderr_contains("[..]cannot find function `qux` in [..] `bar`")
+        .with_stderr_contains("[..]cannot find function `qux`[..]")
+        .with_stderr_contains("[..]in crate `bar`")
         .run();
 }
 

--- a/tests/testsuite/message_format.rs
+++ b/tests/testsuite/message_format.rs
@@ -138,7 +138,7 @@ test src/lib.rs - bar (line 1) ... FAILED
 failures:
 
 ---- src/lib.rs - bar (line 1) stdout ----
-src/lib.rs:2:1: error[E0425]: cannot find function `bar` in this scope
+src/lib.rs:2:1: error[E0425]: cannot find function `bar`[..]
 [ERROR] aborting due to 1 previous error
 Couldn't compile the test.
 

--- a/tests/testsuite/metabuild.rs
+++ b/tests/testsuite/metabuild.rs
@@ -765,7 +765,7 @@ fn metabuild_failed_build_json() {
                 "children": "{...}",
                 "code": "{...}",
                 "level": "error",
-                "message": "cannot find function `metabuild` in [..] `mb`",
+                "message": "cannot find function `metabuild`[..]",
                 "rendered": "{...}",
                 "spans": "{...}"
               },

--- a/tests/testsuite/replace.rs
+++ b/tests/testsuite/replace.rs
@@ -1443,7 +1443,7 @@ fn override_respects_spec_metadata() {
 [DOWNLOADED] bar v0.1.0+a (registry `dummy-registry`)
 [CHECKING] bar v0.1.0+a
 [CHECKING] foo v0.0.1 ([ROOT]/foo)
-error[E0425]: cannot find function `bar` in crate `bar`
+error[E0425]: cannot find function `bar`[..]
 ...
 [ERROR] could not compile `foo` (lib) due to 1 previous error
 


### PR DESCRIPTION
Between https://github.com/rust-lang/rust/pull/126810 and https://github.com/rust-lang/rust/pull/126810 the output of `rustc` for resolution errors is going to change in such a way that some existing cargo tests will fail. Change them to support both the current and future output, so that those PRs can land in `rustc`.

<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.

### What does this PR try to resolve?

Explain the motivation behind this change.
A clear overview along with an in-depth explanation are helpful.

You can use `Fixes #<issue number>` to associate this PR to an existing issue.

### How should we test and review this PR?

Demonstrate how you test this change and guide reviewers through your PR.
With a smooth review process, a pull request usually gets reviewed quicker.

If you don't know how to write and run your tests, please read the guide:
https://doc.crates.io/contrib/tests

### Additional information

Other information you want to mention in this PR, such as prior arts,
future extensions, an unresolved problem, or a TODO list.
-->
<!-- homu-ignore:end -->
