### PR TITLE
Make it clear that `CARGO_CFG_TARGET_FAMILY` is multi-valued

### DIFF
--- a/src/doc/src/reference/environment-variables.md
+++ b/src/doc/src/reference/environment-variables.md
@@ -342,7 +342,7 @@ let out_dir = env::var("OUT_DIR").unwrap();
   those defined in `RUSTFLAGS`). Some examples of what these variables are:
     * `CARGO_CFG_UNIX` --- Set on [unix-like platforms].
     * `CARGO_CFG_WINDOWS` --- Set on [windows-like platforms].
-    * `CARGO_CFG_TARGET_FAMILY=unix` --- The [target family].
+    * `CARGO_CFG_TARGET_FAMILY=unix,wasm` --- The [target family].
     * `CARGO_CFG_TARGET_OS=macos` --- The [target operating system].
     * `CARGO_CFG_TARGET_ARCH=x86_64` --- The CPU [target architecture].
     * `CARGO_CFG_TARGET_VENDOR=apple` --- The [target vendor].


### PR DESCRIPTION
`target_family` / `CARGO_CFG_TARGET_FAMILY` can take multiple values, but this is not particularly clear in the documentation. To resolve this, I've changed the example to document this.

[A crater run](https://github.com/rust-lang/rust/pull/124355#issuecomment-2091278128) found a few instances where this value was incorrectly assumed to be a single value.