### PR TITLE
test: migrate metabuild, metadata and net_config to snapbox

### DIFF
--- a/tests/testsuite/metadata.rs
+++ b/tests/testsuite/metadata.rs
@@ -1,11 +1,12 @@
 //! Tests for the `cargo metadata` command.
 
-#![allow(deprecated)]
-
 use cargo_test_support::install::cargo_home;
 use cargo_test_support::paths::CargoPathExt;
+use cargo_test_support::prelude::*;
 use cargo_test_support::registry::Package;
-use cargo_test_support::{basic_bin_manifest, basic_lib_manifest, main_file, project, rustc_host};
+use cargo_test_support::{
+    basic_bin_manifest, basic_lib_manifest, main_file, project, rustc_host, str,
+};
 use serde_json::json;
 
 #[cargo_test]
@@ -16,74 +17,78 @@ fn cargo_metadata_simple() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [
-                    "wycats@example.com"
-                ],
-                "categories": [],
-                "default_run": null,
-                "name": "foo",
-                "version": "0.5.0",
-                "id": "[..]foo#0.5.0",
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "edition": "2015",
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "homepage": null,
-                "documentation": null,
-                "targets": [
-                    {
-                        "kind": [
-                            "bin"
-                        ],
-                        "crate_types": [
-                            "bin"
-                        ],
-                        "doc": true,
-                        "doctest": false,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/foo.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
-        ],
-        "workspace_members": ["path+file:[..]foo#0.5.0"],
-        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
-        "resolve": {
-            "nodes": [
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file:[..]foo#0.5.0"
-                }
-            ],
-            "root": "path+file:[..]foo#0.5.0"
-        },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/foo.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.5.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -95,9 +100,16 @@ fn cargo_metadata_warns_on_implicit_version() {
         .file("Cargo.toml", &basic_bin_manifest("foo"))
         .build();
 
-    p.cargo("metadata").with_stderr("[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems").run();
+    p.cargo("metadata")
+        .with_stderr_data(str![[r#"
+[WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 
-    p.cargo("metadata --format-version 1").with_stderr("").run();
+"#]])
+        .run();
+
+    p.cargo("metadata --format-version 1")
+        .with_stderr_data("")
+        .run();
 }
 
 #[cargo_test]
@@ -118,72 +130,78 @@ crate-type = ["lib", "staticlib"]
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "name": "foo",
-                "readme": null,
-                "repository": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.5.0",
-                "rust_version": null,
-                "id": "[..]foo#0.5.0",
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "edition": "2015",
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "targets": [
-                    {
-                        "kind": [
-                            "lib",
-                            "staticlib"
-                        ],
-                        "crate_types": [
-                            "lib",
-                            "staticlib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
-        ],
-        "workspace_members": ["path+file:[..]foo#0.5.0"],
-        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
-        "resolve": {
-            "nodes": [
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file:[..]foo#0.5.0"
-                }
-            ],
-            "root": "path+file:[..]foo#0.5.0"
-        },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib",
+            "staticlib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib",
+            "staticlib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.5.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -208,79 +226,85 @@ optional_feat = []
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "name": "foo",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.5.0",
-                "id": "[..]foo#0.5.0",
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "edition": "2015",
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "targets": [
-                    {
-                        "kind": [
-                            "lib"
-                        ],
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/lib.rs"
-                    }
-                ],
-                "features": {
-                  "default": [
-                      "default_feat"
-                  ],
-                  "default_feat": [],
-                  "optional_feat": []
-                },
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {
+        "default": [
+          "default_feat"
         ],
-        "workspace_members": ["path+file:[..]foo#0.5.0"],
-        "workspace_default_members": ["path+file:[..]foo#0.5.0"],
-        "resolve": {
-            "nodes": [
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [
-                      "default",
-                      "default_feat"
-                    ],
-                    "id": "path+file:[..]foo#0.5.0"
-                }
-            ],
-            "root": "path+file:[..]foo#0.5.0"
-        },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+        "default_feat": [],
+        "optional_feat": []
+      },
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [
+          "default",
+          "default_feat"
+        ],
+        "id": "path+[ROOTURL]/foo#0.5.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -314,290 +338,292 @@ fn cargo_metadata_with_deps_and_version() {
     Package::new("bar", "0.0.1").dep("baz", "0.0.1").publish();
 
     p.cargo("metadata -q --format-version 1")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "dependencies": [
-                    {
-                        "features": [],
-                        "kind": null,
-                        "name": "baz",
-                        "optional": false,
-                        "registry": null,
-                        "rename": null,
-                        "req": "^0.0.1",
-                        "source": "registry+https://github.com/rust-lang/crates.io-index",
-                        "target": null,
-                        "uses_default_features": true
-                    }
-                ],
-                "description": null,
-                "edition": "2015",
-                "features": {},
-                "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
-                "keywords": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null,
-                "name": "bar",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "source": "registry+https://github.com/rust-lang/crates.io-index",
-                "targets": [
-                    {
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "kind": [
-                            "lib"
-                        ],
-                        "name": "bar",
-                        "src_path": "[..]src/lib.rs"
-                    }
-                ],
-                "version": "0.0.1"
-            },
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "dependencies": [],
-                "description": null,
-                "edition": "2015",
-                "features": {},
-                "id": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1",
-                "keywords": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null,
-                "name": "baz",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "source": "registry+https://github.com/rust-lang/crates.io-index",
-                "targets": [
-                    {
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "kind": [
-                            "lib"
-                        ],
-                        "name": "baz",
-                        "src_path": "[..]src/lib.rs"
-                    }
-                ],
-                "version": "0.0.1"
-            },
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "dependencies": [
-                    {
-                        "features": [],
-                        "kind": null,
-                        "name": "bar",
-                        "optional": false,
-                        "registry": null,
-                        "rename": null,
-                        "req": "*",
-                        "source": "registry+https://github.com/rust-lang/crates.io-index",
-                        "target": null,
-                        "uses_default_features": true
-                    },
-                    {
-                        "features": [],
-                        "kind": "dev",
-                        "name": "foobar",
-                        "optional": false,
-                        "registry": null,
-                        "rename": null,
-                        "req": "*",
-                        "source": "registry+https://github.com/rust-lang/crates.io-index",
-                        "target": null,
-                        "uses_default_features": true
-                    }
-                ],
-                "description": "foo",
-                "edition": "2015",
-                "features": {},
-                "id": "path+file:[..]foo#0.5.0",
-                "keywords": [],
-                "license": "MIT",
-                "license_file": null,
-                "links": null,
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null,
-                "name": "foo",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "source": null,
-                "targets": [
-                    {
-                        "crate_types": [
-                            "bin"
-                        ],
-                        "doc": true,
-                        "doctest": false,
-                        "test": true,
-                        "edition": "2015",
-                        "kind": [
-                            "bin"
-                        ],
-                        "name": "foo",
-                        "src_path": "[..]src/foo.rs"
-                    }
-                ],
-                "version": "0.5.0"
-            },
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "dependencies": [],
-                "description": null,
-                "edition": "2015",
-                "features": {},
-                "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1",
-                "keywords": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null,
-                "name": "foobar",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "source": "registry+https://github.com/rust-lang/crates.io-index",
-                "targets": [
-                    {
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "kind": [
-                            "lib"
-                        ],
-                        "name": "foobar",
-                        "src_path": "[..]src/lib.rs"
-                    }
-                ],
-                "version": "0.0.1"
-            }
-        ],
-        "resolve": {
-            "nodes": [
-                {
-                    "dependencies": [
-                        "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
-                    ],
-                    "deps": [
-                        {
-                            "dep_kinds": [
-                              {
-                                "kind": null,
-                                "target": null
-                              }
-                            ],
-                            "name": "baz",
-                            "pkg": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
-                        }
-                    ],
-                    "features": [],
-                    "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
-                },
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
-                },
-                {
-                    "dependencies": [
-                        "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
-                        "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
-                    ],
-                    "deps": [
-                        {
-                            "dep_kinds": [
-                              {
-                                "kind": null,
-                                "target": null
-                              }
-                            ],
-                            "name": "bar",
-                            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
-                        },
-                        {
-                            "dep_kinds": [
-                              {
-                                "kind": "dev",
-                                "target": null
-                              }
-                            ],
-                            "name": "foobar",
-                            "pkg": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
-                        }
-                    ],
-                    "features": [],
-                    "id": "path+file:[..]foo#0.5.0"
-                },
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
-                }
-            ],
-            "root": "path+file:[..]foo#0.5.0"
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "features": [],
+          "kind": null,
+          "name": "baz",
+          "optional": false,
+          "registry": null,
+          "rename": null,
+          "req": "^0.0.1",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.1/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.0.1/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.0.1"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/baz-0.0.1/Cargo.toml",
+      "metadata": null,
+      "name": "baz",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "baz",
+          "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/baz-0.0.1/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.0.1"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "features": [],
+          "kind": null,
+          "name": "bar",
+          "optional": false,
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "target": null,
+          "uses_default_features": true
         },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_members": [
-            "path+file:[..]foo#0.5.0"
+        {
+          "features": [],
+          "kind": "dev",
+          "name": "foobar",
+          "optional": false,
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": "foo",
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": "MIT",
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/foo.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foobar-0.0.1/Cargo.toml",
+      "metadata": null,
+      "name": "foobar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foobar",
+          "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foobar-0.0.1/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.0.1"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [
+          "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
         ],
-        "workspace_default_members": [
-            "path+file:[..]foo#0.5.0"
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "baz",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
+          }
         ],
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#baz@0.0.1"
+      },
+      {
+        "dependencies": [
+          "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1",
+          "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
+        ],
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "bar",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.0.1"
+          },
+          {
+            "dep_kinds": [
+              {
+                "kind": "dev",
+                "target": null
+              }
+            ],
+            "name": "foobar",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
+          }
+        ],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.5.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -621,80 +647,90 @@ name = "ex"
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "name": "foo",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.1.0",
-                "id": "[..]foo#0.1.0",
-                "keywords": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "edition": "2015",
-                "source": null,
-                "dependencies": [],
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/lib.rs"
-                    },
-                    {
-                        "kind": [ "example" ],
-                        "crate_types": [ "bin" ],
-                        "doc": false,
-                        "doctest": false,
-                        "test": false,
-                        "edition": "2015",
-                        "name": "ex",
-                        "src_path": "[..]/foo/examples/ex.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
-        ],
-        "workspace_members": [
-            "path+file:[..]foo#0.1.0"
-        ],
-        "workspace_default_members": [
-            "path+file:[..]foo#0.1.0"
-        ],
-        "resolve": {
-            "root": "path+file://[..]foo#0.1.0",
-            "nodes": [
-                {
-                    "id": "path+file:[..]foo#0.1.0",
-                    "features": [],
-                    "dependencies": [],
-                    "deps": []
-                }
-            ]
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
         },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": false,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "example"
