### PR TITLE
Allow `unexpected_builtin_cfgs` lint in `user_specific_cfgs` test

### DIFF
--- a/tests/testsuite/build.rs
+++ b/tests/testsuite/build.rs
@@ -6338,7 +6338,7 @@ fn user_specific_cfgs_are_filtered_out() {
         )
         .build();
 
-    p.cargo("rustc -- --cfg debug_assertions --cfg proc_macro")
+    p.cargo("rustc -- --cfg debug_assertions --cfg proc_macro -Aunknown_lints -Aunexpected_builtin_cfgs")
         .run();
     p.process(&p.bin("foo")).run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

This PR allows the to be added `unexpected_builtin_cfgs` lint from https://github.com/rust-lang/rust/pull/126158 in the `user_specific_cfgs_are_filtered_out` test in order to be able to merge the lint in rust-lang/rust CI.

### How should we test and review this PR?

The new lint is described in https://github.com/rust-lang/rust/pull/126158#issue-2341646795 and testing should be "as simple" as executing the test with my rustc branch.

### Additional information

https://github.com/rust-lang/rust/pull/126158#issuecomment-2190730869 shows the test failing with the addition of the lint.