### PR TITLE
test: migrate registry and registry_auth to snapbox

### DIFF
--- a/tests/testsuite/registry_auth.rs
+++ b/tests/testsuite/registry_auth.rs
@@ -1,7 +1,5 @@
 //! Tests for registry authentication.
 
-#![allow(deprecated)]
-
 use cargo_test_support::compare::assert_e2e;
 use cargo_test_support::registry::{Package, RegistryBuilder, Token};
 use cargo_test_support::str;
@@ -40,16 +38,6 @@ fn make_project() -> Project {
     p
 }
 
-static SUCCESS_OUTPUT: &'static str = "\
-[UPDATING] `alternative` index
-[LOCKING] 2 packages to latest compatible versions
-[DOWNLOADING] crates ...
-[DOWNLOADED] bar v0.0.1 (registry `alternative`)
-[COMPILING] bar v0.0.1 (registry `alternative`)
-[COMPILING] foo v0.0.1 ([CWD])
-[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [..]s
-";
-
 #[cargo_test]
 fn requires_credential_provider() {
     let _registry = RegistryBuilder::new()
@@ -61,18 +49,19 @@ fn requires_credential_provider() {
     let p = make_project();
     p.cargo("check")
         .with_status(101)
-        .with_stderr(
-            r#"[UPDATING] `alternative` index
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
 [LOCKING] 2 packages to latest compatible versions
-error: failed to download `bar v0.0.1 (registry `alternative`)`
+[ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
 
 Caused by:
   unable to get packages from source
 
 Caused by:
   authenticated registries require a credential-provider to be configured
-  see https://doc.rust-lang.org/cargo/reference/registry-authentication.html for details"#,
-        )
+  see https://doc.rust-lang.org/cargo/reference/registry-authentication.html for details
+
+"#]])
         .run();
 }
 
@@ -85,7 +74,18 @@ fn simple() {
         .build();
 
     let p = make_project();
-    cargo(&p, "build").with_stderr(SUCCESS_OUTPUT).run();
+    cargo(&p, "build")
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
 }
 
 #[cargo_test]
@@ -98,7 +98,18 @@ fn simple_with_asymmetric() {
         .build();
 
     let p = make_project();
-    cargo(&p, "build").with_stderr(SUCCESS_OUTPUT).run();
+    cargo(&p, "build")
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
+        .run();
 }
 
 #[cargo_test]
@@ -117,7 +128,16 @@ fn environment_config() {
             registry.index_url().as_str(),
         )
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", registry.token())
-        .with_stderr(SUCCESS_OUTPUT)
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -133,7 +153,16 @@ fn environment_token() {
     let p = make_project();
     cargo(&p, "build")
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", registry.token())
-        .with_stderr(SUCCESS_OUTPUT)
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -154,7 +183,16 @@ fn environment_token_with_asymmetric() {
     let p = make_project();
     cargo(&p, "build")
         .env("CARGO_REGISTRIES_ALTERNATIVE_SECRET_KEY", registry.key())
-        .with_stderr(SUCCESS_OUTPUT)
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[LOCKING] 2 packages to latest compatible versions
+[DOWNLOADING] crates ...
+[DOWNLOADED] bar v0.0.1 (registry `alternative`)
+[COMPILING] bar v0.0.1 (registry `alternative`)
+[COMPILING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }
 
@@ -179,9 +217,20 @@ fn bad_environment_token_with_asymmetric_subject() {
             "CARGO_REGISTRIES_ALTERNATIVE_SECRET_KEY_SUBJECT",
             "incorrect",
         )
-        .with_stderr_contains(
-            "  token rejected for `alternative`, please run `cargo login --registry alternative`",
-        )
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  token rejected for `alternative`, please run `cargo login --registry alternative`
+  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+
+Caused by:
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
+  body:
+  Unauthorized message from server.
+
+"#]])
         .with_status(101)
         .run();
 }
@@ -203,9 +252,20 @@ fn bad_environment_token_with_asymmetric_incorrect_subject() {
             "CARGO_REGISTRIES_ALTERNATIVE_SECRET_KEY_SUBJECT",
             "incorrect",
         )
-        .with_stderr_contains(
-            "  token rejected for `alternative`, please run `cargo login --registry alternative`",
-        )
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  token rejected for `alternative`, please run `cargo login --registry alternative`
+  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+
+Caused by:
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
+  body:
+  Unauthorized message from server.
+
+"#]])
         .with_status(101)
         .run();
 }
@@ -230,9 +290,20 @@ fn bad_environment_token_with_incorrect_asymmetric() {
             "CARGO_REGISTRIES_ALTERNATIVE_SECRET_KEY",
             "k3.secret.9Vxr5hVlI_g_orBZN54vPz20bmB4O76wB_MVqUSuJJJqHFLwP8kdn_RY5g6J6pQG",
         )
-        .with_stderr_contains(
-            "  token rejected for `alternative`, please run `cargo login --registry alternative`",
-        )
+        .with_stderr_data(str![[r#"
+[UPDATING] `alternative` index
+[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
+
+Caused by:
+  token rejected for `alternative`, please run `cargo login --registry alternative`
+  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+
+Caused by:
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
+  body:
+  Unauthorized message from server.
+
+"#]])
         .with_status(101)
         .run();
 }
@@ -249,15 +320,15 @@ fn missing_token() {
     let p = make_project();
     cargo(&p, "build")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([..])`
+[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
   no token found for `alternative`, please run `cargo login --registry alternative`
-  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
-        )
+  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+
+"#]])
         .run();
 }
 
@@ -272,8 +343,7 @@ fn missing_token_git() {
     let p = make_project();
     cargo(&p, "build")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [LOCKING] 2 packages to latest compatible versions
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
@@ -283,8 +353,9 @@ Caused by:
 
 Caused by:
   no token found for `alternative`, please run `cargo login --registry alternative`
-  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN",
-        )
+  or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
+
+"#]])
         .run();
 }
 
@@ -301,20 +372,20 @@ fn incorrect_token() {
     cargo(&p, "build")
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", "incorrect")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
-[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([..])`
+[ERROR] failed to get `bar` as a dependency of package `foo v0.0.1 ([ROOT]/foo)`
 
 Caused by:
   token rejected for `alternative`, please run `cargo login --registry alternative`
   or use environment variable CARGO_REGISTRIES_ALTERNATIVE_TOKEN
 
 Caused by:
-  failed to get successful HTTP response from `http://[..]/index/config.json`, got 401
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/index/config.json`, got 401
   body:
-  Unauthorized message from server.",
-        )
+  Unauthorized message from server.
+
+"#]])
         .run();
 }
 
@@ -331,18 +402,18 @@ fn incorrect_token_git() {
     cargo(&p, "build")
         .env("CARGO_REGISTRIES_ALTERNATIVE_TOKEN", "incorrect")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[ERROR] failed to download from `http://[..]/dl/bar/0.0.1/download`
+[ERROR] failed to download from `http://127.0.0.1:[..]/dl/bar/0.0.1/download`
 
 Caused by:
-  failed to get successful HTTP response from `http://[..]/dl/bar/0.0.1/download` (127.0.0.1), got 401
+  failed to get successful HTTP response from `http://127.0.0.1:[..]/dl/bar/0.0.1/download` (127.0.0.1), got 401
   body:
-  Unauthorized message from server.",
-        )
+  Unauthorized message from server.
+
+"#]])
         .run();
 }
 
@@ -360,18 +431,17 @@ fn anonymous_alt_registry() {
     let p = make_project();
     cargo(&p, &format!("install --index {} bar", registry.index_url()))
         .with_status(101)
-        .with_stderr(
-            "\
-[UPDATING] `[..]` index
-[ERROR] no token found for `[..]`
+        .with_stderr_data(str![[r#"
+[UPDATING] `sparse+http://127.0.0.1:[..]/index/` index
+[ERROR] no token found for `sparse+http://127.0.0.1:[..]/index/`
 consider setting up an alternate registry in Cargo's configuration
 as described by https://doc.rust-lang.org/cargo/reference/registries.html
 
 [registries]
-my-registry = { index = \"[..]\" }
+my-registry = { index = "sparse+http://127.0.0.1:[..]/index/" }
 
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -424,8 +494,7 @@ fn duplicate_index() {
             server.index_url().as_str(),
         )
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [LOCKING] 2 packages to latest compatible versions
 [ERROR] failed to download `bar v0.0.1 (registry `alternative`)`
@@ -434,10 +503,9 @@ Caused by:
   unable to get packages from source
 
 Caused by:
-  multiple registries are configured with the same index url \
-  'registry+file://[..]/alternative-registry': alternative1, alternative2
-",
-        )
+  multiple registries are configured with the same index url 'registry+[ROOTURL]/alternative-registry': alternative1, alternative2
+
+"#]])
         .run();
 }
 


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/registry.rs`
- `tests/testsuite/registry_auth.rs`

### Additional information

Parameterize shared logic over inline snapshots to prevent the content from being appended multiple times in `str![]` when it's called multiple times within a reusable function.

Big thanks to @weihanglo for helping me out!