+          ],
+          "name": "ex",
+          "src_path": "[ROOT]/foo/examples/ex.rs",
+          "test": false
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -719,80 +755,91 @@ crate-type = ["rlib", "dylib"]
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "name": "foo",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.1.0",
-                "id": "[..]foo#0.1.0",
-                "keywords": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "edition": "2015",
-                "source": null,
-                "dependencies": [],
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/lib.rs"
-                    },
-                    {
-                        "kind": [ "example" ],
-                        "crate_types": [ "rlib", "dylib" ],
-                        "doc": false,
-                        "doctest": false,
-                        "test": false,
-                        "edition": "2015",
-                        "name": "ex",
-                        "src_path": "[..]/foo/examples/ex.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
-        ],
-        "workspace_members": [
-            "path+file:[..]foo#0.1.0"
-        ],
-         "workspace_default_members": [
-            "path+file:[..]foo#0.1.0"
-        ],
-        "resolve": {
-            "root": "path+file://[..]foo#0.1.0",
-            "nodes": [
-                {
-                    "id": "path+file:[..]foo#0.1.0",
-                    "features": [],
-                    "dependencies": [],
-                    "deps": []
-                }
-            ]
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
         },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+        {
+          "crate_types": [
+            "rlib",
+            "dylib"
+          ],
+          "doc": false,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "example"
+          ],
+          "name": "ex",
+          "src_path": "[ROOT]/foo/examples/ex.rs",
+          "test": false
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -822,125 +869,139 @@ fn workspace_metadata() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": {
+    "foo": {
+      "bar": 3
+    },
+    "tool1": "hello",
+    "tool2": [
+      1,
+      2,
+      3
+    ]
+  },
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [
-                    "wycats@example.com"
-                ],
-                "categories": [],
-                "default_run": null,
-                "name": "bar",
-                "version": "0.5.0",
-                "id": "[..]bar#0.5.0",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "edition": "2015",
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "bar",
-                        "src_path": "[..]bar/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]bar/Cargo.toml",
-                "metadata": null,
-                "publish": null
-            },
-            {
-                "authors": [
-                    "wycats@example.com"
-                ],
-                "categories": [],
-                "default_run": null,
-                "name": "baz",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.5.0",
-                "id": "[..]baz#0.5.0",
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "edition": "2015",
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "baz",
-                        "src_path": "[..]baz/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]baz/Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
-        ],
-        "workspace_members": [
-            "path+file:[..]bar#0.5.0",
-            "path+file:[..]baz#0.5.0"
-        ],
-        "workspace_default_members": [
-            "path+file:[..]bar#0.5.0",
-            "path+file:[..]baz#0.5.0"
-        ],
-        "resolve": {
-            "nodes": [
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file:[..]bar#0.5.0"
-                },
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file:[..]baz#0.5.0"
-                }
-            ],
-            "root": null
-        },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": {
-            "tool1": "hello",
-            "tool2": [1, 2, 3],
-            "foo": {
-              "bar": 3
-            }
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/bar#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/bar/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/foo/bar/src/lib.rs",
+          "test": true
         }
