### PR TITLE
test:  fix several assertions

### DIFF
--- a/tests/testsuite/git.rs
+++ b/tests/testsuite/git.rs
@@ -2855,7 +2855,7 @@ fn use_the_cli() {
 [UPDATING] git repository `[ROOTURL]/dep1`
 [RUNNING] `git fetch --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
 From [ROOTURL]/dep1
- * [new ref]         HEAD       -> origin/HEAD
+ * [new ref] [..] -> origin/HEAD[..]
 [LOCKING] 2 packages to latest compatible versions
 [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
 [RUNNING] `rustc --crate-name dep1 [..]`

--- a/tests/testsuite/publish_lockfile.rs
+++ b/tests/testsuite/publish_lockfile.rs
@@ -241,7 +241,7 @@ fn note_resolve_changes() {
 [ARCHIVING] Cargo.toml.orig
 [ARCHIVING] src/main.rs
 [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
-[WARNING] no (git) Cargo.toml found at `target/tmp/[..]/foo/Cargo.toml` in workdir `[..]`
+[WARNING] no (git) Cargo.toml found at `[..]/foo/Cargo.toml` in workdir `[..]`
 
 "#]].unordered())
         .run();


### PR DESCRIPTION
These were found during submodule update. See each commit for details.

```console
---- git::use_the_cli stdout ----
running `/projects/rust/build/aarch64-apple-darwin/stage2-tools/aarch64-apple-darwin/release/cargo check -v`
thread 'git::use_the_cli' panicked at tests/testsuite/git.rs:2872:10:

---- expected: tests/testsuite/git.rs:2854:18
++++ actual:   stderr
   1    1 | [UPDATING] git repository `[ROOTURL]/dep1`
   2    2 | [RUNNING] `git fetch --verbose --force --update-head-ok [..][ROOTURL]/dep1[..] [..]+HEAD:refs/remotes/origin/HEAD[..]`
   3    3 | From [ROOTURL]/dep1
   4      -  * [new ref]         HEAD       -> origin/HEAD
        4 +  * [new ref]                    -> origin/HEAD
   5    5 | [LOCKING] 2 packages to latest compatible versions
   6    6 | [CHECKING] dep1 v0.5.0 ([ROOTURL]/dep1#[..])
   7    7 | [RUNNING] `rustc --crate-name dep1 [..]`
   8    8 | [CHECKING] foo v0.5.0 ([ROOT]/foo)
   9    9 | [RUNNING] `rustc --crate-name foo [..]`
  10   10 | [FINISHED] `dev` profile [unoptimized + debuginfo] target(s) in [ELAPSED]s

Update with SNAPSHOTS=overwrite


---- publish_lockfile::note_resolve_changes stdout ----
running `/projects/rust/build/aarch64-apple-darwin/stage2-tools/aarch64-apple-darwin/release/cargo generate-lockfile`
running `/projects/rust/build/aarch64-apple-darwin/stage2-tools/aarch64-apple-darwin/release/cargo package --no-verify -v --allow-dirty`
thread 'publish_lockfile::note_resolve_changes' panicked at tests/testsuite/publish_lockfile.rs:247:10:

---- expected: tests/testsuite/publish_lockfile.rs:234:27
++++ actual:   stderr
   1    1 | [PACKAGING] foo v0.0.1 ([ROOT]/foo)
   2    2 | [ARCHIVING] Cargo.lock
   3    3 | [UPDATING] `dummy-registry` index
   4    4 | [NOTE] package `multi v0.1.0` added to the packaged Cargo.lock file, was originally sourced from `[ROOT]/foo/multi`
   5    5 | [NOTE] package `patched v1.0.0` added to the packaged Cargo.lock file, was originally sourced from `[ROOT]/foo/patched`
   6    6 | [ARCHIVING] Cargo.toml
   7    7 | [ARCHIVING] Cargo.toml.orig
   8    8 | [ARCHIVING] src/main.rs
   9    9 | [PACKAGED] 4 files, [FILE_SIZE]B ([FILE_SIZE]B compressed)
  10      - [WARNING] no (git) Cargo.toml found at `target/tmp/[..]/foo/Cargo.toml` in workdir `[..]`
       10 + [WARNING] no (git) Cargo.toml found at `build/[HOST_TARGET]/stage2-tools/[HOST_TARGET]/tmp/cit/t2393/foo/Cargo.toml` in workdir `/projects/rust/`
```
