### PR TITLE
test: migrate search, source_replacement and standard_lib to snapbox

### DIFF
--- a/tests/testsuite/source_replacement.rs
+++ b/tests/testsuite/source_replacement.rs
@@ -1,11 +1,9 @@
 //! Tests for `[source]` table (source replacement).
 
-#![allow(deprecated)]
-
 use std::fs;
 
 use cargo_test_support::registry::{Package, RegistryBuilder, TestRegistry};
-use cargo_test_support::{cargo_process, paths, project, t};
+use cargo_test_support::{cargo_process, paths, project, str, t};
 
 fn setup_replacement(config: &str) -> TestRegistry {
     let crates_io = RegistryBuilder::new()
@@ -52,7 +50,10 @@ fn crates_io_token_not_sent_to_replacement() {
 
     p.cargo("publish --no-verify --registry crates-io")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr_contains("[UPDATING] crates.io index")
+        .with_stderr_data(str![[r#"
+[UPDATING] crates.io index
+...
+"#]])
         .run();
 }
 
@@ -69,22 +70,20 @@ fn token_sent_to_correct_registry() {
 
     cargo_process("yank foo@0.0.1 --registry crates-io")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [YANK] foo@0.0.1
-",
-        )
+
+"#]])
         .run();
 
     cargo_process("yank foo@0.0.1 --registry alternative")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [YANK] foo@0.0.1
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -107,12 +106,11 @@ fn ambiguous_registry() {
     cargo_process("yank foo@0.0.1")
         .replace_crates_io(crates_io.index_url())
         .with_status(101)
-        .with_stderr(
-            "\
-error: crates-io is replaced with remote registry alternative;
+        .with_stderr_data(str![[r#"
+[ERROR] crates-io is replaced with remote registry alternative;
 include `--registry alternative` or `--registry crates-io`
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -132,12 +130,11 @@ fn yank_with_default_crates_io() {
 
     cargo_process("yank foo@0.0.1")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [YANK] foo@0.0.1
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -157,12 +154,11 @@ fn yank_with_default_alternative() {
 
     cargo_process("yank foo@0.0.1")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `alternative` index
 [YANK] foo@0.0.1
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -209,27 +205,26 @@ fn publish_with_replacement() {
     // for the verification step.
     p.cargo("publish --registry crates-io")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] crates.io index
 [WARNING] manifest has no documentation, homepage or repository.
 See https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info.
-[PACKAGING] foo v0.0.1 ([..])
-[PACKAGED] [..]
-[VERIFYING] foo v0.0.1 ([..])
+[PACKAGING] foo v0.0.1 ([ROOT]/foo)
+[PACKAGED] 3 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
+[VERIFYING] foo v0.0.1 ([ROOT]/foo)
 [UPDATING] `alternative` index
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v1.0.0 (registry `alternative`)
 [COMPILING] bar v1.0.0
-[COMPILING] foo v0.0.1 ([..]foo-0.0.1)
-[FINISHED] `dev` profile [..]
-[UPLOADING] foo v0.0.1 ([..])
+[COMPILING] foo v0.0.1 ([ROOT]/foo/target/package/foo-0.0.1)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+[UPLOADING] foo v0.0.1 ([ROOT]/foo)
 [UPLOADED] foo v0.0.1 to registry `crates-io`
 [NOTE] waiting for `foo v0.0.1` to be available at registry `crates-io`.
 You may press ctrl-c to skip waiting; the crate should be available shortly.
 [PUBLISHED] foo v0.0.1 at registry `crates-io`
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -246,10 +241,10 @@ fn undefined_default() {
     cargo_process("yank foo@0.0.1")
         .replace_crates_io(crates_io.index_url())
         .with_status(101)
-        .with_stderr(
-            "[ERROR] registry index was not found in any configuration: `undefined`
-",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] registry index was not found in any configuration: `undefined`
+
+"#]])
         .run();
 }
 
@@ -286,16 +281,15 @@ fn source_replacement_with_registry_url() {
 
     p.cargo("check")
         .replace_crates_io(crates_io.index_url())
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [UPDATING] `using-registry-url` index
 [LOCKING] 2 packages to latest compatible versions
 [DOWNLOADING] crates ...
 [DOWNLOADED] bar v0.0.1 (registry `using-registry-url`)
 [CHECKING] bar v0.0.1
-[CHECKING] foo v0.0.1 ([CWD])
-[FINISHED] `dev` profile [..]
-",
-        )
+[CHECKING] foo v0.0.1 ([ROOT]/foo)
+[FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s
+
+"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/search.rs`
- `tests/testsuite/source_replacement.rs`
- `tests/testsuite/standard_lib.rs`