-    }"#,
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/baz#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/baz/Cargo.toml",
+      "metadata": null,
+      "name": "baz",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "baz",
+          "src_path": "[ROOT]/foo/baz/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/bar#0.5.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/baz#0.5.0"
+      }
+    ],
+    "root": null
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/baz#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/baz#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -979,182 +1040,192 @@ fn workspace_metadata_with_dependencies_no_deps() {
 
     p.cargo("metadata --no-deps -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [
-                    "wycats@example.com"
-                ],
-                "categories": [],
-                "default_run": null,
-                "name": "bar",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.5.0",
-                "id": "[..]bar#0.5.0",
-                "keywords": [],
-                "source": null,
-                "license": null,
-                "dependencies": [
-                   {
-                      "features": [],
-                      "kind": null,
-                      "name": "artifact",
-                      "optional": false,
-                      "path": "[..]/foo/artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true,
-                      "artifact": {
-                          "kinds": [
-                            "bin"
-                          ],
-                          "lib": false,
-                          "target": null
-                        }
-                    }, 
-                    {
-                      "features": [],
-                      "kind": null,
-                      "name": "baz",
-                      "optional": false,
-                      "path": "[..]/foo/baz",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    }
-                  ],
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "edition": "2015",
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "bar",
-                        "src_path": "[..]bar/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]bar/Cargo.toml",
-                "metadata": null,
-                "publish": null
-            },
-            {
-              "authors": [
-                "wycats@example.com"
-              ],
-              "categories": [],
-              "default_run": null,
-              "dependencies": [],
-              "description": null,
-              "documentation": null,
-              "edition": "2015",
-              "features": {},
-              "homepage": null,
-              "id": "path+file:[..]/foo/artifact#0.5.0",
-              "keywords": [],
-              "license": null,
-              "license_file": null,
-              "links": null,
-              "manifest_path": "[..]/foo/artifact/Cargo.toml",
-              "metadata": null,
-              "name": "artifact",
-              "publish": null,
-              "readme": null,
-              "repository": null,
-              "rust_version": null,
-              "source": null,
-              "targets": [
-                {
-                  "crate_types": [
-                    "bin"
-                  ],
-                  "doc": true,
-                  "doctest": false,
-                  "edition": "2015",
-                  "kind": [
-                    "bin"
-                  ],
-                  "name": "artifact",
-                  "src_path": "[..]/foo/artifact/src/main.rs",
-                  "test": true
-                }
-              ],
-              "version": "0.5.0"
-            },
-            {
-                "authors": [
-                    "wycats@example.com"
-                ],
-                "categories": [],
-                "default_run": null,
-                "name": "baz",
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.5.0",
-                "id": "[..]baz#0.5.0",
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "edition": "2015",
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": ["lib"],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "baz",
-                        "src_path": "[..]baz/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]baz/Cargo.toml",
-                "metadata": null,
-                "publish": null
-            }
-        ],
-        "workspace_members": [
-            "path+file:[..]bar#0.5.0",
-            "path+file:[..]/foo/artifact#0.5.0",
-            "path+file:[..]baz#0.5.0"
-        ],
-        "workspace_default_members": [
-            "path+file:[..]bar#0.5.0",
-            "path+file:[..]/foo/artifact#0.5.0",
-            "path+file:[..]baz#0.5.0"
-        ],
-        "resolve": null,
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "artifact": {
+            "kinds": [
+              "bin"
+            ],
+            "lib": false,
+            "target": null
+          },
+          "features": [],
+          "kind": null,
+          "name": "artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": null,
+          "name": "baz",
+          "optional": false,
+          "path": "[ROOT]/foo/baz",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/bar#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/bar/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/foo/bar/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/artifact#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/artifact/Cargo.toml",
+      "metadata": null,
+      "name": "artifact",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "artifact",
+          "src_path": "[ROOT]/foo/artifact/src/main.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/baz#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/baz/Cargo.toml",
+      "metadata": null,
+      "name": "baz",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "baz",
+          "src_path": "[ROOT]/foo/baz/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/artifact#0.5.0",
+    "path+[ROOTURL]/foo/baz#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/artifact#0.5.0",
+    "path+[ROOTURL]/foo/baz#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -1247,549 +1318,550 @@ fn workspace_metadata_with_dependencies_and_resolve() {
 
     p.cargo("metadata -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_json(
-            r#"
-            {
-              "metadata": null,
-              "packages": [
-                {
-                  "authors": [],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/artifact#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/artifact/Cargo.toml",
-                  "metadata": null,
-                  "name": "artifact",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "staticlib",
-                        "cdylib",
-                        "rlib"
-                      ],
-                      "doc": true,
-                      "doctest": true,
-                      "edition": "2015",
-                      "kind": [
-                        "staticlib",
-                        "cdylib",
-                        "rlib"
-                      ],
-                      "name": "artifact",
-                      "src_path": "[..]/foo/artifact/src/lib.rs",
-                      "test": true
-                    },
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": true,
-                      "doctest": false,
-                      "edition": "2015",
-                      "kind": [
-                        "bin"
-                      ],
-                      "name": "bar-name",
-                      "src_path": "[..]/foo/artifact/src/main.rs",
-                      "test": true
-                    },
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": true,
-                      "doctest": false,
-                      "edition": "2015",
-                      "kind": [
-                        "bin"
-                      ],
-                      "name": "baz-name",
-                      "src_path": "[..]/foo/artifact/src/main.rs",
-                      "test": true
-                    }
-                  ],
-                  "version": "0.5.0"
-                },
-                {
-                  "authors": [],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [
-                    {
-                      "artifact": {
-                        "kinds": [
-                          "cdylib",
-                          "staticlib",
-                          "bin:baz-name"
-                        ],
-                        "lib": true,
-                        "target": "wasm32-unknown-unknown"
-                      },
-                      "features": [],
-                      "kind": null,
-                      "name": "artifact",
-                      "optional": false,
-                      "path": "[..]/foo/artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "artifact": {
-                        "kinds": [
-                          "bin:a-name"
-                        ],
-                        "lib": false,
-                        "target": null
-                      },
-                      "features": [],
-                      "kind": null,
-                      "name": "bin-only-artifact",
-                      "optional": false,
-                      "path": "[..]/foo/bin-only-artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "features": [],
-                      "kind": null,
-                      "name": "non-artifact",
-                      "optional": false,
-                      "path": "[..]/foo/non-artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "features": [],
-                      "kind": "dev",
-                      "name": "artifact",
-                      "optional": false,
-                      "path": "[..]/foo/artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "artifact": {
-                        "kinds": [
-                          "bin:b-name"
-                        ],
-                        "lib": false,
-                        "target": null
-                      },
-                      "features": [],
-                      "kind": "dev",
-                      "name": "bin-only-artifact",
-                      "optional": false,
-                      "path": "[..]/foo/bin-only-artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "features": [],
-                      "kind": "dev",
-                      "name": "non-artifact",
-                      "optional": false,
-                      "path": "[..]/foo/non-artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "artifact": {
-                        "kinds": [
-                          "bin"
-                        ],
-                        "lib": false,
-                        "target": "target"
-                      },
-                      "features": [],
-                      "kind": "build",
-                      "name": "artifact",
-                      "optional": false,
-                      "path": "[..]/foo/artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "artifact": {
-                        "kinds": [
-                          "bin"
-                        ],
-                        "lib": false,
-                        "target": "wasm32-unknown-unknown"
-                      },
-                      "features": [],
-                      "kind": "build",
-                      "name": "bin-only-artifact",
-                      "optional": false,
-                      "path": "[..]/foo/bin-only-artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "features": [],
-                      "kind": "build",
-                      "name": "non-artifact",
-                      "optional": false,
-                      "path": "[..]/foo/non-artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    }
-                  ],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/bar#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/bar/Cargo.toml",
-                  "metadata": null,
-                  "name": "bar",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "lib"
-                      ],
-                      "doc": true,
-                      "doctest": true,
-                      "edition": "2015",
-                      "kind": [
-                        "lib"
-                      ],
-                      "name": "bar",
-                      "src_path": "[..]/foo/bar/src/lib.rs",
-                      "test": true
-                    },
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": false,
-                      "doctest": false,
-                      "edition": "2015",
-                      "kind": [
-                        "custom-build"
-                      ],
-                      "name": "build-script-build",
-                      "src_path": "[..]/foo/bar/build.rs",
-                      "test": false
-                    }
-                  ],
-                  "version": "0.5.0"
-                },
-                {
-                  "authors": [],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/bin-only-artifact#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/bin-only-artifact/Cargo.toml",
-                  "metadata": null,
-                  "name": "bin-only-artifact",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": true,
-                      "doctest": false,
-                      "edition": "2015",
-                      "kind": [
-                        "bin"
-                      ],
-                      "name": "a-name",
-                      "src_path": "[..]/foo/bin-only-artifact/src/main.rs",
-                      "test": true
-                    },
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": true,
-                      "doctest": false,
-                      "edition": "2015",
-                      "kind": [
-                        "bin"
-                      ],
-                      "name": "b-name",
-                      "src_path": "[..]/foo/bin-only-artifact/src/main.rs",
-                      "test": true
-                    }
-                  ],
-                  "version": "0.5.0"
-                },
-                {
-                  "authors": [],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/non-artifact#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/non-artifact/Cargo.toml",
-                  "metadata": null,
-                  "name": "non-artifact",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "lib"
-                      ],
-                      "doc": true,
-                      "doctest": true,
-                      "edition": "2015",
-                      "kind": [
-                        "lib"
-                      ],
-                      "name": "non_artifact",
-                      "src_path": "[..]/foo/non-artifact/src/lib.rs",
-                      "test": true
-                    }
-                  ],
-                  "version": "0.5.0"
-                }
-              ],
-              "resolve": {
-                "nodes": [
-                  {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file://[..]/foo/artifact#0.5.0"
-                  },
-                  {
-                    "dependencies": [
-                      "path+file://[..]/foo/artifact#0.5.0",
-                      "path+file://[..]/foo/bin-only-artifact#0.5.0",
-                      "path+file://[..]/foo/non-artifact#0.5.0"
-                    ],
-                    "deps": [
-                      {
-                        "dep_kinds": [
-                          {
-                            "extern_name": "artifact",
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "artifact": "cdylib",
-                            "compile_target": "wasm32-unknown-unknown",
-                            "extern_name": "artifact",
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "artifact": "staticlib",
-                            "compile_target": "wasm32-unknown-unknown",
-                            "extern_name": "artifact",
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "artifact": "bin",
-                            "bin_name": "baz-name",
-                            "compile_target": "wasm32-unknown-unknown",
-                            "extern_name": "baz_name",
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "kind": "dev",
-                            "target": null
-                          },
-                          {
-                            "artifact": "bin",
-                            "bin_name": "bar-name",
-                            "compile_target": "<target>",
-                            "extern_name": "bar_name",
-                            "kind": "build",
-                            "target": null
-                          },
-                          {
-                            "artifact": "bin",
-                            "bin_name": "baz-name",
-                            "compile_target": "<target>",
-                            "extern_name": "baz_name",
-                            "kind": "build",
-                            "target": null
-                          }
-                        ],
-                        "name": "artifact",
-                        "pkg": "path+file://[..]/foo/artifact#0.5.0"
-                      },
-                      {
-                        "dep_kinds": [
-                          {
-                            "artifact": "bin",
-                            "bin_name": "a-name",
-                            "extern_name": "a_name",
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "artifact": "bin",
-                            "bin_name": "b-name",
-                            "extern_name": "b_name",
-                            "kind": "dev",
-                            "target": null
-                          },
-                          {
-                            "artifact": "bin",
-                            "bin_name": "a-name",
-                            "compile_target": "wasm32-unknown-unknown",
-                            "extern_name": "a_name",
-                            "kind": "build",
-                            "target": null
-                          },
-                          {
-                            "artifact": "bin",
-                            "bin_name": "b-name",
-                            "compile_target": "wasm32-unknown-unknown",
-                            "extern_name": "b_name",
-                            "kind": "build",
-                            "target": null
-                          }
-                        ],
-                        "name": "",
-                        "pkg": "path+file://[..]/foo/bin-only-artifact#0.5.0"
-                      },
-                      {
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "kind": "dev",
-                            "target": null
-                          },
-                          {
-                            "kind": "build",
-                            "target": null
-                          }
-                        ],
-                        "name": "non_artifact",
-                        "pkg": "path+file://[..]/foo/non-artifact#0.5.0"
-                      }
-                    ],
-                    "features": [],
-                    "id": "path+file://[..]/foo/bar#0.5.0"
-                  },
-                  {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file://[..]/foo/bin-only-artifact#0.5.0"
-                  },
-                  {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file://[..]/foo/non-artifact#0.5.0"
-                  }
-                ],
-                "root": null
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/artifact#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/artifact/Cargo.toml",
+      "metadata": null,
+      "name": "artifact",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "staticlib",
+            "cdylib",
+            "rlib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "staticlib",
+            "cdylib",
+            "rlib"
+          ],
+          "name": "artifact",
+          "src_path": "[ROOT]/foo/artifact/src/lib.rs",
+          "test": true
+        },
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "bar-name",
+          "src_path": "[ROOT]/foo/artifact/src/main.rs",
+          "test": true
+        },
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "baz-name",
+          "src_path": "[ROOT]/foo/artifact/src/main.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "artifact": {
+            "kinds": [
+              "cdylib",
+              "staticlib",
+              "bin:baz-name"
+            ],
+            "lib": true,
+            "target": "wasm32-unknown-unknown"
+          },
+          "features": [],
+          "kind": null,
+          "name": "artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "artifact": {
+            "kinds": [
+              "bin:a-name"
+            ],
+            "lib": false,
+            "target": null
+          },
+          "features": [],
+          "kind": null,
+          "name": "bin-only-artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/bin-only-artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": null,
+          "name": "non-artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/non-artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": "dev",
+          "name": "artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "artifact": {
+            "kinds": [
+              "bin:b-name"
+            ],
+            "lib": false,
+            "target": null
+          },
+          "features": [],
+          "kind": "dev",
+          "name": "bin-only-artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/bin-only-artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": "dev",
+          "name": "non-artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/non-artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "artifact": {
+            "kinds": [
+              "bin"
+            ],
+            "lib": false,
+            "target": "target"
+          },
+          "features": [],
+          "kind": "build",
+          "name": "artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "artifact": {
+            "kinds": [
+              "bin"
+            ],
+            "lib": false,
+            "target": "wasm32-unknown-unknown"
+          },
+          "features": [],
+          "kind": "build",
+          "name": "bin-only-artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/bin-only-artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": "build",
+          "name": "non-artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/non-artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/bar#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/bar/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/foo/bar/src/lib.rs",
+          "test": true
+        },
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": false,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "custom-build"
+          ],
+          "name": "build-script-build",
+          "src_path": "[ROOT]/foo/bar/build.rs",
+          "test": false
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/bin-only-artifact#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/bin-only-artifact/Cargo.toml",
+      "metadata": null,
+      "name": "bin-only-artifact",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "a-name",
+          "src_path": "[ROOT]/foo/bin-only-artifact/src/main.rs",
+          "test": true
+        },
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "b-name",
+          "src_path": "[ROOT]/foo/bin-only-artifact/src/main.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/non-artifact#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/non-artifact/Cargo.toml",
+      "metadata": null,
+      "name": "non-artifact",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "non_artifact",
+          "src_path": "[ROOT]/foo/non-artifact/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/artifact#0.5.0"
+      },
+      {
+        "dependencies": [
+          "path+[ROOTURL]/foo/artifact#0.5.0",
+          "path+[ROOTURL]/foo/bin-only-artifact#0.5.0",
+          "path+[ROOTURL]/foo/non-artifact#0.5.0"
+        ],
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "extern_name": "artifact",
+                "kind": null,
+                "target": null
               },
-              "target_directory": "[..]/foo/target",
-              "version": 1,
-              "workspace_members": [
-                "path+file://[..]/foo/bar#0.5.0",
-                "path+file://[..]/foo/artifact#0.5.0",
-                "path+file://[..]/foo/bin-only-artifact#0.5.0",
-                "path+file://[..]/foo/non-artifact#0.5.0"
-              ],
-              "workspace_default_members": [
-                "path+file://[..]/foo/bar#0.5.0",
-                "path+file://[..]/foo/artifact#0.5.0",
-                "path+file://[..]/foo/bin-only-artifact#0.5.0",
-                "path+file://[..]/foo/non-artifact#0.5.0"
-              ],
-              "workspace_root": "[..]/foo"
-            }
-    "#,
+              {
+                "artifact": "cdylib",
+                "compile_target": "wasm32-unknown-unknown",
+                "extern_name": "artifact",
+                "kind": null,
+                "target": null
+              },
+              {
+                "artifact": "staticlib",
+                "compile_target": "wasm32-unknown-unknown",
+                "extern_name": "artifact",
+                "kind": null,
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "baz-name",
+                "compile_target": "wasm32-unknown-unknown",
+                "extern_name": "baz_name",
+                "kind": null,
+                "target": null
+              },
+              {
+                "kind": "dev",
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "bar-name",
+                "compile_target": "<target>",
+                "extern_name": "bar_name",
+                "kind": "build",
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "baz-name",
+                "compile_target": "<target>",
+                "extern_name": "baz_name",
+                "kind": "build",
+                "target": null
+              }
+            ],
+            "name": "artifact",
+            "pkg": "path+[ROOTURL]/foo/artifact#0.5.0"
+          },
+          {
+            "dep_kinds": [
+              {
+                "artifact": "bin",
+                "bin_name": "a-name",
+                "extern_name": "a_name",
+                "kind": null,
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "b-name",
+                "extern_name": "b_name",
+                "kind": "dev",
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "a-name",
+                "compile_target": "wasm32-unknown-unknown",
+                "extern_name": "a_name",
+                "kind": "build",
+                "target": null
+              },
+              {
+                "artifact": "bin",
+                "bin_name": "b-name",
+                "compile_target": "wasm32-unknown-unknown",
+                "extern_name": "b_name",
+                "kind": "build",
+                "target": null
+              }
+            ],
+            "name": "",
+            "pkg": "path+[ROOTURL]/foo/bin-only-artifact#0.5.0"
+          },
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              },
+              {
+                "kind": "dev",
+                "target": null
+              },
+              {
+                "kind": "build",
+                "target": null
+              }
+            ],
+            "name": "non_artifact",
+            "pkg": "path+[ROOTURL]/foo/non-artifact#0.5.0"
+          }
+        ],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/bar#0.5.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/bin-only-artifact#0.5.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/non-artifact#0.5.0"
+      }
+    ],
+    "root": null
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/artifact#0.5.0",
+    "path+[ROOTURL]/foo/bin-only-artifact#0.5.0",
+    "path+[ROOTURL]/foo/non-artifact#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/artifact#0.5.0",
+    "path+[ROOTURL]/foo/bin-only-artifact#0.5.0",
+    "path+[ROOTURL]/foo/non-artifact#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -1800,13 +1872,13 @@ fn cargo_metadata_with_invalid_manifest() {
 
     p.cargo("metadata --format-version 1")
         .with_status(101)
