### PR TITLE
test: Auto-redact `... after last build at ...`; Migrate `freshness` to Snapbox

### DIFF
--- a/crates/cargo-test-support/src/compare.rs
+++ b/crates/cargo-test-support/src/compare.rs
@@ -200,6 +200,16 @@ fn add_common_redactions(subs: &mut snapbox::Redactions) {
         regex!(r"ns/iter \(\+/- (?<redacted>[0-9]+(\.[0-9]+)?)\)"),
     )
     .unwrap();
+
+    // Following 3 subs redact:
+    //   "1719325877.527949100s, 61549498ns after last build at 1719325877.466399602s"
+    //   "1719503592.218193216s, 1h 1s after last build at 1719499991.982681034s"
+    // into "[DIRTY_REASON_NEW_TIME], [DIRTY_REASON_DIFF] after last build at [DIRTY_REASON_OLD_TIME]"
+    subs.insert(
+        "[TIME_DIFF_AFTER_LAST_BUILD]",
+        regex!(r"(?<redacted>[0-9]+(\.[0-9]+)?s, (\s?[0-9]+(\.[0-9]+)?(s|ns|h))+ after last build at [0-9]+(\.[0-9]+)?s)"),
+       )
+       .unwrap();
 }
 
 static MIN_LITERAL_REDACTIONS: &[(&str, &str)] = &[


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
Thanks for submitting a pull request 🎉! Here are some tips for you:

* If this is your first contribution, read "Cargo Contribution Guide" first:
  https://doc.crates.io/contrib/
* Run `cargo fmt --all` to format your code changes.
* Small commits and pull requests are always preferable and easy to review.
* If your idea is large and needs feedback from the community, read how:
  https://doc.crates.io/contrib/process/#working-on-large-features
* Cargo takes care of compatibility. Read our design principles:
  https://doc.crates.io/contrib/design.html
* When changing help text of cargo commands, follow the steps to generate docs:
  https://github.com/rust-lang/cargo/tree/master/src/doc#building-the-man-pages
* If your PR is not finished, set it as "draft" PR or add "WIP" in its title.
* It's ok to use the CI resources to test your PR, but please don't abuse them.
-->

### What does this PR try to resolve?

Part of #14039.

Migrate `tests/testsuite/freshness.rs` to snapbox.

### How should we test and review this PR?

I followed #14039. The `#![allow(deprecated)]` was removed and `tests/testsuite/freshness.rs` is still passing.

### Additional information

The redaction for "dirty reason" was a bit tricky

https://github.com/rust-lang/cargo/blob/7dcf764cbcff23b54fd061473f5ce66223cc0f86/src/cargo/core/compiler/fingerprint/dirty_reason.rs#L131

Current implementation would redact
- `1719325877.527949100s, 61549498ns after last build at 1719325877.466399602s`
- `1719503592.218193216s, 1h 1s after last build at 1719499991.982681034s`

into `[DIRTY_REASON_NEW_TIME], [DIRTY_REASON_DIFF] after last build at [DIRTY_REASON_OLD_TIME]`

Please let me know if that seems right.

<!-- homu-ignore:end -->
