### PR TITLE
test: omit target-dir name

### DIFF
--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -249,7 +249,7 @@ fn note_resolve_changes() {
 [NOTE] package `multi v0.1.0` added to the packaged Cargo.lock file, was originally sourced from `[..]/foo/multi`
 [NOTE] package `patched v1.0.0` added to the packaged Cargo.lock file, was originally sourced from `[..]/foo/patched`
 [PACKAGED] [..] files, [..] ([..] compressed)
-[WARNING] no (git) Cargo.toml found at `target/tmp/[..]/foo/Cargo.toml` in workdir `[..]`
+[WARNING] no (git) Cargo.toml found at `[..]/foo/Cargo.toml` in workdir `[..]`
 ",
         )
         .run();


### PR DESCRIPTION
This was found during submodule update in rust-lang/rust repo.

```
---- publish_lockfile::note_resolve_changes stdout ----
thread 'publish_lockfile::note_resolve_changes' panicked at tests/testsuite/publish_lockfile.rs:255:10:

error: Expected lines did not match (ignoring order):
0   6        Packaging foo v0.0.1 ([..])
1   0        Archiving Cargo.lock
2   0        Archiving Cargo.toml
3   1        Archiving Cargo.toml.orig
4   0        Archiving src/main.rs
5   0         Updating `dummy-registry` index
6   2     note: package `multi v0.1.0` added to the packaged Cargo.lock file, was originally sourced from `[..]`
7   2     note: package `patched v1.0.0` added to the packaged Cargo.lock file, was originally sourced from `[..]`
8   0         Packaged 4 files, 2.1KiB (1.1KiB compressed)
9        -warning: no (git) Cargo.toml found at `target/tmp/[..]/foo/Cargo.toml` in workdir `[..]`
    9    +warning: no (git) Cargo.toml found at `build/aarch64-apple-darwin/stage2-tools/aarch64-apple-darwin/tmp/cit/t0/foo/Cargo.toml` in workdir `[..]`
```