-        .with_stderr(
-            "\
-[ERROR] failed to parse manifest at `[..]`
+        .with_stderr_data(str![[r#"
+[ERROR] failed to parse manifest at `[ROOT]/foo/Cargo.toml`
 
 Caused by:
-  virtual manifests must be configured with [workspace]",
-        )
+  virtual manifests must be configured with [workspace]
+
+"#]])
         .run();
 }
 
@@ -1825,15 +1897,15 @@ fn cargo_metadata_with_invalid_authors_field() {
 
     p.cargo("metadata")
         .with_status(101)
-        .with_stderr(
-            r#"[ERROR] invalid type: string "", expected a vector of strings or workspace
+        .with_stderr_data(str![[r#"
+[ERROR] invalid type: string "", expected a vector of strings or workspace
  --> Cargo.toml:3:27
   |
 3 |                 authors = ""
   |                           ^^
   |
-"#,
-        )
+
+"#]])
         .run();
 }
 
@@ -1852,16 +1924,15 @@ fn cargo_metadata_with_invalid_version_field() {
 
     p.cargo("metadata")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [ERROR] invalid type: integer `1`, expected SemVer version
  --> Cargo.toml:3:27
   |
 3 |                 version = 1
   |                           ^
   |
-",
-        )
+
+"#]])
         .run();
 }
 
@@ -1880,15 +1951,15 @@ fn cargo_metadata_with_invalid_publish_field() {
 
     p.cargo("metadata")
         .with_status(101)
-        .with_stderr(
-            r#"[ERROR] invalid type: string "foo", expected a boolean, a vector of strings, or workspace
+        .with_stderr_data(str![[r#"
+[ERROR] invalid type: string "foo", expected a boolean, a vector of strings, or workspace
  --> Cargo.toml:3:27
   |
 3 |                 publish = "foo"
   |                           ^^^^^
   |
-"#,
-        )
+
+"#]])
         .run();
 }
 
@@ -1914,12 +1985,12 @@ fn cargo_metadata_with_invalid_artifact_deps() {
     p.cargo("metadata -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [LOCKING] 2 packages to latest compatible versions
-[ERROR] dependency `artifact` in package `foo` requires a `bin:notfound` artifact to be present.",
-        )
+[ERROR] dependency `artifact` in package `foo` requires a `bin:notfound` artifact to be present.
+
+"#]])
         .run();
 }
 
@@ -1945,62 +2016,14 @@ fn cargo_metadata_with_invalid_duplicate_renamed_deps() {
 
     p.cargo("metadata")
         .with_status(101)
-        .with_stderr(
-            "\
+        .with_stderr_data(str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [LOCKING] 2 packages to latest compatible versions
-[ERROR] the crate `foo v0.5.0 ([..])` depends on crate `bar v0.5.0 ([..])` multiple times with different names",
-        )
+[ERROR] the crate `foo v0.5.0 ([ROOT]/foo)` depends on crate `bar v0.5.0 ([ROOT]/foo/bar)` multiple times with different names
+
+"#]])
         .run();
 }
-
-const MANIFEST_OUTPUT: &str = r#"
-{
-    "packages": [{
-        "authors": [
-            "wycats@example.com"
-        ],
-        "categories": [],
-        "default_run": null,
-        "name":"foo",
-        "version":"0.5.0",
-        "id":"path+file://[..]/foo#0.5.0",
-        "source":null,
-        "dependencies":[],
-        "keywords": [],
-        "license": null,
-        "license_file": null,
-        "links": null,
-        "description": null,
-        "edition": "2015",
-        "targets":[{
-            "kind":["bin"],
-            "crate_types":["bin"],
-            "doc": true,
-            "doctest": false,
-            "test": true,
-            "edition": "2015",
-            "name":"foo",
-            "src_path":"[..]/foo/src/foo.rs"
-        }],
-        "features":{},
-        "manifest_path":"[..]Cargo.toml",
-        "metadata": null,
-        "publish": null,
-        "readme": null,
-        "repository": null,
-        "rust_version": null,
-        "homepage": null,
-        "documentation": null
-    }],
-    "workspace_members": [ "path+file:[..]foo#0.5.0" ],
-    "workspace_default_members": [ "path+file:[..]foo#0.5.0" ],
-    "resolve": null,
-    "target_directory": "[..]foo/target",
-    "version": 1,
-    "workspace_root": "[..]/foo",
-    "metadata": null
-}"#;
 
 #[cargo_test]
 fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
@@ -2011,7 +2034,69 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_relative() {
 
     p.cargo("metadata --no-deps --manifest-path foo/Cargo.toml")
         .cwd(p.root().parent().unwrap())
-        .with_json(MANIFEST_OUTPUT)
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/foo.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
+        )
         .run();
 }
 
@@ -2025,7 +2110,69 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_absolute() {
     p.cargo("metadata --no-deps --manifest-path")
         .arg(p.root().join("Cargo.toml"))
         .cwd(p.root().parent().unwrap())
-        .with_json(MANIFEST_OUTPUT)
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/foo.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
+        )
         .run();
 }
 
@@ -2039,10 +2186,10 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_relative() {
     p.cargo("metadata --no-deps --manifest-path foo")
         .cwd(p.root().parent().unwrap())
         .with_status(101)
-        .with_stderr(
-            "[ERROR] the manifest-path must be \
-             a path to a Cargo.toml file",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] the manifest-path must be a path to a Cargo.toml file
+
+"#]])
         .run();
 }
 
@@ -2057,10 +2204,10 @@ fn cargo_metadata_no_deps_path_to_cargo_toml_parent_absolute() {
         .arg(p.root())
         .cwd(p.root().parent().unwrap())
         .with_status(101)
-        .with_stderr(
-            "[ERROR] the manifest-path must be \
-             a path to a Cargo.toml file",
-        )
+        .with_stderr_data(str![[r#"
+[ERROR] the manifest-path must be a path to a Cargo.toml file
+
+"#]])
         .run();
 }
 
@@ -2072,7 +2219,69 @@ fn cargo_metadata_no_deps_cwd() {
         .build();
 
     p.cargo("metadata --no-deps")
-        .with_json(MANIFEST_OUTPUT)
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/foo.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
+        )
         .run();
 }
 
@@ -2085,12 +2294,12 @@ fn cargo_metadata_bad_version() {
 
     p.cargo("metadata --no-deps --format-version 2")
         .with_status(1)
-        .with_stderr_contains(
-            "\
-error: invalid value '2' for '--format-version <VERSION>'
+        .with_stderr_data(str![[r#"
+[ERROR] invalid value '2' for '--format-version <VERSION>'
   [possible values: 1]
-",
-        )
+
+...
+"#]])
         .run();
 }
 
@@ -2142,60 +2351,76 @@ fn package_metadata() {
         .build();
 
     p.cargo("metadata --no-deps")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": ["wycats@example.com"],
-                "categories": ["database"],
-                "default_run": null,
-                "name": "foo",
-                "readme": "README.md",
-                "repository": "https://github.com/rust-lang/cargo",
-                "rust_version": null,
-                "homepage": "https://rust-lang.org",
-                "documentation": "https://doc.rust-lang.org/stable/std/",
-                "version": "0.1.0",
-                "id": "[..]foo#0.1.0",
-                "keywords": ["database"],
-                "source": null,
-                "dependencies": [],
-                "edition": "2015",
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]foo/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]foo/Cargo.toml",
-                "metadata": {
-                    "bar": {
-                        "baz": "quux"
-                    }
-                },
-                "publish": null
-            }
-        ],
-        "workspace_members": ["[..]foo#0.1.0"],
-        "workspace_default_members": ["[..]foo#0.1.0"],
-        "resolve": null,
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [
+        "database"
+      ],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": "https://doc.rust-lang.org/stable/std/",
+      "edition": "2015",
+      "features": {},
+      "homepage": "https://rust-lang.org",
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [
+        "database"
+      ],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": {
+        "bar": {
+          "baz": "quux"
+        }
+      },
+      "name": "foo",
+      "publish": null,
+      "readme": "README.md",
+      "repository": "https://github.com/rust-lang/cargo",
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -2222,56 +2447,74 @@ fn package_publish() {
         .build();
 
     p.cargo("metadata --no-deps")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": ["wycats@example.com"],
-                "categories": ["database"],
-                "default_run": null,
-                "name": "foo",
-                "readme": "README.md",
-                "repository": "https://github.com/rust-lang/cargo",
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "version": "0.1.0",
-                "id": "[..]foo#0.1.0",
-                "keywords": ["database"],
-                "source": null,
-                "dependencies": [],
-                "edition": "2015",
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "targets": [
-                    {
-                        "kind": [ "lib" ],
-                        "crate_types": [ "lib" ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]foo/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]foo/Cargo.toml",
-                "metadata": null,
-                "publish": ["my-registry"]
-            }
-        ],
-        "workspace_members": ["[..]foo#0.1.0"],
-        "workspace_default_members": ["[..]foo#0.1.0"],
-        "resolve": null,
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [
+        "database"
+      ],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [
+        "database"
+      ],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": [
+        "my-registry"
+      ],
+      "readme": "README.md",
+      "repository": "https://github.com/rust-lang/cargo",
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -2297,77 +2540,78 @@ fn cargo_metadata_path_to_cargo_toml_project() {
 
     p.cargo("metadata --manifest-path")
         .arg(p.root().join("target/package/bar-0.5.0/Cargo.toml"))
-        .with_json(
-            r#"
-            {
-                "packages": [
-                {
-                    "authors": [
-                        "wycats@example.com"
-                    ],
-                    "categories": [],
-                    "default_run": null,
-                    "dependencies": [],
-                    "description": null,
-                    "edition": "2015",
-                    "features": {},
-                    "id": "[..]#bar@0.5.0",
-                    "keywords": [],
-                    "license": null,
-                    "license_file": null,
-                    "links": null,
-                    "manifest_path": "[..]Cargo.toml",
-                    "metadata": null,
-                    "publish": null,
-                    "name": "bar",
-                    "readme": null,
-                    "repository": null,
-                    "rust_version": null,
-                    "homepage": null,
-                    "documentation": null,
-                    "source": null,
-                    "targets": [
-                    {
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "kind": [
-                            "lib"
-                        ],
-                        "name": "bar",
-                        "src_path": "[..]src/lib.rs"
-                    }
-                    ],
-                    "version": "0.5.0"
-                }
-                ],
-                "resolve": {
-                    "nodes": [
-                    {
-                        "dependencies": [],
-                        "deps": [],
-                        "features": [],
-                        "id": "[..]#bar@0.5.0"
-                    }
-                    ],
-                    "root": "path+file:[..]#bar@0.5.0"
-                },
-                "target_directory": "[..]",
-                "version": 1,
-                "workspace_members": [
-                    "path+file:[..]#bar@0.5.0"
-                ],
-                "workspace_default_members": [
-                    "path+file:[..]#bar@0.5.0"
-                ],
-                "workspace_root": "[..]",
-                "metadata": null
-            }
-            "#,
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/target/package/bar-0.5.0/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/foo/target/package/bar-0.5.0/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0"
+  },
+  "target_directory": "[ROOT]/foo/target/package/bar-0.5.0/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/target/package/bar-0.5.0#bar@0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo/target/package/bar-0.5.0"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -2388,77 +2632,78 @@ fn package_edition_2018() {
         )
         .build();
     p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-                "packages": [
-                    {
-                        "authors": [
-                            "wycats@example.com"
-                        ],
-                        "categories": [],
-                        "default_run": null,
-                        "dependencies": [],
-                        "description": null,
-                        "edition": "2018",
-                        "features": {},
-                        "id": "path+file:[..]#0.1.0",
-                        "keywords": [],
-                        "license": null,
-                        "license_file": null,
-                        "links": null,
-                        "manifest_path": "[..]Cargo.toml",
-                        "metadata": null,
-                        "publish": null,
-                        "name": "foo",
-                        "readme": null,
-                        "repository": null,
-                        "rust_version": null,
-                        "homepage": null,
-                        "documentation": null,
-                        "source": null,
-                        "targets": [
-                            {
-                                "crate_types": [
-                                    "lib"
-                                ],
-                                "doc": true,
-                                "doctest": true,
-                                "test": true,
-                                "edition": "2018",
-                                "kind": [
-                                    "lib"
-                                ],
-                                "name": "foo",
-                                "src_path": "[..]src/lib.rs"
-                            }
-                        ],
-                        "version": "0.1.0"
-                    }
-                ],
-                "resolve": {
-                    "nodes": [
-                        {
-                            "dependencies": [],
-                            "deps": [],
-                            "features": [],
-                            "id": "path+file:[..]#0.1.0"
-                        }
-                    ],
-                    "root": "path+file:[..]#0.1.0"
-                },
-                "target_directory": "[..]",
-                "version": 1,
-                "workspace_members": [
-                    "path+file:[..]#0.1.0"
-                ],
-                "workspace_default_members": [
-                    "path+file:[..]#0.1.0"
-                ],
-                "workspace_root": "[..]",
-                "metadata": null
-            }
-            "#,
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2018",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2018",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -2525,91 +2770,92 @@ fn target_edition_2018() {
         )
         .build();
     p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-                "packages": [
-                    {
-                        "authors": [
-                            "wycats@example.com"
-                        ],
-                        "categories": [],
-                        "default_run": null,
-                        "dependencies": [],
-                        "description": null,
-                        "edition": "2015",
-                        "features": {},
-                        "id": "path+file:[..]#0.1.0",
-                        "keywords": [],
-                        "license": null,
-                        "license_file": null,
-                        "links": null,
-                        "manifest_path": "[..]Cargo.toml",
-                        "metadata": null,
-                        "publish": null,
-                        "name": "foo",
-                        "readme": null,
-                        "repository": null,
-                        "rust_version": null,
-                        "homepage": null,
-                        "documentation": null,
-                        "source": null,
-                        "targets": [
-                            {
-                                "crate_types": [
-                                    "lib"
-                                ],
-                                "doc": true,
-                                "doctest": true,
-                                "test": true,
-                                "edition": "2018",
-                                "kind": [
-                                    "lib"
-                                ],
-                                "name": "foo",
-                                "src_path": "[..]src/lib.rs"
-                            },
-                            {
-                                "crate_types": [
-                                    "bin"
-                                ],
-                                "doc": true,
-                                "doctest": false,
-                                "test": true,
-                                "edition": "2015",
-                                "kind": [
-                                    "bin"
-                                ],
-                                "name": "foo",
-                                "src_path": "[..]src/main.rs"
-                            }
-                        ],
-                        "version": "0.1.0"
-                    }
-                ],
-                "resolve": {
-                    "nodes": [
-                        {
-                            "dependencies": [],
-                            "deps": [],
-                            "features": [],
-                            "id": "path+file:[..]#0.1.0"
-                        }
-                    ],
-                    "root": "path+file:[..]#0.1.0"
-                },
-                "target_directory": "[..]",
-                "version": 1,
-                "workspace_members": [
-                    "path+file:[..]#0.1.0"
-                ],
-                "workspace_default_members": [
-                    "path+file:[..]#0.1.0"
-                ],
-                "workspace_root": "[..]",
-                "metadata": null
-            }
-            "#,
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2018",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        },
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/main.rs",
+          "test": true
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -2637,217 +2883,219 @@ fn rename_dependency() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
 {
-    "packages": [
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.1.0/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "targets": [
         {
-            "authors": [],
-            "categories": [],
-            "default_run": null,
-            "dependencies": [],
-            "description": null,
-            "edition": "2015",
-            "features": {},
-            "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
-            "keywords": [],
-            "license": null,
-            "license_file": null,
-            "links": null,
-            "manifest_path": "[..]",
-            "metadata": null,
-            "publish": null,
-            "name": "bar",
-            "readme": null,
-            "repository": null,
-            "rust_version": null,
-            "homepage": null,
-            "documentation": null,
-            "source": "registry+https://github.com/rust-lang/crates.io-index",
-            "targets": [
-                {
-                    "crate_types": [
-                        "lib"
-                    ],
-                    "doc": true,
-                    "doctest": true,
-                    "test": true,
-                    "edition": "2015",
-                    "kind": [
-                        "lib"
-                    ],
-                    "name": "bar",
-                    "src_path": "[..]"
-                }
-            ],
-            "version": "0.1.0"
-        },
-        {
-            "authors": [],
-            "categories": [],
-            "default_run": null,
-            "dependencies": [],
-            "description": null,
-            "edition": "2015",
-            "features": {},
-            "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0",
-            "keywords": [],
-            "license": null,
-            "license_file": null,
-            "links": null,
-            "manifest_path": "[..]",
-            "metadata": null,
-            "publish": null,
-            "name": "bar",
-            "readme": null,
-            "repository": null,
-            "rust_version": null,
-            "homepage": null,
-            "documentation": null,
-            "source": "registry+https://github.com/rust-lang/crates.io-index",
-            "targets": [
-                {
-                    "crate_types": [
-                        "lib"
-                    ],
-                    "doc": true,
-                    "doctest": true,
-                    "test": true,
-                    "edition": "2015",
-                    "kind": [
-                        "lib"
-                    ],
-                    "name": "bar",
-                    "src_path": "[..]"
-                }
-            ],
-            "version": "0.2.0"
-        },
-        {
-            "authors": [],
-            "categories": [],
-            "default_run": null,
-            "dependencies": [
-                {
-                    "features": [],
-                    "kind": null,
-                    "name": "bar",
-                    "optional": false,
-                    "rename": null,
-                    "registry": null,
-                    "req": "^0.1.0",
-                    "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "target": null,
-                    "uses_default_features": true
-                },
-                {
-                    "features": [],
-                    "kind": null,
-                    "name": "bar",
-                    "optional": false,
-                    "rename": "baz",
-                    "registry": null,
-                    "req": "^0.2.0",
-                    "source": "registry+https://github.com/rust-lang/crates.io-index",
-                    "target": null,
-                    "uses_default_features": true
-                }
-            ],
-            "description": null,
-            "edition": "2015",
-            "features": {},
-            "id": "[..]foo#0.0.1",
-            "keywords": [],
-            "license": null,
-            "license_file": null,
-            "links": null,
-            "manifest_path": "[..]",
-            "metadata": null,
-            "publish": null,
-            "name": "foo",
-            "readme": null,
-            "repository": null,
-            "rust_version": null,
-            "homepage": null,
-            "documentation": null,
-            "source": null,
-            "targets": [
-                {
-                    "crate_types": [
-                        "lib"
-                    ],
-                    "doc": true,
-                    "doctest": true,
-                    "test": true,
-                    "edition": "2015",
-                    "kind": [
-                        "lib"
-                    ],
-                    "name": "foo",
-                    "src_path": "[..]"
-                }
-            ],
-            "version": "0.0.1"
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.1.0/src/lib.rs",
+          "test": true
         }
-    ],
-    "resolve": {
-        "nodes": [
-            {
-                "dependencies": [],
-                "deps": [],
-                "features": [],
-                "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
-            },
-            {
-                "dependencies": [],
-                "deps": [],
-                "features": [],
-                "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
-            },
-            {
-                "dependencies": [
-                    "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
-                    "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
-                ],
-                "deps": [
-                    {
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": null
-                          }
-                        ],
-                        "name": "bar",
-                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
-                    },
-                    {
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": null
-                          }
-                        ],
-                        "name": "baz",
-                        "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
-                    }
-                ],
-                "features": [],
-                "id": "[..]foo#0.0.1"
-            }
-        ],
-        "root": "[..]foo#0.0.1"
+      ],
+      "version": "0.1.0"
     },
-    "target_directory": "[..]",
-    "version": 1,
-    "workspace_members": [
-        "[..]foo#0.0.1"
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.2.0/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": "registry+https://github.com/rust-lang/crates.io-index",
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/bar-0.2.0/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.2.0"
+    },
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "features": [],
+          "kind": null,
+          "name": "bar",
+          "optional": false,
+          "registry": null,
+          "rename": null,
+          "req": "^0.1.0",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": null,
+          "name": "bar",
+          "optional": false,
+          "registry": null,
+          "rename": "baz",
+          "req": "^0.2.0",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.0.1",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.0.1"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
+      },
+      {
+        "dependencies": [
+          "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
+          "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
+        ],
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "bar",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
+          },
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "baz",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.2.0"
+          }
+        ],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.0.1"
+      }
     ],
-    "workspace_default_members": [
-        "[..]foo#0.0.1"
-    ],
-    "workspace_root": "[..]",
-    "metadata": null
-}"#,
+    "root": "path+[ROOTURL]/foo#0.0.1"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.0.1"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.0.1"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -2869,89 +3117,90 @@ fn metadata_links() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-              "packages": [
-                {
-                  "authors": [],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [],
-                  "description": null,
-                  "edition": "2015",
-                  "features": {},
-                  "id": "[..]foo#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": "a",
-                  "manifest_path": "[..]/foo/Cargo.toml",
-                  "metadata": null,
-                  "publish": null,
-                  "name": "foo",
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "homepage": null,
-                  "documentation": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "lib"
-                      ],
-                      "doc": true,
-                      "doctest": true,
-                      "test": true,
-                      "edition": "2015",
-                      "kind": [
-                        "lib"
-                      ],
-                      "name": "foo",
-                      "src_path": "[..]/foo/src/lib.rs"
-                    },
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": false,
-                      "doctest": false,
-                      "test": false,
-                      "edition": "2015",
-                      "kind": [
-                        "custom-build"
-                      ],
-                      "name": "build-script-build",
-                      "src_path": "[..]/foo/build.rs"
-                    }
-                  ],
-                  "version": "0.5.0"
-                }
-              ],
-              "resolve": {
-                "nodes": [
-                  {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "[..]foo#0.5.0"
-                  }
-                ],
-                "root": "[..]foo#0.5.0"
-              },
-              "target_directory": "[..]/foo/target",
-              "version": 1,
-              "workspace_members": [
-                "[..]foo#0.5.0"
-              ],
-              "workspace_default_members": [
-                "[..]foo#0.5.0"
-              ],
-              "workspace_root": "[..]/foo",
-              "metadata": null
-            }
-            "#,
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": "a",
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        },
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": false,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "custom-build"
+          ],
+          "name": "build-script-build",
+          "src_path": "[ROOT]/foo/build.rs",
+          "test": false
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.5.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.5.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run()
 }
@@ -2975,93 +3224,95 @@ fn deps_with_bin_only() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-              "packages": [
-                {
-                  "name": "foo",
-                  "version": "0.1.0",
-                  "id": "[..]foo#0.1.0",
-                  "license": null,
-                  "license_file": null,
-                  "description": null,
-                  "source": null,
-                  "dependencies": [
-                    {
-                      "name": "bdep",
-                      "source": null,
-                      "req": "*",
-                      "kind": null,
-                      "rename": null,
-                      "optional": false,
-                      "uses_default_features": true,
-                      "path": "[..]/foo/bdep",
-                      "features": [],
-                      "target": null,
-                      "registry": null
-                    }
-                  ],
-                  "targets": [
-                    {
-                      "kind": [
-                        "lib"
-                      ],
-                      "crate_types": [
-                        "lib"
-                      ],
-                      "name": "foo",
-                      "src_path": "[..]/foo/src/lib.rs",
-                      "edition": "2015",
-                      "doc": true,
-                      "doctest": true,
-                      "test": true
-                    }
-                  ],
-                  "features": {},
-                  "manifest_path": "[..]/foo/Cargo.toml",
-                  "metadata": null,
-                  "publish": null,
-                  "authors": [],
-                  "categories": [],
-                  "default_run": null,
-                  "keywords": [],
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "homepage": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "links": null
-                }
-              ],
-              "workspace_members": [
-                "[..]foo#0.1.0"
-              ],
-              "workspace_default_members": [
-                "[..]foo#0.1.0"
-              ],
-              "resolve": {
-                "nodes": [
-                  {
-                    "id": "[..]foo#0.1.0",
-                    "dependencies": [],
-                    "deps": [],
-                    "features": []
-                  }
-                ],
-                "root": "[..]foo#0.1.0"
-              },
-              "target_directory": "[..]/foo/target",
-              "version": 1,
-              "workspace_root": "[..]foo",
-              "metadata": null
-            }
-            "#,
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "features": [],
+          "kind": null,
+          "name": "bdep",
+          "optional": false,
+          "path": "[ROOT]/foo/bdep",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.1.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": null,
+      "name": "foo",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.1.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
 
+#[allow(deprecated)]
 #[cargo_test]
 fn filter_platform() {
     // Testing the --filter-platform flag.
@@ -3396,17 +3647,19 @@ fn filter_platform() {
 
     // Normal metadata, no filtering, returns *everything*.
     p.cargo("metadata")
-        .with_stderr_unordered(
-            "\
-[UPDATING] [..]
+        .with_stderr_data(
+            str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
+[UPDATING] `dummy-registry` index
 [LOCKING] 5 packages to latest compatible versions
 [DOWNLOADING] crates ...
-[DOWNLOADED] normal-dep v0.0.1 [..]
-[DOWNLOADED] host-dep v0.0.1 [..]
-[DOWNLOADED] alt-dep v0.0.1 [..]
-[DOWNLOADED] cfg-dep v0.0.1 [..]
-",
+[DOWNLOADED] normal-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] host-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] cfg-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] alt-dep v0.0.1 (registry `dummy-registry`)
+
+"#]]
+            .unordered(),
         )
         .with_json(
             &r#"
@@ -3525,14 +3778,16 @@ fn filter_platform() {
     // Filter on alternate, removes cfg and host.
     p.cargo("metadata --filter-platform")
         .arg(alt_target)
-        .with_stderr_unordered(
-            "\
+        .with_stderr_data(
+            str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [DOWNLOADING] crates ...
-[DOWNLOADED] normal-dep v0.0.1 [..]
-[DOWNLOADED] host-dep v0.0.1 [..]
-[DOWNLOADED] alt-dep v0.0.1 [..]
-",
+[DOWNLOADED] normal-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] host-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] alt-dep v0.0.1 (registry `dummy-registry`)
+
+"#]]
+            .unordered(),
         )
         .with_json(
             &r#"
@@ -3608,13 +3863,15 @@ fn filter_platform() {
     // Filter on host, removes alt and cfg.
     p.cargo("metadata --filter-platform")
         .arg(&host_target)
-        .with_stderr_unordered(
-            "\
+        .with_stderr_data(
+            str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [DOWNLOADING] crates ...
-[DOWNLOADED] normal-dep v0.0.1 [..]
-[DOWNLOADED] host-dep v0.0.1 [..]
-",
+[DOWNLOADED] normal-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] host-dep v0.0.1 (registry `dummy-registry`)
+
+"#]]
+            .unordered(),
         )
         .with_json(
             &r#"
@@ -3691,14 +3948,16 @@ fn filter_platform() {
     p.cargo("metadata --filter-platform")
         .arg(&host_target)
         .env("RUSTFLAGS", "--cfg=foobar")
-        .with_stderr_unordered(
-            "\
+        .with_stderr_data(
+            str![[r#"
 [WARNING] please specify `--format-version` flag explicitly to avoid compatibility problems
 [DOWNLOADING] crates ...
-[DOWNLOADED] normal-dep v0.0.1 [..]
-[DOWNLOADED] host-dep v0.0.1 [..]
-[DOWNLOADED] cfg-dep v0.0.1 [..]
-",
+[DOWNLOADED] normal-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] host-dep v0.0.1 (registry `dummy-registry`)
+[DOWNLOADED] cfg-dep v0.0.1 (registry `dummy-registry`)
+
+"#]]
+            .unordered(),
         )
         .with_json(
             &r#"
@@ -3820,73 +4079,78 @@ fn dep_kinds() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-              "packages": "{...}",
-              "workspace_members": "{...}",
-              "workspace_default_members": "{...}",
-              "target_directory": "{...}",
-              "version": 1,
-              "workspace_root": "{...}",
-              "metadata": null,
-              "resolve": {
-                "nodes": [
-                  {
-                    "id": "[..]#bar@0.1.0",
-                    "dependencies": [],
-                    "deps": [],
-                    "features": []
-                  },
-                  {
-                    "id": "[..]foo#0.1.0",
-                    "dependencies": [
-                      "[..]#bar@0.1.0",
-                      "[..]#winapi@0.1.0"
-                    ],
-                    "deps": [
-                      {
-                        "name": "bar",
-                        "pkg": "[..]#bar@0.1.0",
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": null
-                          },
-                          {
-                            "kind": "dev",
-                            "target": null
-                          },
-                          {
-                            "kind": "build",
-                            "target": null
-                          }
-                        ]
-                      },
-                      {
-                        "name": "winapi",
-                        "pkg": "[..]#winapi@0.1.0",
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": "cfg(windows)"
-                          }
-                        ]
-                      }
-                    ],
-                    "features": []
-                  },
-                  {
-                    "id": "[..]#winapi@0.1.0",
-                    "dependencies": [],
-                    "deps": [],
-                    "features": []
-                  }
-                ],
-                "root": "[..]foo#0.1.0"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
+      },
+      {
+        "dependencies": [
+          "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0",
+          "registry+https://github.com/rust-lang/crates.io-index#winapi@0.1.0"
+        ],
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              },
+              {
+                "kind": "dev",
+                "target": null
+              },
+              {
+                "kind": "build",
+                "target": null
               }
-            }
-            "#,
+            ],
+            "name": "bar",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#bar@0.1.0"
+          },
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": "cfg(windows)"
+              }
+            ],
+            "name": "winapi",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.1.0"
+          }
+        ],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#winapi@0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -3936,69 +4200,76 @@ fn dep_kinds_workspace() {
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
-            {
-              "packages": "{...}",
-              "workspace_members": "{...}",
-              "workspace_default_members": "{...}",
-              "target_directory": "[..]/foo/target",
-              "version": 1,
-              "workspace_root": "[..]/foo",
-              "metadata": null,
-              "resolve": {
-                "nodes": [
-                  {
-                    "id": "path+file://[..]/foo/bar#0.1.0",
-                    "dependencies": [
-                      "path+file://[..]/foo#0.1.0"
-                    ],
-                    "deps": [
-                      {
-                        "name": "foo",
-                        "pkg": "path+file://[..]/foo#0.1.0",
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": null
-                          }
-                        ]
-                      }
-                    ],
-                    "features": []
-                  },
-                  {
-                    "id": "path+file://[..]/foo/dep#0.5.0",
-                    "dependencies": [],
-                    "deps": [],
-                    "features": []
-                  },
-                  {
-                    "id": "path+file://[..]/foo#0.1.0",
-                    "dependencies": [
-                      "path+file://[..]/foo/dep#0.5.0"
-                    ],
-                    "deps": [
-                      {
-                        "name": "dep",
-                        "pkg": "path+file://[..]/foo/dep#0.5.0",
-                        "dep_kinds": [
-                          {
-                            "kind": null,
-                            "target": null
-                          }
-                        ]
-                      }
-                    ],
-                    "features": [
-                      "feat1"
-                    ]
-                  }
-                ],
-                "root": "path+file://[..]/foo#0.1.0"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": "{...}",
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [
+          "path+[ROOTURL]/foo#0.1.0"
+        ],
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
               }
-            }
-            "#,
+            ],
+            "name": "foo",
+            "pkg": "path+[ROOTURL]/foo#0.1.0"
+          }
+        ],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/bar#0.1.0"
+      },
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo/dep#0.5.0"
+      },
+      {
+        "dependencies": [
+          "path+[ROOTURL]/foo/dep#0.5.0"
+        ],
+        "deps": [
+          {
+            "dep_kinds": [
+              {
+                "kind": null,
+                "target": null
+              }
+            ],
+            "name": "dep",
+            "pkg": "path+[ROOTURL]/foo/dep#0.5.0"
+          }
+        ],
+        "features": [
+          "feat1"
+        ],
+        "id": "path+[ROOTURL]/foo#0.1.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.1.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.1.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/bar#0.1.0",
+    "path+[ROOTURL]/foo#0.1.0",
+    "path+[ROOTURL]/foo/dep#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -4024,7 +4295,10 @@ fn cargo_metadata_non_utf8() {
         .cwd(p.root().join(base))
         .arg("--format-version")
         .arg("1")
-        .with_stderr("error: path contains invalid UTF-8 characters")
+        .with_stderr_data(str![[r#"
+[ERROR] path contains invalid UTF-8 characters
+
+"#]])
         .with_status(101)
         .run();
 }
@@ -4065,204 +4339,205 @@ fn workspace_metadata_with_dependencies_no_deps_artifact() {
 
     p.cargo("metadata --no-deps -Z bindeps")
         .masquerade_as_nightly_cargo(&["bindeps"])
-        .with_json(
-            r#"
-            {
-              "metadata": null,
-              "packages": [
-                {
-                  "authors": [
-                    "wycats@example.com"
-                  ],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [
-                    {
-                      "artifact": {
-                        "kinds": [
-                          "bin"
-                        ],
-                        "lib": false,
-                        "target": null
-                      },
-                      "features": [],
-                      "kind": null,
-                      "name": "artifact",
-                      "optional": false,
-                      "path": "[..]/foo/artifact",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "features": [],
-                      "kind": null,
-                      "name": "baz",
-                      "optional": false,
-                      "path": "[..]/foo/baz",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    },
-                    {
-                      "features": [],
-                      "kind": null,
-                      "name": "baz-renamed",
-                      "optional": false,
-                      "path": "[..]/foo/baz",
-                      "registry": null,
-                      "rename": null,
-                      "req": "*",
-                      "source": null,
-                      "target": null,
-                      "uses_default_features": true
-                    }
-                  ],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/bar#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/bar/Cargo.toml",
-                  "metadata": null,
-                  "name": "bar",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "lib"
-                      ],
-                      "doc": true,
-                      "doctest": true,
-                      "edition": "2015",
-                      "kind": [
-                        "lib"
-                      ],
-                      "name": "bar",
-                      "src_path": "[..]/foo/bar/src/lib.rs",
-                      "test": true
-                    }
-                  ],
-                  "version": "0.5.0"
-                },
-                {
-                  "authors": [
-                    "wycats@example.com"
-                  ],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/artifact#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/artifact/Cargo.toml",
-                  "metadata": null,
-                  "name": "artifact",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "bin"
-                      ],
-                      "doc": true,
-                      "doctest": false,
-                      "edition": "2015",
-                      "kind": [
-                        "bin"
-                      ],
-                      "name": "artifact",
-                      "src_path": "[..]/foo/artifact/src/main.rs",
-                      "test": true
-                    }
-                  ],
-                  "version": "0.5.0"
-                },
-                {
-                  "authors": [
-                    "wycats@example.com"
-                  ],
-                  "categories": [],
-                  "default_run": null,
-                  "dependencies": [],
-                  "description": null,
-                  "documentation": null,
-                  "edition": "2015",
-                  "features": {},
-                  "homepage": null,
-                  "id": "path+file://[..]/foo/baz#0.5.0",
-                  "keywords": [],
-                  "license": null,
-                  "license_file": null,
-                  "links": null,
-                  "manifest_path": "[..]/foo/baz/Cargo.toml",
-                  "metadata": null,
-                  "name": "baz",
-                  "publish": null,
-                  "readme": null,
-                  "repository": null,
-                  "rust_version": null,
-                  "source": null,
-                  "targets": [
-                    {
-                      "crate_types": [
-                        "lib"
-                      ],
-                      "doc": true,
-                      "doctest": true,
-                      "edition": "2015",
-                      "kind": [
-                        "lib"
-                      ],
-                      "name": "baz",
-                      "src_path": "[..]/foo/baz/src/lib.rs",
-                      "test": true
-                    }
-                  ],
-                  "version": "0.5.0"
-                }
-              ],
-              "resolve": null,
-              "target_directory": "[..]/foo/target",
-              "version": 1,
-              "workspace_members": [
-                "path+file://[..]/foo/bar#0.5.0",
-                "path+file://[..]/foo/artifact#0.5.0",
-                "path+file://[..]/foo/baz#0.5.0"
-              ],
-              "workspace_default_members": [
-                "path+file://[..]/foo/bar#0.5.0",
-                "path+file://[..]/foo/artifact#0.5.0",
-                "path+file://[..]/foo/baz#0.5.0"
-              ],
-              "workspace_root": "[..]/foo"
-            }
-"#,
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [
+        {
+          "artifact": {
+            "kinds": [
+              "bin"
+            ],
+            "lib": false,
+            "target": null
+          },
+          "features": [],
+          "kind": null,
+          "name": "artifact",
+          "optional": false,
+          "path": "[ROOT]/foo/artifact",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": null,
+          "name": "baz",
+          "optional": false,
+          "path": "[ROOT]/foo/baz",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        },
+        {
+          "features": [],
+          "kind": null,
+          "name": "baz-renamed",
+          "optional": false,
+          "path": "[ROOT]/foo/baz",
+          "registry": null,
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
+        }
+      ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/bar#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/bar/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "bar",
+          "src_path": "[ROOT]/foo/bar/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/artifact#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/artifact/Cargo.toml",
+      "metadata": null,
+      "name": "artifact",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "bin"
+          ],
+          "doc": true,
+          "doctest": false,
+          "edition": "2015",
+          "kind": [
+            "bin"
+          ],
+          "name": "artifact",
+          "src_path": "[ROOT]/foo/artifact/src/main.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    },
+    {
+      "authors": [
+        "wycats@example.com"
+      ],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/baz#0.5.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/baz/Cargo.toml",
+      "metadata": null,
+      "name": "baz",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "baz",
+          "src_path": "[ROOT]/foo/baz/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.5.0"
+    }
+  ],
+  "resolve": null,
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/artifact#0.5.0",
+    "path+[ROOTURL]/foo/baz#0.5.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/bar#0.5.0",
+    "path+[ROOTURL]/foo/artifact#0.5.0",
+    "path+[ROOTURL]/foo/baz#0.5.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }
@@ -4304,247 +4579,248 @@ fn versionless_packages() {
     Package::new("foobar", "0.0.1").publish();
 
     p.cargo("metadata -q --format-version 1")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
 {
+  "metadata": null,
   "packages": [
     {
-      "name": "bar",
-      "version": "0.0.0",
-      "id": "[..]bar#0.0.0",
-      "license": null,
-      "license_file": null,
-      "description": null,
-      "source": null,
+      "authors": [],
+      "categories": [],
+      "default_run": null,
       "dependencies": [
         {
-          "name": "baz",
-          "source": null,
-          "req": "*",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
           "features": [],
-          "target": null,
+          "kind": null,
+          "name": "baz",
+          "optional": false,
+          "path": "[ROOT]/foo/baz",
           "registry": null,
-          "path": "[..]/baz"
+          "rename": null,
+          "req": "*",
+          "source": null,
+          "target": null,
+          "uses_default_features": true
         },
         {
-          "name": "foobar",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.0.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
           "features": [],
+          "kind": null,
+          "name": "foobar",
+          "optional": false,
+          "registry": null,
+          "rename": null,
+          "req": "^0.0.1",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
           "target": null,
-          "registry": null
+          "uses_default_features": true
         }
       ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/bar#0.0.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/bar/Cargo.toml",
+      "metadata": null,
+      "name": "bar",
+      "publish": [],
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
       "targets": [
         {
-          "kind": [
+          "crate_types": [
             "lib"
           ],
-          "crate_types": [
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
             "lib"
           ],
           "name": "bar",
-          "src_path": "[..]/bar/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
+          "src_path": "[ROOT]/foo/bar/src/lib.rs",
           "test": true
         }
       ],
-      "features": {},
-      "manifest_path": "[..]/bar/Cargo.toml",
-      "metadata": null,
-      "publish": [],
-      "authors": [],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": null,
-      "homepage": null,
-      "documentation": null,
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
+      "version": "0.0.0"
     },
     {
-      "name": "baz",
-      "version": "0.0.0",
-      "id": "[..]baz#0.0.0",
-      "license": null,
-      "license_file": null,
-      "description": null,
-      "source": null,
+      "authors": [],
+      "categories": [],
+      "default_run": null,
       "dependencies": [
         {
-          "name": "foobar",
-          "source": "registry+https://github.com/rust-lang/crates.io-index",
-          "req": "^0.0.1",
-          "kind": null,
-          "rename": null,
-          "optional": false,
-          "uses_default_features": true,
           "features": [],
+          "kind": null,
+          "name": "foobar",
+          "optional": false,
+          "registry": null,
+          "rename": null,
+          "req": "^0.0.1",
+          "source": "registry+https://github.com/rust-lang/crates.io-index",
           "target": null,
-          "registry": null
+          "uses_default_features": true
         }
       ],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo/baz#0.0.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/baz/Cargo.toml",
+      "metadata": null,
+      "name": "baz",
+      "publish": [],
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
       "targets": [
         {
-          "kind": [
+          "crate_types": [
             "lib"
           ],
-          "crate_types": [
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
             "lib"
           ],
           "name": "baz",
-          "src_path": "[..]/baz/src/lib.rs",
-          "edition": "2015",
-          "doc": true,
-          "doctest": true,
+          "src_path": "[ROOT]/foo/baz/src/lib.rs",
           "test": true
         }
       ],
-      "features": {},
-      "manifest_path": "[..]/baz/Cargo.toml",
-      "metadata": null,
-      "publish": [],
-      "authors": [],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": null,
-      "homepage": null,
-      "documentation": null,
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
+      "version": "0.0.0"
     },
     {
-      "name": "foobar",
-      "version": "0.0.1",
-      "id": "[..]#foobar@0.0.1",
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1",
+      "keywords": [],
       "license": null,
       "license_file": null,
-      "description": null,
+      "links": null,
+      "manifest_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foobar-0.0.1/Cargo.toml",
+      "metadata": null,
+      "name": "foobar",
+      "publish": null,
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
       "source": "registry+https://github.com/rust-lang/crates.io-index",
-      "dependencies": [],
       "targets": [
         {
-          "kind": [
-            "lib"
-          ],
           "crate_types": [
             "lib"
           ],
-          "name": "foobar",
-          "src_path": "[..]/foobar-0.0.1/src/lib.rs",
-          "edition": "2015",
           "doc": true,
           "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foobar",
+          "src_path": "[ROOT]/home/.cargo/registry/src/-[HASH]/foobar-0.0.1/src/lib.rs",
           "test": true
         }
       ],
-      "features": {},
-      "manifest_path": "[..]/foobar-0.0.1/Cargo.toml",
-      "metadata": null,
-      "publish": null,
-      "authors": [],
-      "categories": [],
-      "keywords": [],
-      "readme": null,
-      "repository": null,
-      "homepage": null,
-      "documentation": null,
-      "edition": "2015",
-      "links": null,
-      "default_run": null,
-      "rust_version": null
+      "version": "0.0.1"
     }
-  ],
-  "workspace_members": [
-    "[..]bar#0.0.0",
-    "[..]baz#0.0.0"
-  ],
-  "workspace_default_members": [
-    "[..]bar#0.0.0",
-    "[..]baz#0.0.0"
   ],
   "resolve": {
     "nodes": [
       {
-        "id": "[..]bar#0.0.0",
         "dependencies": [
-          "[..]baz#0.0.0",
-          "[..]#foobar@0.0.1"
+          "path+[ROOTURL]/foo/baz#0.0.0",
+          "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
         ],
         "deps": [
           {
-            "name": "baz",
-            "pkg": "[..]baz#0.0.0",
             "dep_kinds": [
               {
                 "kind": null,
                 "target": null
               }
-            ]
+            ],
+            "name": "baz",
+            "pkg": "path+[ROOTURL]/foo/baz#0.0.0"
           },
           {
-            "name": "foobar",
-            "pkg": "[..]#foobar@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
                 "target": null
               }
-            ]
+            ],
+            "name": "foobar",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
           }
         ],
-        "features": []
+        "features": [],
+        "id": "path+[ROOTURL]/foo/bar#0.0.0"
       },
       {
-        "id": "[..]baz#0.0.0",
         "dependencies": [
-          "[..]#foobar@0.0.1"
+          "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
         ],
         "deps": [
           {
-            "name": "foobar",
-            "pkg": "[..]#foobar@0.0.1",
             "dep_kinds": [
               {
                 "kind": null,
                 "target": null
               }
-            ]
+            ],
+            "name": "foobar",
+            "pkg": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
           }
         ],
-        "features": []
+        "features": [],
+        "id": "path+[ROOTURL]/foo/baz#0.0.0"
       },
       {
-        "id": "[..]#foobar@0.0.1",
         "dependencies": [],
         "deps": [],
-        "features": []
+        "features": [],
+        "id": "registry+https://github.com/rust-lang/crates.io-index#foobar@0.0.1"
       }
     ],
     "root": null
   },
-  "target_directory": "[..]/foo/target",
+  "target_directory": "[ROOT]/foo/target",
   "version": 1,
-  "workspace_root": "[..]",
-  "metadata": null
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo/bar#0.0.0",
+    "path+[ROOTURL]/foo/baz#0.0.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo/bar#0.0.0",
+    "path+[ROOTURL]/foo/baz#0.0.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
 }
-"#,
+"#]]
+            .json(),
         )
         .run();
 }
@@ -4572,85 +4848,89 @@ local-time = 1979-05-27
         .build();
 
     p.cargo("metadata")
-        .with_json(
-            r#"
+        .with_stdout_data(
+            str![[r#"
+{
+  "metadata": null,
+  "packages": [
     {
-        "packages": [
-            {
-                "authors": [],
-                "categories": [],
-                "default_run": null,
-                "name": "foo",
-                "version": "0.0.0",
-                "id": "[..]foo#0.0.0",
-                "keywords": [],
-                "source": null,
-                "dependencies": [],
-                "edition": "2015",
-                "license": null,
-                "license_file": null,
-                "links": null,
-                "description": null,
-                "readme": null,
-                "repository": null,
-                "rust_version": null,
-                "homepage": null,
-                "documentation": null,
-                "homepage": null,
-                "documentation": null,
-                "targets": [
-                    {
-                        "kind": [
-                            "lib"
-                        ],
-                        "crate_types": [
-                            "lib"
-                        ],
-                        "doc": true,
-                        "doctest": true,
-                        "test": true,
-                        "edition": "2015",
-                        "name": "foo",
-                        "src_path": "[..]/foo/src/lib.rs"
-                    }
-                ],
-                "features": {},
-                "manifest_path": "[..]Cargo.toml",
-                "metadata": {
-                  "local-date": {
-                    "$__toml_private_datetime": "1979-05-27"
-                  },
-                  "local-datetime": {
-                    "$__toml_private_datetime": "1979-05-27T07:32:00"
-                  },
-                  "local-time": {
-                    "$__toml_private_datetime": "1979-05-27"
-                  },
-                  "offset-datetime": {
-                    "$__toml_private_datetime": "1979-05-27T07:32:00Z"
-                  }
-                },
-                "publish": []
-            }
-        ],
-        "workspace_members": ["path+file:[..]foo#0.0.0"],
-        "workspace_default_members": ["path+file:[..]foo#0.0.0"],
-        "resolve": {
-            "nodes": [
-                {
-                    "dependencies": [],
-                    "deps": [],
-                    "features": [],
-                    "id": "path+file:[..]foo#0.0.0"
-                }
-            ],
-            "root": "path+file:[..]foo#0.0.0"
+      "authors": [],
+      "categories": [],
+      "default_run": null,
+      "dependencies": [],
+      "description": null,
+      "documentation": null,
+      "edition": "2015",
+      "features": {},
+      "homepage": null,
+      "id": "path+[ROOTURL]/foo#0.0.0",
+      "keywords": [],
+      "license": null,
+      "license_file": null,
+      "links": null,
+      "manifest_path": "[ROOT]/foo/Cargo.toml",
+      "metadata": {
+        "local-date": {
+          "$__toml_private_datetime": "1979-05-27"
         },
-        "target_directory": "[..]foo/target",
-        "version": 1,
-        "workspace_root": "[..]/foo",
-        "metadata": null
-    }"#,
+        "local-datetime": {
+          "$__toml_private_datetime": "1979-05-27T07:32:00"
+        },
+        "local-time": {
+          "$__toml_private_datetime": "1979-05-27"
+        },
+        "offset-datetime": {
+          "$__toml_private_datetime": "1979-05-27T07:32:00Z"
+        }
+      },
+      "name": "foo",
+      "publish": [],
+      "readme": null,
+      "repository": null,
+      "rust_version": null,
+      "source": null,
+      "targets": [
+        {
+          "crate_types": [
+            "lib"
+          ],
+          "doc": true,
+          "doctest": true,
+          "edition": "2015",
+          "kind": [
+            "lib"
+          ],
+          "name": "foo",
+          "src_path": "[ROOT]/foo/src/lib.rs",
+          "test": true
+        }
+      ],
+      "version": "0.0.0"
+    }
+  ],
+  "resolve": {
+    "nodes": [
+      {
+        "dependencies": [],
+        "deps": [],
+        "features": [],
+        "id": "path+[ROOTURL]/foo#0.0.0"
+      }
+    ],
+    "root": "path+[ROOTURL]/foo#0.0.0"
+  },
+  "target_directory": "[ROOT]/foo/target",
+  "version": 1,
+  "workspace_default_members": [
+    "path+[ROOTURL]/foo#0.0.0"
+  ],
+  "workspace_members": [
+    "path+[ROOTURL]/foo#0.0.0"
+  ],
+  "workspace_root": "[ROOT]/foo"
+}
+"#]]
+            .json(),
         )
         .run();
 }

--- a/tests/testsuite/net_config.rs
+++ b/tests/testsuite/net_config.rs
@@ -1,8 +1,7 @@
 //! Tests for network configuration.
 
-#![allow(deprecated)]
-
 use cargo_test_support::project;
+use cargo_test_support::str;
 
 #[cargo_test]
 fn net_retry_loads_from_config() {
@@ -33,10 +32,11 @@ fn net_retry_loads_from_config() {
 
     p.cargo("check -v")
         .with_status(101)
-        .with_stderr_contains(
-            "[WARNING] spurious network error \
-             (1 tries remaining): [..]",
-        )
+        .with_stderr_data(str![[r#"
+...
+[WARNING] spurious network error (1 tries remaining): [..]
+...
+"#]])
         .run();
 }
 
@@ -67,10 +67,11 @@ fn net_retry_git_outputs_warning() {
 
     p.cargo("check -v -j 1")
         .with_status(101)
-        .with_stderr_contains(
-            "[WARNING] spurious network error \
-             (2 tries remaining): [..]",
-        )
-        .with_stderr_contains("[WARNING] spurious network error (1 tries remaining): [..]")
+        .with_stderr_data(str![[r#"
+...
+[WARNING] spurious network error (2 tries remaining): [..]
+[WARNING] spurious network error (1 tries remaining): [..]
+...
+"#]])
         .run();
 }


### PR DESCRIPTION
### What does this PR try to resolve?

Part of https://github.com/rust-lang/cargo/issues/14039.

Migrate following to snapbox:

- `tests/testsuite/metabuild.rs`
- `tests/testsuite/metadata.rs`
- `tests/testsuite/net_config.rs`